### PR TITLE
Fill cityguard behavior help (id 354) EN/RU/UA

### DIFF
--- a/behaviors/cityguard.xml
+++ b/behaviors/cityguard.xml
@@ -2,7 +2,16 @@
 <behavior type="DefaultBehavior">
   <cmd></cmd>
   <description>Городские стражники защищают жителей, карают преступников, помогают Правителям.</description>
-  <help id="354" level="-1" type="BehaviorHelp">
+  <help id="354" labels="cityguard" level="-1" type="BehaviorHelp">
+    <extra l="en">guard guards watch patrol whistle bribe order law</extra>
+    <extra l="ru">стража патруль свисток взятка подкуп порядок закон драка</extra>
+    <extra l="ua">варта патруль свисток хабар підкуп лад закон бійка</extra>
+    <keyword l="en">cityguard guards</keyword>
+    <keyword l="ru">стражник стража</keyword>
+    <keyword l="ua">стражник варта</keyword>
+    <text l="en">=City guards= keep order in the streets of Midgaard and other lawful towns. Catch yourself {hh686stealing{x within sight of one and you are set upon at once -- and a single guard's whistle brings every other guard within earshot at a run, so a crowded street is a poor place to practice light fingers. They also break up brawls, wading in with a truncheon until the fighting stops, and they stand by one another to the last. A guard sneers at a handful of coins -- offer too little and you may earn a clout for the insult -- but slip him a thousand silver or more and he will happily nod off and look the other way for a while.</text>
+    <text l="ru">=Городские стражники= следят за порядком на улицах Мидгаарда и других мирных городов. Стоит тебе попасться на {hh686воровстве{x у них на глазах -- и тебя тут же скрутят, а свист одного стражника сзывает бегом всех собратьев в пределах слышимости, так что людная улица -- не лучшее место для шаловливых пальцев. Еще они разнимают драки, орудуя дубинкой, пока потасовка не утихнет, и стоят друг за друга до последнего. На горстку монет стражник лишь фыркнет -- предложишь слишком мало, и можешь схлопотать за оскорбление, -- зато за тысячу серебряных и больше он с удовольствием задремлет и на время отвернется.</text>
+    <text l="ua">=Міські стражники= пильнують лад на вулицях Мідгаарда та інших мирних міст. Варто тобі попастися на {hh686крадіжці{x у них на очах -- і тебе вмить скрутять, а свист одного стражника бігцем скликає всіх побратимів у межах чутності, тож велелюдна вулиця -- кепське місце для пустотливих пальців. Ще вони розбороняють бійки, орудуючи кийком, доки колотнеча не вщухне, і стоять одне за одного до останнього. На жменю монет стражник лише пирхне -- запропонуєш замало, і можеш схопити за образу, -- зате за тисячу срібняків і більше він залюбки задрімає й на час відвернеться.</text>
   </help>
   <id>75</id>
   <nameRus>стражник</nameRus>


### PR DESCRIPTION
Fills the empty `BehaviorHelp` for the cityguard behavior (id 354, keyword `cityguard`/`стражник`). Three-language body documents: guards keep order in lawful towns, attack thieves caught using the {hh686 steal skill, break up brawls + whistle to summon fellow guards, assist one another, and can be bribed (>= 1000 silver -> the guard dozes off). No hard line breaks, ASCII punctuation, links the steal skill. Hot-reloadable via `plug reload most`.