### PR TITLE
Update vampire initiation help: say keyword, not bow

### DIFF
--- a/generic-skills/vampire.xml
+++ b/generic-skills/vampire.xml
@@ -31,11 +31,11 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">vampiric</group>
   <help id="836" labels="cmd skill" level="-1" type="SkillHelp">
-    <extra l="en">morph unmorph &apos;vampiric form&apos;</extra>
-    <extra l="ru">&apos;форма вампира&apos; инициация невампир &apos;ритуал инициации&apos; вампир</extra>
-    <extra l="ua">"форма вампіра" ініціація невампір "ритуал ініціації" вампір</extra>
+    <extra l="en">morph unmorph &apos;vampiric form&apos; initiation</extra>
+    <extra l="ru">&apos;форма вампира&apos; инициация посвящение невампир &apos;ритуал инициации&apos; вампир</extra>
+    <extra l="ua">"форма вампіра" ініціація посвячення невампір "ритуал ініціації" вампір</extra>
     <text l="en">Every young vampire must once undergo an initiation ritual with their Master
-{hh44Guild{x (you need to {hh1095bow{x to them and pay 50 {hh125quest points{x).
+{hh44Guild{x (you need to say 'initiation' to them and pay 50 {hh125quest points{x).
 
 %FMT% *vampire*
 
@@ -51,7 +51,7 @@ Revert to ordinary appearance. The form can be switched at will.
 
 %SA% %H% {hh769touch{x, {hh626bite{x, {hh697suck{x, {hh539bloodletting{x</text>
     <text l="ru">Каждый молодой вампир должен один раз пройти ритуал инициации у своего Мастера
-{hh44Гильдии{x (нужно ему {hh1095поклониться{x и заплатить 50 {hh125квестовых очков{x).
+{hh44Гильдии{x (нужно сказать ему 'посвящение' и заплатить 50 {hh125квестовых очков{x).
 
 %FMT% *вампир*
 
@@ -69,7 +69,7 @@ Revert to ordinary appearance. The form can be switched at will.
 %SA% %H% {hh769коснуться{x, {hh626кусать{x, {hh697сосать{x, {hh539кровопускание{x
 </text>
     <text l="ua">Кожен молодий вампір повинен один раз пройти ритуал ініціації у свого Майстра
-{hh44Гільдії{x (потрібно йому {hh1095вклонитися{x і заплатити 50 {hh125квестових балів{x).
+{hh44Гільдії{x (потрібно сказати йому 'посвячення' і заплатити 50 {hh125квестових балів{x).
 
 %FMT% *вампір*
 

--- a/professions/vampire.xml
+++ b/professions/vampire.xml
@@ -15,7 +15,7 @@ hybrid class, vampires command potent {hh237vampiric{x magic and deal terrible
 damage in melee when they take their {hh836bat form{x.
 
 Every young vampire must undergo a one-time initiation ritual with the Master
-of their {hh44Guild{x (bow to him and pay 50 {hh125quest points{x). On
+of their {hh44Guild{x (say 'initiation' to him and pay 50 {hh125quest points{x). On
 transformation, the vampire grows in size and might; his name is hidden and
 replaced with &quot;{DCreature of the Night{x&quot;, but he becomes vulnerable to
 daylight. Veteran vampires put their victims to sleep with a vampiric
@@ -30,7 +30,7 @@ themselves in graves to ambush foes with their {hh552bone daggers{x.
 ближнем бою в состоянии {hh836трансформации{x.
 
 Каждый молодой вампир должен один раз пройти ритуал инициации у своего Мастера
-{hh44Гильдии{x (нужно ему поклониться и заплатить 50 {hh125квестовых очков{x).
+{hh44Гильдии{x (нужно сказать ему 'посвящение' и заплатить 50 {hh125квестовых очков{x).
 При смене облика размер и мощь вампира увеличиваются, его имя становится скрытым
 и заменяется на &quot;{DСоздание Ночи{x&quot;, но он становится уязвим к воздействию дневного
 света. Опытные вампиры усыпляют жертв вампирским {hh769прикосновением{x и
@@ -45,7 +45,7 @@ themselves in graves to ambush foes with their {hh552bone daggers{x.
 бою в стані {hh836трансформації{x.
 
 Кожен молодий вампір повинен один раз пройти ритуал ініціації у свого Майстра
-{hh44Гільдії{x (треба йому поклонитися і заплатити 50 {hh125квестових очок{x).
+{hh44Гільдії{x (треба сказати йому 'посвячення' і заплатити 50 {hh125квестових очок{x).
 При зміні вигляду розмір і міць вампіра збільшуються, його ім'я стає прихованим
 і замінюється на &quot;{DСтворіння Ночі{x&quot;, але він стає вразливим до дії денного
 світла. Досвідчені вампіри присипляють жертв вампірським {hh769дотиком{x і завдають


### PR DESCRIPTION
Vampire initiation moved from the `bow` social to a spoken keyword to the guildmaster (Fenia `master vampire` behavior). Both helps updated in EN/RU/UA:
- ProfessionHelp 144 (`professions/vampire.xml`)
- SkillHelp 836 (`generic-skills/vampire.xml`)

'bow to him' -> 'say initiation / посвящение / посвячення to him', dropped the dead `{hh1095` bow link, added the keyword to the skill help search terms.