### PR TITLE
atlas: register the Eastern Road zone in the world map command

### DIFF
--- a/commands/fenia/map.xml
+++ b/commands/fenia/map.xml
@@ -60,8 +60,8 @@ From there, you can go to places like:
 {R%A%{x {hh1853Orodruin{x, {hh1429Arcadia{x, and {hh1431Drakyri Isle{x
 
 {CNORTH-EAST{x
-If you exit through the Eastern Gate and turn north from the Crossroads, you can 
-come to {hh1855Moria{x. From Moria, you can reach places such as:
+If you exit through the Eastern Gate, you come out onto the {hh5085Eastern Road{x. Turn
+north from its Crossroads to come to {hh1855Moria{x. From Moria, you can reach places such as:
 %A% {hh1414Kingdom of Mirrors{x, with an exit to {hh1534The Hut{x
 %A% {hh2060Dwarven Kingdom{x, with exits to {hh2061Dwarven Day Care{x and {hh2059Dwarven Catacombs{x
 {R%A%{x {hh2075The Unholy Abbey{x and {hh1418Blight{x
@@ -173,8 +173,8 @@ Finally, it&apos;s worth remembering that some places in the world cannot be rea
 {R%A%{x {hh1853Ородруин{x, {hh1429Аркадию{x и {hh1431Остров Дракири{x
 
 {CСЕВЕРО-ВОСТОК{x
-Если выйти через Восточные Ворота и повернуть на север от Перекрестка, можно
-прийти в {hh1855Морию{x. Из Мории можно попасть в такие места:
+Если выйти через Восточные Ворота, попадаешь на {hh5085Восточную Дорогу{x. Повернув
+на север от ее Перекрестка, можно прийти в {hh1855Морию{x. Из Мории можно попасть в такие места:
 %A% {hh1414Королевство Зеркал{x, с выходом в {hh1534Хижину{x
 %A% {hh2060Королевство Дварфов{x, с выходами в {hh2061Детский сад Дварфов{x и {hh2059Подземелья Дварфов{x
 {R%A%{x {hh2075Дьявольский Монастырь{x и {hh1418Запустение{x
@@ -287,8 +287,9 @@ P.S. Все крупные города окружены {hh50пригорода
 {R%A%{x {hh1853Ородруїн{x, {hh1429Аркадію{x і {hh1431Острів Дракири{x
 
 {CПІВНІЧНИЙ СХІД{x
-Якщо вийти через Східні Ворота і повернути на північ від Перехрестя, 
-можна потрапити в {hh1855Морію{x. З Мории можна потрапити в такі місця:
+Якщо вийти через Східні Ворота, потрапляєш на {hh5085Східну Дорогу{x. Повернувши
+на північ від її Перехрестя, можна потрапити в {hh1855Морію{x. З Морії можна
+потрапити в такі місця:
 %A% {hh1414Королівство Дзеркал{x, з виходом у {hh1534Хижку{x
 %A% {hh2060Королівство Дварфів{x, з виходами у {hh2061Дитячий сад Дварфів{x і {hh2059Підземелля Дварфів{x
 {R%A%{x {hh2075Диявольський Монастир{x і {hh1418Запустіння{x


### PR DESCRIPTION
Follow-up to the Midennir/Eastern Road split (dreamland_areas #311). Introduces the new {hh5085 Eastern Road zone by name in the Eastern Gate section of the `atlas` command (help 224), in EN/RU/UA, so the Crossroads/Eastern Road hub is clickable. Also corrects a stray RU `Мории` -> UA `Морії` in the touched Ukrainian line.

Drone-synced; takes effect on plugin reload (and the {hh5085 anchor resolves once easternroad.are boots).