### PR TITLE
Translate NPC race helps to EN and UA

### DIFF
--- a/races/aarakocra.xml
+++ b/races/aarakocra.xml
@@ -8,7 +8,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">ааракокран ааракокра ааракокраны</keyword>
     <keyword l="ua">ааракокран ааракокра ааракокри</keyword>
-    <text l="en"></text>
+    <text l="en">=Aarakocrans= -- sapient bird-folk with a city of perches and
+nests high in the mountains. Talons instead of hands, feathers
+instead of a hairdo, and wild luck in the air. Not particularly
+strong, but agile to a fault.
+
+Well-protected against sound -- they make enough noise themselves
+to build up a tolerance. Acid, on the other hand, eats their
+feathers in an instant. In battle they disarm, parry, and dodge.
+Fly, naturally.
+
+The main settlement is {hh2065Aarakokran City{x, hovering above
+{hh1867Elemental Canyon{x. Getting to them without wings takes
+either magic or luck.
+</text>
     <text l="ru">=Ааракокраны= -- разумные птицелюди с городом из жёрдочек и
 гнёзд высоко в горах. Лапы вместо рук, перья вместо причёски, и
 дикое везение в воздухе. Не больно сильны, зато ловки до неприличия.
@@ -20,7 +33,18 @@
 Главное поселение -- {hh2065Ааракокран{x, парящий над {hh1867Каньоном Стихий{x.
 Чтобы попасть к ним без крыльев, понадобятся либо магия, либо везение.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Ааракокрани= -- розумні птахолюди з містом із жердинок і гнізд
+високо в горах. Пазурі замість рук, пірʼя замість зачіски, і дика
+удача в повітрі. Не надто сильні, зате спритні до непристойності.
+
+Добре захищені від звуку -- самі шумлять достатньо, щоб виробити
+імунітет. Зате кислота їхнє пірʼя виїдає вмить. У бою вміють
+обеззброювати, парирувати й ухилятися. Літають, ясна річ.
+
+Головне поселення -- {hh2065Ааракокран{x, що ширяє над
+{hh1867Каньйоном Стихій{x. Щоб потрапити до них без крил, потрібна
+або магія, або везіння.
+</text>
   </help>
   <nameFemale>ааракокра</nameFemale>
   <nameMlt>ааракокран|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/air elemental.xml
+++ b/races/air elemental.xml
@@ -9,7 +9,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">воздушный элементаль воздушная элементаль</keyword>
     <keyword l="ua">повітряний елементаль повітряна елементаль</keyword>
-    <text l="en"></text>
+    <text l="en">=Air elementals= -- clots of sentient wind, released by mages
+or broken loose on their own. No body to speak of -- just a draft
+that knows how to curse and brawl. They see through invisibility.
+
+Lightning is no threat to them, more of a snack. Summons and
+ordinary weapon strikes pass through almost without a trace --
+like through smoke. Force magic, though, disperses them in a single
+blow.
+
+They fly, deal area attacks, and are remarkably quick. The natural
+habitat is {hh1867Elemental Canyon{x.
+</text>
     <text l="ru">=Воздушные элементали= -- сгустки разумного ветра, выпущенные
 магами или сорвавшиеся с воли. Тела как такового нет -- только
 сквозняк, который умеет ругаться и драться. Видят сквозь невидимость.
@@ -21,7 +32,17 @@
 Летают, бьют площадными атаками и весьма проворны. Естественная
 среда -- {hh1867Каньон Стихий{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Повітряні елементалі= -- згустки розумного вітру, випущені
+магами або зірвані з волі. Тіла як такого немає -- лише протяг,
+що вміє лаятися й битися. Бачать крізь невидимість.
+
+Блискавки для них не шкода, а радше закуска. Призиви й удари
+звичайною зброєю проходять майже без сліду -- як крізь дим. Зате
+силова магія розвіює їх одним ударом.
+
+Літають, бʼють площадними атаками і вельми спритні. Природне
+середовище -- {hh1867Каньйон Стихій{x.
+</text>
   </help>
   <imm>lightning</imm>
   <nameFemale>воздушная элементаль</nameFemale>

--- a/races/amphibia.xml
+++ b/races/amphibia.xml
@@ -8,7 +8,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">амфибия амфибии самец амфибии самка амфибии</keyword>
     <keyword l="ua">амфібія амфібії самець амфібії самиця амфібії</keyword>
-    <text l="en"></text>
+    <text l="en">=Amphibians= -- a catch-all class of cold-blooded creatures
+willing to live both in water and on land, with no special
+enthusiasm for either. Frogs, newts, salamanders, and the rest
+of the slimy crowd fit here.
+
+They swim naturally and breathe through gills and lungs both.
+Disease slides off -- the slime won't let it stick. Cold, though,
+they cannot take: a freeze sends them into hibernation or worse.
+In battle they fling muck up from under their feet.
+
+The class exists mainly for mechanics -- so spells and hunting
+skills tuned to amphibians work correctly.
+</text>
     <text l="ru">=Амфибии= -- собирательный класс холоднокровных существ, готовых
 жить и в воде, и на суше, но без особого энтузиазма к ни тому, ни другому.
 Сюда относятся лягушки, тритоны, саламандры и прочая склизкая братия.
@@ -20,7 +32,18 @@
 Класс используется в основном механически -- чтобы заклинания и
 охотничьи умения, заточенные под амфибий, правильно работали.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Амфібії= -- збиральний клас холоднокровних істот, готових
+жити і у воді, і на суші, але без особливого ентузіазму до жодного
+з варіантів. Сюди йдуть жаби, тритони, саламандри й інша слизька
+братія.
+
+Природно плавають, дихають і зябрами, і легенями. Хвороби їх не
+беруть -- слиз не пускає. Зате холоду не переносять: при заморозці
+впадають у сплячку або гірше. У бою кидаються багном з-під лап.
+
+Клас використовується переважно механічно -- щоб закляття й
+мисливські вміння, заточені під амфібій, правильно спрацьовували.
+</text>
   </help>
   <imm>disease</imm>
   <nameFemale>самка амфибии</nameFemale>

--- a/races/angel.xml
+++ b/races/angel.xml
@@ -9,7 +9,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">небожитель небожительница ангел небожители ангелы</keyword>
     <keyword l="ua">небожитель небожителька небожителі ангели</keyword>
-    <text l="en"></text>
+    <text l="en">=Celestials= -- angelic beings of the higher spheres, messengers
+of those gods still bothered to meddle in mortal affairs. Winged,
+glowing, and usually a touch condescending.
+
+They see through invisibility and the hidden. Holy power and dark
+energy bounce off -- the sides they've chosen protect them. They
+fly, naturally. In battle they are quick, strike whole areas,
+parry, trip, and crush.
+
+They turn up in {hh2057Valhalla{x, in {hh2076Armageddon{x, and on
+the rare mission abroad. Don't strike at one on holy ground --
+they don't forgive that.
+</text>
     <text l="ru">=Небожители= -- ангельские существа высших сфер, посланники
 тех богов, которым ещё не лень вмешиваться в дела смертных. Крылатые,
 светящиеся, и обычно слегка снисходительные.
@@ -23,7 +35,19 @@
 миссиях по белу свету. На святой территории не нападай -- этого они
 не прощают.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Небожителі= -- ангельські істоти вищих сфер, посланці тих
+богів, яким ще не ліньки втручатися в справи смертних. Крилаті,
+осяйні, і зазвичай злегка поблажливі.
+
+Бачать крізь невидимість і прихованих. Свята сила й темна енергія
+від них відскакують -- обрані сторони їх захищають. Літають, ясно
+як днем. У бою швидкі, бʼють площадними атаками, парирують,
+підсікають і нищать.
+
+Зустрічаються у {hh2057Вальгаллі{x, в {hh2076Армагеддоні{x і в
+рідкісних місіях по білу світу. На святій території не нападай --
+цього вони не пробачать.
+</text>
   </help>
   <nameFemale>небожительница</nameFemale>
   <nameMale>небожитель</nameMale>

--- a/races/bat.xml
+++ b/races/bat.xml
@@ -9,7 +9,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">летучая мышь летучие мыши кажан</keyword>
     <keyword l="ua">кажан кажани</keyword>
-    <text l="en"></text>
+    <text l="en">=Bats= -- furry nocturnal hunters with echolocation in place
+of sight. Small, thin-boned, and unpleasant to the touch. Fond of
+caves, ruins, and any dark corner.
+
+They see by infravision and sense the living nearby. Bright light
+doesn't bother them -- echolocation works at any brightness. Loud
+sound, on the other hand, is murder: echolocation drowns out and
+the bat goes blind.
+
+Colonies turn up in {hh1855Moria{x, in {hh1442Mirkwood{x, and other
+dim caverns. Singly they're no threat, but a swarm can drive anyone
+to the brink.
+</text>
     <text l="ru">=Летучие мыши= -- мохнатые ночные охотники с эхолокацией вместо
 зрения. Маленькие, тонкокостные, и неприятные на ощупь. Любят пещеры,
 руины и любые тёмные углы.
@@ -23,7 +35,18 @@
 сумрачных пещерах. Сами по себе угрозы не представляют, но множеством
 способны вынести из себя кого угодно.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Кажани= -- волохаті нічні мисливці з ехолокацією замість
+зору. Маленькі, тонкокості, і неприємні на дотик. Люблять печери,
+руїни й будь-які темні кутки.
+
+Бачать у тепловому спектрі й чують живе поблизу. Яскраве світло
+на них не діє -- ехолокація працює за будь-якого освітлення. Зате
+гучний звук для них смерть: ехолокація захлинається, кажан губиться.
+
+Колонії трапляються в {hh1855Морії{x, у {hh1442Лихоліссі{x і інших
+сутінкових печерах. Самі по собі загрози не становлять, але масою
+здатні вивести з себе будь-кого.
+</text>
   </help>
   <imm>light</imm>
   <nameFemale>самка летучей мыши</nameFemale>

--- a/races/bear.xml
+++ b/races/bear.xml
@@ -8,7 +8,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">медведь медведица медведи</keyword>
     <keyword l="ua">ведмідь ведмедиця ведмеді</keyword>
-    <text l="en"></text>
+    <text l="en">=Bears= -- large, shaggy, good-natured right up until the
+good nature ends. Strong, hardy, slow to wind up, but once wound
+up -- best step aside.
+
+The thick hide deflects crushing blows and holds the cold -- even
+in winter a bear doesn't freeze. Wounds close on the move. They
+swim well. In battle they often fall into {hh829berserk rage{x,
+knock the weapon out with a paw, and in a hug can crush even a
+larger foe.
+
+They turn up in {hh1442Mirkwood{x, in {hh1858The Continuity of
+Parks{x, and other places where the forest is thicker than the
+patches on a traveller's trousers.
+</text>
     <text l="ru">=Медведи= -- крупные, мохнатые, добродушные ровно до момента,
 когда добродушие заканчивается. Сильны, выносливы, медленны на разгон,
 но если уж разогнались -- держись.
@@ -21,7 +34,18 @@
 Встречаются в {hh1442Лихолесье{x, в {hh1858Непрерывности парков{x и
 других местах, где лес гуще, чем заплатки на штанах путника.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Ведмеді= -- великі, волохаті, добродушні рівно до моменту,
+коли добродушність закінчується. Сильні, витривалі, повільні на
+розгін, але як уже розігналися -- тримайся.
+
+Жирна шкура відбиває дробильні удари й тримає холод -- навіть
+взимку ведмідь не мерзне. Рани гояться на ходу. Чудово плавають.
+У бою часто впадають у {hh829лють{x, вибивають зброю лапою і в
+обіймах можуть розчавити навіть супротивника крупніше.
+
+Зустрічаються в {hh1442Лихоліссі{x, у {hh1858Безперервності Парків{x
+та інших місцях, де ліс гущий, ніж латки на штанах подорожнього.
+</text>
   </help>
   <nameFemale>медведица</nameFemale>
   <nameMlt>медвед|и|ей|ям|ей|ями|ях</nameMlt>

--- a/races/beast.xml
+++ b/races/beast.xml
@@ -6,7 +6,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">зверь звери самка зверя</keyword>
     <keyword l="ua">звір звірі самиця звіра</keyword>
-    <text l="en"></text>
+    <text l="en">=Beasts= -- a broad class of wild animals too lazy to sort
+themselves into proper subdivisions. Tigers, boars, lynxes, various
+unaffiliated felines and canines -- all under one pelt.
+
+The dense fur holds cold and keeps disease out. Fire, though, a
+beast handles poorly: fur catches, and fleeing on burning paws is
+awkward. In battle they are strong and tough, knock down with a
+paw, often go berserk, lash with the tail, and dodge at speed.
+
+They turn up almost anywhere a forest is a forest and a hunter is
+a hunter.
+</text>
     <text l="ru">=Звери= -- широкий класс диких животных, которым лень разбираться
 во всех своих внутренних подразделениях. Тигры, кабаны, рыси, разные
 кошачьи и собачьи неприсоединённые -- все они под одной шкурой класса.
@@ -18,7 +29,17 @@
 
 Встречаются почти везде, где лес есть лес, а охотник есть охотник.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Звірі= -- широкий клас диких тварин, яким ліньки розбиратися
+в усіх своїх внутрішніх підрозділах. Тигри, кабани, рисі, різні
+котячі й собачі неприєднані -- усі вони під однією шкірою класу.
+
+Густе хутро тримає холод і не пускає хвороби. Зате вогонь звір
+переносить погано: шерсть спалахує, а тікати на палаючих лапах
+незручно. У бою сильні й міцні, перекидають лапою, часто впадають
+у лють, хльоскають хвостом і ухиляються на швидкості.
+
+Зустрічаються майже скрізь, де ліс є ліс, а мисливець є мисливець.
+</text>
   </help>
   <nameFemale>самка зверя</nameFemale>
   <nameMlt>звер|и|ей|ям|ей|ями|ях</nameMlt>

--- a/races/beholder.xml
+++ b/races/beholder.xml
@@ -9,7 +9,14 @@
     <extra l="en">beholders</extra>
     <extra l="ru">бехолдеры злобоглазы</extra>
     <extra l="ua">злобоглаз злобоглазка злобоглази</extra>
-    <text l="en"></text>
+    <text l="en">=Beholders= -- an ancient race of psionics from
+{hh1854UnderDark{x. They are huge scaled floating spheres with a
+mouth and a single eye in the middle, plus a few additional eyes
+on stalks reminiscent of mollusc eyes. These creatures are magical.
+The central eye suppresses magic in its field of view, while the
+smaller ones can produce spell effects. Through magic the beholders
+levitate.
+</text>
     <text l="ru">=Злобоглазы= или =бехолдеры= -- древняя раса псиоников из {hh1854Подземья{x.
 Они представляют собой огромный чешуйчатый летающий шар со ртом и единственным
 глазом посередине, а также несколькими дополнительными глазами на стебельках,
@@ -17,7 +24,14 @@
 подавляет магию в поле зрения, а маленькие могут производить заклинательные
 эффекты. За счёт магии бехолдеры левитируют.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Злобоглази= або =бехолдери= -- давня раса псіоніків з
+{hh1854Підземʼя{x. Являють собою величезну лускату літаючу кулю
+з ротом і єдиним оком посередині, а також кількома додатковими
+очима на стеблинках, схожими на очі молюсків. Ці істоти --
+магічні. Центральне око придушує магію в полі зору, а маленькі
+здатні створювати заклинальні ефекти. Завдяки магії бехолдери
+левітують.
+</text>
   </help>
   <imm>mental</imm>
   <nameFemale>злобоглазка</nameFemale>

--- a/races/bird.xml
+++ b/races/bird.xml
@@ -8,7 +8,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">птица птицы самец птицы самка птицы птахи</keyword>
     <keyword l="ua">птаха птахи самець птаха самиця птаха</keyword>
-    <text l="en"></text>
+    <text l="en">=Birds= -- winged, feathered, and best appreciated from a distance.
+Eagles, hawks, pigeons, magpies, and every other busy resident of
+hedges and skies.
+
+Natural fliers. Quick in the air and slippery to hit. Feathers
+muffle sound -- a screech won't deafen a bird. Disease, on the
+other hand, runs through them quickly: a single sick flock can be
+wiped out in a week.
+
+Frail of body but sharp-eyed and nimble -- they spot small things
+on the ground from on high.
+</text>
     <text l="ru">=Птицы= -- крылатые, перьями покрытые. Сюда относятся орлы,
 ястребы, голуби, сороки и прочие занятые жители кустов и небес.
 
@@ -20,7 +31,16 @@
 Телом слабы и хрупки, но ловки и зорки -- мелочи на земле видят
 с воздуха.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Птахи= -- крилаті, пірʼям укриті. Сюди йдуть орли, яструби, голуби,
+сороки та інші зайняті мешканці кущів і небес.
+
+Природно літають. У повітрі швидкі й добре ухиляються від ударів.
+Пірʼя глушить звукові удари -- голосним криком птаха не оглушити.
+Зате піддаються хворобам: одна заражена зграя може вимерти за тиждень.
+
+Тілом слабкі й крихкі, але спритні й зіркі -- дрібниці на землі
+бачать з повітря.
+</text>
   </help>
   <nameFemale>самка птицы</nameFemale>
   <nameMlt>птиц|ы||ам||ами|ах</nameMlt>

--- a/races/cat.xml
+++ b/races/cat.xml
@@ -9,7 +9,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">кот кошка коты кошки</keyword>
     <keyword l="ua">кіт кішка коти кішки</keyword>
-    <text l="en"></text>
+    <text l="en">=Cats= -- small, lithe, silent, and suspiciously clever. At
+times it seems they're appraising you: can you handle the task of
+feeding them.
+
+They see by infravision and through any invisibility, prowl
+silently, strike like lightning, and dodge well. Cold doesn't
+bother them -- the fur holds heat. Fire and water, though, kill
+a cat outright: burns like dry brush, sinks like a stone.
+
+Their special significance is to felars: a felar must never kill
+a cat, and the {hh969Avenger{x comes after such a deed without
+question. To everyone else a cat is either a household freeloader
+or a back-alley mini-predator.
+</text>
     <text l="ru">=Кошки= -- мелкие, гибкие, бесшумные, и подозрительно умные.
 Иногда кажется, что они тебя оценивают: справишься ли ты с задачей
 их кормления.
@@ -23,7 +36,19 @@
 {hh969Мститель{x за такое идёт безоговорочно. Для остальных кошка --
 обычно домашняя нахлебница либо мини-хищник из подворотни.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Коти= -- дрібні, гнучкі, безшумні, і підозріло розумні. Часом
+здається, що вони тебе оцінюють: чи впораєшся ти із завданням їх
+годувати.
+
+Бачать у тепловому спектрі й крізь будь-яку невидимість, крадуться
+безшумно, бʼють блискавично і добре ухиляються. Холод їм не страшний --
+шерсть тримає тепло. Зате вогонь і вода кота гублять разом: горить
+як сухий кущ, тоне як камінь.
+
+Їхня особлива цінність для феларів: убити кота фелару не можна, і
+{hh969Месник{x за таке йде безкомпромісно. Для інших кіт -- зазвичай
+домашня нахлібниця або міні-хижак із підворіття.
+</text>
   </help>
   <hunts registry="race">mouse rat fish</hunts>
   <nameFemale>кошка</nameFemale>

--- a/races/demon.xml
+++ b/races/demon.xml
@@ -9,7 +9,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">демон демоница демоны</keyword>
     <keyword l="ua">демон демониця демони</keyword>
-    <text l="en"></text>
+    <text l="en">=Demons= -- spawn of the lower planes and the fancy of dark
+mages. Huge fangs, horns, sometimes wings, more often hooves,
+always an unpleasant temperament.
+
+Dark energy doesn't touch them -- they're made of it. Fire warms
+rather than burns. Holy power, though, hits the quick: for a demon,
+a blessing is worse than a blade. They see in the dark and by
+infravision. In battle they kick, knock down, fling dirt up from
+under their hooves, and lash with the tail.
+
+The usual habitat is {hh1851Hell{x and {hh1854UnderDark{x; on rare
+occasions a demon shows up in some temple where an idiot mage
+summoned one and failed to bind it. Best fought in a group.
+</text>
     <text l="ru">=Демоны= -- порождения нижних планов и фантазии тёмных магов.
 Огромные клыки, рога, иногда крылья, чаще копыта, всегда -- неприятный
 характер.
@@ -23,7 +36,20 @@
 демона можно встретить в каком-нибудь храме, где идиот-маг вызвал, но
 не смог удержать. Бить рекомендуется группой.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Демони= -- породження нижніх планів і фантазії темних магів.
+Величезні ікла, роги, інколи крила, частіше копита, завжди --
+неприємний характер.
+
+Темна енергія їх не бере -- вони з неї й зроблені. Вогонь теж
+скоріше гріє, ніж пече. Зате свята сила бʼє по живому: для демона
+благословення гірше клинка. Бачать у темряві і в тепловому спектрі.
+У бою хвицають, збивають з ніг, кидаються багном з-під копит і
+хльоскають хвостом.
+
+Звична середа існування -- {hh1851Пекло{x і {hh1854Підземʼя{x;
+зрідка демона можна зустріти в якомусь храмі, де ідіот-маг викликав,
+але не зміг утримати. Бити рекомендується групою.
+</text>
   </help>
   <imm>negative</imm>
   <nameFemale>демоница</nameFemale>

--- a/races/dog.xml
+++ b/races/dog.xml
@@ -8,7 +8,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">пес собака псы собаки</keyword>
     <keyword l="ua">пес собака пси</keyword>
-    <text l="en"></text>
+    <text l="en">=Dogs= -- man's best friend, and the postman's worst foe.
+Loyal to the owner, aggressive to strangers, always ready to
+share their drool and fur.
+
+The fur holds cold -- winter only helps. Wounds get licked on the
+move. Fire, though, is ruin: burning fur on a fast animal is a bad
+combination. In battle they bite like lightning and often fall
+into rage.
+
+Cats can't stand them (mutually), {hh166felars{x especially. Dogs
+turn up almost anywhere, from {hh2089Mother Goose{x to {hh1862Haon
+Dor{x. Many can be tamed and made into followers.
+</text>
     <text l="ru">=Собаки= -- лучшие друзья человека, и худшие враги почтальона.
 Преданы хозяину, агрессивны к чужим, всегда готовы поделиться слюной
 и шерстью.
@@ -22,7 +34,19 @@
 {hh1862Хаон Дора{x. Многих можно приручить и сделать своими
 последователями.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Собаки= -- найкращі друзі людини, і найгірші вороги поштаря.
+Віддані хазяїну, агресивні до чужих, завжди готові поділитися
+слиною й шерстю.
+
+Шерсть тримає холод -- взимку лише краще. Рани на ходу зализують.
+Зате вогонь для них згубний: палаюча шерсть і швидкий звір -- погане
+поєднання. У бою кусають блискавично і часто впадають у лють.
+
+Коти терпіти їх не можуть (взаємно), {hh166фелари{x особливо. Знайти
+собак можна практично де завгодно, від {hh2089Матінки Гуски{x до
+{hh1862Хаон Дора{x. Багатьох можна приручити і зробити своїми
+послідовниками.
+</text>
   </help>
   <nameFemale>собака</nameFemale>
   <nameMlt>собак|и||ам||ами|ах</nameMlt>

--- a/races/draconian.xml
+++ b/races/draconian.xml
@@ -8,7 +8,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">драконид драконидка дракониды</keyword>
     <keyword l="ua">драконід драконідка дракониди</keyword>
-    <text l="en"></text>
+    <text l="en">=Draconians= -- distant kin of dragons by the scale, but without
+the ambition. Bipedal, sapient, scaled, with a tail and a long tongue.
+Best not to cross paths with them at all.
+
+The scales take slashing weapons and poison in stride -- rough work
+doesn't bother them. Piercing weapons, though, slip neatly between
+the plates, and cold locks them up: draconian blood runs cold, and
+without warmth they move poorly. Wounds knit on the move.
+
+In a fight they know how to bash, disarm, kick, fling dirt, parry,
+and tail-swipe, and they come to the aid of their kin. Their main
+seat is {hh2063Dragon Tower{x, where they serve Tiamat's retinue.
+They also den on {hh2090Cloudy Mountain{x. Loners turn up
+occasionally near {hh1543Crystalmir Lake{x.
+</text>
     <text l="ru">=Дракониды= -- дальние родственники драконов по чешуе, но без
 тех амбиций. Прямоходящие, разумные, чешуйчатые, с хвостом и длинным
 языком. Лучше всего тебе с ними вообще не пересекаться.
@@ -21,9 +35,24 @@
 В бою умеют сбивать с ног, обезоруживать, лягаться, бросаться грязью,
 парировать и подсекать хвостом, плюс приходят на выручку сородичам.
 Главное место обитания -- {hh2063Замок Драконов{x, где они служат
-свите Тиамат. Изредка одиночки попадаются у {hh1543Озера Кристалмир{x.
+свите Тиамат. Также водятся на {hh2090Облачной Горе{x. Изредка одиночки
+попадаются у {hh1543Озера Кристалмир{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Драконіди= -- дальні родичі драконів по лусці, але без тих
+амбіцій. Прямоходячі, розумні, лускаті, з хвостом і довгим язиком.
+Найкраще тобі з ними взагалі не перетинатися.
+
+Луска погано рубиться й добре терпить отрути -- грубої роботи не
+боїться. Зате колюча зброя легко входить поміж лусок, а холод їх
+сковує: кров у драконідів холодна, і без тепла ходити їм важко.
+Рани затягуються на ходу.
+
+У бою вміють збивати з ніг, обеззброювати, хвицати, кидати багном,
+парирувати й підсікати хвостом, плюс приходять на виручку родичам.
+Головне місце мешкання -- {hh2063Башта Драконів{x, де вони служать
+свиті Тіамат. Також водяться на {hh2090Хмарній Горі{x. Зрідка одинаки
+трапляються біля {hh1543Озера Кристалмир{x.
+</text>
   </help>
   <nameFemale>драконидка</nameFemale>
   <nameMale>драконид</nameMale>

--- a/races/dragon.xml
+++ b/races/dragon.xml
@@ -9,7 +9,23 @@
     <keyword l="en"></keyword>
     <keyword l="ru">дракон драконица драконы</keyword>
     <keyword l="ua">дракон дракониця дракони</keyword>
-    <text l="en"></text>
+    <text l="en">=Dragons= -- one of the oldest sentient races of Thera. Vast winged
+reptiles with shimmering scales and a maw equally suited to hunting
+deer and rewriting world history. A dragon's intellect rivals a
+human's, and its memory reaches back to when mortals were still
+learning to speak.
+
+Fire is the dragon's element -- it bathes in flame without harm.
+The scales resist charm magic, spells, crushing blows, and mental
+attacks. The one weak spot is the joints between the scales, where
+piercing weapons slip in. They fly, see by {hh830infravision{x and
+through invisibility. In battle they claw an entire area, parry
+strikes, and lash with the tail.
+
+The best-known strongholds are {hh1419Dragon Spyre{x with Fireflash,
+{hh2063Dragon Tower{x with Tiamat herself, and {hh2090Cloudy Mountain{x.
+Without a prepared party and a good spear, don't bother going there.
+</text>
     <text l="ru">=Драконы= -- одна из древнейших разумных рас Тэры. Огромные
 крылатые рептилии с переливающейся чешуёй и пастью, которой удобно
 как охотиться на оленей, так и переписывать историю мира. Интеллект
@@ -23,11 +39,27 @@
 диапазоне{x и сквозь невидимость. В бою бьют когтями всей округе,
 парируют удары и хлещут хвостом.
 
-Самые известные поселения -- {hh1419Пик Драконов{x с Огневспышкой и
-{hh2063Замок Драконов{x с самой Тиамат. Без подготовленной группы и
-хорошего копья туда лучше не соваться.
+Самые известные поселения -- {hh1419Пик Драконов{x с Огневспышкой,
+{hh2063Замок Драконов{x с самой Тиамат и {hh2090Облачная Гора{x. Без
+подготовленной группы и хорошего копья туда лучше не соваться.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Дракони= -- одна з найдавніших розумних рас Тери. Величезні
+крилаті рептилії з переливчастою лускою й пащею, якою зручно як
+полювати на оленів, так і переписувати історію світу. Інтелект
+драконів не поступається людському, памʼять памʼятає часи, коли
+смертні ще вчилися говорити.
+
+Вогонь -- рідна стихія, дракон у ньому купається без шкоди. Луска
+стійка до чарів очарування, до закляттів, до дробних ударів і до
+ментальних атак. Вразливе місце одне: зчленування луски, крізь які
+проходить колюча зброя. Літають, бачать {hh830тепловим зором{x і
+крізь невидимість. У бою бʼють пазурами всю округу, парирують удари
+й хльоскають хвостом.
+
+Найвідоміші поселення -- {hh1419Пік Драконів{x з Огневспалахом,
+{hh2063Башта Драконів{x із самою Тіамат і {hh2090Хмарна Гора{x. Без
+підготованої групи й гарного списа туди краще не сунутися.
+</text>
   </help>
   <imm>fire</imm>
   <nameFemale>драконица</nameFemale>

--- a/races/earth elemental.xml
+++ b/races/earth elemental.xml
@@ -9,7 +9,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">земной элементаль земная элементаль</keyword>
     <keyword l="ua">земний елементаль земна елементаль</keyword>
-    <text l="en"></text>
+    <text l="en">=Earth elementals= -- walking heaps of stone and soil animated
+by magic. Slow, heavy, and remarkably stubborn. Literally.
+
+Stone fears neither poison nor disease -- poisoning a pile of
+granite is pointless. Summons and ordinary weapons bounce off:
+they shatter into rubble, the elemental gathers itself back. Force
+magic and loud sound, though, smash it to gravel: stone cracks
+from resonance. They see the hidden and the living nearby.
+
+In battle they strike whole areas, go berserk, kick, fling clods
+of dirt, and crush with the full mass. The natural home is
+{hh1867Elemental Canyon{x.
+</text>
     <text l="ru">=Земные элементали= -- ходячие груды камня и грунта, оживлённые
 магией. Медленные, тяжёлые, и удивительно упёртые. В прямом смысле.
 
@@ -23,7 +35,19 @@
 комьями земли и сокрушают всей массой. Естественный дом --
 {hh1867Каньон Стихий{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Земні елементалі= -- ходячі купи каменю й ґрунту, оживлені
+магією. Повільні, важкі, і дивовижно вперті. В прямому сенсі.
+
+Каменю не страшні ні отрути, ні хвороби -- труїти купу граніту
+безглуздо. Призиви й звичайна зброя відскакують: то розсипається
+осипом, елементаль збирається наново. Зате силова магія й гучний
+звук розносять його на крихту: камінь тріскає від резонансу.
+Бачать прихованих і живе поблизу.
+
+У бою бʼють площадними ударами, впадають у лють, хвицають, кидаються
+грудками землі і трощать усією масою. Природний дім --
+{hh1867Каньйон Стихій{x.
+</text>
   </help>
   <imm>poison disease</imm>
   <nameFemale>земная элементаль</nameFemale>

--- a/races/fire elemental.xml
+++ b/races/fire elemental.xml
@@ -9,7 +9,23 @@
     <keyword l="en"></keyword>
     <keyword l="ru">огненный элементаль огненная элементаль</keyword>
     <keyword l="ua">вогняний елементаль вогняна елементаль</keyword>
-    <text l="en"></text>
+    <text l="en">=Fire elementals= -- living tongues of flame, just sentient
+enough to know where the fuel is. Hugging them is not advised
+even when it's very cold.
+
+Fire is their native element -- they bathe in it unharmed. Summons
+and ordinary weapons pass through the flame with little effect.
+Cold, though, smothers the fire, and water puts them out for good --
+drowning an elemental in a river is easier than cutting it down.
+
+They glow on their own, betray invisible foes with faerie fire,
+see by infravision and through any concealment. They fly. In
+battle they strike with area flares, go berserk, and crush with
+a mass of flame.
+
+Home is {hh1867Elemental Canyon{x. They also turn up in
+{hh1851Hell{x and other hot spots.
+</text>
     <text l="ru">=Огненные элементали= -- живые языки пламени, разумные ровно
 настолько, чтобы знать, где горючее. В обнимку с ними лучше не
 бросаться, даже если очень холодно.
@@ -26,7 +42,22 @@
 Дом -- {hh1867Каньон Стихий{x. Также встречаются в {hh1851Аду{x и
 других горячих точках.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Вогняні елементалі= -- живі язики полумʼя, розумні рівно
+настільки, щоб знати, де паливо. В обіймах із ними краще не
+кидатися, навіть якщо дуже холодно.
+
+Вогонь для них рідна стихія -- купаються і не шкодяться. Призиви
+й звичайна зброя проходять крізь полумʼя без особливої шкоди. Зате
+холод зводить вогонь нанівець, а вода гасить остаточно -- утопити
+елементаля в річці простіше, ніж зарубати.
+
+Світяться самі, видають невидимих чарівним вогнем, бачать у
+тепловому спектрі і крізь будь-які приховання. Літають. У бою бʼють
+площадними спалахами, впадають у лють і трощать масою полумʼя.
+
+Дім -- {hh1867Каньйон Стихій{x. Також зустрічаються в
+{hh1851Пеклі{x та інших гарячих точках.
+</text>
   </help>
   <imm>fire</imm>
   <nameFemale>огненная элементаль</nameFemale>

--- a/races/fire giant.xml
+++ b/races/fire giant.xml
@@ -9,7 +9,22 @@
     <keyword l="en">&apos;fire giants&apos;</keyword>
     <keyword l="ru">&apos;огненные великаны&apos;</keyword>
     <keyword l="ua">вогняні велетні</keyword>
-    <text l="en"></text>
+    <text l="en">Fire giants -- malicious, ruthless, and warlike creatures. They reach
+three metres in height, but are overall stockier and more solidly built than
+other giant kin. In build they resemble huge dwarves. Their skin is coal-black,
+their hair often a fiery red or bright orange, and from their jutting lower
+jaw yellowish teeth show.
+
+Fire giants are not noted for intellect, so the intellectual classes come
+hard to them. Dexterity, given their enormous size, also leaves something to
+be desired. They handle swords well, and, like all giants, can wield a
+two-handed weapon in one hand. Fire giants are vulnerable to cold and well
+protected from all sorts of fire attacks.
+
+{CDuring the Great Racial Mutation most fire giants died out, and this race
+is no longer available to players. The last surviving fire giants can be
+found in the burnt-out expanses of Mount Doom.{x
+</text>
     <text l="ru">Огненные великаны -- злобные, беспощадные и воинственные создания. Ростом они
 достигают трех метров, однако в целом приземистей и крепче сбиты, чем другие их
 сородичи-великаны. По телосложению напоминают огромных дварфов.
@@ -25,7 +40,22 @@
 более недоступна для игроков. Последних выживших огненных великанов можно найти
 на выжженных просторах Горы Смерти.{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Вогняні велетні -- злобні, безжальні й войовничі створіння. Зростом
+досягають трьох метрів, проте загалом приземкуватіші й міцніше збиті, ніж
+інші їхні родичі-велетні. За статурою нагадують величезних дварфів. Шкіра в
+них вугільно-чорного кольору, волосся часто має вогняно-червоний чи яскраво-
+помаранчевий колір, а з виступаючої нижньої щелепи видніються жовтуваті зуби.
+
+Вогняні велетні не вирізняються розумом, тому інтелектуальні класи даються їм
+з трудом. Спритність, з огляду на величезні розміри, теж залишає бажати
+кращого. Вони добре володіють мечами, і, як і всі велетні, можуть утримати
+дворучну зброю в одній руці. Вогняні велетні вразливі до холоду й добре
+захищені від усіх видів атак вогнем.
+
+{CПід час Великої Мутації Рас більшість вогняних велетнів вимерла, і ця раса
+більше недоступна для гравців. Останніх вцілілих вогняних велетнів можна
+знайти на випалених просторах Гори Смерті.{x
+</text>
   </help>
   <nameFemale>огненн|ая|ую|ой|ую|ой|ой великанш|а|и|е|у|ей|е</nameFemale>
   <nameMale>огненн|ый|ого|ому|ого|ым|ом великан||а|у|а|ом|е</nameMale>

--- a/races/fish.xml
+++ b/races/fish.xml
@@ -8,7 +8,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">рыба рыбы</keyword>
     <keyword l="ua">риба риби</keyword>
-    <text l="en"></text>
+    <text l="en">=Fish= -- cold-blooded dwellers of rivers, seas and lakes,
+usually indifferent to anything that doesn't glitter like bait.
+Scales, fins, gills -- the standard kit.
+
+They swim by default and cannot drown underwater. They glide
+silently, are quick, and dodge well. Out of water, though, they
+perish quickly from drying, fire crisps them instantly, and cold
+locks them up -- a frozen fish won't get free.
+
+Main waters are {hh1543Crystalmir Lake{x, {hh1843Lake of Tears{x,
+and just the Dragon Sea. A favoured catch of {hh166felars{x --
+the goddess Bast looks kindly on fishing.
+</text>
     <text l="ru">=Рыбы= -- холоднокровные обитатели рек, морей и озёр, обычно
 безразличные ко всему, что не блестит как наживка. Чешуя, плавники,
 жабры -- стандартный комплект.
@@ -22,7 +34,19 @@
 просто море Дракона. Излюбленная добыча {hh166феларов{x -- богиня
 Баст благосклонна к рыбной ловле.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Риби= -- холоднокровні мешканці річок, морів і озер, зазвичай
+байдужі до всього, що не блищить як наживка. Луска, плавники,
+зябра -- стандартний комплект.
+
+Плавають за визначенням і у воді втонути не можуть. Ковзають
+безшумно, швидкі й добре ухиляються. Зате на повітрі швидко
+гинуть від висихання, вогонь їх засмажує вмить, а холод сковує --
+замерзла риба не вирветься.
+
+Головні водойми -- {hh1543Озеро Кристалмир{x, {hh1843Озеро Сліз{x,
+і просто море Дракона. Улюблена здобич {hh166феларів{x -- богиня
+Баст прихильна до риболовлі.
+</text>
   </help>
   <imm>drowning</imm>
   <nameFemale>самка рыбы</nameFemale>

--- a/races/frost giant.xml
+++ b/races/frost giant.xml
@@ -9,7 +9,21 @@
     <keyword l="en">&apos;frost giants&apos;</keyword>
     <keyword l="ru">&apos;инеистые великаны&apos;</keyword>
     <keyword l="ua">крижані велетні</keyword>
-    <text l="en"></text>
+    <text l="en">Frost giants, like other evil giants, have a deserved reputation as
+cruel and somewhat dim, but rather skilled warriors. In build they resemble
+huge humans, reaching three to four metres in height. The skin of frost
+giants ranges from snow-white to ivory. You'll find giants with hair of both
+blue and straw colour -- and with eyes of a similar shade. Frost giants are
+not noted for intellect, so the intellectual classes come hard to them.
+Dexterity, given their enormous size, also leaves something to be desired.
+In battle they prefer huge two-handed axes, which, thanks to their stature,
+they can wield in a single hand. Frost giants are vulnerable to fire and
+well protected from all sorts of cold attacks.
+
+{CDuring the Great Racial Mutation most frost giants died out, and this race
+is no longer available to players. The last surviving frost giants can be
+found on the branches of the great ash {hh1852Yggdrasil{x.{x
+</text>
     <text l="ru">Инеистые великаны, как и другие злые великаны, имеют заслуженную репутацию
 жестоких и глуповатых, но довольно умелых воинов. Телосложением они напоминают 
 огромных людей, достигая трех-четырех метров роста.
@@ -25,7 +39,21 @@
 более недоступна для игроков. Последних выживших инеистых великанов можно найти
 на ветвях великого ясеня {hh1852Иггдрасиль.{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Крижані велетні, як і інші злі велетні, мають заслужену репутацію
+жорстоких і дещо тупуватих, але доволі вмілих вояків. Будовою тіла нагадують
+величезних людей, досягаючи трьох-чотирьох метрів зростом. Шкіра крижаних
+велетнів буває білосніжною або кольору слонової кістки. Зустрічаються
+велетні як з блакитним, так і з соломʼяним волоссям -- і з очима схожого
+відтінку. Крижані велетні не вирізняються розумом, тому інтелектуальні класи
+даються їм з трудом. Спритність, з огляду на величезні розміри, теж залишає
+бажати кращого. У бою вони віддають перевагу величезним дворучним сокирам,
+які, завдяки своєму зросту, можуть тримати в одній руці. Крижані велетні
+вразливі до вогню й добре захищені від усіх видів атак холодом.
+
+{CПід час Великої Мутації Рас більшість крижаних велетнів вимерла, і ця раса
+більше недоступна для гравців. Останніх вцілілих крижаних велетнів можна
+знайти на гілках великого ясена {hh1852Іггдрасиль{x.{x
+</text>
   </help>
   <nameFemale>инеист|ая|ую|ой|ую|ой|ой великанш|а|и|е|у|ей|е</nameFemale>
   <nameMale>инеист|ый|ого|ому|ого|ым|ом великан||а|у|а|ом|е</nameMale>

--- a/races/ghost.xml
+++ b/races/ghost.xml
@@ -9,7 +9,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">призрак привидение привидения призраки</keyword>
     <keyword l="ua">привид привиди</keyword>
-    <text l="en"></text>
+    <text l="en">=Ghosts= -- remnants of the dead who couldn't or wouldn't
+move on. Half-transparent, walk through walls, dislike sunlight
+and warm company.
+
+With no flesh, poison and disease don't catch on them; dark energy
+is native; drowning isn't an option either. Ordinary weapons pass
+through with little trace. Holy power, though, cuts the spectral
+fabric like a knife through smoke -- blessing and prayer are deadly
+to them.
+
+They see the living, the dead, and in the dark. They prowl
+silently, fly, swim, and pass through doors -- catching them is
+hard. In battle they strike whole areas, go berserk, dodge, and
+move fast.
+
+Main haunts are {hh1425Ghost Town{x and {hh2078Graveyard{x. They
+turn up at times in libraries where someone died mid-chapter.
+</text>
     <text l="ru">=Призраки= -- остатки умерших, которые не смогли или не захотели
 уйти. Полупрозрачны, проходят сквозь стены, не любят солнечный свет
 и тёплые компании.
@@ -27,7 +44,23 @@
 Иногда встречаются в библиотеках, где умерли так и не дочитавшие
 книгу.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Привиди= -- залишки померлих, які не змогли або не схотіли
+піти. Напівпрозорі, проходять крізь стіни, не люблять сонячне
+світло й теплі компанії.
+
+Безтілесним тілом отрут і хвороб не підхопиш, темна енергія для
+них рідна, втонути вони теж не можуть. Звичайна зброя проходить
+крізь майже без сліду. Зате свята сила ріже примарну тканину як
+ніж по диму -- благословення й молитва для них смертельні.
+
+Бачать живих, мертвих і в темряві. Безшумно крадуться, літають,
+плавають і проходять крізь двері -- ловити їх непросто. У бою бʼють
+площадними атаками, впадають у лють, ухиляються і стрімкі.
+
+Основні пристанища -- {hh1425Місто Привидів{x і {hh2078Цвинтар{x.
+Іноді трапляються в бібліотеках, де померли так і не дочитавши
+книгу.
+</text>
   </help>
   <imm>poison negative disease drowning</imm>
   <nameFemale>женщина-призрак</nameFemale>

--- a/races/ghoul.xml
+++ b/races/ghoul.xml
@@ -9,7 +9,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">упырь упырица упыри</keyword>
     <keyword l="ua">упир упириця упирі</keyword>
-    <text l="en"></text>
+    <text l="en">=Ghouls= -- corpse-eaters and fans of all things decaying.
+Not quite alive, not quite not, but definitely hungry. Long nails,
+crooked teeth, breath... you get the idea.
+
+What's inside them is hard to make worse -- poison, disease and
+dark energy are no obstacle. Charm doesn't work on them either,
+and cold they barely feel. Fire, holy power, bright light and
+silver, though, are an execution for a ghoul: they flare up like
+kindling and retreat with a shriek.
+
+They see the living, the hidden, and by infravision; the curse is
+ever upon them; wounds knit on the move. In battle they go berserk,
+kick, parry, trip, crush, dodge, and move fast.
+
+They prowl near {hh2078Graveyard{x, in {hh1865Chapel Dungeon{x
+and in {hh2039Old Marsh{x. They feed mostly on carrion, but won't
+turn down the fresh either.
+</text>
     <text l="ru">=Упыри= -- труподеды и любители всего разлагающегося. Не то
 живые, не то нет, но определённо голодные. Ногти длинные, зубы кривые,
 дыхание... ну ты понимаешь.
@@ -27,7 +44,24 @@
 {hh2039Старой Топи{x. Питаются в основном падалью, но свежим тоже
 не побрезгуют.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Упирі= -- трупоїди й любителі всього, що розкладається.
+Чи то живі, чи то ні, але точно голодні. Нігті довгі, зуби криві,
+дихання... ну ти розумієш.
+
+Що в них усередині, погіршити вже важко -- отрути, хвороби й темна
+енергія упирю не завада. Очарування на них теж не діє, і холоду
+вони майже не відчувають. Зате вогонь, свята сила, яскраве світло
+і срібло для упиря -- кара: спалахують як скіпка і відступають з
+вереском.
+
+Бачать живе, прихованих і в тепловому спектрі, прокляття при них
+завжди, рани заростають на ходу. У бою впадають у лють, хвицають,
+парирують, підсікають, нищать, ухиляються і стрімкі.
+
+Промишляють біля {hh2078Цвинтаря{x, в {hh1865Підземеллі Каплиці{x
+і в {hh2039Старому Болоті{x. Харчуються переважно падаллю, але
+свіжим теж не погребують.
+</text>
   </help>
   <imm>poison negative disease</imm>
   <nameFemale>упырица</nameFemale>

--- a/races/giant.xml
+++ b/races/giant.xml
@@ -6,7 +6,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">гигант гигантша гиганты</keyword>
     <keyword l="ua">велетень велетка велетні</keyword>
-    <text l="en"></text>
+    <text l="en">=Giants= -- huge humanoid beings whose distant kin once
+quarrelled with the gods and lost. Since then they live far off,
+fight often, and swing clubs with style.
+
+Strong as mammoths, hardy as mountains, slow as avalanches. The
+thick hide takes neither fire nor frost -- climate is something
+a giant ignores. Lightning, though, drops one on the spot, and
+mental magic is ruinous to a slow-thinking mind. In battle they
+bash, disarm, kick, parry, often go berserk, rescue their kin,
+and crush anything small. Ranged weapons are rarely needed -- a
+rock underfoot will do.
+
+They turn up in {hh1862Haon Dor{x, in the mountains around
+{hh2090Cloudy Mountain{x, and in the oddest places like
+{hh1382Machine Dreams{x. There are several kinds --
+{hh161fire giants{x, {hh160frost giants{x, {hh165storm giants{x,
+and {hh153cloud giants{x.
+</text>
     <text l="ru">=Гиганты= -- огромные человекоподобные существа, чьи дальние
 родственники когда-то поспорили с богами и не выиграли. С тех пор
 живут далеко, дерутся часто, дубинами размахивают со вкусом.
@@ -23,7 +40,23 @@
 несколько -- {hh161огненные{x, {hh160инеистые{x, {hh165штормовые{x и
 {hh153облачные{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Велетні= -- величезні людиноподібні істоти, чиї дальні родичі
+колись посварилися з богами й програли. З того часу живуть далеко,
+бʼються часто, дубинами розмахують зі смаком.
+
+Сильні як мамонти, витривалі як гори, повільні як лавина. Товсту
+шкуру не пробити ні вогнем, ні морозом -- клімат велетень ігнорує.
+Зате блискавки бʼють його наповал, а ментальна магія для тугого
+розуму згубна. У бою збивають з ніг, обеззброюють, хвицають,
+парирують, часто впадають у лють, рятують родичів і розчавлюють
+усе дрібне. Дальньобійної зброї зазвичай не треба -- каменя під
+ногою вистачить.
+
+Зустрічаються в {hh1862Хаон Дорі{x, в горах навколо {hh2090Хмарної
+Гори{x, і в найнесподіваніших місцях на кшталт {hh1382Машинних
+Мрій{x. Різновидів кілька -- {hh161вогняні велетні{x, {hh160крижані
+велетні{x, {hh165штормові велетні{x і {hh153хмарні велетні{x.
+</text>
   </help>
   <nameFemale>гигантша</nameFemale>
   <nameMlt>гигант|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/goblin.xml
+++ b/races/goblin.xml
@@ -8,7 +8,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">гоблин гоблинша гоблины</keyword>
     <keyword l="ua">гоблін гоблінка гобліни</keyword>
-    <text l="en"></text>
+    <text l="en">=Goblins= -- small, green, noisy, and remarkably tough to
+kill. A pack of goblins is noise, filth, and a surprisingly
+coordinated 'overwhelm with numbers' tactic.
+
+They're used to dirt and infection -- disease barely touches them.
+Magic, though, mows them down fast: spells and mental attacks
+pass through a thin skull with no resistance. They see by
+infravision. One on one they're weak, in numbers -- a problem.
+
+Main nests are {hh2049Goblin Stronghold{x, {hh2081Goblin Nation{x,
+and the villages around them. Their hatred for {hh1439gnomes{x is
+in their nature and not up for discussion.
+</text>
     <text l="ru">=Гоблины= -- мелкие, зелёные, шумные и удивительно живучие.
 Стая гоблинов -- это шум, грязь и неожиданно слаженная тактика
 "завалить количеством".
@@ -22,7 +34,19 @@
 гоблинов{x и деревни вокруг них. Их злоба к {hh1439гномам{x по природе
 и не обсуждается.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Гобліни= -- дрібні, зелені, галасливі і дивовижно живучі.
+Зграя гоблінів -- це шум, бруд і несподівано злагоджена тактика
+«завалити кількістю».
+
+Звиклі до бруду й зарази -- хвороби їх майже не беруть. Зате
+магія їх викошує швидко: і закляття, і ментальні атаки йдуть крізь
+тонкий череп без опору. Бачать у тепловому спектрі. По одному
+слабкі, в великій кількості -- проблема.
+
+Головні гніздилища -- {hh2049Твердиня Гоблінів{x, {hh2081Земля
+Гоблінів{x і села навколо них. Їхня злоба до {hh1439гномів{x за
+природою і не обговорюється.
+</text>
   </help>
   <nameFemale>гоблинша</nameFemale>
   <nameMlt>гоблин|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/golem.xml
+++ b/races/golem.xml
@@ -6,7 +6,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">голем конструкция големы конструкции</keyword>
     <keyword l="ua">голем конструкція големи</keyword>
-    <text l="en"></text>
+    <text l="en">=Golems= -- artificial constructs animated by magic. Made of stone,
+clay, iron, flesh, or whatever else the creator fancied. They don't
+breed or grow -- they're assembled one at a time.
+
+Poison and disease can't touch the body -- there's nothing in there
+to poison. Ordinary weapons bounce off: steel on steel chips slowly.
+Magic, though, passes through them like wind through a grate --
+spells and mental attacks cut deep.
+
+Slow and dim in a fight, but tough. They shield their master with
+their bulk and strike with the full mass of the body.
+</text>
     <text l="ru">=Големы= -- искусственные конструкции, оживлённые магией. Бывают
 из камня, глины, железа, плоти и других материалов на вкус создателя.
 Сами не размножаются и не растут -- их собирают по одному.
@@ -19,7 +30,18 @@
 В бою медлительны и тупы, но крепки телом. Прикрывают хозяина
 собой и бьют всей массой.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Големи= -- штучні конструкції, оживлені магією. З каменю, глини,
+заліза, плоті та інших матеріалів на смак творця. Самі не розмножуються
+і не ростуть -- їх збирають по одному.
+
+Тіло не піддається отруті й хворобам -- труїти його марно. До звичайної
+зброї стійкі: сталь об сталь щербиться повільно. Зате слабкі перед
+магією: закляття й ментальні атаки проходять крізь, як вітер крізь
+решітку.
+
+У бою повільні й тупі, та міцні тілом. Прикривають хазяїна собою
+і бʼють усією масою.
+</text>
   </help>
   <imm>poison disease</imm>
   <nameFemale>конструкция</nameFemale>

--- a/races/hobgoblin.xml
+++ b/races/hobgoblin.xml
@@ -8,7 +8,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">хобгоблин хобгоблинша хобгоблины</keyword>
     <keyword l="ua">хобгоблін хобгоблінка хобгобліни</keyword>
-    <text l="en"></text>
+    <text l="en">=Hobgoblins= -- older, meaner, better-organized goblins. The
+same green snouts, only bigger and with discipline. They wear
+armour, hold formation, and don't run as a rabble.
+
+Used to poison and disease -- not every goblin cauldron is fit
+for humans, but to a hobgoblin it's nothing. They see by
+infravision. In battle they kick, fling dirt, parry, trip, and
+dodge well.
+
+Their main gathering point is {hh1855Moria{x and {hh1439Gnome
+Village{x, where they traditionally besiege anything that moves.
+With goblins they sometimes unite, sometimes don't.
+</text>
     <text l="ru">=Хобгоблины= -- старшие, злее, организованнее гоблины. Те же
 зелёные хари, только крупнее и с дисциплиной. Носят брони, держат
 строй, и просто так толпой не бегают.
@@ -22,7 +34,19 @@
 они традиционно осаждают всё что движется. С гоблинами иногда
 объединяются, иногда нет.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Хобгобліни= -- старші, лютіші, організованіші гобліни. Ті
+ж зелені пики, тільки крупніші й з дисципліною. Носять броні,
+тримають стрій, і просто так натовпом не бігають.
+
+Звиклі до отрут і хвороб -- не кожен гоблінський котел годиться
+для людей, а хобгоблінові хоч би що. Бачать у тепловому спектрі.
+У бою хвицають, кидаються багном, парирують, підсікають і добре
+ухиляються.
+
+Головне місце збору -- {hh1855Морія{x і {hh1439Село Гномів{x, де
+вони традиційно облягають усе, що рухається. З гоблінами часом
+обʼєднуються, часом ні.
+</text>
   </help>
   <nameFemale>хобгоблинша</nameFemale>
   <nameMlt>хобгоблин|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/hoofed.xml
+++ b/races/hoofed.xml
@@ -6,7 +6,16 @@
     <keyword l="en"></keyword>
     <keyword l="ru">копытный копытные</keyword>
     <keyword l="ua">копитний копитна копитні</keyword>
-    <text l="en"></text>
+    <text l="en">=Hoofed= -- herbivorous beasts with hooves in place of paws:
+deer, elk, boars, bison, and other lovers of grass and a fast run.
+
+Big and tough, they hit harder with a hoof than you'd think, knock
+down at a charge, and in danger fall into rage.
+
+They turn up in {hh1850Prairies{x, in {hh2091Pastures{x, and other
+open places. A favoured prey of centaurs -- the very ones who also
+{hh876double-kick{x.
+</text>
     <text l="ru">=Копытные= -- травоядные звери с копытами вместо лап: олени,
 лоси, кабаны, бизоны и прочие любители травы и быстрого бега.
 
@@ -17,7 +26,16 @@
 местах. Любимая добыча кентавров -- тех самых, что и {hh876бьют
 копытом{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Копитні= -- травоїдні звірі з копитами замість лап: олені,
+лосі, кабани, бізони та інші любителі трави і швидкого бігу.
+
+Великі і міцні, бʼють копитом сильніше, ніж здається, перекидають
+з розгону і в небезпеці впадають у лють.
+
+Зустрічаються в {hh1850Преріях{x, у {hh2091Пасовиськах{x та інших
+відкритих місцях. Улюблена здобич кентаврів -- тих самих, що й
+{hh876бʼють копитом{x.
+</text>
   </help>
   <nameFemale>копытная</nameFemale>
   <nameMlt>копытн|ые|ых|ым|ых|ыми|ых</nameMlt>

--- a/races/horse.xml
+++ b/races/horse.xml
@@ -7,7 +7,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">конь лошадь кобыла кони</keyword>
     <keyword l="ua">кінь кобила коні</keyword>
-    <text l="en"></text>
+    <text l="en">=Horses= -- noble four-legged creatures, the backbone of any
+army and many a farm. Strong, hardy, and uncannily good at being
+in the right place.
+
+They hit with a hoof, knock down at a charge, crush by mass, and
+rescue their rider. They go berserk for familiar owners -- defend
+them and head into battle. Charm magic, though, takes them easily:
+a horse is sensitive to another's will. Loud sound terrifies
+them -- a herd scatters a kilometre from a blast.
+
+Main stables are in {hh2073Camelot{x, in {hh2095King Castle{x, and
+similar respectable courts. They also roam as wild herds on the
+prairies. Horses vary -- from worn-out nags to war destriers.
+</text>
     <text l="ru">=Лошади= -- благородные четвероногие, основа любой армии и
 многих сельских хозяйств. Сильны, выносливы, и удивительно умеют
 быть в нужном месте.
@@ -21,7 +34,21 @@
 и в подобных уважаемых дворах. Также водятся как дикие табуны в
 прериях. Кони бывают разные -- от заезженных кляч до боевых дестриеров.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Коні= -- благородні чотириногі, основа будь-якої армії і
+багатьох сільських господарств. Сильні, витривалі, і дивовижно
+вміють бути в потрібному місці.
+
+Бʼють копитом, перекидають з розгону, тиснуть масою і рятують
+вершника. У лють впадають на знайомих хазяях -- захищають і йдуть
+у бій. Зате магія очарування бере їх легко: кінь чутливий до чужої
+волі. Гучний звук лякає -- табун від вибуху розбігається на
+кілометр.
+
+Головні стайні -- в {hh2073Камелоті{x, в {hh2095Королівському
+замку{x і в подібних поважних дворах. Також водяться як дикі
+табуни в преріях. Коні бувають різні -- від заїжджених шкап до
+бойових дестрієрів.
+</text>
   </help>
   <nameFemale>лошадь</nameFemale>
   <nameMlt>кон|и|ей|ям|ей|ями|ях</nameMlt>

--- a/races/illithid.xml
+++ b/races/illithid.xml
@@ -9,7 +9,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">иллитид иллитидка иллитиды</keyword>
     <keyword l="ua">ілітід ілітідка ілітіди</keyword>
-    <text l="en"></text>
+    <text l="en">=Illithids= -- psionics from the deepest reaches of the
+underworld, with an octopus head and a habit of sucking brains
+through their tentacles. Indecently clever, which makes them all
+the more unpleasant.
+
+Mentally invulnerable and immune to charm -- professionals at it.
+Spells also fade off: their thin skin shunts magic through its
+own channels. They see by infravision, sense the hidden, and prowl
+silently.
+
+In battle they strike whole areas, parry, kick, trip, and dodge
+well. Illithid colonies are in {hh1856Sewers{x and in {hh1423The
+City of Anon{x. Don't engage one alone -- you have only one brain,
+and without it you won't last long.
+</text>
     <text l="ru">=Иллитиды= -- псионики из самых глубин подземного мира, с
 головой осьминога и манерой высасывать мозги через щупальца. Умны
 до неприличия, и от того ещё противнее.
@@ -24,7 +38,20 @@
 {hh1423Городе Анон{x. В одиночку с ними лучше не связываться -- мозг
 тебе достанется только один и без него ты долго не протянешь.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Ілітіди= -- псіоніки з найглибших закутків підземного світу,
+з головою восьминога й манерою висмоктувати мізки крізь щупальця.
+Непристойно розумні, і від цього ще огидніші.
+
+Ментально невразливі і не піддаються очаруванню -- професіонали
+з цього питання. Закляття теж сходять нанівець: тонка шкіра
+відводить магію своїми каналами. Бачать у тепловому спектрі,
+чують сховане і крадуться безшумно.
+
+У бою бʼють площадними атаками, парирують, хвицають, підсікають
+і добре ухиляються. Колонії ілітідів є у {hh1856Каналізації{x і
+в {hh1423Місті Анон{x. Поодинці з ними краще не звʼязуватися --
+мозок тобі дістався один, і без нього довго не протягнеш.
+</text>
   </help>
   <imm>charm mental</imm>
   <nameFemale>иллитидка</nameFemale>

--- a/races/insect.xml
+++ b/races/insect.xml
@@ -8,7 +8,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">насекомое насекомые</keyword>
     <keyword l="ua">комаха комахи</keyword>
-    <text l="en"></text>
+    <text l="en">=Insects= -- the endless class of small chitinous citizens
+of Thera. Beetles, ants, bees, wasps, and much else you'd rather
+not inspect closely without a net.
+
+Many fly, all are fast and hard to swat. Chitin keeps disease out,
+and an insect's thoughts are too scattered to charm -- mental magic
+doesn't take. Fire, though, warps the chitin in an instant, and
+cold locks it up no less -- in summer the bee stings, in winter
+it doesn't leave the hive.
+
+You can find them anywhere -- from {hh2092Temple of Themis{x to
+{hh1844Zoo of Midgaard{x. They're rarely a serious threat, except
+when what bites you is large, venomous, and both at once.
+</text>
     <text l="ru">=Насекомые= -- бесконечный класс мелких хитиновых граждан Тэры.
 Жуки, муравьи, пчёлы, осы, и многое другое, что лучше не разглядывать
 вблизи без сачка.
@@ -22,7 +35,20 @@
 Мидгаарда{x. Серьёзной опасности обычно не представляют, кроме
 случаев, когда тебя кусает что-то большое, ядовитое и одновременно.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Комахи= -- нескінченний клас дрібних хітинових громадян Тери.
+Жуки, мурахи, бджоли, оси, і багато чого ще, що краще не
+розглядати зблизька без сачка.
+
+Багато хто літає, усі швидкі й важкоуловимі. Хітин не пускає заразу,
+а думки в комахи надто розрізнені, щоб їх зачарувати -- магія
+розуму по них не діє. Зате вогонь хітин коробить вмить, а холод
+сковує не гірше -- влітку бджола жалить, взимку не вилазить з вулика.
+
+Знайти їх можна скрізь -- від {hh2092Храму Феміди{x до
+{hh1844Зоопарку Мідгаарда{x. Серйозної небезпеки зазвичай не
+становлять, окрім випадків, коли тебе кусає щось велике, отруйне
+і одночасно.
+</text>
   </help>
   <imm>mental</imm>
   <nameFemale>самк|а|и|е|у|ой|е насекомого</nameFemale>

--- a/races/invertebrate.xml
+++ b/races/invertebrate.xml
@@ -8,7 +8,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">беспозвоночный беспозвоночные</keyword>
     <keyword l="ua">безхребетний безхребетна безхребетні</keyword>
-    <text l="en"></text>
+    <text l="en">=Invertebrates= -- everything slimy and chitinous that gets by
+without a spine: molluscs, jellyfish, octopuses, starfish, and
+the rest of the watery-tentacular kind. Most live in water, some
+crawled onto land for whatever reason.
+
+The formless flesh lets in neither mental attacks nor disease.
+Charm and ordinary weapons also wane -- cut or not, it pulls
+itself back together. Fire, though, dries and sears the protein,
+and cold turns it to ice: both are fatal. They swim and regenerate,
+but move slowly -- ambushing suits them better than running.
+
+The class is used mostly for mechanics -- spells, hunting skills,
+and the Dragon Sea inventory.
+</text>
     <text l="ru">=Беспозвоночные= -- всё то склизкое и хитиновое, что обходится
 без позвоночника: моллюски, медузы, осьминоги, морские звёзды и
 прочие водянисто-щупальцевые. Большинство живёт в воде, некоторые
@@ -23,7 +36,20 @@
 Класс используется в основном для механики -- заклинания, охотничьи
 умения и инвентаризация моря Дракона.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Безхребетні= -- усе те слизьке й хітинове, що обходиться без
+хребта: молюски, медузи, восьминоги, морські зірки та інші
+водянисто-щупальцеві. Більшість живе у воді, деякі виповзли на
+сушу навіщось.
+
+Безформна плоть не пускає ні ментальні атаки, ні хвороби.
+Очарування й звичайна зброя теж сходять нанівець -- ріж, не ріж,
+воно стулюється назад. Зате вогонь сушить і скручує білок, а холод
+перетворює на лід: обидва смертельні. Плавають і регенерують, але
+рухаються повільно -- сидіти в засідці їм простіше, ніж бігати.
+
+Клас використовується переважно для механіки -- закляття, мисливські
+вміння та інвентаризація моря Дракона.
+</text>
   </help>
   <imm>mental disease</imm>
   <nameFemale>беспозвоночная</nameFemale>

--- a/races/kobold.xml
+++ b/races/kobold.xml
@@ -9,7 +9,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">кобольд кобольдша кобольды</keyword>
     <keyword l="ua">кобольд кобольдка кобольди</keyword>
-    <text l="en"></text>
+    <text l="en">=Kobolds= -- small scaly underground dwellers, distant kin
+of dragons, very very distant. Crafty, cowardly, fond of traps
+and pack tactics.
+
+Used to poison -- they themselves dab it on their arrows. They
+see in the dark and by infravision. Magic, though, mows them down
+fast: the thin scales don't hold spells. In battle they hit from
+behind, kick, fling dirt, trip, go berserk, and move fast.
+
+Kobold colonies sit near {hh2065Aarakokran City{x, in {hh1411The
+Keep of the Warlock{x, and around {hh2051Arachnos{x. Their
+favourite occupation is setting traps for passers-by and then
+collecting them.
+</text>
     <text l="ru">=Кобольды= -- маленькие чешуйчатые подземные жители, дальние
 родственники драконов, очень-очень дальние. Хитры, трусоваты, любят
 ловушки и стайную тактику.
@@ -23,7 +36,20 @@
 Убежище Колдуна{x и в окрестностях {hh2051Арахноса{x. Их любимое
 занятие -- расставлять ловушки на проходящих и потом их собирать.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Кобольди= -- маленькі лускаті підземні мешканці, дальні
+родичі драконів, дуже-дуже дальні. Хитрі, боязкі, люблять пастки
+і зграйну тактику.
+
+Звиклі до отрут -- самі їх і підмішують у свої стріли. Бачать у
+темряві і в тепловому спектрі. Зате магія їх викошує швидко:
+тонка луска не тримає закляттів. У бою бʼють зі спини, хвицають,
+кидаються багном, підсікають, впадають у лють і стрімкі.
+
+Колонії кобольдів є біля {hh2065Ааракокрана{x, в {hh1411Таємному
+Сховищі Чарівника{x і в околицях {hh2051Арахноса{x. Їхнє улюблене
+заняття -- розставляти пастки на тих, хто проходить, і потім їх
+збирати.
+</text>
   </help>
   <nameFemale>кобольдша</nameFemale>
   <nameMlt>кобольд|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/lich.xml
+++ b/races/lich.xml
@@ -9,7 +9,23 @@
     <keyword l="en"></keyword>
     <keyword l="ru">лич мужчина лич женщина лич личи</keyword>
     <keyword l="ua">ліч чоловік ліч жінка ліч лічі</keyword>
-    <text l="en"></text>
+    <text l="en">=Liches= -- mages who refused to die, and now resent the
+living for their short-sightedness. Dried-up mummies in rich
+robes, with embers for eyes and magic in every finger.
+
+Dead flesh fears not cold, poison, disease, or dark energy -- the
+necromancer's favourite element. They parry ordinary weapons:
+chipping a mummy with iron takes a while. Holy power, though, cuts
+lich-fabric into ribbons -- a blessing is worse than a blade.
+
+They see through invisibility and by infravision, and the ward
+against good is always upon them. They wield magic professionally --
+which is, after all, the very reason they refused death.
+
+The best-known seat is {hh2070Lich Tower{x. Liches sometimes set
+up bases in {hh1854UnderDark{x, in the {hh1837Ruins of Thalos{x,
+and other forgotten places.
+</text>
     <text l="ru">=Личи= -- маги, которые отказались умирать, и теперь жалеют
 живых их недальновидностью. Высушенные мумии в богатых робах, с
 глазами как угольки и магией в каждом пальце.
@@ -27,7 +43,23 @@
 устраивают опорные базы в {hh1854Подземье{x, в {hh1837Руинах Старого
 Талоса{x и в других забытых местах.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Лічі= -- маги, які відмовилися помирати, і тепер шкодують
+живих їхньою недалекоглядністю. Висушені мумії в багатих робах,
+з очима як вуглинки і магією в кожному пальці.
+
+Мертвій плоті не страшні холод, отрути, хвороби й темна енергія --
+улюблена стихія некроманта. Звичайну зброю ловлять парадом:
+кришити мумію залізом довго. Зате свята сила ріже лічеву тканину
+на стрічки -- для них благословення гірше клинка.
+
+Бачать крізь невидимість і в тепловому спектрі, захист від добра
+з ними завжди. Магією володіють професійно -- власне, заради
+магії й відмовилися від смерті.
+
+Найвідоміша резиденція -- {hh2070Башта Ліча{x. Інколи лічі
+влаштовують опорні бази в {hh1854Підземʼї{x, у {hh1837Руїнах
+Старого Талоса{x і в інших забутих місцях.
+</text>
   </help>
   <imm>cold poison negative disease</imm>
   <nameFemale>женщина лич</nameFemale>

--- a/races/lizard.xml
+++ b/races/lizard.xml
@@ -9,7 +9,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">ящер ящерица ящеры рептилия</keyword>
     <keyword l="ua">ящір ящірка ящери рептилія</keyword>
-    <text l="en"></text>
+    <text l="en">=Lizards= -- cold-blooded scaled dwellers of warm climes,
+from small lizards to large monitors. Love the sun, hate the
+cold -- but that's habit, not weakness.
+
+Acid and poison are taken in stride by the scales -- a lizard
+won't refuse to use them either. Wounds knit on the move, the
+tail regrows as needed. They hide in grass and under stones, see
+the living through cover and in the dark. In battle they're
+fast, dodge, and lash with the tail.
+
+The densest population is in {hh2077Freeport{x, where various
+kinds of lizards make up a sizeable share of the fauna. They
+also live in {hh1838New Thalos{x and the surrounding deserts.
+</text>
     <text l="ru">=Ящеры= -- холоднокровные чешуйчатые жители тёплых краёв, от
 мелких ящериц до больших варанов. Любят солнце, ненавидят холод --
 но это повадка, не уязвимость.
@@ -23,7 +36,19 @@
 варианты ящеров составляют значительную часть фауны. Также водятся
 в {hh1838Новом Талосе{x и в окрестных пустынях.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Ящери= -- холоднокровні лускаті мешканці теплих країв, від
+дрібних ящірок до великих варанів. Люблять сонце, ненавидять
+холод -- але це звичка, не вразливість.
+
+Кислоту й отрути луска терпить добре -- ящер сам не проти
+використати. Рани гояться на ходу, хвоста за потребою відрощують
+заново. Ховаються в траві і під каменями, бачать живе крізь
+укриття і в темряві. У бою швидкі, ухиляються і хльоскають хвостом.
+
+Найщільніше поголівʼя -- у {hh2077Вільній Гавані{x, де різні види
+ящерів складають значну частину фауни. Також водяться у
+{hh1838Новому Талосі{x і в околишніх пустелях.
+</text>
   </help>
   <nameFemale>рептилия</nameFemale>
   <nameMale>ящер</nameMale>

--- a/races/mammal.xml
+++ b/races/mammal.xml
@@ -6,7 +6,17 @@
     <keyword l="en"></keyword>
     <keyword l="ru">млекопитающее млекопитающие человекоподобный гуманоид</keyword>
     <keyword l="ua">ссавець ссавці людиноподібний гуманоїд</keyword>
-    <text l="en"></text>
+    <text l="en">=Mammals= -- a collective class of Theran creatures that
+includes all warm-blooded animals with hair or fur: wolves,
+bears, cats, deer, apes, and hundreds of their third cousins
+twice removed.
+
+The race is used mostly inside game mechanics -- so spells, traps,
+and skills targeting mammals work correctly. It also covers
+humanoid creatures lacking a more specific race; such ones in
+battle bash, disarm, fling dirt, run fast and dodge on the move,
+go berserk, and rescue their kin.
+</text>
     <text l="ru">=Млекопитающие= -- собирательный класс существ Тэры, к которому
 относятся все теплокровные звери с шерстью или мехом: волки, медведи,
 кошки, олени, обезьяны, и сотни их троюродных братьев, дядек и тёток.
@@ -17,7 +27,17 @@
 расы; такие в бою сбивают с ног, обезоруживают, бросаются грязью, быстры
 и уклоняются на ходу, впадают в ярость и спасают сородичей.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Ссавці= -- збиральний клас істот Тери, до якого належать
+усі теплокровні звірі з шерстю або хутром: вовки, ведмеді, коти,
+олені, мавпи, і сотні їхніх троюрідних братів, дядьків і тіток.
+
+Раса в основному застосовується всередині ігрової механіки --
+щоб закляття, пастки й уміння, що діють на ссавців, правильно
+спрацьовували. До неї відносяться також людиноподібні істоти без
+своєї точнішої раси; такі в бою збивають з ніг, обеззброюють,
+кидаються багном, швидкі й ухиляються на ходу, впадають у лють
+і рятують родичів.
+</text>
   </help>
   <nameFemale>человекоподобная</nameFemale>
   <nameMlt>человекоподобн|ые|ых|ым|ых|ыми|ых</nameMlt>

--- a/races/mermaid.xml
+++ b/races/mermaid.xml
@@ -8,7 +8,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">тритон русалка тритоны русалки</keyword>
     <keyword l="ua">тритон русалка тритони русалки</keyword>
-    <text l="en"></text>
+    <text l="en">=Mermaids and tritons= -- sapient water-dwellers with a human
+torso and a fish tail. They sing beautifully, swim gracefully,
+and often lead land-bound men into very wet situations.
+
+They swim by default and can't drown even if they tried. They
+see by infravision -- underwater that's more useful than it
+sounds. Fire and loud sound, though, are ruinous to them: flame
+dries the scales, and resonance deafens water-creatures as
+effectively as dynamite. In battle they bash, disarm, parry, lash
+with the tail, dodge, and rescue their own.
+
+The main habitat is the waters around {hh1429Arcadia{x and other
+coastal places. They often guard magical underwater treasures
+or simply distract poorly prepared sailors.
+</text>
     <text l="ru">=Русалки и тритоны= -- разумные водные жители с человеческим
 торсом и рыбьим хвостом. Поют красиво, плавают изящно, и часто
 заводят сухопутных мужиков в очень мокрые ситуации.
@@ -23,7 +37,21 @@
 прибрежных мест. Зачастую служат стражами магических подводных
 сокровищ или просто отвлекают плохо подготовленных моряков.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Русалки і тритони= -- розумні водні мешканці з людським
+торсом і рибʼячим хвостом. Співають гарно, плавають витончено,
+і часто заводять сухопутних мужиків у дуже мокрі ситуації.
+
+Плавають за визначенням, під водою не втонуть навіть якщо
+схочуть. Бачать у тепловому спектрі -- під водою це корисніше,
+ніж здається. Зате вогонь і гучний звук для них згубні: полумʼя
+сушить луску, а резонанс оглушує водних створінь не гірше від
+динаміту. У бою збивають з ніг, обеззброюють, парирують,
+хльоскають хвостом, ухиляються і рятують своїх.
+
+Головне місце мешкання -- води навколо {hh1429Аркадії{x та інших
+прибережних місць. Часто служать стражами магічних підводних
+скарбів або просто відволікають погано підготовлених моряків.
+</text>
   </help>
   <imm>drowning</imm>
   <nameFemale>русалка</nameFemale>

--- a/races/minotaur.xml
+++ b/races/minotaur.xml
@@ -6,7 +6,23 @@
     <keyword l="en"></keyword>
     <keyword l="ru">минотавр мужчина минотавр женщина минотавр минотавры</keyword>
     <keyword l="ua">мінотавр чоловік мінотавр жінка мінотавр мінотаври</keyword>
-    <text l="en"></text>
+    <text l="en">=Minotaurs= -- half-man, half-bull, with a heavy temper and
+an even heavier fist. Tall, muscular, horned, and dreadfully easy
+to offend.
+
+Strong beyond decency, the thick body absorbs crushing blows and
+breaks summons -- you don't pluck a minotaur out from under its
+guards just like that. Mental attacks, though, knock a minotaur
+out for a long while: their intellect is tactical, not strategic.
+
+In battle they bash, disarm, kick, fling dirt, parry, crush with
+mass, rescue their kin, and often fall into {hh829berserk rage{x.
+Surprisingly fast for their size.
+
+The main seat is {hh1841Mahn-Tor{x, a labyrinthine fortress in
+the southeast. Now and then minotaurs turn up in other dark
+dungeons too.
+</text>
     <text l="ru">=Минотавры= -- получеловек-полубык с тяжёлым нравом и ещё
 более тяжёлым кулаком. Высокие, мускулистые, рогатые, и страшно
 обидчивые.
@@ -24,7 +40,23 @@
 юго-востоке. Изредка минотавры встречаются и в других тёмных
 подземельях.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Мінотаври= -- напівлюдина-напівбик з важким норовом і ще
+більш важким кулаком. Високі, мускулясті, рогаті, і страшенно
+образливі.
+
+Сильні до непристойності, товсте тіло гасить дробильні удари й
+зриває призиви -- мінотавра з-під охорони просто так не висмикнеш.
+Зате ментальні атаки мінотавра вибивають надовго: інтелект у них
+тактичний, не стратегічний.
+
+У бою збивають з ніг, обеззброюють, хвицають, кидаються багном,
+парирують, трощать масою, рятують родичів, часто впадають у
+{hh829лють{x. Стрімкі для своїх розмірів.
+
+Головне обійстя -- {hh1841Махʼн-Тор{x, лабіринтна фортеця на
+південному сході. Зрідка мінотаври трапляються і в інших темних
+підземеллях.
+</text>
   </help>
   <nameFemale>женщина минотавр</nameFemale>
   <nameMlt>минотавр|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/modron.xml
+++ b/races/modron.xml
@@ -6,7 +6,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">модрон объект модроны</keyword>
     <keyword l="ua">модрон обʼєкт модрони</keyword>
-    <text l="en"></text>
+    <text l="en">=Modrons= -- geometrically correct beings from the plane of
+absolute mechanics. Spheres, cubes, pyramids with little legs and
+a single eye, and no concept of funny.
+
+Not subject to charm, mental attacks, or disease -- the mind isn't
+arranged on human lines. Dark and holy energy both pass them by:
+for geometry, good and evil do not exist. Fire, cold, and acid
+also slide off without much damage. In battle they aid their kin
+and their fellows from the plane, but solo they're slow.
+
+They appear now and then in {hh2084Nirvana{x and other places of
+warped reality. Arrived on business, left on business, no
+conversation managed.
+</text>
     <text l="ru">=Модроны= -- геометрически правильные существа из плана
 абсолютной механики. Сферы, кубы, пирамиды с лапками и единственным
 глазом, и без понятия о смешном.
@@ -20,7 +33,20 @@
 Изредка появляются в {hh2084Нирване{x и других местах с искажённой
 реальностью. Прибыли по делу, ушли по делу, поговорить не вышло.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Модрони= -- геометрично правильні істоти з плану абсолютної
+механіки. Сфери, куби, піраміди з лапками і єдиним оком, і без
+поняття про смішне.
+
+Не підвладні очаруванню, ментальним атакам і хворобам -- розум
+влаштований не по-людськи. Темна і свята енергія їх обходять
+стороною: для геометрії добра і зла не існує. Вогонь, холод і
+кислота теж ковзають без особливого збитку. У бою допомагають
+родичам і одноплановцям, але поодинці повільні.
+
+Зрідка зʼявляються в {hh2084Нірвані{x та інших місцях зі
+скривленою реальністю. Прибули у справі, пішли у справі,
+поговорити не вийшло.
+</text>
   </help>
   <imm>charm negative holy mental disease</imm>
   <nameFemale>объект</nameFemale>

--- a/races/ogre.xml
+++ b/races/ogre.xml
@@ -8,7 +8,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">огр мужчина огр женщина огр огры</keyword>
     <keyword l="ua">огр чоловік огр жінка огр огри</keyword>
-    <text l="en"></text>
+    <text l="en">=Ogres= -- big, dumb, brutish. That's all you need to know
+about them at first glance. At second glance -- that they're
+strong as well.
+
+Thick hide and a permanent layer of grime make an ogre nearly
+immune to disease. They see by infravision. In battle they bash,
+kick, parry with whatever's at hand, go berserk, and crush
+anything smaller. They walk slowly, and that's their main
+weakness -- a fast opponent simply outpaces them.
+
+Bands of ogres live near {hh1873Mount Doom{x, in {hh2075The
+Unholy Abbey{x, and similar foul places. Negotiating with one is
+usually impossible: either run, or fight.
+</text>
     <text l="ru">=Огры= -- большие, тупые, грубые. Это всё, что нужно про них
 знать в первом приближении. Во втором -- что они ещё и сильные.
 
@@ -22,7 +35,19 @@
 Монастыре{x и в подобных скверных местах. Договориться с ним обычно
 невозможно: либо беги, либо бей.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Огри= -- великі, тупі, грубі. Це все, що потрібно про них
+знати в першому наближенні. У другому -- що вони ще й сильні.
+
+Товста шкура й постійний бруд роблять огра майже непідвладним
+хворобам. Бачать у тепловому спектрі. У бою збивають з ніг,
+хвицають, парирують чим попало, впадають у лють і трощать усе,
+що менше. Ходять повільно, і в цьому їхня головна слабкість --
+швидкого супротивника просто не наздогнати.
+
+Зграї огрів водяться біля {hh1873Гори Смерті{x, у {hh2075Нечестивому
+Абатстві{x і в подібних мерзенних місцях. Домовитися з ним зазвичай
+неможливо: або біжи, або бий.
+</text>
   </help>
   <nameFemale>женщина огр</nameFemale>
   <nameMlt>огр|ы|ов|ам|ов|ами|ах</nameMlt>

--- a/races/oompa-loompa.xml
+++ b/races/oompa-loompa.xml
@@ -6,7 +6,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">умпа-лумпа умпа-лумпийка умпа-лумпы</keyword>
     <keyword l="ua">умпа-лумпа умпа-лумпійка умпа-лумпи</keyword>
-    <text l="en"></text>
+    <text l="en">=Oompa-Loompas= -- small, orange, green-haired workers of
+the chocolate industry. They sing at inopportune moments, work
+at opportune ones, and rarely leave their single place of
+employment.
+
+Furnace heat is nothing to an Oompa-Loompa -- fire is more cosy
+than dangerous. Cold, though, they cannot stand: in the northern
+regions they flatly refuse to work. In battle they don't desert
+each other, but as warriors they're so-so.
+
+All of them on Thera live in {hh1564Chocolate Factory{x under
+the management of their proprietor-confectioner. Tourists are
+permitted to observe, but chocolate to go -- only through the
+register.
+</text>
     <text l="ru">=Умпа-лумпы= -- мелкие, оранжевые, с зелёной шевелюрой
 работяги шоколадной индустрии. Поют в неподходящие моменты, работают
 в подходящие, и редко покидают своё единственное место занятости.
@@ -20,7 +34,20 @@
 руководством своего хозяина-кондитера. Туристам разрешено наблюдать,
 но шоколад на вынос -- только через кассу.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Умпа-лумпи= -- дрібні, помаранчеві, із зеленою шевелюрою
+працівники шоколадної індустрії. Співають у невідповідні моменти,
+працюють у відповідні, і рідко покидають єдине місце своєї
+зайнятості.
+
+Жара печей умпа-лумпам не страшна -- вогонь скоріше затишний,
+ніж небезпечний. Зате холоду вони не переносять: у північних
+областях працювати відмовляються наотріз. У бою один одного не
+кидають, але вояки з них так собі.
+
+Усі, скільки їх є в Тері, живуть на {hh1564Шоколадній Фабриці{x
+під керівництвом свого хазяїна-кондитера. Туристам дозволено
+спостерігати, але шоколад на винос -- лише через касу.
+</text>
   </help>
   <nameFemale>умпа-лумпийка</nameFemale>
   <nameMlt>умпа-лумп|ы||ам||ами|ах</nameMlt>

--- a/races/plant.xml
+++ b/races/plant.xml
@@ -6,7 +6,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">растение растения</keyword>
     <keyword l="ua">рослина рослини</keyword>
-    <text l="en"></text>
+    <text l="en">=Plants= -- the class of green, flowery, and prickly
+residents of Thera. Most just stand and quietly photosynthesise.
+Some walk, bite, occasionally sing, and that lot is usually best
+avoided.
+
+The woody and watery body is not subject to charm (you can't
+fool a plant), poison and disease don't take, drowning isn't an
+option, and wooden weapons can't pierce it -- it's made of the
+same. Fire, though, is an execution for a plant: burns bright
+and fast.
+
+Plants are often large and strong; they move slowly, but crush
+everything that lands under the vine.
+
+The wild botanical garden is {hh1842Emerald Forest{x and
+{hh2039Old Marsh{x, with the particularly lively varieties. In
+ordinary regions plants behave more decently.
+</text>
     <text l="ru">=Растения= -- класс зелёных, цветочных и колючих обитателей
 Тэры. Большинство стоит и тихо фотосинтезирует. Некоторые -- ходят,
 кусают, иногда поют, и обычно с этим классом лучше не сталкиваться.
@@ -23,7 +40,24 @@
 Топь{x, с особо живыми разновидностями. В обычных областях растения
 ведут себя приличнее.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Рослини= -- клас зелених, квіткових і колючих мешканців
+Тери. Більшість стоїть і тихо фотосинтезує. Деякі -- ходять,
+кусають, іноді співають, і з цим класом зазвичай краще не
+стикатися.
+
+Деревʼяне і водянисте тіло не підвладне очаруванню (рослину не
+обманеш), отрути й хвороби на ньому не приживаються, втонути воно
+теж не може, і деревʼяною зброєю його не пробити -- воно саме з
+цього матеріалу. Зате вогонь для рослини -- кара: горить яскраво
+і швидко.
+
+Розмірами рослини часто великі і сильні; рухаються повільно, зате
+трощать усе, що під лозою опиниться.
+
+Дикий ботанічний сад -- {hh1842Смарагдовий Ліс{x і {hh2039Старе
+Болото{x, з особливо живими різновидами. У звичайних областях
+рослини поводяться пристойніше.
+</text>
   </help>
   <imm>charm poison disease drowning wood</imm>
   <nameFemale>растение</nameFemale>

--- a/races/rat.xml
+++ b/races/rat.xml
@@ -8,7 +8,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">крыса крысы самец крысы самка крысы</keyword>
     <keyword l="ua">щур щурі самець щура самиця щура</keyword>
-    <text l="en"></text>
+    <text l="en">=Rats= can be found almost anywhere it's dark and smelly: in
+{hh1856Sewers{x, in {hh1854UnderDark{x, on dumps and in cellars.
+Small, fast, evasive. A single rat is no threat, but if a swarm
+shows up, even a seasoned fighter goes home without his trousers.
+
+They see by infravision and prowl silently. Immune to disease --
+many rats are the disease. Sensitive to mental influences and
+loud sound (nobody likes a screech). In battle they rely on
+speed, manoeuvrability, and tail strikes.
+
+A favourite prey of {hh166felars{x, whom the goddess Bast doesn't
+forbid to hunt rodents. To everyone else -- just food or a reason
+to feel queasy.
+</text>
     <text l="ru">=Крыс= можно встретить почти везде, где темно и пахнет: в
 {hh1856канализации{x, в {hh1854Подземье{x, на свалках и в подвалах.
 Мелкие, быстрые, увёртливые. Одна крыса -- не угроза, но если их
@@ -23,7 +36,20 @@
 ловить грызунов. Для всех остальных -- просто еда либо повод
 побрезговать.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Щурів= можна зустріти майже скрізь, де темно й пахне: у
+{hh1856Каналізації{x, в {hh1854Підземʼї{x, на смітниках і в
+підвалах. Дрібні, швидкі, спритні. Один щур -- не загроза, але
+якщо їх зграя, то навіть досвідчений боєць повертається додому
+без штанів.
+
+Бачать у тепловому спектрі і крадуться безшумно. Імунні до
+хвороб -- багато щурів самі і є хвороба. Чутливі до ментальних
+впливів і гучних звуків (ніхто не любить крик). У бою покладаються
+на швидкість, маневреність і удари хвостом.
+
+Улюблена здобич {hh166феларів{x, яким богиня Баст не забороняє
+ловити гризунів. Для всіх інших -- просто їжа або привід погидувати.
+</text>
   </help>
   <imm>disease</imm>
   <nameFemale>самка крысы</nameFemale>

--- a/races/rodent.xml
+++ b/races/rodent.xml
@@ -7,7 +7,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">грызун грызуны</keyword>
     <keyword l="ua">гризун гризуни</keyword>
-    <text l="en"></text>
+    <text l="en">=Rodents= -- a collective class of small critters with two
+large front teeth and a habit of gnawing anything not nailed down.
+Mice, squirrels, beavers, hamsters, and rats' cousins all fit here.
+
+Small, fast, breeding like from a bucket. They catch infection
+rarely -- evidently an evolutionary tip from the filthy burrows.
+They sense the hidden, but they don't take to a fight and at the
+first sign of danger they bolt. Main weapon -- speed of paw.
+
+The class works mostly mechanically -- for hunting skills of
+felars and similar predators.
+</text>
     <text l="ru">=Грызуны= -- собирательный класс мелких зверьков с двумя
 большими передними зубами и обыкновением грызть всё, что не
 приколочено. Сюда входят мыши, белки, бобры, хомяки и кузены крыс.
@@ -20,7 +31,18 @@
 Класс работает в основном механически -- для охотничьих умений
 феларов и подобных хищников.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Гризуни= -- збиральний клас дрібних звірят із двома великими
+передніми зубами і звичкою гризти усе, що не прибито цвяхами.
+Сюди входять миші, білки, бобри, хомʼяки і кузени щурів.
+
+Дрібні, швидкі, плодяться як із відра. Заразу підхоплюють рідко --
+безумовно підказка еволюції від брудних нір. Чують прихованих,
+але в бійку лізти не люблять і при першій небезпеці тікають.
+Головна зброя -- швидкість лап.
+
+Клас працює переважно механічно -- для мисливських умінь феларів
+і подібних хижаків.
+</text>
   </help>
   <imm>disease</imm>
   <nameFemale>самка грызуна</nameFemale>

--- a/races/school monster.xml
+++ b/races/school monster.xml
@@ -6,7 +6,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">гомункул гомункулы</keyword>
     <keyword l="ua">гомункул гомункули</keyword>
-    <text l="en"></text>
+    <text l="en">=Homunculi= -- small artificial creatures crafted by novice
+mages for practice. Part frog, part golem, part whatever was
+lying around at the time.
+
+Magic can't summon them -- they themselves are the result of
+magic and refuse to migrate between casters. Spells, though, run
+right through a homunculus: coarse magic isn't fit for fine work.
+
+They dwell in {hh1433MUD School{x, where they serve as practice
+targets for freshly minted heroes. Out in the wild they're nearly
+unheard of -- only the odd escapee.
+</text>
     <text l="ru">=Гомункулы= -- мелкие искусственные существа, созданные
 магами-новичками для тренировки. Часть от лягушки, часть от голема,
 часть от чего-то рядом лежавшего.
@@ -19,7 +30,18 @@
 мишенями для свежеиспечённых героев. На воле почти не встречаются --
 разве что случайно сбежавший.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Гомункули= -- дрібні штучні істоти, створені магами-новачками
+для тренування. Частина від жаби, частина від голема, частина
+від чогось, що поряд лежало.
+
+Магія їх не викликає -- самі вони результат магії і кочувати
+між заклинателями відмовляються. Зате закляття, навпаки, прошивають
+гомункула наскрізь: груба магія для тонкої роботи непридатна.
+
+Мешкають у {hh1433Школі Новачків{x, де служать навчальними
+мішенями для свіжоспечених героїв. На волі майже не зустрічаються --
+хіба що випадково втік.
+</text>
   </help>
   <imm>summon</imm>
   <nameFemale>гомункул</nameFemale>

--- a/races/snake.xml
+++ b/races/snake.xml
@@ -8,7 +8,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">змея змей змеи</keyword>
     <keyword l="ua">змія змій змії</keyword>
-    <text l="en"></text>
+    <text l="en">=Snakes= -- legless, scaled, and often venomous. They slither
+silently, strike unexpectedly, and as a rule don't take kindly
+to anyone stepping on their tail.
+
+Foreign poison and their own do no harm to a snake -- they bathe
+in it. Fire, though, warps the scales in an instant: a hot snake
+is a sick snake. In battle they're fast, dodge, and strike with
+the tail.
+
+Snake nests turn up in {hh1855Moria{x, in {hh1418Blight{x, in
+{hh1406Drow City{x, and other rocky shady places. Many kinds
+are venomous, some -- lethally.
+</text>
     <text l="ru">=Змеи= -- безногие, чешуйчатые, и часто ядовитые. Бесшумно
 ползут, неожиданно бьют, и в большинстве своём не любят, когда им
 наступают на хвост.
@@ -21,7 +33,18 @@
 {hh1406Городе Дроу{x и других каменистых сумрачных местах. Многие
 виды ядовиты, некоторые -- смертельно.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Змії= -- безногі, лускаті, і часто отруйні. Безшумно
+повзуть, несподівано бʼють, і в більшості своїй не люблять, коли
+їм наступають на хвоста.
+
+Чужа і власна отрута для змії не шкода -- самі в ній купаються.
+Зате вогонь луску коробить вмить: гаряча змія -- хвора змія. У
+бою швидкі, ухиляються і бʼють хвостом.
+
+Гнізда змій трапляються в {hh1855Морії{x, в {hh1418Запустінні{x,
+в {hh1406Місті Дроу{x і інших камʼянистих сутінкових місцях.
+Багато видів отруйні, деякі -- смертельно.
+</text>
   </help>
   <imm>poison</imm>
   <nameFemale>змея</nameFemale>

--- a/races/spider.xml
+++ b/races/spider.xml
@@ -7,7 +7,19 @@
     <keyword l="en"></keyword>
     <keyword l="ru">паук паучиха пауки</keyword>
     <keyword l="ua">павук павучиха павуки</keyword>
-    <text l="en"></text>
+    <text l="en">=Spiders= -- multi-legged, multi-eyed, and often venomous.
+They spin webs, bite, and at large size cause genuine panic in
+heroes.
+
+Foreign poison doesn't worry them: they're the specialists.
+They sense the living nearby. Fire, though, is an execution for
+a spider: webs burn well, the spider too. In battle they dodge
+well, but as a rule they're small.
+
+The main nest is {hh2051Arachnos{x, where the largest and most
+unpleasant ones live. They also occur in {hh1406Drow City{x and
+in {hh1862Haon Dor{x.
+</text>
     <text l="ru">=Пауки= -- многоногие, многоглазые, и часто ядовитые. Плетут
 паутину, кусают, и в больших размерах вызывают у героев искреннюю
 панику.
@@ -19,7 +31,19 @@
 Главное гнездилище -- {hh2051Арахнос{x, где живут самые крупные и
 неприятные. Также водятся в {hh1406Городе Дроу{x и в {hh1862Хаон Доре{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Павуки= -- багатоногі, багатоокі, і часто отруйні. Плетуть
+павутиння, кусають, і у великих розмірах викликають у героїв
+щиру паніку.
+
+Чужої отрути не бояться: самі з цього питання спеціалісти. Чують
+живе поблизу. Зате вогонь для павука -- кара: павутина горить
+добре, сам павук теж. У бою добре ухиляються, але в масі своїй
+дрібні.
+
+Головне гніздилище -- {hh2051Арахнос{x, де живуть найбільші й
+найнеприємніші. Також водяться у {hh1406Місті Дроу{x і в
+{hh1862Хаон Дорі{x.
+</text>
   </help>
   <hunts registry="race">insect</hunts>
   <imm>poison</imm>

--- a/races/undead.xml
+++ b/races/undead.xml
@@ -9,7 +9,23 @@
     <keyword l="en"></keyword>
     <keyword l="ru">нежить мертвяк нежити</keyword>
     <keyword l="ua">нежить мертв'як нежиті</keyword>
-    <text l="en"></text>
+    <text l="en">=Undead= -- the general class of unquiet dead: skeletons,
+zombies, vampires, liches, ghosts, and other violators of funeral
+rites. The common thread is that they're no longer alive but
+somehow still mobile.
+
+Dead flesh fears no poison or disease, drowning won't take
+either -- they're dead already. Dark energy fortifies them rather
+than harms. Holy power, silver, and bright light, though, cut
+undead like the living: for them it's a real weapon.
+
+They see by infravision, sense good, evil, the living, and other
+dead, wounds knit on the move. In battle they go berserk, parry,
+dodge, and move fast.
+
+The class is used mechanically -- for class abilities of paladins,
+clerics, and other respected exterminators.
+</text>
     <text l="ru">=Нежить= -- общий класс не упокоенных мёртвых: скелеты, зомби,
 вампиры, личи, призраки, и прочие нарушители правил похорон. Объединяет
 их то, что они уже не живые, но почему-то всё ещё мобильные.
@@ -26,7 +42,22 @@
 Класс используется механически -- для классовых способностей паладинов,
 жрецов, и других уважаемых истребителей.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Нежить= -- загальний клас не упокоєних мертвих: скелети,
+зомбі, вампіри, лічі, привиди, та інші порушники правил похорону.
+Обʼєднує їх те, що вони вже не живі, але чомусь усе ще рухливі.
+
+Мертвій плоті не страшні отрути й хвороби, потонути теж не
+вийде -- і так уже мертві. Темна енергія їх укріплює, а не шкодить.
+Зате свята сила, срібло і яскраве світло ріжуть нежить як живе:
+для них це справжня зброя.
+
+Бачать у тепловому спектрі, чують добро, зло, живе та інших
+мертвих, рани заростають на ходу. У бою впадають у лють, парирують,
+ухиляються і стрімкі.
+
+Клас використовується механічно -- для класових здібностей
+паладинів, жерців, та інших шанованих винищувачів.
+</text>
   </help>
   <imm>poison disease drowning</imm>
   <nameFemale>нежить</nameFemale>

--- a/races/unique.xml
+++ b/races/unique.xml
@@ -4,7 +4,16 @@
     <keyword l="en"></keyword>
     <keyword l="ru">уникальный уникальные</keyword>
     <keyword l="ua">унікальний унікальна унікальні</keyword>
-    <text l="en"></text>
+    <text l="en">=Uniques= -- special beings with no colleagues in their race.
+One of a kind, most often important to the storyline.
+
+Abilities -- whatever is written into the specific creature. The
+class is used mechanically, so mass-effect spells don't catch
+lore-valuable characters in the common net.
+
+They turn up in all sorts of places, from {hh2057Valhalla{x to
+{hh1854UnderDark{x. Each is its own thing.
+</text>
     <text l="ru">=Уникальные= -- особые существа, у которых нет коллег по
 расе. Один в своём роде, чаще всего сюжетно важный.
 
@@ -15,7 +24,16 @@
 Встречаются в самых разных местах, от {hh2057Вальгаллы{x до
 {hh1854Подземья{x. Каждый -- сам по себе.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Унікальні= -- особливі істоти, у яких немає колег по расі.
+Один у своєму роді, найчастіше сюжетно важливий.
+
+Здібності -- які прописані в конкретній істоті. Клас
+використовується механічно, щоб закляття масової дії не ловили
+лорно цінних персонажів у спільну сітку.
+
+Зустрічаються в найрізноманітніших місцях, від {hh2057Вальгалли{x
+до {hh1854Підземʼя{x. Кожен -- сам по собі.
+</text>
   </help>
   <nameFemale>уникальная</nameFemale>
   <nameMale>уникальный</nameMale>

--- a/races/water elemental.xml
+++ b/races/water elemental.xml
@@ -9,7 +9,23 @@
     <keyword l="en"></keyword>
     <keyword l="ru">водный элементаль водная элементаль</keyword>
     <keyword l="ua">водяний елементаль водяна елементаль</keyword>
-    <text l="en"></text>
+    <text l="en">=Water elementals= -- sapient blobs of water, animated by
+magic or broken loose on their own. They flow as they ought to
+flow, strike with a watery fist, and are hard to hug.
+
+Drowning isn't on the cards -- they are water themselves. Fire
+and ordinary weapons score poorly: flame is quenched, the blade
+cleaves the current. Cold, though, is ruinous: water freezes
+and the elemental turns into immobile ice.
+
+They swim by default, sense the hidden. In battle they strike
+with area waves, dodge, are quick, and crush with all the
+pressure.
+
+Natural habitat is {hh1867Elemental Canyon{x. They also turn up
+in large bodies of water and underground lakes. Unlike fish,
+these talk.
+</text>
     <text l="ru">=Водные элементали= -- разумные сгустки воды, оживлённые
 магией или сорвавшиеся с воли. Текут, как должны течь, бьют водяным
 кулаком, и обнять их сложно.
@@ -26,7 +42,22 @@
 крупных водоёмах и подземных озёрах. В отличие от рыб, эти
 разговаривают.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Водяні елементалі= -- розумні згустки води, оживлені магією
+або зірвані з волі. Течуть, як мають текти, бʼють водяним кулаком,
+і обійняти їх складно.
+
+Втонути їм не світить -- самі і є вода. Вогонь і звичайна зброя
+пробивають слабко: полумʼя гаситься, клинок розсікає течію. Зате
+холод для них згубний: вода застигає, і елементаль перетворюється
+в нерухомий лід.
+
+Плавають за визначенням, чують прихованих. У бою бʼють площадними
+хвилями, ухиляються, стрімкі і трощать усім напором.
+
+Природне середовище -- {hh1867Каньйон Стихій{x. Іноді зустрічаються
+в крупних водоймах і підземних озерах. На відміну від риб, ці
+розмовляють.
+</text>
   </help>
   <imm>drowning</imm>
   <nameFemale>водная элементаль</nameFemale>

--- a/races/wolf.xml
+++ b/races/wolf.xml
@@ -9,7 +9,20 @@
     <keyword l="en"></keyword>
     <keyword l="ru">волк волчица волки</keyword>
     <keyword l="ua">вовк вовчиця вовки</keyword>
-    <text l="en"></text>
+    <text l="en">=Wolves= -- forest hunters with army discipline and a permanent
+appetite. Grey, long-legged, with eyes that show you everything
+you ought not to have done.
+
+The thick fur holds the frost -- winter is only a plus. Wounds
+knit on the move, they sense prey by warmth from a kilometre off.
+Fire, though, devours the fur fast, and a burning wolf is a dead
+wolf. In battle, as a pack, they are merciless: they go berserk,
+dodge, chase at speed, and always rescue a packmate.
+
+Packs live in {hh1862Haon Dor{x, in {hh1442Mirkwood{x, and in
+{hh1855Moria{x. In winter they sometimes come close to villages --
+and then the village has to choose: the stores or the watchdog.
+</text>
     <text l="ru">=Волки= -- лесные охотники с дисциплиной армейской и аппетитом
 постоянным. Серые, длинноногие, с глазами, в которых видно всё, что
 тебе следовало не делать.
@@ -24,7 +37,20 @@
 {hh1855Мории{x. Зимой иногда подходят к деревням -- тогда деревне
 приходится решать: запасы или сторожевая собака.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Вовки= -- лісові мисливці з армійською дисципліною й
+постійним апетитом. Сірі, довгоногі, з очима, в яких видно все,
+чого тобі не варто було робити.
+
+Густе хутро тримає мороз -- взимку тільки в плюс. Рани заростають
+на ходу, здобич чують по теплу за кілометр. Зате вогонь шерсть
+пожирає швидко, і палаючий вовк -- мертвий вовк. У бою зграєю
+безжальні: впадають у лють, ухиляються, женуться стрімко і
+завжди виручають родича.
+
+Зграї водяться в {hh1862Хаон Дорі{x, у {hh1442Лихоліссі{x і в
+{hh1855Морії{x. Взимку іноді підходять до сіл -- тоді селу
+доводиться вирішувати: запаси або сторожовий пес.
+</text>
   </help>
   <nameFemale>волчица</nameFemale>
   <nameMlt>волк|и|ов|ам|ов|ами|ах</nameMlt>

--- a/races/worm.xml
+++ b/races/worm.xml
@@ -8,7 +8,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">червь черви</keyword>
     <keyword l="ua">черв'як черв'яки</keyword>
-    <text l="en"></text>
+    <text l="en">=Worms= -- legless, eyeless, and usually underground. From
+earthworms to huge cavern kind, capable of swallowing a horse
+without wincing.
+
+Underground, neither mental attack, nor bright light, nor loud
+sound is anything to a worm -- there are simply no sensors for
+them. Drowning isn't an option either: it's indifferent to water.
+Fire, though, dries it out in a minute, and acid eats through
+the boneless body faster than it can regenerate. In battle it
+strikes with body-and-tail, but moves slowly.
+
+Large worms live in {hh1854UnderDark{x, in {hh1841Mahn-Tor{x,
+and in the surrounding underground tunnels. Best not encountered
+without a tested rope and several companions.
+</text>
     <text l="ru">=Черви= -- безногие, безглазые, и обычно подземные. От
 дождевых до огромных пещерных, способных проглотить лошадь и не
 поморщиться.
@@ -23,7 +37,19 @@
 окрестных подземных туннелях. С ним лучше не сталкиваться без
 проверенной верёвки и нескольких товарищей.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Черви= -- безногі, безокі, і зазвичай підземні. Від дощових
+до величезних печерних, здатних проковтнути коня і не скривитися.
+
+Під землею ні ментальна атака, ні яскраве світло, ні гучний звук
+червʼякові не страшні -- сенсорів для них просто немає. Втонути
+теж не вийде: до води байдужий. Зате вогонь висушує за хвилину,
+а кислота розʼїдає безкісткове тіло швидше, ніж воно встигає
+регенерувати. У бою бʼє тілом-хвостом, але рухається повільно.
+
+Великі черви водяться в {hh1854Підземʼї{x, в {hh1841Махʼн-Торі{x
+і в околишніх підземних тунелях. З ним краще не стикатися без
+перевіреної мотузки і кількох товаришів.
+</text>
   </help>
   <imm>mental light sound</imm>
   <nameFemale>самк|а|и|е|у|ой|е червя</nameFemale>

--- a/races/wyvern.xml
+++ b/races/wyvern.xml
@@ -9,7 +9,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">виверн виверна виверны</keyword>
     <keyword l="ua">віверн віверна віверни</keyword>
-    <text l="en"></text>
+    <text l="en">=Wyverns= -- two-legged two-winged reptiles with a venomous
+tail, distant kin of dragons and meaner of temperament. Large,
+toothy, and unwelcoming.
+
+Their own and foreign poison does no harm to a wyvern -- they
+drip it from their sting themselves. Bright light, though, blinds
+their sensitive eyes in an instant: during a daylight raid a
+wyvern rapidly loses bearings. They see through invisibility
+and concealment, fly through the air and are fast. In battle
+they dodge and strike with the venomous tail.
+
+The main hunting ground is {hh1835Wyvern Tower{x in the southeast.
+Now and then they also turn up in {hh1441Midennir{x. Don't tangle
+with this fellow without a good group.
+</text>
     <text l="ru">=Виверны= -- двуногие двукрылые рептилии с ядовитым хвостом,
 дальние родственники драконов и более скверные характером. Большие,
 зубастые, и неприветливые.
@@ -24,7 +38,20 @@
 изредка попадаются в {hh1441Миденнире{x. С таким парнем без хорошей
 группы лучше не связываться.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Віверни= -- двоногі двокрилі рептилії з отруйним хвостом,
+дальні родичі драконів і гіршого характеру. Великі, зубаті, і
+непривітні.
+
+Власна й чужа отрута віверні не шкодить -- самі капають нею з
+жала. Зате яскраве світло чутливі очі сліпить вмить: під час
+денного нальоту віверна стрімко втрачає орієнтацію. Бачать крізь
+невидимість і приховання, в повітрі літають і швидкі. У бою
+ухиляються і бʼють отруйним хвостом.
+
+Головне місце полювання -- {hh1835Вивернова Башта{x на південному
+сході. Також зрідка трапляються в {hh1441Міденнірі{x. З таким
+хлопцем без гарної групи краще не звʼязуватися.
+</text>
   </help>
   <imm>poison</imm>
   <nameFemale>виверна</nameFemale>

--- a/races/zombie.xml
+++ b/races/zombie.xml
@@ -9,7 +9,26 @@
     <keyword l="en"></keyword>
     <keyword l="ru">зомби</keyword>
     <keyword l="ua">зомбі</keyword>
-    <text l="en"></text>
+    <text l="en">=Zombies= -- walking corpses under a grim necromancer's
+command or a curse. They shamble slowly, stink strongly, and in
+numbers can wear down even a seasoned hero.
+
+A dead body is not subject to poison, disease, or drowning --
+what's already rotting inside, you can't kill again. Charm doesn't
+work either, dark energy only feeds a zombie, cold and piercing
+weapons pass right through the decaying flesh. Fire, holy power,
+bright light, and silver, though, are an execution for a zombie:
+the body flares up or crumbles.
+
+They sense the living from afar. In battle they parry with
+whatever's at hand and crush by mass, but move slowly -- that's
+their main weakness.
+
+Main spawn points are {hh1446Old Midgaard{x, graveyards, and
+other places where a necro wanted some practice. Zombies in
+{hh2050Firetop Mountain{x are especially nasty, with baked-on
+bones.
+</text>
     <text l="ru">=Зомби= -- ходячие трупы под мрачной командой некроманта или
 порчей. Шевелятся медленно, воняют сильно, и численностью способны
 вынести даже опытного героя.
@@ -27,7 +46,23 @@
 прочие места, где некрос захотел практики. Зомби в {hh2050Огненной
 Горе{x -- особенно неприятные, с пропечёнными костями.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Зомбі= -- ходячі трупи під похмурою командою некроманта
+або порчею. Шевеляться повільно, смердять сильно, і кількістю
+здатні винести навіть досвідченого героя.
+
+Мертве тіло не підвладне отрутам, хворобам і утопленню -- що
+всередині гниє, того вже не вбити. Очарування на них теж не діє,
+темна енергія зомбі тільки підгодовує, холод і колюча зброя
+проходять повз розкладану плоть. Зате вогонь, свята сила, яскраве
+світло і срібло для зомбі -- кара: тіло спалахує або розсипається.
+
+Чують живе здалеку. У бою парирують чим попало і трощать масою,
+але рухаються повільно -- це їхня головна слабкість.
+
+Основні точки появи -- {hh1446Старий Мідгаард{x, цвинтарі та інші
+місця, де некрос захотів практики. Зомбі в {hh2050Вогняній Горі{x --
+особливо неприємні, з пропеченими кістками.
+</text>
   </help>
   <imm>poison disease drowning</imm>
   <nameFemale>зомби</nameFemale>


### PR DESCRIPTION
## Summary

Fills the previously empty `<text l=\"en\">` and `<text l=\"ua\">` blocks for all 52 NPC race XMLs. Each translation mirrors the RU body prop-for-prop (data-grounded, no invented imm/res/vuln) and keeps every `{hh}` anchor monolingual in its language.

## What changed

**EN bodies (52 races).** Use the target's `<name l=\"en\">` for area anchors (Dragon Spyre, UnderDark, Mahn-Tor, Goblin Stronghold, Mount Doom, Lake of Tears, etc.) and the EN keyword for help articles (felars, infravision, double-kick, Avenger, berserk rage). Voice is middle-ground -- preserves Dreamland's \"funny, dark, post-modernistic\" tone, idiomatic where the source has a punchline, otherwise literal.

**UA bodies (52 races).** Use the target's `<name l=\"ua\">` for area anchors (Пік Драконів, Підземʼя, Махʼн-Тор, Твердиня Гоблінів, Гора Смерті, Озеро Сліз, etc.) and the UA keyword for help articles (фелари, тепловий зір, лють, Месник). Slightly punchier than literal RU; modifier-letter apostrophe `ʼ` (U+02BC) used in word-internal positions (памʼять, бʼють, обʼєкт, Махʼн-Тор); no `э` per UA orthography; lore names per CLAUDE.md (Тера, Тіамат).

**Cloudy Mountain (vnum 2090) added to dragon and draconian** in all three languages (RU/EN/UA) -- both races have established presence there and the link was missing.

## Out of scope

- PC race bodies: unchanged. This PR is NPC-only per the prior convention.
- Empty `<keyword l=\"en\">` and `<extra l=\"en\">` fields in NPC races: left empty. Same scope as PR #121.
- Beholder/fire giant/frost giant: their RU bodies remain the legacy text from before PR #120; the EN and UA are now filled by straightforward translation, no rephrasing of the legacy content.

## Test plan

- [ ] After drone propagates: `help golem`, `help dragon`, `help lich` (each in EN, RU, UA via player locale) -- verify monolingual rendering.
- [ ] Click a few `{hh}` anchors per language to confirm targets resolve correctly (e.g. dragon EN → Dragon Spyre, Dragon Tower, Cloudy Mountain; dragon UA → Пік Драконів, Башта Драконів, Хмарна Гора).
- [ ] Spot-check kobold UA anchor `Таємне Сховище Чарівника` (locative) matches area's UA name.