### PR TITLE
[13057] socials: substitution of the pronoun to the name in social.

### DIFF
--- a/socials/aargh.xml
+++ b/socials/aargh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты орешь от осознания своего идиотизма!</msgCharAuto>
-  <msgCharFound>Ты в отчаяньи рычишь и начинаешь душить $S!</msgCharFound>
+  <msgCharFound>Ты в отчаяньи рычишь и начинаешь душить $C4!</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>AAAAAARRRRRRGGGGGGHHHHHH!!!!!!</msgCharNoArgument>
   <msgCharNotFound>Ты приходишь в полное отчаянье, понимая, что тут некого душить!</msgCharNotFound>

--- a/socials/abite.xml
+++ b/socials/abite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты кусаешь локти.</msgCharAuto>
-  <msgCharFound>Ты покусываешь $S за шейку.</msgCharFound>
+  <msgCharFound>Ты покусываешь $C2 за шейку.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты эротично шепчешь: &quot;ну... кто меня куснет?&quot;.</msgCharNoArgument>
   <msgCharNotFound>Голодный? А укусить-то некого.</msgCharNotFound>

--- a/socials/ajudge.xml
+++ b/socials/ajudge.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>На самом деле тебе этого не очень хочется.</msgCharAuto>
-  <msgCharFound>Ты оцениваешь $s по десятибальной системе.</msgCharFound>
+  <msgCharFound>Ты оцениваешь $C4 по десятибальной системе.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Кого?</msgCharNoArgument>
   <msgCharNotFound>Сейчас их тут нет.</msgCharNotFound>

--- a/socials/blush.xml
+++ b/socials/blush.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты краснеешь от собственной глупости.</msgCharAuto>
-  <msgCharFound>Ты волнуешься, видя $S.</msgCharFound>
+  <msgCharFound>Ты волнуешься, видя $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Твои щеки наливаются румянцем.</msgCharNoArgument>
   <msgCharNotFound>Ты краснеешь, не видя таких людей тут.</msgCharNotFound>

--- a/socials/caress.xml
+++ b/socials/caress.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты нежно ласкаешь $S.</msgCharFound>
+  <msgCharFound>Ты нежно ласкаешь $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Поласкать? Кого?</msgCharNoArgument>
   <msgCharNotFound>Гм...</msgCharNotFound>

--- a/socials/chuckle.xml
+++ b/socials/chuckle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты смеешься над собственной шуткой, так как больше некому.</msgCharAuto>
-  <msgCharFound>Ты смеешься над $S шуткой.</msgCharFound>
+  <msgCharFound>Ты смеешься над шуткой $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты вежливо смеешься.</msgCharNoArgument>
   <msgCharNotFound>Ты не можешь найти, с кем посмеяться.</msgCharNotFound>

--- a/socials/clap.xml
+++ b/socials/clap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты хлопаешь в ладоши, радуясь своим подвигам.</msgCharAuto>
-  <msgCharFound>Ты хлопаешь в ладоши, радуясь $S подвигам.</msgCharFound>
+  <msgCharFound>Ты хлопаешь в ладоши, радуясь подвигам $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты поднимаешь руки, сомкнутые вместе, в приветствии.</msgCharNoArgument>
   <msgCharNotFound>Нечему хлопать...</msgCharNotFound>

--- a/socials/comfort.xml
+++ b/socials/comfort.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты тщетно пытаешься утешиться.</msgCharAuto>
-  <msgCharFound>Ты утешаешь $S.</msgCharFound>
+  <msgCharFound>Ты утешаешь $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Тебе неудобно?</msgCharNoArgument>
   <msgCharNotFound>Утешить кого?</msgCharNotFound>

--- a/socials/conspire.xml
+++ b/socials/conspire.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>$c1 не доверяет даже себе.</msgCharAuto>
-  <msgCharFound>Ты знакомишь $S со своими тайными планами.</msgCharFound>
+  <msgCharFound>Ты знакомишь $C4 со своими тайными планами.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты делаешь условные знаки ушами, надеясь на ответ.</msgCharNoArgument>
   <msgCharNotFound>Ты плетешь козни против себя?.</msgCharNotFound>

--- a/socials/criticize.xml
+++ b/socials/criticize.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты критикуешь себя.</msgCharAuto>
-  <msgCharFound>Ты критикуешь $S с сердечностью змеи.</msgCharFound>
+  <msgCharFound>Ты критикуешь $C4 с сердечностью змеи.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Да, но кого?</msgCharNoArgument>
   <msgCharNotFound>Ну и где, где жертва твоих замечаний?</msgCharNotFound>

--- a/socials/cuddle.xml
+++ b/socials/cuddle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>На самом деле ты уже и так прижат(а) сам к себе :)</msgCharAuto>
-  <msgCharFound>Ты прижимаешь к себе $S.</msgCharFound>
+  <msgCharFound>Ты прижимаешь к себе $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Кого ты хочешь сегодня прижать к себе?</msgCharNoArgument>
   <msgCharNotFound>Таких тут нет.</msgCharNotFound>

--- a/socials/curse.xml
+++ b/socials/curse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты проклинаешь себя за оши_п_ки.</msgCharAuto>
-  <msgCharFound>Ты проклинаешь $S.</msgCharFound>
+  <msgCharFound>Ты проклинаешь $C4.</msgCharFound>
   <msgCharFound2>Ты проклинаешь %2$C4 и %3$C4!</msgCharFound2>
   <msgCharNoArgument>Ты чертыхаешься.</msgCharNoArgument>
   <msgCharNotFound>Тихо, тихо, спокойно. Посчитай до 12-ти.</msgCharNotFound>

--- a/socials/flash.xml
+++ b/socials/flash.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Это не здорово.</msgCharAuto>
-  <msgCharFound>Ты поспешно распахиваешь свой плащ, пытаясь привлечь $S внимание.</msgCharFound>
+  <msgCharFound>Ты поспешно распахиваешь свой плащ, пытаясь привлечь внимание $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты распахиваешь полы своего плаща, и все видят, что под ним!</msgCharNoArgument>
   <msgCharNotFound>Эксбиционист! Таких тут нет!</msgCharNotFound>

--- a/socials/gasp.xml
+++ b/socials/gasp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты глядишь на себя и задыхаешься!</msgCharAuto>
-  <msgCharFound>Ты задыхаешься от удивления $S действиями.</msgCharFound>
+  <msgCharFound>Ты задыхаешься от удивления действиями $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты задыхаешься от удивления.</msgCharNoArgument>
   <msgCharNotFound>Никто тебя не душит.</msgCharNotFound>

--- a/socials/hand.xml
+++ b/socials/hand.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты чмокаешь себя в ладошку!</msgCharAuto>
-  <msgCharFound>Ты целуешь $S руку.</msgCharFound>
+  <msgCharFound>Ты целуешь руку $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Поцеловать чью-то ручку?</msgCharNoArgument>
   <msgCharNotFound>Ты не можешь найти Леди своей мечты.</msgCharNotFound>

--- a/socials/hug.xml
+++ b/socials/hug.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты обнимаешь себя.</msgCharAuto>
-  <msgCharFound>Ты обнимаешь $S.</msgCharFound>
+  <msgCharFound>Ты обнимаешь $C4.</msgCharFound>
   <msgCharFound2>Ты обнимаешь %2$C4 и %3$C4.</msgCharFound2>
   <msgCharNoArgument>Кого обнять?</msgCharNoArgument>
   <msgCharNotFound>Извини, не видно таких здесь.</msgCharNotFound>

--- a/socials/kiss.xml
+++ b/socials/kiss.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>У всех жена ушла... :(</msgCharAuto>
-  <msgCharFound>Ты целуешь $S.</msgCharFound>
+  <msgCharFound>Ты целуешь $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Поцеловать, а кого??</msgCharNoArgument>
   <msgCharNotFound>Никогда нет рядом, когда надо.</msgCharNotFound>

--- a/socials/knee.xml
+++ b/socials/knee.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>О ЧЕМ ты думаешь ?!??!?!?!?!</msgCharAuto>
-  <msgCharFound>Ты бьешь коленом $S в пах.</msgCharFound>
+  <msgCharFound>Ты бьешь коленом $C4 в пах.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты поднимаешь колено.</msgCharNoArgument>
   <msgCharNotFound>Кого сделать импотентом?</msgCharNotFound>

--- a/socials/nudge.xml
+++ b/socials/nudge.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>По какой-то непонятной причине ты толкаешь себя локтем.</msgCharAuto>
-  <msgCharFound>Ты толкаешь $S локтем.</msgCharFound>
+  <msgCharFound>Ты толкаешь $C4 локтем.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Кого подтолкнуть?</msgCharNoArgument>
   <msgCharNotFound>Кого?</msgCharNotFound>

--- a/socials/nuzzle.xml
+++ b/socials/nuzzle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Извини, но это проблематично.</msgCharAuto>
-  <msgCharFound>Ты мягко трешься носом о $S шею.</msgCharFound>
+  <msgCharFound>Ты мягко трешься носом о шею $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>В кого воткнуться носом??</msgCharNoArgument>
   <msgCharNotFound>Нее... здесь таких нет...</msgCharNotFound>

--- a/socials/pinch.xml
+++ b/socials/pinch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты щипаешь себя, чтобы убедиться, что это не сон!</msgCharAuto>
-  <msgCharFound>Ты щипаешь $S за попку и ухмыляешься.</msgCharFound>
+  <msgCharFound>Ты щипаешь $C4 за попку и ухмыляешься.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты произносишь: &apos;{gЩепоточку того, щепоточку этого{x&apos;</msgCharNoArgument>
   <msgCharNotFound>Ты бы рад, но кого?</msgCharNotFound>

--- a/socials/polite.xml
+++ b/socials/polite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты смеешься над своей шуткой, потому что больше никто не смеется.</msgCharAuto>
-  <msgCharFound>Ты высказываешь неодобрение по поводу $S шутки.</msgCharFound>
+  <msgCharFound>Ты высказываешь неодобрение по поводу шутки $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты вежливо смеешься.</msgCharNoArgument>
   <msgCharNotFound>Не с кем посмеяться.</msgCharNotFound>

--- a/socials/pound.xml
+++ b/socials/pound.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты вбиваешь $S в камень мощным ударом.</msgCharFound>
+  <msgCharFound>Ты вбиваешь $C4 в камень мощным ударом.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты разминаешь кулак. Выразительно.</msgCharNoArgument>
   <msgCharNotFound>Никого тут нет.</msgCharNotFound>

--- a/socials/pray.xml
+++ b/socials/pray.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>И вы шото говорите про самолюбие? Не смешите мои тапки...</msgCharAuto>
-  <msgCharFound>Ты падаешь ниц перед $M.</msgCharFound>
+  <msgCharFound>Ты падаешь ниц перед $C5.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты чувствуешь себя просветленным и чуть-чуть, совсем чуть-чуть идиотом....</msgCharNoArgument>
   <msgCharNotFound>Вокруг-ни души, и только бесчисленные Войды внимают твоим молитвам.</msgCharNotFound>

--- a/socials/punch.xml
+++ b/socials/punch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты лупишь себя кулаком. И ты этого заслуживаешь.</msgCharAuto>
-  <msgCharFound>Ты шутливо тыкаешь $S кулаком.</msgCharFound>
+  <msgCharFound>Ты шутливо тыкаешь $C4 кулаком.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Врезать кому?</msgCharNoArgument>
   <msgCharNotFound>Не с кем тут боксировать.</msgCharNotFound>

--- a/socials/scream.xml
+++ b/socials/scream.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты истошно ревешь на себя. Да... так можно снимать стрессы!</msgCharAuto>
-  <msgCharFound>ARRRRRRRRRRGH!!!!! Да ! Это $S ошибка!!!</msgCharFound>
+  <msgCharFound>ARRRRRRRRRRGH!!!!! Да ! Это ошибка $C2!!!</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>ARRRRRRRRRRGH!!!!!</msgCharNoArgument>
   <msgCharNotFound>Твои легкие не вдохнут столько воздуха!</msgCharNotFound>

--- a/socials/shake.xml
+++ b/socials/shake.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты трясешься.</msgCharAuto>
-  <msgCharFound>Ты пожимаешь $S руку.</msgCharFound>
+  <msgCharFound>Ты пожимаешь руку $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты хватаешься за голову.</msgCharNoArgument>
   <msgCharNotFound>Этой персоны тут не видно.</msgCharNotFound>

--- a/socials/snap.xml
+++ b/socials/snap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты хрустишь пальцами, как пианист.</msgCharAuto>
-  <msgCharFound>Ты хрустишь пальцами, привлекая $S внимание.</msgCharFound>
+  <msgCharFound>Ты хрустишь пальцами, привлекая внимание $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты хрустишь пальцами.</msgCharNoArgument>
   <msgCharNotFound>Поломаешь, пальцы-то... Чем потом выделываться будешь?</msgCharNotFound>

--- a/socials/snicker.xml
+++ b/socials/snicker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты тихонько хихикаешь, радуясь своим умыслам.</msgCharAuto>
-  <msgCharFound>Ты тихонько хихикаешь, секретничая с $Y.</msgCharFound>
+  <msgCharFound>Ты тихонько хихикаешь, секретничая с $C5.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты тихонько хихикаешь.</msgCharNoArgument>
   <msgCharNotFound>Хех?</msgCharNotFound>

--- a/socials/sniff.xml
+++ b/socials/sniff.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты тяжело сопишь на себя.</msgCharAuto>
-  <msgCharFound>Ты тяжело сопишь на $X.</msgCharFound>
+  <msgCharFound>Ты тяжело сопишь на $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты тяжело сопишь.</msgCharNoArgument>
   <msgCharNotFound>Нечего тут сопеть!</msgCharNotFound>

--- a/socials/spank.xml
+++ b/socials/spank.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты шлепаешь себя. Хммм.</msgCharAuto>
-  <msgCharFound>Ты игриво шлепаешь $S.</msgCharFound>
+  <msgCharFound>Ты игриво шлепаешь $C4.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Кого-то шлепнуть?</msgCharNoArgument>
   <msgCharNotFound>И никого...</msgCharNotFound>

--- a/socials/stroke.xml
+++ b/socials/stroke.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Гм... ты делаешь такие вещи, которых делать не должен.</msgCharAuto>
-  <msgCharFound>Ты мягко гладишь $S по бедру. $C1 взволнованно дышит.</msgCharFound>
+  <msgCharFound>Ты мягко гладишь $C4 по бедру, $C1 взволнованно дышит.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты плавно гладишь воздух.</msgCharNoArgument>
   <msgCharNotFound>Попрактикуйся на себе?</msgCharNotFound>

--- a/socials/strut.xml
+++ b/socials/strut.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты важно вышагиваешь, бормоча о своих достоинствах.</msgCharAuto>
-  <msgCharFound>Ты важно вышагиваешь, пытаясь привлечь $S внимание.</msgCharFound>
+  <msgCharFound>Ты важно вышагиваешь, пытаясь привлечь внимание $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты важно вышагиваешь.</msgCharNoArgument>
   <msgCharNotFound>Лучше бы тебе не шевелиться.</msgCharNotFound>

--- a/socials/support.xml
+++ b/socials/support.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты пытаешься не вешать нос.</msgCharAuto>
-  <msgCharFound>Ты обнимаешь $S за плечи и ободряюще улыбаешься $M.</msgCharFound>
+  <msgCharFound>Ты обнимаешь $C4 за плечи и ободряюще улыбаешься $M.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты полностью поддерживаешщь эту идею.</msgCharNoArgument>
   <msgCharNotFound>Никого нет.</msgCharNotFound>

--- a/socials/sweep.xml
+++ b/socials/sweep.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты берешь $S на руки и целуешь долго и страстно.</msgCharFound>
+  <msgCharFound>Ты берешь $C4 на руки и целуешь долго и страстно.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты вздыхаешь, глядя на свои пустые руки.</msgCharNoArgument>
   <msgCharNotFound>Предмет страсти испарился.</msgCharNotFound>

--- a/socials/tight.xml
+++ b/socials/tight.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты крепко обвил $S руками.</msgCharFound>
+  <msgCharFound>Ты крепко обвил $C4 руками.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument></msgCharNoArgument>
   <msgCharNotFound>Вот, и обнять некого.</msgCharNotFound>

--- a/socials/tweak.xml
+++ b/socials/tweak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Это запрещено.</msgCharAuto>
-  <msgCharFound>Ты нежно щипаешь $S за щеку.</msgCharFound>
+  <msgCharFound>Ты нежно щипаешь $C4 за щеку.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ущипнуть кого?</msgCharNoArgument>
   <msgCharNotFound>Такой щеки тут нет.</msgCharNotFound>

--- a/socials/twiddle.xml
+++ b/socials/twiddle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты сворачиваешь свое ухо в трубочку. Разворачиваешь - но внутри ничего нет.</msgCharAuto>
-  <msgCharFound>Ты вертишь $S уши.</msgCharFound>
+  <msgCharFound>Ты вертишь уши $C2.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты терпеливо перебираешь пальцами.</msgCharNoArgument>
   <msgCharNotFound>Ты не видишь здесь таких.</msgCharNotFound>

--- a/socials/undress.xml
+++ b/socials/undress.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Прекрати - не время и не место...</msgCharAuto>
-  <msgCharFound>Ты глазами раздеваешь $S...</msgCharFound>
+  <msgCharFound>Ты глазами раздеваешь $C4...</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты начинаешь раздеваться... может кто-то заметит?</msgCharNoArgument>
   <msgCharNotFound>Не-ту...</msgCharNotFound>

--- a/socials/whip.xml
+++ b/socials/whip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты избиваешь сам себя в ярости.</msgCharAuto>
-  <msgCharFound>Ты полосуешь $S по спине кнутом.</msgCharFound>
+  <msgCharFound>Ты полосуешь $C4 по спине кнутом.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты грозно пощелкиваешь кнутом.</msgCharNoArgument>
   <msgCharNotFound>Некого располосовать.</msgCharNotFound>

--- a/socials/wrestle.xml
+++ b/socials/wrestle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты героически борешься со своей совестью.</msgCharAuto>
-  <msgCharFound>Ты бросаешь $S через плечо на пол.</msgCharFound>
+  <msgCharFound>Ты бросаешь $C4 через плечо на пол.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument></msgCharNoArgument>
   <msgCharNotFound>Тут таких нет.</msgCharNotFound>

--- a/socials/wrist.xml
+++ b/socials/wrist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Social type="Social">
   <msgCharAuto>Ты бьешь себя по рукам.</msgCharAuto>
-  <msgCharFound>Ты бьешь $S по рукам.</msgCharFound>
+  <msgCharFound>Ты бьешь $C4 по рукам.</msgCharFound>
   <msgCharFound2></msgCharFound2>
   <msgCharNoArgument>Ты замахиваешься.</msgCharNoArgument>
   <msgCharNotFound>Никого нет.</msgCharNotFound>


### PR DESCRIPTION
You need to check the behavior: curse <victim>, flash <victim>, pray <victim>.

Add to: https://github.com/dreamland-mud/dreamland_code/pull/5.
https://trello.com/c/YywdhiFe/102-13057-ruffina-socials-социалы-с-двумя-целями-выглядят-нелепо-когда-одна-из-целей-ты-сам

Заменил "его"-"ее" на имя цели-жертвы в соответствующем падеже.
Не смог протестировать:
curse - не могу проверить, срабатывает админское проклятие от Kadm;
flash - Ты опупеваешь! священник показывает - не с заглавной буквы;
pray - Ты умоляешь Богов о помощи! - срабатывает молитва.