### PR TITLE
Feature/rename human vampire

### DIFF
--- a/generic-skills/unmorph.xml
+++ b/generic-skills/unmorph.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skill type="GenericSkill">
-  <command type="SKILL(human)">
+  <command type="SKILL(unmorph)">
+    <alias>
+        <node>human</node>
+    </alias>
     <cat>class</cat>
-    <hint>(вампиры) принять человеческий облик</hint>
-    <name>human</name>
+    <hint>(вампиры) принять обычный облик</hint>
+    <name>unmorph</name>
     <position>fight</position>
     <russian>
       <node>человек</node>
@@ -16,5 +19,5 @@
     <ordered>true</ordered>
     <professional>true</professional>
   </mob>
-  <nameRus>человеческий облик</nameRus>
+  <nameRus>обычный облик</nameRus>
 </skill>

--- a/generic-skills/unmorph.xml
+++ b/generic-skills/unmorph.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skill type="GenericSkill">
   <command type="SKILL(unmorph)">
-    <alias>
+    <aliases>
         <node>human</node>
-    </alias>
+    </aliases>
     <cat>class</cat>
     <hint>(вампиры) принять обычный облик</hint>
     <name>unmorph</name>

--- a/generic-skills/unmorph.xml
+++ b/generic-skills/unmorph.xml
@@ -9,7 +9,8 @@
     <name>unmorph</name>
     <position>fight</position>
     <russian>
-      <node>детрансформироваться</node>
+      <node>невампир</node>
+      <node>человек</node>      
     </russian>
   </command>
   <dammsg></dammsg>

--- a/generic-skills/unmorph.xml
+++ b/generic-skills/unmorph.xml
@@ -9,7 +9,7 @@
     <name>unmorph</name>
     <position>fight</position>
     <russian>
-      <node>человек</node>
+      <node>детрансформироваться</node>
     </russian>
   </command>
   <dammsg></dammsg>

--- a/generic-skills/vampire.xml
+++ b/generic-skills/vampire.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skill type="VampireSkill">
   <affect type="DefaultAffectHandler">
-    <wearoff>Кровожадность проходит и ты вновь обретаешь человеческий облик.</wearoff>
+    <wearoff>Кровожадность проходит и ты вновь принимаешь свой обычный облик.</wearoff>
   </affect>
   <beats>12</beats>
   <classes>


### PR DESCRIPTION
See related PR in dreamland_code. Needs good Russian name ('детрансформироваться' barely exists in vocabularies). Strictly speaking, `human` and `vampire` don't have to be two separate commands; something like `vampire on|off` will work (or better option).