### PR TITLE
map.xml: fix Jher/Ciquala atlas anchors (EN mislabel + UA untranslated)

### DIFF
--- a/commands/fenia/map.xml
+++ b/commands/fenia/map.xml
@@ -111,7 +111,7 @@ If you overcome the tricks and insidious shadow guardians of the Grove, you can 
 and {hh2063Dragon Tower{x({Y%A%{x).
 Through the underground passages in the forest, you can get to:
 {R%A%{x {hh1526Trillium Caverns{x and {hh1421Ciquala Lair{x
-{R%A%{x {hh1873Kurgan Mount Doom{x, {hh1874Lions Lair{x, and the eerie {hh1515Abyss{x.
+{R%A%{x {hh1873Kurgan Mount Doom{x, {hh1874Lair of Jher{x, and the eerie {hh1515Abyss{x.
 
 P.S. All major cities are surrounded by {hh50suburbs{x, where mansions of wealthy adventurers are built.
 Finally, it&apos;s worth remembering that some places in the world cannot be reached on foot and are not mentioned in the atlas... Safe travels!
@@ -337,8 +337,8 @@ P.S. Все крупные города окружены {hh50пригорода
 Якщо подолати підступи і хитрі тіньові варти, можливо досягти Башти Чаклунства,
 королівства {hh2066Галактики{x({Y%A%{x) і {hh2063Замка Драконів{x({Y%A%{x).
 Через підземні ходи у лісі можна потрапити в:
-{R%A%{x {hh1526Трельські Печери{x і {hh1421Убежище Сайкалы{x
-{R%A%{x {hh1873Гору Смерті{x, {hh1874Убежище Джеры{x і жахлива {hh1515Безодня{x.
+{R%A%{x {hh1526Трельські Печери{x і {hh1421Лігво Сайкуали{x
+{R%A%{x {hh1873Гору Смерті{x, {hh1874Лігво Джера{x і жахлива {hh1515Безодня{x.
 
 P.S. Усі крупні міста оточені {hh50передмістями{x, у яких будуються маєтки
 багатих пригодників. І, нарешті, варто пам&apos;ятати, що у деякі місця світу


### PR DESCRIPTION
Fixes flagged during the jher.are.xml translation, in the Haon-Dor-underground cluster of the textual atlas (help 224).

- **EN** (line 114): `{hh1874Lions Lair{x` was wrong -- help id 1874 is the **Lair of Jher**, not Lions Lair. The real Lions Lair (`lioncastle.are.xml`) is a Lion-Pride clan zone with its own help 5055 and is intentionally off the public map. -> `{hh1874Lair of Jher{x`.
- **UA** (lines 340-341): two anchors carried untranslated **RU** text -> `{hh1421Лігво Сайкуали{x` and `{hh1874Лігво Джера{x`.

XML well-formed. RU branch already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)