### PR TITLE
katana: drop skill beat-lag (beats 24->0) so command redirects to craft

### DIFF
--- a/generic-skills/katana.xml
+++ b/generic-skills/katana.xml
@@ -3,7 +3,7 @@
   <affect type="DefaultAffectHandler">
     <removeCharSelf>Ты вновь можешь создать катану.</removeCharSelf>
   </affect>
-  <beats>24</beats>
+  <beats>0</beats>
   <classes>
     <node name="samurai">
       <level>72</level>


### PR DESCRIPTION
Follow-up to the quest 9501 katana craft-migration. The `katana` DefaultSkillCommand applied a 24-beat wait before `skillcommand/katana/run` redirects to `craft katana`; the craft gate (`checkActor`) rejects `wait > 0`, so a master-samurai could never forge via the `katana` shortcut — only `craft katana` worked. The ritual self-paces with per-stage sleeps, so the command needs no lag.

(Note: immortals still hit `wait=1` from `Character::setWait`'s immortal branch, so gods keep using `craft katana`; mortal samurai get a working `katana`.)