### PR TITLE
Track behavior definitions for remort/game-NPC migrations

### DIFF
--- a/behaviors/babayaga.xml
+++ b/behaviors/babayaga.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Баба Яга выдает плату за прожитые жизни -- ремортные бонусы за очки жизни, с возможностью возврата.</description>
+  <help id="359" level="-1" type="BehaviorHelp">
+  </help>
+  <id>80</id>
+  <nameRus>Баба Яга</nameRus>
+  <props>null</props>
+  <target>mob</target>
+</behavior>

--- a/behaviors/koschei.xml
+++ b/behaviors/koschei.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Кощей Бессмертный выменивает постоянные ремортные бонусы на квестовые победы.</description>
+  <help id="358" level="-1" type="BehaviorHelp">
+  </help>
+  <id>79</id>
+  <nameRus>Кощей</nameRus>
+  <props>null</props>
+  <target>mob</target>
+</behavior>

--- a/behaviors/roulette croupier.xml
+++ b/behaviors/roulette croupier.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Крупье запускает рулетку, принимает ставки на разные исходы и выдает выигрыши.</description>
+  <help id="356" level="-1" type="BehaviorHelp">
+  </help>
+  <id>77</id>
+  <nameRus>крупье</nameRus>
+  <props>null</props>
+  <target>mob</target>
+</behavior>

--- a/behaviors/roulette table.xml
+++ b/behaviors/roulette table.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Игровой стол рулетки: крутит колесо, объявляет выпавшее число и разыгрывает ставки.</description>
+  <help id="357" level="-1" type="BehaviorHelp">
+  </help>
+  <id>78</id>
+  <nameRus>стол рулетки</nameRus>
+  <props>null</props>
+  <target>obj</target>
+</behavior>


### PR DESCRIPTION
The bedit-created behavior definitions for `koschei` (79), `babayaga` (80), `roulette croupier` (77) and `roulette table` (78) existed only as untracked files on live `runtime/share/DL/behaviors/` -- the hosting backflow never committed them. A fresh clone would lack them and the behaviors would be undefined at boot. This commits all four verbatim from live (ids/help-ids 356-359/targets), restoring repo<->live parity. The untracked live copies were removed first so drone's checkout recreates them tracked without conflict.