### PR TITLE
Add 'set fathers' behavior + skill (tier-1 starter)

### DIFF
--- a/behaviors/set fathers.xml
+++ b/behaviors/set fathers.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Скромный комплект -- последняя память об отце.</description>
+  <help id="5073" level="-1" type="BehaviorHelp">
+  </help>
+  <id>66</id>
+  <nameRus>отцовское наследство</nameRus>
+  <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:true,&quot;max_level&quot;:35,&quot;total_count&quot;:3}
+</props>
+  <target>obj</target>
+</behavior>

--- a/other-skills/set fathers.xml
+++ b/other-skills/set fathers.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Отцовское наследство покидает тебя.</removeCharSelf>
+  </affect>
+  <dammsg mg="m"></dammsg>
+  <help id="5074" level="-1" type="SkillHelp">
+  </help>
+  <name l="en">set fathers</name>
+  <name l="ru">отцовское наследство</name>
+  <name l="ua"></name>
+</skill>


### PR DESCRIPTION
3-piece newbie set (father's belt + 2x father's cufflinks via double_wrist) for tier-1 blacksmith content. max_level 35. Bonus on completion: hp+20, hr+1, dr+1, saves-1 via the standard set-affect pattern (DefaultAffectHandler in other-skills/, applied/stripped from dreamland_fenia behaviors/set fathers/onEquip + onRemove).

Behavior id 66 (next free, max was 65 at set wood nymph), help ids 5073 + 5074 (above current max 5072 per abc maxhelp).

Pairs with the Fenia behavior dir and quest.are.xml product/recipe additions in companion PRs.