### PR TITLE
Align EN zone names in atlas help 224 with area-file canon

### DIFF
--- a/commands/fenia/map.xml
+++ b/commands/fenia/map.xml
@@ -30,88 +30,88 @@ even in a {hh1378group!{x
 
 {CIN THE CITY OF MIDGAARD{x
 From the streets of Midgaard, you can reach places such as:
-%A% {hh1433School{x with an Arena and an exit to {hh2046Museum of Zoology{x, {hh1435Newbie Zone{x
+%A% {hh1433MUD School{x with an Arena and an exit to {hh2046Zoology Museum{x, {hh1435Newbie Zone{x
 %A% {hh2092Temple of Themis{x, {hh1846Temple of Tananda{x and {hh2087Temple of the Rat God{x
-%A% {hh1844Zoo{x, {hh2100Junkyard{x, {hh1839Casino{x, {hh1870Circus{x, and {hh2088Library{x
-%A% {hh2094House of Cuifael{x, {hh1403Chessboard{x, and {hh1382Machine Dreams{x
+%A% {hh1844Zoo of Midgaard{x, {hh2100City Dump{x, {hh1839Casino{x, {hh1870Circus{x, and {hh2088Library{x
+%A% {hh2094Quifael Area{x, {hh1403Chessboard{x, and {hh1382Machine Dreams{x
 %A% base of the Bivrest Bridge, leading to the abode of the gods, {hh2057Valhalla{x
-{Y%A%{x {hh2078Cemetery{x, with a descent to {hh1865Chapel Dungeon{x
-{R%A%{x {hh2079Dangerous District{x and {hh1845Prison{x
+{Y%A%{x {hh2078Graveyard{x, with a descent to {hh1865Chapel{x
+{R%A%{x {hh2079Dangerous Neighborhood{x and {hh1845Prison{x
 
-If you fly from the Temple Square, you&apos;ll find yourself {hh2047In the Air{x, from where you can get to 
-{hh2048Astral{x({R%A%{x) and the domains of the Githanki. And if you climb up the Naris Chain, you can
-reach {hh2022Redfern&apos;s Residence{x, {hh2093Dylan&apos;s Zone{x({Y%A%{x), and {hh2023Divided Souls{x({R%A%{x),
-with an exit to the {hh1527Bangzu Gardens{x({R%A%{x).
+If you fly from the Temple Square, you&apos;ll find yourself {hh2047In the Air{x, from where you can get to
+{hh2048Astral Plane{x({R%A%{x) and the domains of the Githanki. And if you climb up the Naris Chain, you can
+reach {hh2022Redferne Residence{x, {hh2093Dylan Area{x({Y%A%{x), and {hh2023Divided Souls{x({R%A%{x),
+with an exit to the {hh1527Bangzui Gardens{x({R%A%{x).
 
-Lovers of dungeon exploration will be able to descend from Midgaard to {hh1849Metropolitan{x,
-with stops at the Zoo, {hh1850Prairies{x, and {hh1851Hell{x({R%A%{x), and in {hh1856Sewers{x({Y%A%{x), with a passage
-to the vast and mysterious {hh1854Underworld{x.
+Lovers of dungeon exploration will be able to descend from Midgaard to {hh1849Metro{x,
+with stops at the Zoo, {hh1850Prairie{x, and {hh1851Descent to Hell{x({R%A%{x), and in {hh1856Sewers{x({Y%A%{x), with a passage
+to the vast and mysterious {hh1854UnderDark{x.
 
 {CNORTHERN THERA{x
 If you exit through the Northern Gate, you&apos;ll find yourself on the spacious {hh1859Northern Plains{x.
 From there, you can go to places like:
-%A% {hh1446Old Midgaard{x and {hh1858Park Continuity{x
-%A% {hh1860Offcol{x and {hh1861New Offcol{x
-%A% {hh1864Olympus{x and {hh2068Ancient Troy{x 
-%A% {hh1442Mirkwood{x and {hh2095Royal Castle{x
-%A% {hh2067Elven Valley{x and {hh2050The Fire Mountain{x
-%A% {hh2091Centaurs&apos; Pastures{x, with an exit to {hh1857Planetary Geometry{x
-{Y%A%{x {hh1419Dragon&apos;s Peak{x, with an exit to {hh2090Cloud Mountain{x
-{R%A%{x {hh1853Orodruin{x, {hh1429Arcadia{x, and {hh1431Draciri Island{x
+%A% {hh1446Old Midgaard{x and {hh1858The Continuity of Parks{x
+%A% {hh1860Ofcol{x and {hh1861New Ofcol{x
+%A% {hh1864Olympus{x and {hh2068Old Troya{x
+%A% {hh1442Mirkwood{x and {hh2095King Castle{x
+%A% {hh2067Valley of the Elves{x and {hh2050Firetop Mountain{x
+%A% {hh2091Pastures{x, with an exit to {hh1857Planetary Geometry{x
+{Y%A%{x {hh1419Dragon Spyre{x, with an exit to {hh2090Cloudy Mountain{x
+{R%A%{x {hh1853Orodruin{x, {hh1429Arcadia{x, and {hh1431Drakyri Isle{x
 
 {CNORTH-EAST{x
 If you exit through the Eastern Gate and turn north from the Crossroads, you can 
 come to {hh1855Moria{x. From Moria, you can reach places such as:
-%A% {hh1414Kingdom of Mirrors{x, with an exit to {hh1534Hut{x
-%A% {hh2060Dwarven Kingdom{x, with exits to {hh2061Dwarven Kindergarten{x and {hh2059Dwarven Dungeon{x
-{R%A%{x {hh2075Devil&apos;s Monastery{x and {hh1418Desolation{x
+%A% {hh1414Kingdom of Mirrors{x, with an exit to {hh1534The Hut{x
+%A% {hh2060Dwarven Kingdom{x, with exits to {hh2061Dwarven Day Care{x and {hh2059Dwarven Catacombs{x
+{R%A%{x {hh2075The Unholy Abbey{x and {hh1418Blight{x
 
-Moria also includes a trail around the northern walls of Midgaard, from where 
-you can wander into the deadly {hh1525Park of Twilight Winds{x({R%A%{x).
+Moria also includes a trail around the northern walls of Midgaard, from where
+you can wander into the deadly {hh1525Shady Breezes Park{x({R%A%{x).
 And if you turn north from the outpost on the Eastern Road, you will see:
-%A% {hh1543Crystal Mirror Lake{x, with an exit to {hh1510Antaria{x
-%A% the town of {hh1505Utekha{x and the kingdom of {hh2073Camelot{x
+%A% {hh1543Crystalmir Lake{x, with an exit to {hh1510Antharia{x
+%A% the town of {hh1505Solace{x and the kingdom of {hh2073Camelot{x
 
 {CEASTERN THERA{x
-If you go from the Crossroads further along the Eastern Road, you will pass by the villages 
-of {hh1866Smurfs{x and {hh1439Gnomes{x, see the {hh2080Sacred Grove{x, with exits to {hh2084Nirvana{x({Y%A%{x) and the reality 
-of the {hh2129Old Talos{x, and, finally, you will arrive in {hh1838New Talos{x.
+If you go from the Crossroads further along the Eastern Road, you will pass by {hh1866Smurfville{x
+and {hh1439Gnome Village{x, see the {hh2080Holy Grove{x, with exits to {hh2084Nirvana{x({Y%A%{x) and the reality
+of {hh2129Old Thalos{x, and, finally, you will arrive in {hh1838New Thalos{x.
 
-From New Talos, you can exit to {hh2038Shaolin Temple{x, to the {hh2037Bazaar{x, part of the Temple of Tananda, and to 
+From New Thalos, you can exit to {hh2038Shaolin Temple{x, to the {hh2037Bazaar{x, part of the Temple of Tananda, and to
 {hh1425Ghost Town{x({R%A%{x). And from the Dragon Sea east of the city, you can sail to:
 %A% {hh1401Dark Continent{x
-%A% {hh2081Goblin Land{x, with an exit to {hh1540Wonderland{x
-%A% {hh2077Free Harbor{x, with an exit to {hh2076Armageddon{x({R%A%{x)
+%A% {hh2081Goblin Nation{x, with an exit to {hh1540Wonderland{x
+%A% {hh2077Freeport{x, with an exit to {hh2076Armageddon{x({R%A%{x)
 
 {CSOUTH-EAST{x
-If you turn south from the Crossroads, you will find yourself in the Dwarven Forest, growing 
-around the {hh1837Ruins of Old Talos{x. From there, you can go to places like:
-%A% {hh1423City of Anon{x, with its {hh1871village{x and {hh1872fortifications{x
-{Y%A%{x Dominion of {hh1841Mah&apos;n&apos;tor{x, {hh1867Canyon of Elements{x, with an exit to the flying {hh2065Aarakocran{x
-{Y%A%{x {hh1835Wyvern Tower{x and {hh1506Witch Sabbat{x in Dunkeldorf
-{R%A%{x {hh1406Drow City{x, {hh2070Lich Tower{x, icy {hh1520Island{x, {hh2069Caves{x, and Hell
+If you turn south from the Crossroads, you will find yourself in the Dwarven Forest, growing
+around the {hh1837Ruins of Thalos{x. From there, you can go to places like:
+%A% {hh1423The City of Anon{x, with its {hh1871village{x and {hh1872fortifications{x
+{Y%A%{x {hh1841The Keep of Mahn-Tor{x and {hh1867Elemental Canyon{x, with an exit to the flying {hh2065Aarakokran City{x
+{Y%A%{x {hh1835Wyvern Tower{x and {hh1506Coven{x in Dunkeldorf
+{R%A%{x {hh1406Drow City{x, {hh2070Lich Tower{x, icy {hh1520Isles of Pirate Lords{x, {hh2069Caverns{x, and Descent to Hell
 
 {CSOUTHERN THERA{x
-Through the Southern Gates of Midgaard, you can reach the forest of {hh1441Midenir{x({Y%A%{x) with exits to 
-{hh1449Ring of Fairies{x, {hh2049Goblin Fortress{x({R%A%{x), and {hh1842Emerald Forest{x({Y%A%{x), washing the {hh1843Lake of Tears{x. 
+Through the Southern Gates of Midgaard, you can reach the forest of {hh1441Midennir{x({Y%A%{x) with exits to
+{hh1449Ring of Fairies{x, {hh2049Goblin Stronghold{x({R%A%{x), and {hh1842Emerald Forest{x({Y%A%{x), washing the {hh1843Lake of Tears{x.
 You can also set sail south down the river and arrive at {hh2089Mother Goose{x,
-in {hh1848Amber Castle{x, or {hh2064Sands of Sorrow{x, with an exit to {hh2085Great Pyramids{x.
+in {hh1848Amber Castle{x, or {hh2064Sands of Sorrow{x, with an exit to {hh2085The Great Pyramid{x.
 
 {CWESTERN THERA{x
 Beyond the Western Gates of Midgaard lies the huge ancient forest {hh1862Haon Dor{x, from 
 which you can go to places such as:
-%A% {hh2062Shire{x and {hh2054Gerikhelm{x, with its infamous {hh2056Dungeon{x({R%A%{x)
-%A% {hh1532Enchanted Forest{x and {hh1840Temple of Zava{x
-%A% {hh2071Valley of Titans{x, with exits to the tree {hh1852Yggdrasil{x({Y%A%{x) and tree-like {hh2074Cannabis{x
-{Y%A%{x {hh2039Old Bog{x, {hh1411Wizard&apos;s Hidden Refuge{x, {hh2082Troll Cave{x, and the spider nest {hh2051Arachno{x
-{R%A%{x {hh2086Westland{x and the flying part of the {hh1520Pirate Islands{x
+%A% {hh2062Shire{x and {hh2054Greater Gerighelm{x, with its infamous {hh2056Prison of Gerighelm{x({R%A%{x)
+%A% {hh1532Magic Forest{x and {hh1840Temple of Zava{x
+%A% {hh2071Valley of the Titans{x, with exits to the tree {hh1852Yggdrasil{x({Y%A%{x) and tree-like {hh2074Cannabis{x
+{Y%A%{x {hh2039Old Marsh{x, {hh1411The Keep of the Warlock{x, {hh2082Troll Den{x, and the spider nest {hh2051Arachnos{x
+{R%A%{x {hh2086Westland{x and the flying part of the {hh1520Isles of Pirate Lords{x
 
-Deep in the forest, there is the Grove of Shadows, surrounding the {hh1836Supreme Sorcery Tower{x({Y%A%{x).
-If you overcome the tricks and insidious shadow guardians of the Grove, you can reach Sorcery Tower itself, the kingdom of {hh2066Galaxy{x({Y%A%{x), 
-and {hh2063Dragon Castle{x({Y%A%{x).
+Deep in the forest, there is the Grove of Shadows, surrounding the {hh1836High Tower of Sorcery{x({Y%A%{x).
+If you overcome the tricks and insidious shadow guardians of the Grove, you can reach Sorcery Tower itself, the kingdom of {hh2066Galaxy{x({Y%A%{x),
+and {hh2063Dragon Tower{x({Y%A%{x).
 Through the underground passages in the forest, you can get to:
-{R%A%{x {hh1526Trully Caves{x and {hh1421Lair of Saiku{x
-{R%A%{x {hh1873Mountain of Death{x, {hh1874Lair of Jera{x, and the eerie {hh1515Abyss{x.
+{R%A%{x {hh1526Trillium Caverns{x and {hh1421Ciquala Lair{x
+{R%A%{x {hh1873Kurgan Mount Doom{x, {hh1874Lions Lair{x, and the eerie {hh1515Abyss{x.
 
 P.S. All major cities are surrounded by {hh50suburbs{x, where mansions of wealthy adventurers are built.
 Finally, it&apos;s worth remembering that some places in the world cannot be reached on foot and are not mentioned in the atlas... Safe travels!


### PR DESCRIPTION
## Summary

The EN rendering of help 224 was carrying its own translations of zone names that diverged from the canonical EN names defined in each area file's \`<areadata><name l=\"en\">\`. This switches every \`{hh<vnum>X{x\` reference in \`<text l=\"en\">\` to the area-file canonical name.

A handful of vnums needed a small surrounding-text rephrase because the old sentence form depended on the obsolete name:
- 1866/1439: \`the villages of Smurfs and Gnomes\` → \`Smurfville and Gnome Village\` (the canonical names already say \"village\")
- 1841: \`Dominion of Mah'n'tor, Canyon of Elements\` → \`The Keep of Mahn-Tor and Elemental Canyon\`
- 1837: \`Ruins of Old Talos\` → \`Ruins of Thalos\` (per maintainer; obsolete \"Old\" dropped)
- 2091: \`Centaurs' Pastures\` → \`Pastures\` (canonical name)
- 2063: \`Dragon Castle\` → \`Dragon Tower\` (canonical name in \`draconia.are.xml\`)

Pure 1:1 substitutions: 1419, 1421, 1423, 1431, 1433, 1505, 1506, 1510, 1520 (×2), 1525, 1526, 1527, 1532, 1534, 1543, 1836, 1838, 1844, 1849, 1850, 1851, 1854, 1858, 1860, 1861, 1865, 1867, 1873, 1874, 2022, 2039, 2046, 2048, 2049, 2050, 2051, 2054, 2056, 2059, 2061, 2065, 2067, 2068, 2069, 2071, 2075, 2077, 2078, 2079, 2080, 2081, 2082, 2085, 2090, 2093, 2094, 2095, 2100, 2129.

## Test plan

- [x] Only \`<text l=\"en\">\` block touched; RU and UA blocks unchanged
- [x] Every \`{hh<vnum>X{x\` still resolves to the same help article (vnum unchanged)
- [x] \`help atlas\` in EN locale renders the new names; \`plug reload most\` will pick this up

🤖 Generated with [Claude Code](https://claude.com/claude-code)