### PR TITLE
Add blacksmith craft skill and profession help stub

### DIFF
--- a/craft-professions/blacksmith.xml
+++ b/craft-professions/blacksmith.xml
@@ -1,6 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CraftProfession type="CraftProfession">
-  <baseExp>1000</baseExp> 
+  <baseExp>1000</baseExp>
+  <help id="5071" level="-1" type="CraftProfessionHelp">
+    <keyword l="en">blacksmith</keyword>
+    <keyword l="ru">кузнец</keyword>
+    <keyword l="ua"></keyword>
+    <text l="en"></text>
+    <text l="ru">=Кузнец= -- одно из доступных всем игрокам {hh195ремесел{x или дополнительных
+профессий. TODO: описание того, что умеют кузнецы (ковка оружия, доспехов,
+инструментов и т.п.).
+
+%FMT% *выковать* _желаемый предмет_
+Создает желаемую вещь при наличии нужного рецепта, инструмента и ингредиентов.
+
+TODO: описание базового рабочего процесса -- где взять руду, как выплавлять
+слитки, какие инструменты нужны (молот, наковальня, горн).
+
+{CКАК СТАТЬ КУЗНЕЦОМ{x
+TODO: где найти учителя.
+</text>
+    <text l="ua"></text>
+    <title l="en"></title>
+    <title l="ru">{CДополнительные профессии:{x кузнец</title>
+    <title l="ua"></title>
+  </help>
   <maxLevel>10</maxLevel>
   <mltName>кузнец|ы|ов|ам|ов|ами|ах</mltName>
   <name>blacksmith</name>

--- a/craft-skills/blacksmith.xml
+++ b/craft-skills/blacksmith.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="CraftSkill">
+  <beats>18</beats>
+  <dammsg mg="m"></dammsg>
+  <group registry="skillGroup">adventure</group>
+  <hard>2</hard>
+  <help id="5072" level="-1" type="SkillHelp">
+    <extra l="en">blacksmithing forging smithing expertise</extra>
+    <extra l="ru">мастерство кузнечное ковка</extra>
+    <extra l="ua">майстерність ковальського ремесла</extra>
+    <text l="en">The main skill of the {hh5071blacksmithing{x {hh230craft{x. Improves with use.
+
+The chance of creating most items using blacksmithing blueprints depends on the skill level. The properties of most created items depend on the level of the blacksmith's profession and on the primary class of your character -- for example, warrior classes will create items with increased damage and accuracy.</text>
+    <text l="ru">Основной навык {hh195ремесла{x {hh5071кузнецов{x. Улучшается в процессе использования.
+
+Шанс создание большинства вещей по кузнечным чертежам зависит от степени
+прокачки этого умения. Свойства большинства созданных предметов зависят от
+уровня профессии кузнеца и от основного класса твоего персонажа -- например,
+у воинских классов будут получаться вещи с повышенным уроном и точностью.
+</text>
+    <text l="ua">Основна навичка {hh195ремесла{x {hh5071ковалів{x. Покращується в процесі використання.
+
+Шанс створення більшості речей за ковальськими кресленнями залежить від ступеня
+прокачування цього вміння. Властивості більшості створених предметів залежать від
+рівня професії коваля та від основного класу твого персонажа -- наприклад,
+у воїнських класів будуть отримуватися речі з підвищеним уроном і точністю.
+</text>
+  </help>
+  <mana>50</mana>
+  <name l="en">blacksmith</name>
+  <name l="ru">мастерство кузнеца</name>
+  <name l="ua">майстерність коваля</name>
+  <subprofessions>
+    <node name="blacksmith">
+      <level>1</level>
+    </node>
+  </subprofessions>
+</skill>


### PR DESCRIPTION
## Summary
- Extends the existing blacksmith CraftProfession stub with a help section (id `5071`).
- Adds a new CraftSkill `blacksmith` mirroring `carpenter.xml` with help section (id `5072`).
- Help IDs picked as next free above current max (5070) -- no collisions across `dreamland_world` and `dreamland_areas`.

## Notes
Help text is intentionally a stub -- `TODO` markers left for the eventual description of ingredients, tools, recipes, and how to find a teacher.

ASCII-only punctuation throughout (KOI-8 safe).

## Test plan
- [ ] Server starts without XML parse errors.
- [ ] `help кузнец` and `help мастерство кузнеца` return the stub texts.
- [ ] `{hh5071}` and `{hh5072}` cross-refs resolve in-game.
- [ ] Cross-ref from skill help (`{hh5071кузнецов}`) navigates to profession help.