### PR TITLE
Point Midgaard good/evil hometowns at Southern Midgaard temples

### DIFF
--- a/hometowns/midgaard_evil.xml
+++ b/hometowns/midgaard_evil.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Hometown type="DefaultHometown">
-  <altar>3072</altar>
+  <altar>16506</altar>
   <landing>3049</landing>
   <limits>
     <node allow="false">
@@ -15,6 +15,6 @@
     </node>
   </limits>
   <map>3164</map>
-  <pit>3072</pit>
-  <recall>3071</recall>
+  <pit>16506</pit>
+  <recall>16505</recall>
 </Hometown>

--- a/hometowns/midgaard_good.xml
+++ b/hometowns/midgaard_good.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Hometown type="DefaultHometown">
-  <altar>3070</altar>
+  <altar>16504</altar>
   <landing>3049</landing>
   <limits>
     <node allow="false">
@@ -10,6 +10,6 @@
     </node>
   </limits>
   <map>3164</map>
-  <pit>3070</pit>
-  <recall>3068</recall>
+  <pit>16504</pit>
+  <recall>16502</recall>
 </Hometown>


### PR DESCRIPTION
The Sun Temple (good) and Dark Temple (evil) recall/altar/pit rooms moved into the new Southern Midgaard zone (companion to dreamland_areas #323). Updates good (recall 16502, altar/pit 16504) and evil (recall 16505, altar/pit 16506) hometown vnums. Neutral (Leo Temple, 3001/3054) unchanged.