### PR TITLE
Track cityguard behavior definition (id 75)

### DIFF
--- a/behaviors/cityguard.xml
+++ b/behaviors/cityguard.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Городские стражники защищают жителей, карают преступников, помогают Правителям.</description>
+  <help id="354" level="-1" type="BehaviorHelp">
+  </help>
+  <id>75</id>
+  <nameRus>стражник</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>


### PR DESCRIPTION
The named **cityguard** behavior (created in-game via bedit) backs the cityguard spec->behavior migration but existed only as an untracked file on live. This commits the def so it is version-controlled alongside the other `behaviors/*.xml`. Content is byte-identical to the live file.

Note: its help (id 354) body is currently empty -- a follow-up can fill EN/RU/UA help text for the cityguard concept.