### PR TITLE
katana help: de-wrap paragraphs (no hard line breaks)

### DIFF
--- a/generic-skills/katana.xml
+++ b/generic-skills/katana.xml
@@ -25,44 +25,23 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">weaponsmaster</group>
   <help id="628" level="-1" type="SkillHelp">
-    <text l="en">A samurai who has reached a certain level of life experience can forge a unique
-sword, =katana=. This sword is the soul of the samurai, his honor, which must
-not be tarnished. A samurai who loses his sword is doomed to eternal disgrace 
-before himself and other samurai.
+    <text l="en">A samurai who has reached a certain level of life experience can forge a unique sword, =katana=. This sword is the soul of the samurai, his honor, which must not be tarnished. A samurai who loses his sword is doomed to eternal disgrace before himself and other samurai.
 
 %FMT% *%CMD%*
 
-This craft is taught in no guild: a samurai must first earn its secret through
-an old rite of the masters in {hh1838New Thalos{x. Only then can he forge the blade
-with his own hands, from the proper materials at a burning forge. Such a katana
-belongs to its maker alone, and keeps its own edge -- sharpening itself, growing
-keener from battle to battle.
+This craft is taught in no guild: a samurai must first earn its secret through an old rite of the masters in {hh1838New Thalos{x. Only then can he forge the blade with his own hands, from the proper materials at a burning forge. Such a katana belongs to its maker alone, and keeps its own edge -- sharpening itself, growing keener from battle to battle.
 </text>
-    <text l="ru">Достигнувший определенного жизненного опыта самурай может выковать уникальный
-меч, =катану=. Этот меч -- душа самурая, его честь, которую ни в коем случае
-нельзя замарать. Потерявший свой меч самурай обречен на вечный позор перед 
-самим собой и другими самураями.
+    <text l="ru">Достигнувший определенного жизненного опыта самурай может выковать уникальный меч, =катану=. Этот меч -- душа самурая, его честь, которую ни в коем случае нельзя замарать. Потерявший свой меч самурай обречен на вечный позор перед самим собой и другими самураями.
 
 %FMT% *%CMD%*
 
-Этому ремеслу не учат ни в одной гильдии: сперва самураю нужно постичь его тайну
-в древнем обряде мастеров {hh1838Нового Талоса{x. Лишь тогда он сможет выковать
-клинок собственными руками, из подходящих материалов у горящего горна. Такая
-катана принадлежит лишь своему создателю и сама держит остроту -- затачиваясь
-сама, становясь все острее от битвы к битве.
+Этому ремеслу не учат ни в одной гильдии: сперва самураю нужно постичь его тайну в древнем обряде мастеров {hh1838Нового Талоса{x. Лишь тогда он сможет выковать клинок собственными руками, из подходящих материалов у горящего горна. Такая катана принадлежит лишь своему создателю и сама держит остроту -- затачиваясь сама, становясь все острее от битвы к битве.
 </text>
-    <text l="ua">Самурай, який досяг певного життєвого досвіду, може викувати унікальний
-меч, =катана=. Цей меч -- душа самурая, його честь, яку ні в якому разі
-не можна заплямувати. Самурай, який втратив свій меч, приречений на вічну ганьбу перед
-собою й іншими самураями.
+    <text l="ua">Самурай, який досяг певного життєвого досвіду, може викувати унікальний меч, =катана=. Цей меч -- душа самурая, його честь, яку ні в якому разі не можна заплямувати. Самурай, який втратив свій меч, приречений на вічну ганьбу перед собою й іншими самураями.
 
 %FMT% *%CMD%*
 
-Цьому ремеслу не вчать у жодній гільдії: спершу самураю треба осягнути його таємницю
-в давньому обряді майстрів {hh1838Нового Талоса{x. Лише тоді він зможе викувати
-клинок власними руками, з відповідних матеріалів біля палаючого горна. Така
-катана належить лише своєму творцеві й сама тримає гостроту -- загострюючись
-сама, стаючи все гострішою від битви до битви.
+Цьому ремеслу не вчать у жодній гільдії: спершу самураю треба осягнути його таємницю в давньому обряді майстрів {hh1838Нового Талоса{x. Лише тоді він зможе викувати клинок власними руками, з відповідних матеріалів біля палаючого горна. Така катана належить лише своєму творцеві й сама тримає гостроту -- загострюючись сама, стаючи все гострішою від битви до битви.
 </text>
   </help>
   <mana>300</mana>


### PR DESCRIPTION
Follow-up: the rewritten katana help still carried hard mid-paragraph line breaks. De-wrap each paragraph to a single line in EN/RU/UA (client handles wrapping), matching the zone-wide de-wrap standard.