### PR TITLE
katana: route command through Fenia (DefaultSkillCommand)

### DIFF
--- a/generic-skills/katana.xml
+++ b/generic-skills/katana.xml
@@ -11,7 +11,7 @@
       <rating>1</rating>
     </node>
   </classes>
-  <command type="SKILL(katana)">
+  <command type="DefaultSkillCommand">
     <argtype>undef</argtype>
     <cat>class</cat>
     <hint l="en">Craft a katana from an iron ingot</hint>


### PR DESCRIPTION
Flip the katana skill command type to DefaultSkillCommand so it dispatches to skillcommand/katana/run instead of the C++ SKILL_RUNP. Part of the katana-as-craft migration (dreamland_fenia#62). Loaded on reboot.