### PR TITLE
Remove professional flag from weapon skills

### DIFF
--- a/generic-skills/axe.xml
+++ b/generic-skills/axe.xml
@@ -48,27 +48,27 @@
     <node name="duergar">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="dwarf">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="frost giant">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="svirfnebli">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="urukhai">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
   </raceBonuses>
 </skill>

--- a/generic-skills/dagger.xml
+++ b/generic-skills/dagger.xml
@@ -94,12 +94,12 @@
     <node name="githyanki">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="urukhai">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
   </raceBonuses>
 </skill>

--- a/generic-skills/mace.xml
+++ b/generic-skills/mace.xml
@@ -66,17 +66,17 @@
     <node name="cloud giant">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="troll">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="urukhai">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
   </raceBonuses>
 </skill>

--- a/generic-skills/spear.xml
+++ b/generic-skills/spear.xml
@@ -81,7 +81,7 @@
     <node name="urukhai">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
   </raceBonuses>
 </skill>

--- a/generic-skills/sword.xml
+++ b/generic-skills/sword.xml
@@ -80,7 +80,7 @@ Cамураи достигли высшего мастерства в обращ
     <node name="drow">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="elf">
       <bonus>100</bonus>
@@ -90,17 +90,17 @@ Cамураи достигли высшего мастерства в обращ
     <node name="fire giant">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="githyanki">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
     <node name="storm giant">
       <bonus>100</bonus>
       <level>1</level>
-      <professional>true</professional>
+      <professional>false</professional>
     </node>
   </raceBonuses>
 </skill>

--- a/generic-skills/whip.xml
+++ b/generic-skills/whip.xml
@@ -67,4 +67,11 @@
     <professional>false</professional>
   </mob>
   <nameRus>хлыст</nameRus>
+  <raceBonuses>
+    <node name="drow">
+      <bonus>100</bonus>
+      <level>1</level>
+      <professional>false</professional>
+    </node>
+  </raceBonuses>  
 </skill>


### PR DESCRIPTION
Allows newbies to get race-preferred weapons on level 1 with 100% mastery regardless of their class.
Better survivability.
Plus, add whip as race-preferred by drow.