### PR TITLE
Smith set behaviors and skills (myrmidon/defender/berserker/amazon/gloomstalker)

### DIFF
--- a/behaviors/set amazon.xml
+++ b/behaviors/set amazon.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Мифриловое вооружение стремительной амазонки.</description>
+  <help id="5081" level="-1" type="BehaviorHelp">
+  </help>
+  <id>70</id>
+  <nameRus>набор амазонки</nameRus>
+  <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
+</props>
+  <target>obj</target>
+</behavior>

--- a/behaviors/set berserker.xml
+++ b/behaviors/set berserker.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Стальное снаряжение неистового берсерка -- меч, шлем и топор.</description>
+  <help id="5079" level="-1" type="BehaviorHelp">
+  </help>
+  <id>69</id>
+  <nameRus>набор берсерка</nameRus>
+  <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
+</props>
+  <target>obj</target>
+</behavior>

--- a/behaviors/set defender.xml
+++ b/behaviors/set defender.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Стальной доспех стойкого защитника -- меч, шлем и щит.</description>
+  <help id="5077" level="-1" type="BehaviorHelp">
+  </help>
+  <id>68</id>
+  <nameRus>набор защитника</nameRus>
+  <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
+</props>
+  <target>obj</target>
+</behavior>

--- a/behaviors/set gloomstalker.xml
+++ b/behaviors/set gloomstalker.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Адамантитовое снаряжение охотника тьмы -- два клинка, капюшон и наручи.</description>
+  <help id="5083" level="-1" type="BehaviorHelp">
+  </help>
+  <id>71</id>
+  <nameRus>набор охотника тьмы</nameRus>
+  <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:4}
+</props>
+  <target>obj</target>
+</behavior>

--- a/behaviors/set myrmidon.xml
+++ b/behaviors/set myrmidon.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Бронзовое снаряжение элитного воина-мирмидонянина.</description>
+  <help id="5075" level="-1" type="BehaviorHelp">
+  </help>
+  <id>67</id>
+  <nameRus>набор мирмидонянина</nameRus>
+  <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:60,&quot;total_count&quot;:3}
+</props>
+  <target>obj</target>
+</behavior>

--- a/other-skills/set amazon.xml
+++ b/other-skills/set amazon.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Стремительность амазонки покидает тебя.</removeCharSelf>
+  </affect>
+  <dammsg mg="m"></dammsg>
+  <help id="5082" level="-1" type="SkillHelp">
+  </help>
+  <name l="en">set amazon</name>
+  <name l="ru">стремительность амазонки</name>
+  <name l="ua"></name>
+</skill>

--- a/other-skills/set berserker.xml
+++ b/other-skills/set berserker.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Ярость берсерка стихает в твоих жилах.</removeCharSelf>
+  </affect>
+  <dammsg mg="m"></dammsg>
+  <help id="5080" level="-1" type="SkillHelp">
+  </help>
+  <name l="en">set berserker</name>
+  <name l="ru">ярость берсерка</name>
+  <name l="ua"></name>
+</skill>

--- a/other-skills/set defender.xml
+++ b/other-skills/set defender.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Сияющий ореол защитника гаснет вокруг тебя.</removeCharSelf>
+  </affect>
+  <dammsg mg="m"></dammsg>
+  <help id="5078" level="-1" type="SkillHelp">
+  </help>
+  <name l="en">set defender</name>
+  <name l="ru">стойкость защитника</name>
+  <name l="ua"></name>
+</skill>

--- a/other-skills/set gloomstalker.xml
+++ b/other-skills/set gloomstalker.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Тени отступают, и мир снова наполняется красками.</removeCharSelf>
+  </affect>
+  <dammsg mg="m"></dammsg>
+  <help id="5084" level="-1" type="SkillHelp">
+  </help>
+  <name l="en">set gloomstalker</name>
+  <name l="ru">тени мрака</name>
+  <name l="ua"></name>
+</skill>

--- a/other-skills/set myrmidon.xml
+++ b/other-skills/set myrmidon.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Сила воина-мирмидонянина покидает тебя.</removeCharSelf>
+  </affect>
+  <dammsg mg="m"></dammsg>
+  <help id="5076" level="-1" type="SkillHelp">
+  </help>
+  <name l="en">set myrmidon</name>
+  <name l="ru">сила мирмидонянина</name>
+  <name l="ua"></name>
+</skill>


### PR DESCRIPTION
## Summary
- 5 DefaultBehavior XMLs in `behaviors/` for new smith sets (ids 67-71, BehaviorHelp 5075/5077/5079/5081/5083)
- 5 paired BasicSkill XMLs in `other-skills/` (SkillHelp 5076/5078/5080/5082/5084)
- max_level: myrmidon 60 (low-tier balanced like ashigaru-80), others 110

## Dependencies
Companion PRs in dreamland_areas (item prototypes 138-152) and dreamland_fenia (onEquip/onRemove handlers) should land together. Help ids verified clean via `abc maxhelp` on live (max 5074, picked 5075-5084).

## Test plan
- [ ] `plugin reload all` post-merge -- no Duplicate help ID exception
- [ ] `bedit set myrmidon` shows registered behavior
- [ ] `slist set myrmidon` shows registered skill
- [ ] No orphan references when limbo items load

🤖 Generated with [Claude Code](https://claude.com/claude-code)