### PR TITLE
katana help: rewrite for the craft migration (EN/RU/UA)

### DIFF
--- a/generic-skills/katana.xml
+++ b/generic-skills/katana.xml
@@ -14,9 +14,9 @@
   <command type="DefaultSkillCommand">
     <argtype>undef</argtype>
     <cat>class</cat>
-    <hint l="en">Craft a katana from an iron ingot</hint>
-    <hint l="ru">(самураи) изготовить катану из бруска железа</hint>
-    <hint l="ua">(самураї) виготовити катану з бруска заліза</hint>
+    <hint l="en">Forge a katana from raw materials</hint>
+    <hint l="ru">(самураи) выковать катану из материалов</hint>
+    <hint l="ua">(самураї) викувати катану з матеріалів</hint>
     <name l="en">katana</name>
     <name l="ru">катана</name>
     <name l="ua">катана</name>
@@ -30,41 +30,39 @@ sword, =katana=. This sword is the soul of the samurai, his honor, which must
 not be tarnished. A samurai who loses his sword is doomed to eternal disgrace 
 before himself and other samurai.
 
-%FMT% *%CMD%* _ingot_
+%FMT% *%CMD%*
 
-Create a sword from an iron ingot. A suitable ingot can be found in the {hh2060Kingdom
-of Dwarves{x. After creating the katana, it must be improved through a special ritual
-at the {hh44guild master{x. Such a katana will enhance its parameters, hardening from battle
-to battle. Subsequently, the katana can be made {hh57personal property{x, again seeking 
-help from the guild master. Details can be read on the plaque in the Samurai Guild in {hh1392Midgaard{x.
+This craft is taught in no guild: a samurai must first earn its secret through
+an old rite of the masters in {hh1838New Thalos{x. Only then can he forge the blade
+with his own hands, from the proper materials at a burning forge. Such a katana
+belongs to its maker alone, and keeps its own edge -- sharpening itself, growing
+keener from battle to battle.
 </text>
     <text l="ru">Достигнувший определенного жизненного опыта самурай может выковать уникальный
 меч, =катану=. Этот меч -- душа самурая, его честь, которую ни в коем случае
 нельзя замарать. Потерявший свой меч самурай обречен на вечный позор перед 
 самим собой и другими самураями.
 
-%FMT% *%CMD%* _брусок_
+%FMT% *%CMD%*
 
-Создать меч из бруска железа. Подходящий брусок можно найти в {hh2060Королевстве
-Дварфов{x. После создания катаны, ее необходимо улучшить через специальный ритуал
-у {hh44гильдмастера{x. Такая катана будет улучшать свои параметры, закаляясь от битвы к
-битве. Впоследствии катану можно будет сделать своей {hh57личной собственностью{x, 
-снова обратившись за помощью к гильдмастеру. Подробности можно прочесть на
-табличке в помещении Гильдии Самураев в {hh1392Мидгаарде{x.
+Этому ремеслу не учат ни в одной гильдии: сперва самураю нужно постичь его тайну
+в древнем обряде мастеров {hh1838Нового Талоса{x. Лишь тогда он сможет выковать
+клинок собственными руками, из подходящих материалов у горящего горна. Такая
+катана принадлежит лишь своему создателю и сама держит остроту -- затачиваясь
+сама, становясь все острее от битвы к битве.
 </text>
     <text l="ua">Самурай, який досяг певного життєвого досвіду, може викувати унікальний
 меч, =катана=. Цей меч -- душа самурая, його честь, яку ні в якому разі
-не можна заплямувати. Самурай, який втратив свій меч, приречений на вічний ганьбу перед 
-собою і іншими самураями.
+не можна заплямувати. Самурай, який втратив свій меч, приречений на вічну ганьбу перед
+собою й іншими самураями.
 
-%FMT% *%CMD%* _брусок_
+%FMT% *%CMD%*
 
-Створити меч з бруска заліза. Підходящий брусок можна знайти в {hh2060Королівстві
-Дварфів{x. Після створення катани, її необхідно поліпшити шляхом спеціального ритуалу
-у {hh44гільдмайстра{x. Така катана буде поліпшувати свої параметри, гартуючись від битви до
-битви. Згодом катану можна буде зробити своєю {hh57особистою власністю{x, 
-знову звернувшись за допомогою до гільдмайстра. Подробиці можна прочитати на
-табличці в приміщенні Гільдії Самураїв в {hh1392Мідгаарді{x.
+Цьому ремеслу не вчать у жодній гільдії: спершу самураю треба осягнути його таємницю
+в давньому обряді майстрів {hh1838Нового Талоса{x. Лише тоді він зможе викувати
+клинок власними руками, з відповідних матеріалів біля палаючого горна. Така
+катана належить лише своєму творцеві й сама тримає гостроту -- загострюючись
+сама, стаючи все гострішою від битви до битви.
 </text>
   </help>
   <mana>300</mana>


### PR DESCRIPTION
Help id 628 + the command hints still described the retired katana flow (iron ingot + guild-master ritual + personal-property-via-guildmaster). Rewritten in all three languages to match the deployed craft mechanic: hints that a samurai must first earn the secret through the New Thalos rite, then forges the blade from materials at a lit forge; the katana is personal to its maker and self-sharpening. Lore intro kept (with a UA gender fix). No exact ingredient list -- kept as a hint per design.