### PR TITLE
Fill EN help bodies for 11 skill/spell articles

### DIFF
--- a/commands/fenia/service.xml
+++ b/commands/fenia/service.xml
@@ -5,7 +5,17 @@
     <extra l="en">paid services</extra>
     <extra l="ru">платные услуги</extra>
     <extra l="ua">платні послуги</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%CMD%*
+%FMT% *%CMD%* *name*
+%FMT% *%CMD%* *name* _item_
+
+Many creatures in the world provide =paid services=.
+%A% {hh202Healers{x cure wounds, diseases and poisons
+%A% {hh273Smiths{x {hh273repair{x armor and weapons, and shoe {hh151centaurs{x
+%A% {hh274Enchanters{x cast useful enchantments on items and remove {hh2168corrosion{x
+%A% {hh276Sages{x {hh603identify{x and {hh707locate{x items across the world
+
+You can pay for services with money or quest points, depending on the service. Clan services and services for {hh2127newbies{x are discounted, while {hh192druids{x who hate {hh52Society{x pay double. Some services have a negotiable price that depends on your level, or on the level and condition of the item.</text>
     <text l="ru">%FMT% *%CMD%*
 %FMT% *%CMD%* *название*
 %FMT% *%CMD%* *название* _предмет_

--- a/craft-skills/remove tattoo.xml
+++ b/craft-skills/remove tattoo.xml
@@ -14,7 +14,11 @@
     <keyword l="en"></keyword>
     <keyword l="ru">детатуаж &apos;выведение татуировок&apos;</keyword>
     <keyword l="ua">детатуаж &apos;виведення татуювань&apos;</keyword>
-    <text l="en"></text>
+    <text l="en">This skill lets you remove a {hh242tattoo{x previously applied with special tools and ink. While this skill is unavailable, you can use a special salve sold by the tattoo master in the {hh1850Prairies{x. To use the salve, type {hc{yuse tattoo salve{x.
+
+Marks of {hh1religions{x cannot be removed this way -- for that service you must {hh11turn{x to the immortals.
+
+%SA% %H% {hh242tattooist{x</text>
     <text l="ru">Это умение позволяет вывести {hh242татуировку{x, предварительно нанесенную с помощью специальных инструментов и чернил. Пока это умение недоступно, можно использовать специальную мазь, которая продается у мастера татуировок в {hh1850Прериях{x. Чтобы использовать мазь, напиши {hc{yиспользовать мазь тату{x.
 
 Знаки {hh1религий{x таким образом не выводятся, за этой услугой нужно {hh11обратиться{x к бессмертным.

--- a/generic-skills/acid blast.xml
+++ b/generic-skills/acid blast.xml
@@ -19,7 +19,9 @@
     <extra l="en"></extra>
     <extra l="ru">&apos;кислотный удар&apos; &apos;сгусток кислоты&apos; &apos;удар кислоты&apos; &apos;взрыв кислоты&apos;</extra>
     <extra l="ua">&apos;кислотний удар&apos; &apos;згусток кислоти&apos; &apos;удар кислоти&apos; &apos;вибух кислоти&apos;</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+A magical spell that damages the victim with a glob of acid, scaling with the spell's level. If the victim makes its saving throw, the damage is halved.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Магическое заклинание, наносящее урон жертве сгустком кислоты в зависимости от уровня заклинания. Если у жертвы срабатывает спасбросок, урон уменьшается вдвое.

--- a/generic-skills/blindness.xml
+++ b/generic-skills/blindness.xml
@@ -45,7 +45,13 @@
     <keyword l="en"></keyword>
     <keyword l="ru">ослепить ослепление слепоту</keyword>
     <keyword l="ua">засліпити засліплення сліпоту</keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+The curse of blindness deprives you or your opponent of sight for a few minutes. Sight can be restored with the {hh573cure blindness{x spell.
+
+Blindness can also be caused by the effects of some other skills: for example, a throw of {hh783dirt{x, a {hh706dust cloud{x, the {hh96searing{x property of a weapon, and many others. Blindness from these skills cannot be cured -- it passes on its own.
+
+%SA% %H% {hh1361cast{x</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Проклятие слепоты лишит тебя или твоего противника зрения на несколько минут. Восстановить зрение можно с помощью заклинания {hh573лечить слепоту{x.

--- a/generic-skills/call lightning.xml
+++ b/generic-skills/call lightning.xml
@@ -29,7 +29,9 @@
     <extra l="en">lightning bolt &apos;call lightning&apos; summon &apos;summon lightning&apos;</extra>
     <extra l="ru">молнию молний &apos;призвать молнию&apos; вызвать &apos;вызвать молнию&apos;</extra>
     <extra l="ua">блискавку блискавок &apos;призвати блискавку&apos; виклик &apos;викликати блискавку&apos;</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%*
+
+This spell only works {hh86outdoors{x and only in bad weather, calling down a bolt of lightning that strikes everyone in the area. Be careful! And remember that the weather can be deliberately {hh643worsened{x.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание работает только {hh86вне помещений{x, и только при плохой погоде, вызывая разряд молнии, поражающий всех в данной местности. Осторожнее! Не забудь, что погоду можно предусмотрительно {hh643ухудшить{x.

--- a/generic-skills/charm person.xml
+++ b/generic-skills/charm person.xml
@@ -29,7 +29,33 @@
     <extra l="en"></extra>
     <extra l="ru">количество неотразимость очаровать зачармить чармисов чармить</extra>
     <extra l="ua">кількість нездоланність зачаровувати чармити чармисів чармити</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This spell makes the victim follow you and carry out your {hh1091orders{x. Its success depends on the {hh1359skill level{x, the victim's {hh2035saves vs spells{x, the level difference, intelligence and charisma. Some religions, artifacts or, say, {hh1084scents{x can boost the chance of success.
+
+You cannot charm undead, constructs and other bloodless and soulless creatures. Players are harder to charm than mobs. The charm is unstable and lasts a random number of hours depending on your level. To find out how long the charm will hold, order the charmed victim to show its affects: for example, {y{hcorder goblin affects{x.
+
+%A% The "charm" state applies to any mob following you and obeying your orders
+  (charmies), including {hh15pets{x, {hh545golems{x, summoned {hh63creatures{x and many
+  other cases -- all of them can be given orders.
+%A% Charmed followers will join the fight on your side when you attack someone
+  else. And vice versa: if someone attacks your charmies, you will stand up
+  for them, just as for other members of your {hh1378group{x.
+%A% If you attack your own charmie, the spell breaks and the creature joins the
+  fight against you.
+
+On success, use the {y{hcorder{x command to give all sorts of orders. For details on what orders you can give, see {y{hchelp order{x.
+
+{CHOW MANY CHARMIES YOU CAN HAVE{x
+The number of charmies depends, first of all, on your {hh28class{x:
+%A% Druids, necromancers, witches and warlocks can control {Cfour{x charmies
+%A% Rangers, anti-paladins and vampires -- {Cthree{x
+%A% All other classes -- {Ctwo{x
+%A% {hh2127Newbies{x get a {C+1 bonus{x
+%A% {hh38Intelligence{x or {hh40wisdom{x above {G25{x adds {Gone{x more charmie
+%A% {hh35Charisma{x below {r25{x removes {rone{x charmie, below {R18{x -- removes {Rtwo{x
+%A% The maximum number of charmies with high intelligence and a suitable class is 5
+{Ii Old rules -- visible to immortals only: Each point of {hh35charisma{hx below 25 removes one charmie. Every 4 points of {hh38intelligence{hx add one charmie. Every 30 levels of experience add one charmie. The maximum number of charmies at intelligence 28 at level 100 is 10. {Ix</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Это заклинание заставляет жертву следовать за тобой и исполнять твои {hh1091приказы{x. Успех его использования зависит от {hh1359прокачки{x умения, {hh2035защиты от заклинаний жертвы{x, разницы в уровнях, ума и обаяния. Шанс успеха могут усилить некоторые религии, артефакты или, скажем, {hh1084запахи{x.

--- a/generic-skills/heal.xml
+++ b/generic-skills/heal.xml
@@ -29,7 +29,12 @@
     <extra l="en">critical&apos; cure &apos;cure light&apos; &apos;cure serious&apos;</extra>
     <extra l="ru">&apos;лечить раны&apos; вылечить</extra>
     <extra l="ua">&apos;лікувати рани&apos; зцілити</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%*
+%FMT% *%SPELL%* _%CHAR%_
+
+The ability to heal wounds through prayer is available to many -- from priests to paladins. The number of hit points restored this way grows steadily with the healer's level, but the more powerful the prayer becomes, the more energy it costs.
+
+%SA% %H% {hh1361cast{x, {hh637superior heal{x</text>
     <text l="ru">%FMT% *%SPELL%* 
 %FMT% *%SPELL%* _%CHAR%_
 

--- a/generic-skills/magic jar.xml
+++ b/generic-skills/magic jar.xml
@@ -17,7 +17,11 @@
     <keyword l="en">jar soul</keyword>
     <keyword l="ru"></keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+With this spell a necromancer can trap the victim's soul -- the victim gains no experience and cannot {hh992leave the game{x. It only works on players within your {hh32PK range{x.
+
+Don't forget to carry an empty vessel (a test tube) to drive the soul into.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 С помощью этого заклинания некромант может поймать душу жертвы -- жертва не получает опыта и не может {hh992покинуть игру{x. Действует только на игроков в твоем {hh32ПК-диапазоне{x.

--- a/generic-skills/portal.xml
+++ b/generic-skills/portal.xml
@@ -29,7 +29,13 @@
     <extra l="en">stone warp</extra>
     <extra l="ru">искажающий камень</extra>
     <extra l="ua">перекручуючий камінь</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Creates a temporary portal (similar to the portal to Leo's Temple) to the victim's location. While the portal is open, anyone can step through it, including your {hh15charmies{x.
+
+In its limitations the portal spell is similar to the {hh803gate{x spell.
+
+To create a portal you need to find and clutch an extra component in your hand -- a =warp stone=. These stones are quite rare. By some accounts, warp stones have been seen at the Midgaard Cemetery, in the Sands of Sorrow and in New Thalos. You can find out whether a given object is a warp stone by {hh603identifying{x it.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Создает временный портал (похожий на портал в Храм Лео) к местоположению жертвы. Пока портал работает, в него смогут войти кто угодно, включая твоих {hh15чармисов{x.

--- a/generic-skills/shadowblade.xml
+++ b/generic-skills/shadowblade.xml
@@ -14,7 +14,15 @@
     <extra l="en">blade phantom &apos;recall shadowblade&apos; shadow</extra>
     <extra l="ru">&apos;фантомный клинок&apos; &apos;фантомный меч&apos; &apos;призрачный меч&apos; &apos;темный клинок&apos;</extra>
     <extra l="ua">&apos;фантомний клинок&apos; &apos;фантомний меч&apos; &apos;примарний меч&apos; &apos;темний клинок&apos;</extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%*
+
+For a while it summons a phantom blade, the very essence of an anti-paladin, a symbol of service to the Great Darkness. The blade can cast various {hh1117curses{x on enemies. To make the blade cast more often, it must be fed the souls of slain foes. Only good ones, and only of a level similar to yours or higher, will do.
+
+The blade's parameters depend on your level and on your =rank= in the secret hierarchy of the anti-paladins' {hh44guild{x. Gaining a rank, in turn, depends on the number of worthy opponents you have slain. To ask your guild master about ranks, {y{hcbow{x before him (or her).
+
+If the anti-paladin already knows how to use a second weapon, two such blades can be summoned; otherwise only one. The power of the blade's curses is also boosted by {hh708improved maledictions{x.
+
+If the blade somehow gets lost, just summon a new one by casting this spell again.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 На какое-то время призывает фантомный клинок, саму суть анти-паладина, символ служения Великой Тьме. Клинок умеет колдовать различные {hh1117проклятия{x на врагов. Чтобы клинок колдовал чаще, его нужно напоить душами сраженных противников. Подойдут только добрые и только схожего с тобой уровня или выше.

--- a/skill-groups/healing.xml
+++ b/skill-groups/healing.xml
@@ -6,7 +6,7 @@
     <extra l="en">healing 'disease healing' healing recovery 'cure health' prayers 'removal of debuffs' 'removal of curses'</extra>
     <extra l="ru">исцеление &apos;исцеление болезней&apos; исцеления излечение лечения &apos;лечить здоровье&apos; молитвы &apos;снятие дебаффов&apos; &apos;снятие проклятий&apos;</extra>
     <extra l="ua">зцілення &apos;зцілення хвороб&apos; зцілення лікування лікування &apos;лікувати здоров'я&apos; молитви &apos;зняття дебаффів&apos; &apos;зняття проклять&apos;</extra>
-    <text l="en"></text>
+    <text l="en">A variety of skills, spells and prayers that restore {hh58health{x and heal wounds, and also cure and remove certain {hh1117negative effects{x.</text>
     <text l="ru">Разнообразные умения, заклинания и молитвы, позволяющие восстанавливать {hh58здоровье{x и излечивать раны, а также исцелять и снимать некоторые {hh1117отрицательные воздействия{x.
 </text>
     <text l="ua">Різноманітні навички, заклинання і молитви, що дозволяють відновлювати {hh58здоров'я{x і загоювати рани, а також зцілювати і знімати деякі {hh1117негативні впливи{x.


### PR DESCRIPTION
Completes EN <text> for 11 help nodes that had RU+UA but empty EN. Translated from the two existing sources; id-stable {hh links, %FMT%/%A%/%SA% structure, =term=, ASCII punctuation, no hard breaks preserved. Part of the overnight help-corpus pass (translation, low-variance subset). armor use(906) deferred for a RU/UA clan-name decision.