### PR TITLE
Fill EN+UA for 125 skill/spell/command help bodies

### DIFF
--- a/behaviors/axe lumberjack.xml
+++ b/behaviors/axe lumberjack.xml
@@ -6,13 +6,21 @@
     <extra l="en">chopping woodchopping woodcutting</extra>
     <extra l="ru">бревно бревна дерево деревья лесорубка рубить срубить топоры дровосек</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *use* {Daxe{x
+%FMT% *use* {Daxe{x _%OBJ%_
+
+With a suitable two-handed axe you can chop down a tree in the {hh86forest{x, from which you can then start a {hh249campfire{x -- or perhaps craft a wooden golem Pinocchio or something more useful. Without special skills, logging takes a long time. A {hh170felled{x section of forest can no longer serve as {hh546cover{x for rangers. You can also use an axe to split a suitable wooden object on the ground -- including {hh191druid totems{x.
+</text>
     <text l="ru">%FMT% *использовать* {Dтопор{x
 %FMT% *использовать* {Dтопор{x _%OBJ%_
 
 Найдя подходящий двуручный топор, можно срубить в {hh86лесу{x дерево, из которого потом можно развести {hh249костер{x, а может даже смастерить деревянного голема Буратино или что-то более полезное. Без специальных навыков рубка леса занимает долгое время. {hh170Вырубленный{x участок леса больше не может служить {hh546укрытием{x для рейнджеров. Также топором можно разрубить подходящий деревянный объект на земле -- включая {hh191тотемы{x друидов.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% *використовати* {Dсокира{x
+%FMT% *використовати* {Dсокира{x _%OBJ%_
+
+Знайшовши підходящу дворучну сокиру, можна зрубати в {hh86лісі{x дерево, з якого потім можна розвести {hh249багаття{x, а може навіть змайструвати дерʼяного голема Буратіно або щось корисніше. Без спеціальних навичок рубка лісу займає довгий час. {hh170Вирубана{x ділянка лісу більше не може слугувати {hh546укриттям{x для рейнджерів. Також сокирою можна розрубати підходящий дерʼяний обʼєкт на землі -- включно з {hh191тотемами{x друїдів.
+</text>
   </help>
   <id>48</id>
   <nameRus>топор лесоруба</nameRus>

--- a/behaviors/blacksmith.xml
+++ b/behaviors/blacksmith.xml
@@ -9,7 +9,26 @@
     <keyword l="en">repair condition</keyword>
     <keyword l="ru">ремонтировать состояние</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">During battles your weapon and {hh1015equipment{x take damage. Their condition ({cdurability{x) is shown in square brackets after the item name -- for example, %PAUSE%[{Rawf.{x]%RESUME% means the item is in awful condition and will soon be destroyed entirely and disappear.
+
+To prevent that, you can repair damaged weapons or armor at =blacksmiths= throughout the world, especially in large cities, who can provide you with {hh275paid services{x for repairs.
+
+%FMT% *service* *repair* _item_
+%FMT% *service* *repair* _all_
+Blacksmiths repair armor and weapons -- all other item types can only be repaired by arcane blacksmiths. You can repair all damaged items at once. Before the repair the blacksmith will quote a price. If you are satisfied, confirm the service ({y{hcsay yes{x) or cancel.
+
+{CCANNOT BE REPAIRED:{x
+%A% items of {hh65types{x other than armor and weapons
+%A% items with zero value (masters cannot estimate the repair cost)
+%A% items pulled from {hh12the donation pit{x -- they automatically lose
+  their value as soon as they enter the pit
+
+Instead, you can try to {hh844fix{x them with magic, take them to a skilled {hh670warrior for repairs{x, or learn a special word in the {hh234ancient language{x of Khuzdul. Clothing and items made of cloth or leather can be {hh247sewn up{x with needle and thread. You can find these at a couple of tailors and seamstresses around the world.
+
+%FMT% *service* *horseshoes*
+%FMT% *service* *horseshoes* _item_
+Blacksmiths also fit {hh151centaurs{x with new iron horseshoes, with stats scaled to your level. You can bring your own horseshoes -- the blacksmith will nail them to your hooves, but the additional bonuses will be reduced. New horseshoes replace the old ones, which the blacksmith simply discards.
+</text>
     <text l="ru">Во время сражений твое оружие и {hh1015экипировка{x получают повреждения. Степень их пригодности ({cпрочность{x) указывается в квадратных скобках после названия вещи -- например, %PAUSE%[{Rуж.{x]%RESUME% значит, что вещь в ужасном состоянии и скоро окончательно разрушится и пропадет.
 
 Для того, чтобы этого не произошло, можно отремонтировать поврежденное оружие или броню у =кузнецов= по всему миру, особенно в крупных городах, которые смогут предоставить тебе {hh275платные услуги{x по ремонту.
@@ -30,7 +49,26 @@
 %FMT% *услуга* *подковы* _предмет_
 Кузнецы также снабжают {hh151кентавров{x новыми железными подковами с параметрами в зависимости от твоего уровня. Можно принести свои собственные подковы -- кузнец приколотит их к твоим копытам, но дополнительные бонусы будут снижены. Новые подковы ставятся вместо старых, которые кузнец просто выбрасывает.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Під час битв твоя зброя і {hh1015спорядження{x отримують пошкодження. Ступінь їхньої придатності ({cміцність{x) вказується у квадратних дужках після назви речі -- наприклад, %PAUSE%[{Rжах.{x]%RESUME% означає, що річ у жахливому стані і незабаром остаточно зруйнується і зникне.
+
+Щоб цього не сталося, можна відремонтувати пошкоджену зброю або броню у =ковалів= по всьому світу, особливо у великих містах, які зможуть надати тобі {hh275платні послуги{x з ремонту.
+
+%FMT% *послуга* *ремонт* _предмет_
+%FMT% *послуга* *ремонт* _все_
+Ремонтують броню і зброю -- всі інші типи речей можуть відремонтувати лише ковалі-чарівники. Можна відремонтувати одразу всі пошкоджені речі. Перед ремонтом коваль назве ціну. Якщо все влаштовує, треба підтвердити послугу ({y{hcсказати так{x) або скасувати.
+
+{CНЕМОЖНА РЕМОНТУВАТИ:{x
+%A% речі інших {hh65типів{x, крім броні та зброї
+%A% речі з нульовою вартістю (майстри не можуть оцінити вартість ремонту)
+%A% речі, витягнуті з {hh12ями для пожертвувань{x -- вони автоматично втрачають
+  вартість, як тільки потрапляють у яму
+
+Зате можна спробувати {hh844виправити{x магією, віддати на {hh670ремонт{x досвідченому воїну, або вивчити спеціальне слово на {hh234давній мові{x кхуздул. Одяг, а також речі з тканини або шкіри можна спробувати {hh247зашити{x голкою з ниткою. Знайти їх можна у кількох кравців і швачок по світу.
+
+%FMT% *послуга* *підкови*
+%FMT% *послуга* *підкови* _предмет_
+Ковалі також забезпечують {hh151кентаврів{x новими залізними підковами з параметрами залежно від твого рівня. Можна принести власні підкови -- коваль прибʼє їх до твоїх копит, але додаткові бонуси будуть знижені. Нові підкови ставляться замість старих, які коваль просто викидає.
+</text>
     <title l="en"></title>
     <title l="ru">{CПлатные услуги: {xкузнецы, починка, прочность, подковы</title>
     <title l="ua"></title>

--- a/behaviors/bottle.xml
+++ b/behaviors/bottle.xml
@@ -7,7 +7,14 @@
     <keyword l="en"></keyword>
     <keyword l="ru">бутылочка</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x _%OBJ%_ _%VICT%_
+
+In combat you can smash a bottle or other suitable vessel over a foe's head, producing an effect similar to {hh700a knock on the noggin{x. You need to hold the bottle in your hands for this.
+
+%FMT% {yuse{x _%OBJ%_
+
+In peacetime a bottle tossed on the floor can be spun to play &quot;spin the bottle&quot; with the charming creatures around you. Before {hh1687kissing{x anyone, don't forget to ask everyone for {hh68consent{x first!
+</text>
     <text l="ru">%FMT% {yиспользовать{x _%OBJ%_ _%VICT%_
 
 В бою бутылки или другие подходящие сосуды можно разбить об голову противника, получив эффект, похожий на {hh700заход в бубен{x. Бутылку для этого нужно брать в руки.
@@ -16,7 +23,14 @@
 
 В мирное время брошенную на пол бутылку можно раскрутить, чтобы поиграть в &quot;бутылочку&quot; с симпатичными существами вокруг. Перед тем как {hh1687целовать{x, не забудь сначала попросить всех о {hh68согласии{x на это!
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x _%OBJ%_ _%VICT%_
+
+У бою пляшку або інший підходящий посуд можна розбити об голову противника, отримавши ефект, схожий на {hh700удар по бубону{x. Пляшку для цього треба брати в руки.
+
+%FMT% {yвикористати{x _%OBJ%_
+
+У мирний час кинуту на підлогу пляшку можна розкрутити, щоб пограти у &quot;пляшечку&quot; з симпатичними істотами навколо. Перш ніж {hh1687цілувати{x, не забудь спочатку попросити всіх про {hh68згоду{x на це!
+</text>
   </help>
   <id>11</id>
   <nameRus>бутылк|а|и|е|у|ой|е</nameRus>

--- a/behaviors/caltraps.xml
+++ b/behaviors/caltraps.xml
@@ -9,12 +9,18 @@
     <keyword l="en">shards fractions</keyword>
     <keyword l="ru"></keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">If you {hh1024smash{x something fragile, shards may appear, made from the same {hh201material{x as the original item. 
+
+Ninja can {hh562throw{x sharp shards or spikes under their enemies' feet.
+</text>
     <text l="ru">Если {hh1024разбить{x что-то хрупкое, могут возникнуть осколки, сделанные из того же {hh201материала{x, что и исходный предмет. 
 
 Ниндзя умеют {hh562бросать{x острые осколки или шипы под ноги противникам.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Якщо {hh1024розбити{x щось крихке, можуть зʼявитися осколки, виготовлені з того самого {hh201матеріалу{x, що й вихідний предмет. 
+
+Ніндзя вміють {hh562кидати{x гострі осколки або шипи під ноги противникам.
+</text>
   </help>
   <id>39</id>
   <nameRus>осколки</nameRus>

--- a/behaviors/cauldron.xml
+++ b/behaviors/cauldron.xml
@@ -6,14 +6,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">котел</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Devices that let witches and sorcerers of the {hh1479Order of Shalafi{x {hh93brew potions{x.
+
+%FMT% *use* _%OBJ%_
+
+Put the required components into the cauldron and use it -- then simply wait.
+</text>
     <text l="ru">Приспособления, позволяющие ведьмам и колдунам {hh1479Ордена Шалафи{x {hh93варить зелья{x.
 
 %FMT% *использовать* _%OBJ%_
 
 Положи в котел нужные компоненты и используй -- а затем просто подожди.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Пристосування, що дозволяють відьмам і чарівникам {hh1479Ордену Шалафі{x {hh93варити зілля{x.
+
+%FMT% *використовати* _%OBJ%_
+
+Клади в казан потрібні компоненти і використовуй -- а потім просто чекай.
+</text>
   </help>
   <id>57</id>
   <nameRus>котел для зельеварения</nameRus>

--- a/behaviors/coin.xml
+++ b/behaviors/coin.xml
@@ -6,14 +6,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">орел орлянка решка</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yflip{x _%OBJ%_
+
+Suitable coins can be {hh1024flipped{x on the floor to play heads-or-tails with someone.
+
+%SA% %H% {hh13money{x
+</text>
     <text l="ru">%FMT% {yбросить{x _%OBJ%_
 
 Подходящие монеты можно {hh1024бросить{x на пол, чтобы сыграть в орлянку с кем-нибудь.
 
 %SA% %H% {hh13деньги{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yкинути{x _%OBJ%_
+
+Підходящі монети можна {hh1024кинути{x на підлогу, щоб зіграти в орлянку з кимось.
+
+%SA% %H% {hh13гроші{x
+</text>
   </help>
   <id>15</id>
   <nameRus>монет|а|ы|е|у|ой|е</nameRus>

--- a/behaviors/conflagration.xml
+++ b/behaviors/conflagration.xml
@@ -6,7 +6,14 @@
     <extra l="en">heat fire</extra>
     <extra l="ru"></extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">If a {hh249campfire{x in an area is stoked too high, or if certain powerful fire spells are used, a =conflagration= may break out.
+
+A conflagration continuously deals damage to everyone in the area who lacks {hh633heat protection{x, blinds them, and also {hh249burns{x or {hh4scorches{x their items and items nearby. You can get rid of the smoke in your eyes with {hh296washing{x.
+
+Particularly fierce fires can spread to neighbouring areas -- be careful! A fire can be put out by {hh177flooding{x, heavy {hh1028rain{x, certain ice spells, or a large amount of {hh1075water poured out{x.
+
+Some areas in the world burn permanently.
+</text>
     <text l="ru">Если на местности развести {hh249костер{x слишком сильно или использовать некоторые мощные огненные заклинания -- может начаться =пожар=.
 
 Пожар непрерывно наносит повреждения всем, кто находится на местности без {hh633защиты от тепла{x, ослепляет, а также {hh249сжигает{x или {hh4раскаляет{x их предметы и предметы вокруг. Избавиться от дыма в глазах можно при помощи {hh296умывания{x.
@@ -15,7 +22,14 @@
 
 Некоторые местности в мире перманентно пылают.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Якщо на місцевості розвести {hh249вогнище{x задто сильно або використати деякі потужні вогняні заклинання -- може початися =пожежа=.
+
+Пожежа безперервно завдає шкоди всім, хто перебуває на місцевості без {hh633захисту від тепла{x, осліплює, а також {hh249спалює{x або {hh4розжарює{x їхні предмети та предмети довкола. Позбутися диму в очах можна за допомогою {hh296вмивання{x.
+
+Особливо сильні пожежі можуть поширюватися в сусідні місцевості -- обережніше! Пожежа може згаснути від {hh177затоплення{x, сильного {hh1028дощу{x, деяких крижаних заклинань, а також від великої кількості {hh1075вилитої води{x.
+
+Деякі місцевості у світі горять постійно.
+</text>
     <title l="en"></title>
     <title l="ru">Местность: пожарище</title>
     <title l="ua"></title>

--- a/behaviors/dice.xml
+++ b/behaviors/dice.xml
@@ -6,7 +6,14 @@
     <keyword l="en"></keyword>
     <keyword l="ru">кубики</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yroll{x _%OBJ%_
+
+Dice can be {hh1024rolled{x on the floor to play a game of bones with someone. Different dice sets differ in the total number of dice per roll and the number of sides on each die.
+
+Incidentally, this is exactly how {hh122weapon{x damage is determined. For example, if a sword lists damage as 20d6, it means 20 six-sided dice are rolled to calculate the damage.
+
+%SA% %H% {hh1839casino{x
+</text>
     <text l="ru">%FMT% {yбросить{x _%OBJ%_
 
 Игральные кубики можно {hh1024бросить{x на пол, чтобы сыграть в кости с кем-нибудь. Разные кубики отличаются общим количеством кубиков за бросок и количеством сторон у каждого кубика.
@@ -15,7 +22,14 @@
 
 %SA% %H% {hh1839казино{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yкинути{x _%OBJ%_
+
+Гральні кубики можна {hh1024кинути{x на підлогу, щоб зіграти в кості з кимось. Різні кубики відрізняються загальною кількістю кубиків за кидок і кількістю граней у кожного.
+
+До речі, саме так визначається шкода від {hh122зброї{x. Наприклад, якщо у меча вказана шкода 20d6, це означає, що для обчислення шкоди кидають 20 кубиків, кожен з яких має 6 граней.
+
+%SA% %H% {hh1839казино{x
+</text>
   </help>
   <id>16</id>
   <nameRus>игральны|е|х|м|е|ми|х кост|и|ей|ям|и|ями|ях</nameRus>

--- a/behaviors/enchanter.xml
+++ b/behaviors/enchanter.xml
@@ -9,7 +9,16 @@
     <keyword l="en"></keyword>
     <keyword l="ru">чародей</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">=Enchanters= -- wizards versed in item magic -- offer {hh275paid services{x for enchanting gear.
+
+%FMT% *service* *name* _item_
+{C%A% {yCorrection: {xthe {hh844correction{x spell, removes corrosion
+{C%A% {yFireproofing: {xthe {hh867fireproofing{x spell, applied for a couple of weeks
+{C%A% {yHeat resistance: {xthe {hh633heat protection{x spell, applied for a couple of weeks
+{C%A% {yRecharge: {xthe {hh600recharge{x spell, including on fully drained items
+
+Enchanters who also offer smithing services can repair any items, not just armor and weapons.
+</text>
     <text l="ru">=Чародеи= -- волшебники, искушенные в предметной магии, предоставляют {hh275платные услуги{x по зачарованию вещей.
 
 %FMT% *услуга* *название* _предмет_
@@ -20,7 +29,16 @@
 
 Чародеи, которые в том числе предоставляют кузнечные услуги, могут починить любые предметы, а не только броню и оружие.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Чарівники= -- чаклуни, що розуміються на предметній магії, -- надають {hh275платні послуги{x із зачарування речей.
+
+%FMT% *послуга* *назва* _предмет_
+{C%A% {yВиправлення: {xзаклинання {hh844виправлення{x, прибирає корозію
+{C%A% {yВогнетривкість: {xзаклинання {hh867вогнетривкості{x, вішають на пару тижнів
+{C%A% {yТермостійкість: {xзаклинання {hh633захисту від тепла{x, вішають на пару тижнів
+{C%A% {yПерезарядка: {xзаклинання {hh600перезарядки{x, в тому числі на повністю розряджені
+
+Чарівники, які також надають ковальські послуги, можуть полагодити будь-які предмети, а не лише броню та зброю.
+</text>
     <title l="en"></title>
     <title l="ru">{CПлатные услуги: {xчародеи</title>
     <title l="ua"></title>

--- a/behaviors/feather.xml
+++ b/behaviors/feather.xml
@@ -6,13 +6,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">перо перышко пощекотать щекотать</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x _%OBJ%_
+%FMT% {yuse{x _%OBJ%_ _%CHAR%_
+
+You can tickle someone with the feather. Hee-hee!
+</text>
     <text l="ru">%FMT% {yиспользовать{x _%OBJ%_
 %FMT% {yиспользовать{x _%OBJ%_ _%CHAR%_
 
 Перышком можно кого-нибудь пощекотать. Хи-хи!
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x _%OBJ%_
+%FMT% {yвикористати{x _%OBJ%_ _%CHAR%_
+
+Пірʼячком можна когось полоскотати. Хі-хі!
+</text>
   </help>
   <id>21</id>
   <nameRus>перышк|о|а|у|о|ом|е</nameRus>

--- a/behaviors/fire.xml
+++ b/behaviors/fire.xml
@@ -9,7 +9,14 @@
     <keyword l="en"></keyword>
     <keyword l="ru">костёр костер огонь</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">With something flammable in hand and a source of fire -- a {hh240torch{x, {hh214matches{x, or one of the fire spells -- you can start a campfire. By a fire you recover your strength faster and your wounds {hh2130heal{x more quickly. A fire can also warm you if you are suffering from frostbite or {hh610ice touch{x.
+
+You can keep a fire going by {hh1024feeding{x it flammable objects or by setting other objects on the ground alight. Many things can be burned -- for example, {hh1024containers{x, {hh282logs{x, corpses, vessels holding flammable liquids, and much more -- even your own mortal {hh12body{x! Different objects will burn, melt, or {hh4become red-hot{x depending on their {hh201material{x. A fire stoked too high can turn into a {hh281wildfire{x -- careful!
+
+{hh140Rangers{x start fires automatically when making camp with {hh825field camp{x. Samurai need fire for {hh598tempering blades{x, warriors for {hh670repairs{x, and witches for {hh93brewing potions{x.
+
+A fire can be put out by {hh177flooding{x, heavy {hh1028rain{x, certain ice spells, or a large quantity of {hh1075poured water{x.
+</text>
     <text l="ru">Раздобыв что-нибудь горючее, а также источник огня -- {hh240факел{x, {hh214спички{x или одно из огненных заклинаний -- можно развести костер. У костра лучше восстанавливаются силы и быстрее {hh2130заживают{x раны. А еще у костра можно согреться от обморожения или {hh610ледяного касания{x. 
 
 Костер можно поддерживать просто {hh1024подкладывая{x в него горючие предметы или поджигая другие предметы на земле. Сжечь можно много чего -- например, {hh1024контейнеры{x, {hh282бревна{x, трупы, емкости для горючих жидкостей и многое другое -- даже свою собственную бренную {hh12тушку{x! Разные предметы будут гореть, расплавляться или {hh4раскаляться{x в зависимости от своего {hh201материала{x. Слишком сильно раскочегаренный костер может превратиться в {hh281пожар{x, осторожнее!
@@ -18,7 +25,14 @@
 
 Костер может потухнуть от {hh177затопления{x, сильного {hh1028дождя{x, некоторых ледяных заклинаний, а также от большого количества {hh1075вылитой воды{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Роздобувши щось горюче, а також джерело вогню -- {hh240факел{x, {hh214сірники{x або одне з вогняних заклинань -- можна розвести багаття. Біля багаття краще відновлюються сили і швидше {hh2130гояться{x рани. А ще біля багаття можна зігрітися від обмороження або {hh610льодяного дотику{x.
+
+Багаття можна підтримувати, просто {hh1024підкидаючи{x в нього горючі предмети або підпалюючи інші предмети на землі. Спалити можна багато чого -- наприклад, {hh1024контейнери{x, {hh282колоди{x, трупи, ємності для горючих рідин і багато іншого -- навіть власну бренну {hh12тушку{x! Різні предмети горітимуть, плавитимуться або {hh4розжарюватимуться{x залежно від свого {hh201матеріалу{x. Надто розпалене багаття може перетворитися на {hh281пожежу{x, обережно!
+
+{hh140Рейнджери{x розводять багаття одразу при розбивці польового {hh825табору{x. Самураям багаття стане в пригоді для {hh598загартування мечів{x, воїнам -- для {hh670ремонту{x, а відьмам -- для {hh93варіння зілля{x.
+
+Багаття може згаснути від {hh177затоплення{x, сильного {hh1028дощу{x, деяких крижаних заклинань, а також від великої кількості {hh1075вилитої води{x.
+</text>
   </help>
   <id>22</id>
   <nameRus>пламя</nameRus>

--- a/behaviors/hammer.xml
+++ b/behaviors/hammer.xml
@@ -3,12 +3,18 @@
   <cmd></cmd>
   <description>Кузнечные молоты используются для починки доспехов и оружия.</description>
   <help id="232" level="-1" type="BehaviorHelp">
-    <text l="en"></text>
+    <text l="en">Warriors and samurai use smithing hammers to {hh670repair{x armor and weapons. The hammer cannot be used directly -- simply hold it in your hands before using the repair skill.
+
+The simplest hammer can be found at a merchant in the {hh2060Dwarf Kingdom{x. Higher-quality hammers allow you to restore items better and faster.
+</text>
     <text l="ru">Воины и самураи используют кузнечные молоты используются для {hh670починки{x доспехов и оружия. Использовать молот напрямую нельзя -- просто зажми его в руках перед использованием навыка починки.
 
 Самый простенький молот можно найти у одного торговца в {hh2060Королевстве Дварфов{x. Более качественные молоты позволят восстанавливать вещи лучше и быстрее.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Воїни та самураї використовують ковальські молоти для {hh670ремонту{x броні та зброї. Використовувати молот напряму не можна -- просто затисни його в руках перед використанням навички ремонту.
+
+Найпростіший молот можна знайти в одного торговця в {hh2060Королівстві Дварфів{x. Молоти кращої якості дозволять відновлювати речі краще та швидше.
+</text>
   </help>
   <id>18</id>
   <nameRus>кузнечн|ый|ого|ому|ый|ым|ом молот||а|у||ом|е</nameRus>

--- a/behaviors/matches.xml
+++ b/behaviors/matches.xml
@@ -6,7 +6,22 @@
     <keyword l="en"></keyword>
     <keyword l="ru">коробок &apos;паучьи бега&apos; спичек спички</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x {Dmatches{x _%OBJ%_
+
+Matches can light something flammable to start a {hh249campfire{x. The chance to ignite depends on the flammability and density of the {hh201material{x of the target. Each matchbox holds a limited number of matches -- every ignition attempt uses one.
+
+%FMT% {yuse{x {Dmatches{x
+
+To shake out all the matches and get an empty box, use them without a target.
+
+%FMT% {yuse{x {Dmatches{x _%CHAR%_
+
+An empty matchbox can be used to try to {hh239catch{x a small insect, spider, or worm to enter in the spider races at the {hh1839Casino{x. You can simply place the box with a suitable bait in front of the creature -- or try to catch it outright by using the box directly. Catching by hand is more fun!
+
+%FMT% {yuse{x {Dmatches{x {Dtrack{x
+
+You can enter your captured "pet" in the races by using the box with the insect on the spider-race track, or retrieve it from the track using an empty box.
+</text>
     <text l="ru">%FMT% {yиспользовать{x {Dспички{x _%OBJ%_
 
 Спичками можно поджечь что-нибудь горючее, чтобы развести {hh249костер{x. Вероятность поджечь зависит от горючести и плотности {hh201материала{x предмета. В каждом коробке есть ограниченное число спичек -- каждая попытка поджигания тратит одну из них.
@@ -23,7 +38,22 @@
 
 Можно выставить своего пойманного &quot;питомца&quot; на бега, используя коробок с насекомым на трек для паучьих бегов, или забрать его с трека, используя пустой коробок.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x {Dсірники{x _%OBJ%_
+
+Сірниками можна підпалити щось горюче, щоб розвести {hh249вогнище{x. Вірогідність підпалити залежить від горючості та щільності {hh201матеріалу{x предмета. В кожній коробці є обмежена кількість сірників -- кожна спроба підпалювання витрачає один.
+
+%FMT% {yвикористати{x {Dсірники{x
+
+Щоб висипати всі сірники й отримати порожню коробку, використай їх без цілі.
+
+%FMT% {yвикористати{x {Dсірники{x _%CHAR%_
+
+Порожньою коробкою можна спробувати {hh239впіймати{x якусь дрібну комаху, павукоподібну або черва, щоб потім виставити його на перегони павуків у {hh1839Казино{x. Можна просто покласти коробку з підходящою принадою перед комахою -- або, навпаки, спробувати просто впіймати вручну за допомогою коробки. Ловити вручну веселіше!
+
+%FMT% {yвикористати{x {Dсірники{x {Dтрек{x
+
+Можна виставити свого спійманого "улюбленця" на перегони, використавши коробку з комахою на треку для перегонів павуків, або забрати його з треку, використавши порожню коробку.
+</text>
   </help>
   <id>20</id>
   <nameRus>спич|ки|ек|кам|ки|ками|ках</nameRus>

--- a/behaviors/mirror.xml
+++ b/behaviors/mirror.xml
@@ -7,13 +7,21 @@
     <extra l="en">mirrors</extra>
     <extra l="ru">зеркала</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">%FMT% *use* _%OBJ%_
+%FMT% *use* _%OBJ%_ _%CHAR%_
+
+Use a mirror to admire your otherworldly beauty in it -- if you are not a vampire, of course. Mirrors can be used to apply {hh242tattoos{x. And using a portable mirror on someone else lets you flash sunbeams in their eyes!
+</text>
     <text l="ru">%FMT% *использовать* _%OBJ%_
 %FMT% *использовать* _%OBJ%_ _%CHAR%_
 
 Используй зеркало, чтобы в него полюбоваться своей неземной красотой -- если ты не вампир, разумеется. С помощью зеркал можно наносить на себя {hh242татуировки{x. А использовав переносное зеркало на кого-нибудь еще, можно пустить им в глаза солнечные зайчики!
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% *використовати* _%OBJ%_
+%FMT% *використовати* _%OBJ%_ _%CHAR%_
+
+Використовуй дзеркало, щоб помилуватися в ньому своєю неземною красою -- якщо ти не вампір, звісно. За допомогою дзеркал можна наносити {hh242татуювання{x. А використавши переносне дзеркало на когось іншого, можна пустити їм в очі сонячних зайчиків!
+</text>
   </help>
   <id>50</id>
   <nameRus>зеркало</nameRus>

--- a/behaviors/needle.xml
+++ b/behaviors/needle.xml
@@ -9,12 +9,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">игла швейная</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x {Dneedle{x _%OBJ%_
+
+Items made of {hh201cloth or leather{x (such as {hh65clothing{x) sometimes cannot be repaired by {hh273blacksmiths{x -- but they can be sewn up. Buy a needle and thread at a shop -- and don't forget a thimble, or you might prick your finger!
+</text>
     <text l="ru">%FMT% {yиспользовать{x {Dиголка{x _%OBJ%_
 
 Вещи из {hh201ткани или кожи{x (например, {hh65одежду{x) иногда не могут восстановить {hh273ремонтники{x -- зато эти вещи можно зашить. Купи в магазине иголку с ниткой -- и не забудь наперсток, а то можно уколоть пальчик!
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x {Dголка{x _%OBJ%_
+
+Речі з {hh201тканини або шкіри{x (наприклад, {hh65одяг{x) іноді не можуть відремонтувати {hh273ремонтники{x -- зате ці речі можна зашити. Купи в магазині голку з ниткою -- і не забудь наперсток, а то можна вколоти пальчик!
+</text>
   </help>
   <id>19</id>
   <nameRus>швейн|ая|ой|ой|ую|ой|ой игл|а|ы|е|у|ой|е</nameRus>

--- a/behaviors/newbie weapon.xml
+++ b/behaviors/newbie weapon.xml
@@ -6,10 +6,12 @@
     <extra l="en">subissue</extra>
     <extra l="ru"></extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">The weapon given to {hh2127newbies{x in our world sometimes helps them in combat. It will warn you when it is time to {hh1025flee{x from battle, and may even heal your wounds.
+</text>
     <text l="ru">Оружие, которое выдают {hh2127новичкам{x в нашем мире, иногда помогает им в бою. Оно подскажет, когда пора {hh1025убегать{x из боя, а иногда даже вылечит раны.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Зброя, яку видають {hh2127новачкам{x у нашому світі, іноді допомагає їм у бою. Вона підкаже, коли час {hh1025тікати{x з бою, а іноді навіть вилікує рани.
+</text>
   </help>
   <id>23</id>
   <nameRus>оружие новичков</nameRus>

--- a/behaviors/perfume.xml
+++ b/behaviors/perfume.xml
@@ -6,13 +6,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">парфюмерия</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x _%OBJ%_
+%FMT% {yuse{x _%OBJ%_ _%CHAR%_
+
+Perfumery or cologne is used to give yourself or someone else you apply the bottle to a new and interesting scent. Of course, to detect the scent, the character will need to {hh1084smell{x them.
+</text>
     <text l="ru">%FMT% {yиспользовать{x _%OBJ%_
 %FMT% {yиспользовать{x _%OBJ%_ _%CHAR%_
 
 Парфюмерия или духи используется, чтобы наделить тебя или кого-то другого, на кого ты используешь флакончик, новым и интересным ароматом. Разумеется, чтобы почувствовать этот аромат, персонажа надо будет {hh1084понюхать{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x _%OBJ%_
+%FMT% {yвикористати{x _%OBJ%_ _%CHAR%_
+
+Парфумерія або духи використовуються, щоб наділити тебе або когось іншого, на кого ти використовуєш флакончик, новим і цікавим ароматом. Звісно, щоб відчути цей аромат, персонажа треба буде {hh1084понюхати{x.
+</text>
   </help>
   <id>12</id>
   <nameRus>парфюмери|я|и|и|ю|ей|и</nameRus>

--- a/behaviors/random weapon.xml
+++ b/behaviors/random weapon.xml
@@ -3,7 +3,17 @@
   <cmd></cmd>
   <description></description>
   <help id="251" level="-1" type="BehaviorHelp">
-    <text l="en"></text>
+    <text l="en">Sometimes you can find {hh122a weapon{x with random stats in the corpse of a slain foe! Random weapons are divided into tiers of quality. The higher the tier, the rarer it drops and the faster it disappears:
+{W%A% common{x (no colour) -- does not disappear
+{B%A% uncommon{x (blue) -- after 10 weeks of real time
+{Y%A% rare{x (yellow) -- after 5
+{M%A% epic{x (purple) -- after 3
+{y%A% legendary{x (gold) -- after 2
+  
+Not all weapons in the world can be generated with random stats, and they don't appear with equal frequency on all creatures. Some weapons have their name generated entirely at random. Others have fixed names and some stats, with random parameters added on top. Tougher foes have a chance to yield higher-tier loot.
+
+Good random weapons can be found in chests from {hh127the quest to help robbery victims{x, from {hh129gangsters{x, and especially good ones -- from their boss (before entering the den, don't forget to enable {y{hcsettings autoloot yes{x so you can grab from the corpse in time).
+</text>
     <text l="ru">Иногда в трупе поверженного противника ты сможешь найти {hh122оружие{x со случайными параметрами! Случайное оружие разделено на уровни крутости (тиеры). Чем круче тиер, тем реже оно выпадает и тем быстрее оно исчезает:
 {W%A% обычное{x (без цвета) -- не исчезает
 {B%A% необычное{x (синее) -- через 10 недель реального времени
@@ -15,7 +25,17 @@
 
 Хорошее случайное оружие можно найти в сундуках из {hh127квеста про помощь жертвам{x ограблений, у {hh129гангстеров{x и особенно хорошее -- у их шефа (перед входом в логово не забудь включить {y{hcнастройки автограбеж да{x, чтоб успеть схватить из трупа).
 </text>
-    <text l="ua"></text>
+    <text l="ua">Іноді в трупі поваленого ворога ти можеш знайти {hh122зброю{x з випадковими параметрами! Випадкова зброя поділена на рівні крутості (тири). Що крутіший тир, то рідше вона випадає і то швидше зникає:
+{W%A% звичайна{x (без кольору) -- не зникає
+{B%A% незвичайна{x (синя) -- через 10 тижнів реального часу
+{Y%A% рідкісна{x (жовта) -- через 5
+{M%A% епічна{x (фіолетова) -- через 3
+{y%A% легендарна{x (золота) -- через 2
+  
+Не вся зброя у світі може згенеруватися з випадковими параметрами, і не в усіх істот вона зʼявляється однаково. В деякої зброї вся назва цілком генерується випадковим чином. В інших назви й деякі характеристики фіксовані, а випадкові параметри додаються до наявних. У складніших противників є шанс роздобути крутіші речі.
+
+Гарну випадкову зброю можна знайти в скринях із {hh127квесту про допомогу жертвам{x пограбувань, у {hh129гангстерів{x і особливо гарну -- у їхнього шефа (перед входом у логово не забудь увімкнути {y{hcналаштування автограбіж так{x, щоб встигнути схопити з трупа).
+</text>
   </help>
   <id>25</id>
   <nameRus>случайное оружие</nameRus>

--- a/behaviors/sage.xml
+++ b/behaviors/sage.xml
@@ -9,7 +9,14 @@
     <keyword l="en"></keyword>
     <keyword l="ru">мудрецы отто</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Throughout the world you can find =sages= who provide {hh275paid services{x for {hh603identification{x and locating items -- Otto in Midgaard, for example.
+
+%FMT% *service* *identify* _item_
+Same as the {hh603identify{x spell, shows all the item's stats.
+
+%FMT% *service* *locator* _string_
+Same as the {hh707locator{x spell, shows the locations of all items that have that string in their keywords.
+</text>
     <text l="ru">По всему миру можно найти =мудрецов=, которые предоставляют {hh275платные услуги{x по {hh603опознанию{x и поиску предметов -- например, Отто в Мидгаарде.
 
 %FMT% *услуга* *опознание* _предмет_
@@ -18,7 +25,14 @@
 %FMT% *услуга* *локатор* _строка_
 Аналогично заклинанию {hh707локатора{x, показывает местонахождения всех вещей, которые имеют эту строку в ключевых словах.
 </text>
-    <text l="ua"></text>
+    <text l="ua">По всьому світу можна знайти =мудреців=, які надають {hh275платні послуги{x з {hh603ідентифікації{x та пошуку предметів -- наприклад, Отто в Мідгаарді.
+
+%FMT% *послуга* *ідентифікація* _предмет_
+Аналогічно заклинанню {hh603ідентифікації{x, показує всі параметри предмета.
+
+%FMT% *послуга* *локатор* _рядок_
+Аналогічно заклинанню {hh707локатора{x, показує місцезнаходження всіх речей, які мають цей рядок у ключових словах.
+</text>
     <title l="en"></title>
     <title l="ru">{CПлатные услуги: {xмудрецы</title>
     <title l="ua"></title>

--- a/behaviors/shovel.xml
+++ b/behaviors/shovel.xml
@@ -6,7 +6,16 @@
     <keyword l="en">dig</keyword>
     <keyword l="ru">копаться выкопать закопать</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x {Dshovel{x
+
+The world holds items or treasures buried by someone. To dig them up you will need a shovel. Just {hh1023use{x it in the right spot and, if you are lucky, you may unearth something interesting.
+
+%FMT% {yuse{x {Dshovel{x _%OBJ%_
+
+You can also bury any item for safekeeping. Buried things begin to slowly {hh273decay{x over time, so do not forget to dig them up!
+
+Rumour has it that {hh92Immortals{x have their own secret way of using shovels...
+</text>
     <text l="ru">%FMT% {yиспользовать{x {Dлопата{x
 
 В мире встречаются закопанные кем-то предметы или сокровища. Чтобы выкопать их, понадобится лопата. Просто {hh1023используй{x ее в нужном месте и, если повезет, сможешь выкопать что-то интересное.
@@ -17,7 +26,16 @@
 
 Ходят слухи, что {hh92Бессмертные{x имеют свой, тайный способ использования лопат...
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x {Dлопату{x
+
+У світі трапляються закопані кимось предмети або скарби. Щоб викопати їх, знадобиться лопата. Просто {hh1023використай{x її в потрібному місці і, якщо пощастить, зможеш викопати щось цікаве.
+
+%FMT% {yвикористати{x {Dлопату{x _%OBJ%_
+
+Можна також закопати будь-який предмет для більшої надійності. Закопані речі з часом починають помалу {hh273псуватися{x, тож не забудь їх викопати!
+
+Ходять чутки, що {hh92Безсмертні{x мають свій таємний спосіб використання лопат...
+</text>
   </help>
   <id>2</id>
   <nameRus>лопат|а|ы|е|у|ой|е</nameRus>

--- a/behaviors/snare.xml
+++ b/behaviors/snare.xml
@@ -6,7 +6,15 @@
     <keyword l="en"></keyword>
     <keyword l="ru">ловушка мышеловка</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% {ythrow{x _%OBJ%_
+%FMT% {yput{x {Dbait{x _%OBJ%_
+Cages, mousetraps, and similar items can catch creatures in the room -- not all of them, of course, only {hh2142non-sentient{x, non-quest, {hh15non-follower{x ones, and so on. To catch a creature, place suitable bait in the trap and throw it in front of the creature in the same area. Then wait... and if the bait is right and the trap is the right size, the creature will be caught. 
+
+{RWARNING:{x at this time not all creature races have favourite baits, so not all of them can be caught.
+
+%FMT% {ytake{x {Dcreature{x _%OBJ%_
+You can release the prisoner -- simply by taking the poor thing out of the cage-{hh1024container{x.
+</text>
     <text l="ru">%FMT% {yбросить{x _%OBJ%_
 %FMT% {yположить{x {Dприманка{x _%OBJ%_
 Клетки, мышеловки и другие подобные предметы могут поймать существ в комнате -- не всех, разумеется, а только {hh2142неразумных{x, не-квестовых, {hh15не-последователей{x и т.д. Чтобы поймать существо, надо положить подходящую приманку в ловушку и бросить ее перед существом в той же местности. Затем надо подождать... и, если приманка подходящая и ловушка нужного размера, существо окажется в капкане. 
@@ -16,7 +24,15 @@
 %FMT% {yвзять{x {Dсущество{x _%OBJ%_
 Пленника можно выпустить -- просто достав бедолагу из клетки-{hh1024контейнера{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yкинути{x _%OBJ%_
+%FMT% {yпокласти{x {Dприманку{x _%OBJ%_
+Клітки, мишоловки та подібні предмети можуть зловити істот у кімнаті -- не всіх, звісно, а лише {hh2142нерозумних{x, не-квестових, {hh15не-послідовників{x тощо. Щоб спіймати істоту, треба покласти підходящу принаду в пастку і кинути її перед істотою в тій самій місцевості. Потім зачекай... і, якщо принада підходяща і пастка потрібного розміру, істота опиниться в капкані. 
+
+{RУВАГА:{x на поточний момент не всі раси ігрових істот мають улюблені принади, тому не всіх можна спіймати.
+
+%FMT% {yвзяти{x {Dістоту{x _%OBJ%_
+Полоненого можна відпустити -- просто вийнявши бідолаху з клітки-{hh1024контейнера{x.
+</text>
   </help>
   <id>4</id>
   <nameRus>капкан||а|у||ом|е</nameRus>

--- a/behaviors/spyglass.xml
+++ b/behaviors/spyglass.xml
@@ -9,12 +9,18 @@
     <keyword l="en">binoculars</keyword>
     <keyword l="ru"></keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% *use* _%OBJ%_ _%DIR%_
+
+With a spyglass you can see distant terrain in a given direction.
+</text>
     <text l="ru">%FMT% *использовать* _%OBJ%_ _%DIR%_
 
 С помощью подзорной трубы можно увидеть удаленную местность по направлению.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% *використовати* _%OBJ%_ _%DIR%_
+
+За допомогою підзорної труби можна побачити віддалену місцевість у заданому напрямку.
+</text>
   </help>
   <id>51</id>
   <nameRus>подзорная труба</nameRus>

--- a/behaviors/suicideroom.xml
+++ b/behaviors/suicideroom.xml
@@ -3,10 +3,12 @@
   <cmd></cmd>
   <description>Местность, уйти откуда можно только суицидом.</description>
   <help id="287" level="110" type="BehaviorHelp">
-    <text l="en"></text>
+    <text l="en">A location you can only leave by {hh286suicide{x.
+</text>
     <text l="ru">Местность, уйти откуда можно только {hh286суицидом{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Місцевість, звідки можна вийти лише через {hh286суїцид{x.
+</text>
   </help>
   <id>52</id>
   <nameRus>суицидная</nameRus>

--- a/behaviors/torch.xml
+++ b/behaviors/torch.xml
@@ -6,12 +6,18 @@
     <extra l="en"></extra>
     <extra l="ru">смоляной факел</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">%FMT% {yuse{x {Dtorch{x _%OBJ%_
+
+You can use a torch to set something flammable alight and start a {hh249campfire{x. The chance of ignition depends on the flammability and density of the object's {hh201material{x.
+</text>
     <text l="ru">%FMT% {yиспользовать{x {Dфакел{x _%OBJ%_
 
 Факелом можно поджечь что-нибудь горючее, чтобы развести {hh249костер{x. Вероятность поджечь зависит от горючести и плотности {hh201материала{x предмета.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% {yвикористати{x {Dфакел{x _%OBJ%_
+
+Факелом можна підпалити щось горюче, щоб розвести {hh249багаття{x. Ймовірність підпалити залежить від горючості і щільності {hh201матеріалу{x предмета.
+</text>
   </help>
   <id>3</id>
   <nameRus>факел||а|у||ом|е</nameRus>

--- a/behaviors/trap.xml
+++ b/behaviors/trap.xml
@@ -3,10 +3,12 @@
   <cmd></cmd>
   <description>Зайдя в некоторые места, можно провалиться куда-то или упасть.</description>
   <help id="241" level="-1" type="BehaviorHelp">
-    <text l="en"></text>
+    <text l="en">In some zones you may run into traps, and whether you fall into them depends on your {hh18movement speed{x. Some traps kill instantly, while others will simply drop you somewhere else. Some traps will not trigger on {hh575flying{x characters.
+</text>
     <text l="ru">В некоторых зонах можно наткнуться на ловушки, и от твоей {hh18скорости передвижения{x зависит, попадешься ты в них или нет. Некоторые ловушки мгновенно убивают, а зайдя в другие ты просто провалишься куда-то в другое место. Некоторые ловушки не сработают на {hh575летучих{x персонажей.
 </text>
-    <text l="ua"></text>
+    <text l="ua">У деяких зонах можна натрапити на пастки, і від твоєї {hh18швидкості пересування{x залежить, попадешся ти в них чи ні. Деякі пастки миттєво вбивають, а зайшовши в інші ти просто провалишся кудись в інше місце. Деякі пастки не спрацюють на {hh575летючих{x персонажів.
+</text>
   </help>
   <id>9</id>
   <nameRus>опасн|ая|ой|ой|ую|ой|ой местност|ь|и|и|ь|ью|и</nameRus>

--- a/behaviors/underwater.xml
+++ b/behaviors/underwater.xml
@@ -3,10 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="266" level="-1" type="BehaviorHelp">
-    <text l="en"></text>
+    <text l="en">Flooded areas temporarily or permanently change the {hh2128terrain type{x to underwater.
+</text>
     <text l="ru">Затопленные местности временно или постоянно меняют {hh2128тип местности{x на подводный.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Затоплені місцевості тимчасово або постійно змінюють {hh2128тип місцевості{x на підводний.
+</text>
   </help>
   <id>38</id>
   <nameRus>под водой</nameRus>

--- a/commands/fenia/suicide.xml
+++ b/commands/fenia/suicide.xml
@@ -6,7 +6,14 @@
   <cat>char</cat>
   <extra>spellout</extra>
   <help id="286" level="-1" type="CommandHelp">
-    <text l="en"></text>
+    <text l="en">%FMT% *%CMD%*
+
+Sometimes your character ends up in a completely {hh86cursed{x place from which you can neither leave nor {hh862teleport{x away. Only one option remains -- to end it all :(
+
+This command will only work if you truly find yourself in such a place. You will need to type it twice: the second time with your character's name as confirmation. After death your soul and your corpse will be moved to the temple.
+
+Samurai, however, can end their lives anywhere using {hh743harakiri{x.
+</text>
     <text l="ru">%FMT% *%CMD%*
 
 Иногда твой персонаж попадает в абсолютно {hh86проклятые{x места, откуда нельзя ни выйти, ни {hh862перенестись{x. Остается лишь одно -- покончить с собой :(
@@ -15,7 +22,14 @@
 
 Самураи же могут покончить с собой где угодно при помощи {hh743харакири{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% *%CMD%*
+
+Іноді твій персонаж потрапляє в абсолютно {hh86прокляті{x місця, звідки не можна ні вийти, ні {hh862перенестися{x. Залишається лише одне -- покінчити з собою :(
+
+Ця команда спрацює лише якщо ти справді опинишся в подібному місці. Команду треба буде набрати двічі: вдруге -- з іменем персонажа для підтвердження. Після смерті твоя душа і твій труп перенесуться до храму.
+
+Самураї ж можуть покінчити з собою будь-де за допомогою {hh743харакірі{x.
+</text>
   </help>
   <hint l="en"></hint>
   <hint l="ru">самоубийство персонажа</hint>

--- a/commands/fenia/wash.xml
+++ b/commands/fenia/wash.xml
@@ -6,12 +6,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru"></keyword>
     <keyword l="ua">вмитися</keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% *%CMD%*
+
+To wash the {hh783dirt{x or {hh281smoke{x out of your eyes, find an area with a water source or fountain and wash your face thoroughly.
+</text>
     <text l="ru">%FMT% *%CMD%*
 
 Чтобы промыть глаза от {hh783грязи{x или {hh281дыма{x найди местность с источниками воды или фонтанами и как следует умойся.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% *%CMD%*
+
+Щоб промити очі від {hh783бруду{x або {hh281диму{x, знайди місцевість з джерелом води або фонтаном і як слід умийся.
+</text>
   </help>
   <hint l="en"></hint>
   <hint l="ru">промыть глаза от дыма или грязи</hint>

--- a/craft-professions/carpenter.xml
+++ b/craft-professions/carpenter.xml
@@ -5,7 +5,16 @@
     <keyword l="en">carpenter</keyword>
     <keyword l="ru">плотник</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">=Carpenter= is one of the {hh195crafts{x or secondary professions available to all players. Carpenters can craft from wood {hh810bows{x and {hh537arrows{x, {hh699polearms{x, boats, beds, decorations, and shields.
+
+%FMT% *craft* _desired item_
+Creates the desired item provided you have the required recipe, tool, and ingredients.
+
+To start, try {hh1023felling{x one or several logs in a forest and splitting them into pieces. The favorite tool of many carpenters is a small hatchet, but some blueprints may also require knives and hammers.
+
+{CHOW TO BECOME A CARPENTER{x
+Some of the most skilled carpenters and lumberjacks of Thera can be found in the small town of {hh1506Dunkeldorf{x. If you want to master this profession, try looking for a teacher there.
+</text>
     <text l="ru">=Плотник= -- одно из доступных всем игрокам {hh195ремесел{x или дополнительных профессий. Плотники умеют создавать из дерева {hh810луки{x и {hh537стрелы{x, {hh699древковое оружие{x, лодки, кровати, украшения и щиты.
 
 %FMT% *смастерить* _желаемый предмет_
@@ -16,7 +25,16 @@
 {CКАК СТАТЬ ПЛОТНИКОМ{x
 Одних из самых умелых плотников и лесорубов Тэры можно найти в маленьком городке {hh1506Дюнкельдорф{x. Если хочешь освоить эту профессию, попробуй поискать учителя там.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Тесля= -- одне з {hh195ремесел{x або додаткових професій, доступних усім гравцям. Теслі вміють створювати з дерева {hh810луки{x та {hh537стріли{x, {hh699древкову зброю{x, човни, ліжка, прикраси та щити.
+
+%FMT% *змайструвати* _бажаний предмет_
+Створює бажану річ за наявності потрібного рецепту, інструменту та інгредієнтів.
+
+Для початку спробуй {hh1023зрубати{x одне або кілька колод у лісі та розрубати на частини. Улюбленим інструментом багатьох теслів є маленька сокирка, але для деяких креслень можуть знадобитися ножі та молотки.
+
+{CЯК СТАТИ ТЕСЛЕЮ{x
+Одних з найвправніших теслів та лісорубів Тери можна знайти в маленькому містечку {hh1506Дюнкельдорф{x. Якщо хочеш освоїти цю професію, спробуй пошукати вчителя там.
+</text>
     <title l="en"></title>
     <title l="ru">{CДополнительные профессии:{x плотник</title>
     <title l="ua"></title>

--- a/craft-professions/tattooist.xml
+++ b/craft-professions/tattooist.xml
@@ -8,7 +8,24 @@
     <keyword l="en">tattooist</keyword>
     <keyword l="ru">татуировщик</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">=Tattooist= is one of the {hh195crafts{x or secondary professions available to all players. A tattooist can apply various tattoos to themselves or other players on different body parts: the left or right {hh243wrist{x, {hh246shoulders{x, or {hh244face{x. To apply a tattoo to a given location you must learn the corresponding skills, which become available as you practice.
+
+{CHOW TO BECOME A TATTOOIST{x
+To learn this profession, find a {hh235tattoo master{x and follow his instructions. You will need a =knife= and =ink= to apply tattoos. Any dagger with the =for tattoos= flag can serve as a tattooing knife -- use {hh603identify{x or the site's search tool to find one.
+
+{CTYPES OF TATTOOS{x
+There are several tattoo designs you can apply -- one for each of the {hh81Eight Paths{x and their pairs with neighbors -- and each grants unique bonuses: improved stats, accuracy, damage, hit points, mana, improved skills, and so on. Basic supplies and simple designs can be purchased directly from the teacher; more complex ones will have to be farmed from suitable sentient enemies across Thera.
+
+Some designs always grant the same bonus, while others scale with your level. You can find out which stats a design affects by examining it. To learn exactly how each design changes a given stat you can identify the tattoo itself after it is applied. Or compare your {hh999score{x.
+
+{CHOW TO APPLY TATTOOS{x
+%A% put ink and the design you want applied to your skin into your inventory
+%A% wield a tattooing knife
+%A% use the design on the desired body part:
+%FMT% *use design* %CHAR% _body part_
+
+To {hh245remove a tattoo{x, you need a special ointment, which can be bought from the same tattoo master in the Prairies.
+</text>
     <text l="ru">=Татуировщик= -- одно из доступных всем игрокам {hh195ремесел{x или дополнительных профессий. Татуировщик умеет наносить себе или другим игрокам разные татуировки на различные части тела: левое или правое {hh243запястье{x, {hh246плечи{x или {hh244лицо{x. Для нанесения татуировки на то или иное место нужно разучить соответствующие навыки, которые становятся доступны по мере использования.
 
 {CКАК СТАТЬ ТАТУИРОВЩИКОМ{x
@@ -27,7 +44,24 @@
 
 Чтобы {hh245снять татуировку{x, нужна специальная мазь, которую можно купить там же у тату-мастера в Прериях.
 </text>
-    <text l="ua"></text>
+    <text l="ua">=Татуювальник= -- одне з {hh195ремесел{x або додаткових професій, доступних усім гравцям. Татуювальник вміє наносити собі або іншим гравцям різні татуювання на різні частини тіла: ліве або праве {hh243запʼястя{x, {hh246плечі{x або {hh244обличчя{x. Для нанесення татуювання на те чи інше місце потрібно вивчити відповідні навички, які стають доступні в міру використання.
+
+{CЯК СТАТИ ТАТУЮВАЛЬНИКОМ{x
+Щоб навчитися цієї професії, знайди {hh235тату-майстра{x і слідуй його інструкціям. Для нанесення татуювань знадобляться =ніж= і =чорнило=. Ножем для татуювань може служити будь-який кинджал з прапором =для татуювань= -- використовуй {hh603опізнання{x або пошуковик на сайті, щоб знайти.
+
+{CЯКІ БУВАЮТЬ ТАТУЮВАННЯ{x
+Є кілька малюнків татуювань, які можна наносити -- по одному на кожен з {hh81Восьми Шляхів{x та їхніх пар із сусідами -- і кожен з них дає якісь унікальні бонуси: покращені параметри, точність, шкода, здоровʼя, мана, покращені вміння тощо. Базові витратні матеріали та прості малюнки можна придбати прямо у вчителя, складніші доведеться здобувати з відповідних розумних противників на просторах Тери.
+
+Деякі малюнки завжди дадуть той самий бонус, а інші підсилюватимуться залежно від твого рівня. Дізнатися, які параметри змінює малюнок, можна, подивившись на нього. А от дізнатися, як саме кожен малюнок змінює даний параметр, можна, опізнавши саме татуювання після нанесення. Або порівнявши {hh999рахунок{x.
+
+{CЯК НАНОСИТИ ТАТУЮВАННЯ{x
+%A% візьми в інвентар чорнило та малюнок, який хочеш нанести на шкіру
+%A% озбройся ножем для татуювань
+%A% використай малюнок на потрібну частину тіла:
+%FMT% *використ малюнок* %CHAR% _частина тіла_
+
+Щоб {hh245зняти татуювання{x, потрібна спеціальна мазь, яку можна купити там же у тату-майстра в Преріях.
+</text>
     <title l="en"></title>
     <title l="ru">{CДополнительные профессии:{x татуировщик</title>
     <title l="ua"></title>

--- a/generic-skills/firestorm.xml
+++ b/generic-skills/firestorm.xml
@@ -15,12 +15,18 @@
     <keyword l="en">fire storm</keyword>
     <keyword l="ru">огненный шторм</keyword>
     <keyword l="ua">вогняний шторм</keyword>
-    <text l="en"></text>
+    <text l="en">%FMT% *%SPELL%*
+
+A dreadful spell of {hh134sorcerers{x, dealing damage to all enemies around and creating a {hh281fire{x in the current location. Strength depends on the caster's level.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Жуткое заклинание {hh134колдунов{x, наносящее урон всем противникам вокруг и создающее {hh281пожар{x в текущей местности. Сила зависит от уровня заклинателя.
 </text>
-    <text l="ua"></text>
+    <text l="ua">%FMT% *%SPELL%*
+
+Жахливе заклинання {hh134чаклунів{x, що завдає шкоди всім противникам навколо та створює {hh281пожежу{x в поточній місцевості. Сила залежить від рівня заклинателя.
+</text>
   </help>
   <mana>100</mana>
   <name l="en">firestorm</name>

--- a/generic-skills/hazukure.xml
+++ b/generic-skills/hazukure.xml
@@ -9,12 +9,18 @@
     <keyword l="en">shame</keyword>
     <keyword l="ru">стыд</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{hh1025Fleeing{x from battle is a tremendous disgrace for a {hh136samurai{x. A samurai who flees from combat "reddens with shame" and loses his grip on his combat skills. His name is whispered with contempt, and the spirits of his ancestors refuse to bless his blade. The only way to cleanse himself is to perform {hh743harakiri{x and send his soul before the judgment of the ancestors.
+
+This penalty begins to apply after reaching level 20 -- young samurai are yet to know the meaning of shame.
+</text>
     <text l="ru">{hh1025Побег{x из боя -- огромный позор для {hh136самурая{x. Самурай, сбежавший из боя, &quot;краснеет от стыда&quot; и неспособен как следует владеть боевыми навыками. Его имя шепчется с презрением, и дух предков отказывается благословлять его клинок. Единственный способ очиститься -- совершить {hh743харакири{x и отправить душу на суд предков.
 
 Этот штраф начинает применяться после достижения 20 уровня -- а маленьким самураям позор неведом.
 </text>
-    <text l="ua"></text>
+    <text l="ua">{hh1025Втеча{x з бою -- величезна ганьба для {hh136самурая{x. Самурай, що втік з бою, "червоніє від сорому" і нездатний як слід володіти бойовими вміннями. Його імʼя вимовляють з презирством, і дух предків відмовляється благословляти його клинок. Єдиний спосіб очиститися -- вчинити {hh743харакірі{x і відправити душу на суд предків.
+
+Цей штраф починає діяти після досягнення 20 рівня -- а маленьким самураям сором ще невідомий.
+</text>
     <title l="en"></title>
     <title l="ru">Позор самурая</title>
     <title l="ua"></title>

--- a/other-skills/accuracy.xml
+++ b/other-skills/accuracy.xml
@@ -5,12 +5,18 @@
   </affect>
   <dammsg mg="m"></dammsg>
   <help id="624" labels="language" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Some Quenya words contain the secret of accuracy. An archer or spear-thrower under the effect of this spell will strike their target more precisely, dealing greater damage.
+
+%SA% %H% {hh2044quenya{x
+</text>
     <text l="ru">Некоторые слова на квенье содержат в себе секрет меткости. Лучник или метатель копий под воздействием этого эффекта сможет точнее поразить цель, нанося большие повреждения.
 
 %SA% %H% {hh2044квенья{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Деякі слова квенья містять у собі секрет влучності. Лучник або метальник списів під впливом цього ефекту зможе точніше вразити ціль, завдаючи більшої шкоди.
+
+%SA% %H% {hh2044квенья{x
+</text>
   </help>
   <name l="en">accuracy</name>
   <name l="ru">меткость</name>

--- a/other-skills/acid breath.xml
+++ b/other-skills/acid breath.xml
@@ -3,12 +3,18 @@
   <beats>24</beats>
   <dammsg mg="n">кислотное дыхание</dammsg>
   <help id="542" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">This ancient magic is available only to dragons. The jet of caustic acid they spew will not only strike the victim, but also damage their armor, weapon and inventory. If a dragon is seriously wounded, the power of its acid breath weakens. Part of this powerful magic is available to witches and warlocks.
+
+%SA% %H% {hh778dragon breath{x
+</text>
     <text l="ru">Эта древняя магия доступна только драконам. Струя едкой кислоты, извергаемая ими, не только поразит жертву, но и нанесет повреждения броне, оружию и инвентарю. Если дракон серьезно ранен, сила его кислотных выдохов ослабевает. Часть этой могущественной магии доступна ведьмам и варлокам.
 
 %SA% %H% {hh778дыхание драконов{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Ця стародавня магія доступна тільки драконам. Струмінь їдкої кислоти, що вони виригують, не тільки вразить жертву, але й завдасть пошкоджень броні, зброї та інвентарю. Якщо дракон серйозно поранений, сила його кислотних видихів слабшає. Частина цієї могутньої магії доступна відьмам і ворлокам.
+
+%SA% %H% {hh778дихання драконів{x
+</text>
   </help>
   <mana>100</mana>
   <name l="en">acid breath</name>

--- a/other-skills/ancient rage.xml
+++ b/other-skills/ancient rage.xml
@@ -5,10 +5,12 @@
   </affect>
   <dammsg mg="m"></dammsg>
   <help id="731" labels="language" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Some words in the ancient {hh2043Khuzdul{x language contain the secret of ancient rage. Under the influence of such words, the {hh47damage and accuracy{x of your blows increases. These words also have a cumulative effect, allowing you to extend their duration by speaking them again.
+</text>
     <text l="ru">Некоторые слова на древнем языке {hh2043кхуздул{x содержат в себе секрет древней ярости. Под воздействием таких слов повышается {hh47урон и точность{x наносимых ударов. Эти слова также обладают кумулятивным эффектом, позволяя продлевать их действие при повторном произнесении.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Деякі слова стародавньої мови {hh2043кхуздул{x містять у собі секрет стародавньої лютості. Під впливом таких слів підвищується {hh47шкода та точність{x завданих ударів. Ці слова також мають кумулятивний ефект, дозволяючи продовжувати їхню дію при повторному вимовлянні.
+</text>
   </help>
   <name l="en">ancient rage</name>
   <name l="ru">древняя ярость</name>

--- a/other-skills/backguard.xml
+++ b/other-skills/backguard.xml
@@ -4,10 +4,12 @@
   </affect>
   <dammsg mg="m"></dammsg>
   <help id="669" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Your vigilance prevents anyone from sneaking up behind you to put you to sleep or snap your neck.
+</text>
     <text l="ru">Твоя настороженность не позволяет кому-то подкрасться к тебе сзади с целью усыпить или свернуть шею.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Твоя пильність не дозволяє нікому підкрастися ззаду з метою присипити тебе або звернути шию.
+</text>
   </help>
   <name l="en">backguard</name>
   <name l="ru">настороженность</name>

--- a/other-skills/beer armor.xml
+++ b/other-skills/beer armor.xml
@@ -7,12 +7,18 @@
   </affect>
   <dammsg mg="m"></dammsg>
   <help id="713" labels="language" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">After being doused from a keg over which an Arcadi word was spoken, your skin will be covered with a protective beer film. This film reduces your {hh83armor class{x, making you harder to hit.
+
+%SA% %H% {hh2041arcadi{x, {hh1075pour{x
+</text>
     <text l="ru">После обливания из бочонка, на который было произнесено слово на аркади, твоя кожа покроется пивной защитной пленкой. Такая пленка уменьшает твой {hh83класс защиты{x, не позволяя по тебе попасть.
 
 %SA% %H% {hh2041аркади{x, {hh1075вылить{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Після обливання з бочонка, над яким було вимовлено слово аркаді, твоя шкіра вкриється пивною захисною плівкою. Така плівка зменшує твій {hh83клас броні{x, не дозволяючи по тобі влучити.
+
+%SA% %H% {hh2041аркаді{x, {hh1075вилити{x
+</text>
   </help>
   <name l="en">beer armor</name>
   <name l="ru">пивная броня</name>

--- a/other-skills/corrosion.xml
+++ b/other-skills/corrosion.xml
@@ -8,12 +8,18 @@
     <extra l="en"></extra>
     <extra l="ru">окалина окисление ржавеет ржаветь ржавчина &apos;защита от кислоты&apos; &apos;эффект коррозии&apos;</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">Acid exposure -- from spells such as {hh865acid blob{x or {hh847caustic spring{x -- sometimes corrodes items, causing =corrosion=. Items affected by corrosion have their {hh83armor class{x parameters worsened. Corrosion can be removed with {hh844repair{x magic or a specific word from the {hh2043Khuzdul{x language.
+
+Items cannot be protected from corrosion, but its effect can be removed with the {hh844repair{x spell.
+</text>
     <text l="ru">Воздействие кислотой -- например, от таких заклинаний как {hh865сгусток кислоты{x или {hh847едкий источник{x -- иногда разъедает вещи, вызывая =коррозию=. Подверженные коррозии вещи ухудшают свои параметры {hh83класса защиты{x. Снять коррозию можно магией {hh844починки{x или определенным словом языка {hh2043кхуздул{x.
 
 Защитить вещи от коррозии нельзя, но можно убрать ее эффект заклинанием {hh844починки{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Вплив кислоти -- наприклад, від таких заклинань як {hh865згусток кислоти{x або {hh847їдке джерело{x -- іноді роз'їдає речі, викликаючи =корозію=. Схильні до корозії речі погіршують свої параметри {hh83класу броні{x. Зняти корозію можна магією {hh844лагодження{x або певним словом мови {hh2043кхуздул{x.
+
+Захистити речі від корозії не можна, але можна прибрати її ефект заклинанням {hh844лагодження{x.
+</text>
     <title l="en"></title>
     <title l="ru">Эффект коррозии</title>
     <title l="ua"></title>

--- a/other-skills/creativity.xml
+++ b/other-skills/creativity.xml
@@ -8,12 +8,18 @@
     <keyword l="en"></keyword>
     <keyword l="ru">вдохновение</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">After uttering certain words in the ahenn tongue, you are seized by a thirst to create. Under the influence of such inspiration, enhancement spells (enchant armor, enchant weapon) as well as the sharpen and bless skills become especially effective.
+
+%SA% %H% {hh2040ahenn{x
+</text>
     <text l="ru">После произнесения некоторых слова на языке ахэнн, тебя охватывает жажда творить. Под воздействием такого вдохновения заклинания улучшения (заколдовать броню, заколдовать оружие), а также умения заточить меч и благословить становятся особенно эффективными.
 
 %SA% %H% {hh2040ахэнн{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Після вимовляння певних слів мовою ахенн тебе охоплює жага творити. Під впливом такого натхнення заклинання підсилення (зачарувати броню, зачарувати зброю), а також вміння заточити меч і благословити стають особливо ефективними.
+
+%SA% %H% {hh2040ахенн{x
+</text>
   </help>
   <name l="en">creativity</name>
   <name l="ru">жажда творить</name>

--- a/other-skills/deforestation.xml
+++ b/other-skills/deforestation.xml
@@ -8,12 +8,18 @@
     <extra l="en">sprouts</extra>
     <extra l="ru">побеги</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">Trees in forested terrain can be destroyed -- for example, with {hh282an axe{x, {hh796a hurricane{x, or {hh281fire{x. Destroyed trees will eventually grow back, but you will have to wait a very long time. You can speed up the process by watering the soil or fertilizing it with ash.
+
+Slightly damaged trees (for instance, notched) will heal their wounds in time, while heavily notched ones will dry out and snap.
+</text>
     <text l="ru">Деревья в лесной местности можно уничтожать -- например, {hh282топором{x, {hh796ураганом{x или {hh281пожаром{x. Уничтоженные деревья рано или поздно вырастут, но придется очень долго ждать. Ускорить процесс можно с помощью полива или удобрений пеплом.
 
 Немного поврежденные (например, надрубленные) деревья рано или поздно залечат свои раны, а вот сильно надрубленные -- высохнут и сломаются.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Дерева в лісистій місцевості можна знищувати -- наприклад, {hh282сокирою{x, {hh796ураганом{x або {hh281вогнем{x. Знищені дерева рано чи пізно виростуть знову, але доведеться дуже довго чекати. Пришвидшити процес можна за допомогою поливу або удобрення попелом.
+
+Дещо пошкоджені (наприклад, надрубані) дерева рано чи пізно залікують свої рани, а от сильно надрубані -- всохнуть і зламаються.
+</text>
     <title l="en"></title>
     <title l="ru">Местность: обезлесение, рост леса</title>
     <title l="ua"></title>

--- a/other-skills/dragon strength.xml
+++ b/other-skills/dragon strength.xml
@@ -7,10 +7,12 @@
   <beats>12</beats>
   <dammsg mg="m"></dammsg>
   <help id="565" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Followers of the {hh967Set{x cult may receive the Dragon Strength. A character overflowing with this power gains increased damage, strength and accuracy, but loses dexterity.
+</text>
     <text l="ru">Последователям культа {hh967Сета{x может прийти на помощь Сила Дракона. У персонажа, переполненного этой силой, увеличивается урон, сила и точность, но уменьшается ловкость.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Послідовникам культу {hh967Сета{x може прийти на допомогу Сила Дракона. У персонажа, переповненого цією силою, збільшується шкода, сила та точність, але зменшується спритність.
+</text>
   </help>
   <mana>75</mana>
   <name l="en">dragon strength</name>

--- a/other-skills/fatigue.xml
+++ b/other-skills/fatigue.xml
@@ -9,7 +9,14 @@
     <keyword l="en">cooldown</keyword>
     <keyword l="ru">усталость откат кд кулдаун</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Many skills and spells cause a =cooldown= -- they can only be used once in a certain period of time. Usually a cooldown manifests as a harmless {hh997affect{x of the skill that grants nothing and simply shows the cooldown timer. But some skills cause a state of =fatigue= when they cool down.
+
+The state of extraordinary fatigue sets in after the {hh739haste{x affect fades, or after using certain artifacts and skills -- for example, {hh93brewing{x.
+
+In this state your body responds to you poorly and your reaction speed slows, leading to increased {hh120lag{x after using any skills.
+
+Fatigue usually passes quickly and your body returns to normal. In some cases fatigue can last quite a long time. Experienced spellcasters can attempt to remove fatigue with the {hh736refresh{x spell.
+</text>
     <text l="ru">Многие умения и заклинания вызывают =откат= -- их можно использовать только раз в какой-то период времени. Обычно откат выражается в безобидном {hh997аффекте{x умения, который ничего не дает, а просто показывает таймер отката. Но некоторые умения при откате вызывают состояние =усталости=.
 
 Состояние необычайной усталости наступает после спадания аффекта {hh739ускорения{x или после использования некоторых артефактов и умений -- например, {hh93зельеварения{x.
@@ -18,7 +25,14 @@
 
 Обычно усталость быстро проходит, и твое тело возвращается в норму. В некоторых случаях усталость может продлиться довольно долго. Опытные заклинатели могут попытаться снять усталость заклинанием {hh736освежения{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Багато вмінь та заклинань викликають =відкат= -- їх можна використовувати лише раз за певний проміжок часу. Зазвичай відкат виражається у нешкідливому {hh997афекті{x вміння, який нічого не дає, а просто показує таймер відкату. Але деякі вміння при відкаті викликають стан =втоми=.
+
+Стан незвичайної втоми настає після спадання афекту {hh739прискорення{x або після використання деяких артефактів та вмінь -- наприклад, {hh93зіллєваріння{x.
+
+У цьому стані твоє тіло гірше тебе слухається, а швидкість реакції сповільнюється, призводячи до збільшення {hh120затримки{x після використання будь-яких вмінь.
+
+Зазвичай втома швидко проходить і твоє тіло повертається до норми. У деяких випадках втома може тривати досить довго. Досвідчені чаклуни можуть спробувати зняти втому заклинанням {hh736освіження{x.
+</text>
     <title l="en"></title>
     <title l="ru">{CСостояние: {xусталость, откат от умений</title>
     <title l="ua"></title>

--- a/other-skills/fervor.xml
+++ b/other-skills/fervor.xml
@@ -11,14 +11,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">задор</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">The state of combat fervor usually sets in after the {hh705slow{x effect wears off, or as a result of certain spells.
+
+In this state your body is flooded with extraordinary energy for a very brief time, giving you the ability to land more attacks in the next {hh16combat round{x.
+
+At the same time your reaction speed increases, reducing the {hh120lag{x after using any skills.
+</text>
     <text l="ru">Состояние боевого задора обычно наступает после спадания аффекта {hh705замедления{x или в результате действия некоторых заклинаний.
 
 В этом состоянии твое тело наливается необычайной энергией на очень короткое время, давая тебе возможность нанести больше атак в следующий {hh16боевой раунд{x.
 
 В то же время твоя скорость реакции ускоряется, приводя к уменьшению {hh120задержки{x после использования любых умений.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Стан бойового запалу зазвичай настає після спадання ефекту {hh705уповільнення{x або в результаті дії деяких заклинань.
+
+У цьому стані твоє тіло наповнюється незвичайною енергією на дуже короткий час, даючи тобі можливість завдати більше атак у наступний {hh16бойовий раунд{x.
+
+Водночас твоя швидкість реакції прискорюється, призводячи до зменшення {hh120затримки{x після використання будь-яких вмінь.
+</text>
     <title l="en"></title>
     <title l="ru">{CСостояние: {xбоевой задор</title>
     <title l="ua"></title>

--- a/other-skills/fire breath.xml
+++ b/other-skills/fire breath.xml
@@ -6,12 +6,18 @@
   <beats>24</beats>
   <dammsg mg="n">огненное дыхание</dammsg>
   <help id="658" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Dragons' favourite pastime is blasting you with a cone of raging fire. A victim caught in the stream of fire will not only take damage, but may also be blinded for a time by the smoke. Items in your inventory can also be damaged by fire.
+
+This same effect (brief blindness from smoke and damage to items) is inflicted by most other spells that deal {hh101fire damage{x.
+</text>
     <text l="ru">Излюбленное развлечение драконов -- пульнуть в тебя воронкой бушующего огня. Попав под струю огня, жертва не только получит повреждения, но может и на время ослепнуть от дыма. Вещи в инвентаре тоже могут испортиться от воздействия огня.
 
 Этот же аффект (краткосрочное ослепление от дыма и порчу вещей) дают большинство других заклинаний, наносящих {hh101урон огнем{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Улюблена розвага драконів -- пальнути в тебе воронкою вогню, що вирує. Потрапивши під струмінь вогню, жертва не тільки отримає пошкодження, але може й на деякий час осліпнути від диму. Речі в інвентарі теж можуть зіпсуватися від впливу вогню.
+
+Цей самий ефект (короткочасне осліплення від диму та псування речей) дають більшість інших заклинань, що завдають {hh101шкоди вогнем{x.
+</text>
   </help>
   <mana>200</mana>
   <name l="en">fire breath</name>

--- a/other-skills/frost breath.xml
+++ b/other-skills/frost breath.xml
@@ -3,12 +3,18 @@
   <beats>24</beats>
   <dammsg mg="n">ледяное дыхание</dammsg>
   <help id="755" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Dragons can breathe out an icy cone of frost, striking everyone around them. Such a cone has a frostbite effect, reducing your strength and coating you with frost. This spell also freezes items in your inventory, destroying the most fragile among them. Part of this powerful magic is available to witches and warlocks.
+
+%SA% %H% {hh778dragon breath{x
+</text>
     <text l="ru">Драконы умеют выдыхать леденящую воронку инея, поражая всех вокруг. Такая воронка обладает обмораживающим эффектом, уменьшая твою силу и покрывая инеем. Это заклинание также обмораживает вещи в инвентаре, уничтожая наиболее хрупкие из них. Часть этой могущественной магии доступна ведьмам и варлокам.
 
 %SA% %H% {hh778дыхание драконов{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Дракони вміють видихати крижану воронку інею, вражаючи всіх навколо. Така воронка має обморожувальний ефект, зменшуючи твою силу та вкриваючи інеєм. Це заклинання також обморожує речі в інвентарі, знищуючи найбільш крихкі з них. Частина цієї могутньої магії доступна відьмам і ворлокам.
+
+%SA% %H% {hh778дихання драконів{x
+</text>
   </help>
   <mana>125</mana>
   <name l="en">frost breath</name>

--- a/other-skills/gas breath.xml
+++ b/other-skills/gas breath.xml
@@ -3,12 +3,18 @@
   <beats>24</beats>
   <dammsg mg="m">выхлоп газа</dammsg>
   <help id="696" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Dragons can breathe a cone of poisonous gas, striking everyone around them. The poison vapors settle on food and liquid containers, tainting them permanently. Part of this powerful magic is accessible to witches and warlocks.
+
+%SA% %H% {hh778dragon breath{x
+</text>
     <text l="ru">Драконы умеют выдыхать воронку ядовитого газа, поражая всех вокруг. Пары яда оседают на еде и емкостях для жидкости, навсегда отравляя их. Часть этой могущественной магии доступна ведьмам и варлокам.
 
 %SA% %H% {hh778дыхание драконов{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Дракони вміють видихати конус отруйного газу, вражаючи всіх навколо. Пари отрути осідають на їжі та ємностях для рідини, назавжди отруюючи їх. Частина цієї могутньої магії доступна відьмам та варлокам.
+
+%SA% %H% {hh778дихання драконів{x
+</text>
   </help>
   <mana>175</mana>
   <name l="en">gas breath</name>

--- a/other-skills/general purpose.xml
+++ b/other-skills/general purpose.xml
@@ -3,10 +3,12 @@
   <beats>12</beats>
   <dammsg mg="p">универсальные боеприпасы</dammsg>
   <help id="2135" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">This long-forgotten spell deals damage to the enemy with lead projectiles fired at tremendous speed. According to legend, this magic came from a distant and very frightening world where almost every adult wields it. Fortunately, in the Dream World this spell can only be found on certain ancient {hh121wands{x in {hh1851Hell{x.
+</text>
     <text l="ru">Это давно забытое заклинание наносит противнику повреждения выпущенными с огромной скоростью свинцовыми снарядами. По легенде эта магия пришла из одного далекого и очень страшного мира, где ей владеют почти все совершеннолетние. К счастью, в Мире Мечты найти это заклинание можно только на некоторых древних {hh121жезлах{x в {hh1851Аду{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Це давно забуте заклинання завдає противнику пошкоджень свинцевими снарядами, випущеними з величезною швидкістю. За легендою ця магія прийшла з одного далекого і дуже страшного світу, де нею володіють майже всі повнолітні. На щастя, у Світі Мрії знайти це заклинання можна лише на деяких древніх {hh121жезлах{x в {hh1851Пеклі{x.
+</text>
   </help>
   <name l="en">general purpose</name>
   <name l="ru">универсальные боеприпасы</name>

--- a/other-skills/high explosive.xml
+++ b/other-skills/high explosive.xml
@@ -3,10 +3,12 @@
   <beats>12</beats>
   <dammsg mg="f">взрывчатка</dammsg>
   <help id="2136" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">This long-forgotten spell deals damage to an enemy with explosive projectiles packed with blasting compounds. According to legend, this magic came from a distant barbaric world where it is used to destroy entire cities. Fortunately, in the Dreamland this spell can only be found on certain ancient {hh121wands{x in {hh1851Hell{x.
+</text>
     <text l="ru">Это давно забытое заклинание наносит противнику повреждения разрывными снарядами со взрывчатыми веществами. По легенде эта магия пришла из одного далекого варварского мира, где она применяется для разрушения целых городов. К счастью, в Мире Мечты найти это заклинание можно только на некоторых древних {hh121жезлах{x в {hh1851Аду{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Це давно забуте заклинання завдає противнику пошкоджень розривними снарядами з вибуховими речовинами. За легендою ця магія прийшла з одного далекого варварського світу, де вона застосовується для руйнування цілих міст. На щастя, у Світі Мрій знайти це заклинання можна тільки на деяких стародавніх {hh121жезлах{x в {hh1851Пеклі{x.
+</text>
   </help>
   <name l="en">high explosive</name>
   <name l="ru">взрывчатка</name>

--- a/other-skills/incandescent.xml
+++ b/other-skills/incandescent.xml
@@ -12,14 +12,24 @@
     <keyword l="en"></keyword>
     <keyword l="ru">накал</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Under the effect of the {hh682incandescence{x prayer and certain other {hh101fire{x-type effects, heat-conducting items may temporarily become red-hot.
+
+Red-hot items in your equipment deal periodic damage to their owner. And if you try to pick up a red-hot item from the ground, it will deal damage as well.
+
+The spell {hh633protection from high temperatures{x will prevent items from heating up. Water or ice will cool already red-hot items.
+</text>
     <text l="ru">Под воздействием молитвы {hh682накаливания{x и некоторых других воздействий {hh101огненного{x типа теплопроводящие вещи могут временно раскалиться до высоких температур.
 
 Раскаленные вещи в экипировке наносят периодический урон владельцу. А если попытаться поднять раскаленную вещь с земли, она также нанесет урон.
 
 Предотвратить накаливание вещей поможет заклинание {hh633защиты от высоких температур{x. А остудить уже раскаленные вещи помогут вода или лед.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Під впливом молитви {hh682розжарення{x та деяких інших впливів {hh101вогняного{x типу теплопровідні речі можуть тимчасово розжаритися до високих температур.
+
+Розжарені речі в екіпіровці завдають переодичну шкоду власнику. А якщо спробувати підняти розжарену річ з землі, вона також завдасть шкоди.
+
+Запобігти розжаренню речей допоможе заклинання {hh633захисту від високих температур{x. А охолодити вже розжарені речі допоможуть вода або лід.
+</text>
     <title l="en"></title>
     <title l="ru">{CВещи:{x аффект накала</title>
     <title l="ua"></title>

--- a/other-skills/lightning breath.xml
+++ b/other-skills/lightning breath.xml
@@ -6,12 +6,18 @@
     <extra l="en"></extra>
     <extra l="ru">дыхание электрическое</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">Some breath attacks can strike you with a bolt of lightning. Such a bolt throws you into shock, and you are unable to react to anything for a short time afterward. Part of this powerful magic is available to witches and warlocks.
+
+%SA% %H% {hh778dragon breath{x
+</text>
     <text l="ru">Некоторые выдохи способны поразить тебя разрядом молнии. Такой разряд ввергает в шок, и ты не можешь ни на что реагировать некоторое время после. Часть этой могущественной магии доступна ведьмам и варлокам.
 
 %SA% %H% {hh778дыхание драконов{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Деякі видихи здатні вразити тебе розрядом блискавки. Такий розряд занурює у шок, і ти не можеш ні на що реагувати деякий час після. Частина цієї могутньої магії доступна відьмам і ворлокам.
+
+%SA% %H% {hh778дихання драконів{x
+</text>
   </help>
   <mana>150</mana>
   <name l="en">lightning breath</name>

--- a/other-skills/set morris dancer.xml
+++ b/other-skills/set morris dancer.xml
@@ -8,7 +8,14 @@
     <extra l="en">morris set</extra>
     <extra l="ru">комплект костюм &apos;костюм танцора морриса&apos; морриса набор сет танцора</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">Morris is an old dance performed in unison by a group of dancers dressed in white clothing with bells. They often carry a rod carved from Yule wood. The costume of such a dancer can be assembled from items scattered across the [Machine Dreams] area. There you can also meet the choreographer, who will help you obtain any missing pieces.
+
+This costume will make you very charming, and will increase your damage, accuracy, mana and hit points. In combat it will lend your movements a special flair. Sometimes, quite unexpectedly, your feet will break into a dance all on their own.
+
+Set level: 3 Number of items: 4
+
+%SA% %H% {hh67sets{x
+</text>
     <text l="ru">Моррис -- старинный танец, который слаженно исполняет группа танцоров, одетых в белую одежду с колокольчиками. В руках они часто держат жезл, выточенный из йольского дерева. Костюм такого танцора можно собрать из предметов, разбросанных по местности [Машинные Мечты]. Там же можно познакомиться с хореографичкой, которая поможет добыть недостающие вещи.
 
 Этот костюм сделает тебя очень обаятельным, увеличит урон, точность, ману и здоровье. В бою придаст движениям особую прыть. Иногда, совершенно неожиданно, твои ноги сами будут пускаться в пляс.
@@ -17,7 +24,14 @@
 
 %SA% %H% {hh67комплекты{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Морріс -- старовинний танець, який злагоджено виконує група танцюристів, одягнених у білий одяг із дзвіночками. У руках вони часто тримають жезл, виточений з йольського дерева. Костюм такого танцюриста можна зібрати з предметів, розкиданих по місцевості [Машинні Мрії]. Там же можна познайомитися з хореографкою, яка допоможе роздобути відсутні речі.
+
+Цей костюм зробить тебе дуже чарівним, збільшить шкоду, точність, ману та здоровʼя. У бою надасть рухам особливої спритності. Іноді, зовсім несподівано, твої ноги самі будуть пускатися у танок.
+
+Рівень комплекту: 3 Кількість предметів: 4
+
+%SA% %H% {hh67комплекти{x
+</text>
     <title l="en"></title>
     <title l="ru">{CКомплекты: {xКостюм танцора морриса</title>
     <title l="ua"></title>

--- a/other-skills/set myrvale noriva.xml
+++ b/other-skills/set myrvale noriva.xml
@@ -11,7 +11,14 @@
     <keyword l="en">noriva set</keyword>
     <keyword l="ru">комплект норива</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Mir&apos;vale Noriva is one of the three junior houses inhabiting the island of {hh1431Drakiri{x. Members of this house specialize in the healing arts and also take an interest in botany. Their symbol is an open hand above a burning ring. House Noriva is responsible for training and instructing the healers of Drakiri.
+
+The clothing set of this house is available to the cleric class. When all items are assembled together, the cleric gains protection from weapons and spells, and his prayers acquire exceptional power.
+
+Set level: 78 Number of items: 12
+
+%SA% %H% {hh67sets{x
+</text>
     <text l="ru">Мир&apos;вейл Норива -- один из трех младших домов, населяющих остров {hh1431Дракири{x. Члены этого дома специализируются в лекарском искусстве, а также интересуются ботаникой. Их символ -- открытая рука над пылающим кольцом. Дом Норива отвечает за обучение и тренировку лекарей Дракири.
 
 Комплект одежды этого дома доступен классу клериков. Когда все предметы собраны воедино, клерик получает защиту от оружия и заклинаний, а его молитвы приобретают особую силу.
@@ -20,7 +27,14 @@
 
 %SA% %H% {hh67комплекты{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Мір&apos;вейл Норіва -- один з трьох молодших домів, що населяють острів {hh1431Дракірі{x. Члени цього дому спеціалізуються на лікарському мистецтві, а також цікавляться ботанікою. Їхній символ -- відкрита долоня над палаючим кільцем. Дім Норіва відповідає за навчання та тренування лікарів Дракірі.
+
+Комплект одягу цього дому доступний класу кліриків. Коли всі предмети зібрані докупи, клерик отримує захист від зброї та заклинань, а його молитви набувають особливої сили.
+
+Рівень комплекту: 78 Кількість предметів: 12
+
+%SA% %H% {hh67комплекти{x
+</text>
     <title l="en"></title>
     <title l="ru">{CКомплекты: {xОдежда Норива</title>
     <title l="ua"></title>

--- a/other-skills/set secret of sidhe.xml
+++ b/other-skills/set secret of sidhe.xml
@@ -8,14 +8,24 @@
     <extra l="en">set</extra>
     <extra l="ru">брони комплект &apos;комплект брони сидхов&apos; набор сет &apos;сет сидха&apos; сидха сидхов</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">The Sidhe armor set can be assembled from equipment worn by the Sidhe who inhabit the Arcadia area. Because the Sidhe always take a clear stance in the struggle between good and evil, this set grants no advantages to neutral characters. For good and evil characters it provides protection against opposing forces, and increases their damage, accuracy and hit points. Elves and dark elves will also receive iron resistance, compensating for their natural vulnerability.
+
+Set level: 68 Number of items: 5
+
+%SA% %H% {hh67sets{x
+</text>
     <text l="ru">Комплект сидхийской брони можно составить из экипировки сидхов, населяющих местность Аркадия. Из-за склонности сидхов всегда занимать четкую позицию в борьбе сил добра и зла, этот набор не даст никаких преимуществ нейтральным персонажам. Добрым и злым он даст защиту от противоположных сил, увеличит их урон, точность и здоровье. Эльфам и темным эльфам комплект подарит сопротивляемость к железу, тем самым компенсируя их природную уязвимость. 
 
 Уровень комплекта: 68 Количество предметов: 5
 
 %SA% %H% {hh67комплекты{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Комплект сідхійської броні можна скласти з екіпіровки сідхів, що населяють місцевість Аркадія. Через схильність сідхів завжди займати чітку позицію у боротьбі сил добра і зла, цей набір не дасть жодних переваг нейтральним персонажам. Добрим і злим він дасть захист від протилежних сил, збільшить їхню шкоду, точність та здоровʼя. Ельфам і темним ельфам комплект подарує стійкість до заліза, тим самим компенсуючи їхню природну вразливість.
+
+Рівень комплекту: 68 Кількість предметів: 5
+
+%SA% %H% {hh67комплекти{x
+</text>
     <title l="en"></title>
     <title l="ru">{CКомплекты: {xБроня Сидхов</title>
     <title l="ua"></title>

--- a/other-skills/set shevale reykaris.xml
+++ b/other-skills/set shevale reykaris.xml
@@ -8,7 +8,14 @@
     <keyword l="en">reykaris set</keyword>
     <keyword l="ru">комплект набор одежда рейкарис сет шивейл</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Shi&apos;vale Reykaris is one of the three elder houses inhabiting the island of {hh1431Drakiri{x. This house specializes in dark magic and necromancy. The symbol of Reykaris is a humanoid skull with eye sockets blazing with fire.
+
+The Reykaris house set is available to the necromancer class. When all items are assembled together, the necromancer gains protection from weapons and spells, and his spells acquire exceptional power.
+
+Set level: 85 Number of items: 9
+
+%SA% %H% {hh67sets{x
+</text>
     <text l="ru">Ши&apos;вейл Рейкарис -- один из трех старших домов, населяющих остров {hh1431Дракири{x. Этот дом специализируется в темной магии и некромантии. Символ Рейкарис -- череп гуманоида с пылающими огнем глазницами.
 
 Комплект одежд дома Рейкарис доступен классу некромантов. Когда все предметы собраны воедино, некромант получает защиту от оружия и заклинаний, а его заклинания приобретают особую силу.
@@ -17,7 +24,14 @@
 
 %SA% %H% {hh67комплекты{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Ші&apos;вейл Рейкаріс -- один з трьох старших домів, що населяють острів {hh1431Дракірі{x. Цей дім спеціалізується на темній магії та некромантії. Символ Рейкаріс -- череп гуманоїда з палаючими вогнем очницями.
+
+Комплект одягу дому Рейкаріс доступний класу некромантів. Коли всі предмети зібрані докупи, некромант отримує захист від зброї та заклинань, а його заклинання набувають особливої сили.
+
+Рівень комплекту: 85 Кількість предметів: 9
+
+%SA% %H% {hh67комплекти{x
+</text>
     <title l="en"></title>
     <title l="ru">{CКомплекты: {xОдежда Рейкарис</title>
     <title l="ua"></title>

--- a/other-skills/set travellers joy.xml
+++ b/other-skills/set travellers joy.xml
@@ -8,14 +8,24 @@
     <extra l="en">set travellers</extra>
     <extra l="ru">комплект набор одежда одежды путешественника путешественников сет</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">The traveller's set can be assembled from the gear of adventurers who have stopped at the {hh1505"Last Refuge"{x inn. This set will improve your stats, increase damage, accuracy, and hit points. In combat it will attempt to {hh657heal wounds{x.
+
+Set level: 14 Number of items: 4
+
+%SA% %H% {hh67sets{x
+</text>
     <text l="ru">Комплект путешественника можно составить из экипировки приключенцев, остановившихся в гостинице {hh1505Утехи{x &quot;Последний Приют&quot;. Этот набор улучшит твои характеристики, увеличит урон, точность и здоровье. В бою попытается {hh657залечить раны{x.
 
 Уровень комплекта: 14 Количество предметов: 4
 
 %SA% %H% {hh67комплекты{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Комплект мандрівника можна скласти з екіпіровки пригодників, що зупинилися в готелі {hh1505"Останній Притулок"{x. Цей набір поліпшить твої характеристики, збільшить шкоду, влучність і здоровʼя. У бою спробує {hh657залікувати рани{x.
+
+Рівень комплекту: 14 Кількість предметів: 4
+
+%SA% %H% {hh67комплекти{x
+</text>
     <title l="en"></title>
     <title l="ru">{CКомплекты: {xОтрада путешественника</title>
     <title l="ua"></title>

--- a/other-skills/sidhe armor.xml
+++ b/other-skills/sidhe armor.xml
@@ -8,12 +8,18 @@
     <extra l="en"></extra>
     <extra l="ru">тайное знание Сидхов</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">Dark and light elves sometimes have very interesting dreams -- a word comes to them containing the secret of the Sidhe people, who once learned to resist their innate vulnerability to iron.
+
+%SA% %H% {hh2040ahenn{x, {hh2044quenya{x
+</text>
     <text l="ru">Темным и светлым эльфам иногда снятся очень интересные сны -- к ним является слово, содержащее в себе секрет народа Сидхов, научившихся когда-то противостоять врожденной уязвимости к железу.
 
 %SA% %H% {hh2040ахэнн{x, {hh2044квенья{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Темним і світлим ельфам іноді сняться дуже цікаві сни -- до них являється слово, що містить у собі секрет народу Сідхів, які колись навчилися протистояти вродженій вразливості до заліза.
+
+%SA% %H% {hh2040ахенн{x, {hh2044квенья{x
+</text>
   </help>
   <name l="en">sidhe armor</name>
   <name l="ru">броня сидхов</name>

--- a/other-skills/spores.xml
+++ b/other-skills/spores.xml
@@ -8,10 +8,12 @@
     <extra l="en"></extra>
     <extra l="ru">галлюциногенные споры</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">Fungal spores arising in the brain as a result of eating {hh197hallucinogenic mushrooms{x.
+</text>
     <text l="ru">Грибные споры, возникающие в мозгу в результате поедания {hh197галлюциногенных грибов{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Грибні спори, що виникають у мозку внаслідок вживання {hh197галюциногенних грибів{x.
+</text>
   </help>
   <name l="en">spores</name>
   <name l="ru">грибные споры</name>

--- a/other-skills/synesthesia.xml
+++ b/other-skills/synesthesia.xml
@@ -4,10 +4,12 @@
   </affect>
   <dammsg mg="m"></dammsg>
   <help id="5066" level="-1" type="SkillHelp">
-    <text l="en"></text>
+    <text l="en">Some {hh86locations{x cause visitors an interesting disorder in which their perception of {hh43colors{x is altered. This works, naturally, only for sighted players who are not using the {hh2133blind client{x and have not enabled {hh2132screen reader{x mode.
+</text>
     <text l="ru">Некоторые {hh86местности{x вызывают у посетителей интересное расстройство, при котором изменяется восприятие {hh43цветов{x. Работает, разумеется, только у зрячих игроков без {hh2133клиента незрячих{x и без включенного режима {hh2132скринридера{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Деякі {hh86місцевості{x викликають у відвідувачів цікавий розлад, при якому змінюється сприйняття {hh43кольорів{x. Працює, звичайно, лише у зрячих гравців без {hh2133клієнта незрячих{x і без увімкненого режиму {hh2132скринридера{x.
+</text>
   </help>
   <name l="en">synesthesia</name>
   <name l="ru">синестезия</name>

--- a/races/arial.xml
+++ b/races/arial.xml
@@ -23,14 +23,24 @@
     <keyword l="en">arials</keyword>
     <keyword l="ru">ариал ариалы ариелла</keyword>
     <keyword l="ua">аріал аріали аріелла</keyword>
-    <text l="en"></text>
+    <text l="en">Arials are half-human, half-bird -- the kings of the skies in the Dreamland. Their extraordinarily high intelligence and {hh563affinity for magic{x make them natural-born spellcasters. But to {hh575fly{x they must stay light, and this takes a toll on their strength and stamina. They easily endure the howl of wind and other loud sounds, yet their fragile build makes them prone to {hh614illness{x. And their delicate plumage is highly {hh101vulnerable{x to acid.
+
+Adult, sapient arials possess impressive snow-white or pale-grey wings, with only subtle avian features -- pale skin, sharpened nails, a hooked nose, and enormous black pupils. A hypothesis exists that in the course of development or evolution, arials pass through a journey from a semi-wild avian form to a humanoid one nearly indistinguishable from humans. How this transformation happens and what the history of this evolutionary process is remains, for now, a mystery.
+
+Arials prefer to stay silent about the origins of their race, their ancestral homeland, and in general about any traditions and laws of their society. Half-forgotten legends speak of a lost city deep in the Southern Mountains, inhabited by semi-sapient winged creatures -- {hh2065aarakocra{x. Unfortunately, no cartographer expedition has ever returned from those lands alive, so confirming or disproving the connection between arials and aarakocra is not yet possible.
+</text>
     <text l="ru">Ариалы -- полулюди-полуптицы, короли небес Мира Мечты. Чрезвычайно высокий интеллект и {hh563склонность к колдовству{x делают их прирожденными магами. Но для {hh575полета{x им приходиться быть легкими, а это сказывается на их силе и выносливости. Они легко переносят шум ветра и другие громкие звуки, но из-за хрупкого телосложения часто {hh614болеют{x. А их тонкое оперение весьма {hh101уязвимо{x к кислоте.
 
 Взрослые разумные ариалы обладают внушительными снежно-белыми или светло-серыми крыльями и лишь небольшими чертами птиц -- бледной кожей, заостренными ногтями, крючковатым носом и огромными черными зрачками. Существует гипотеза, что в процессе развития или эволюции ариалы проходят путь от полудикой птичьей до гуманоидной формы, почти неотличимой от людей. Как происходит эта трансформация и какова история данного эволюционного процесса пока остается загадкой.
 
 Ариалы предпочитают сохранять молчание о происхождении своей расы, исторической родине, и в целом, о любых традициях и законах своего общества. Полузабытые предания говорят, что в глубине Южных гор есть затерянный город, населенный полуразумными крылатыми созданиями, {hh2065ааракокра{x. К сожалению, экспедициям картографов еще ни разу не удалось вернуться из тех краев в живых, так что подтвердить или опровергнуть связь ариалов и ааракокра пока не представляется возможным.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Аріали -- напівлюди-напівптахи, королі небес Світу Мрій. Надзвичайно високий інтелект і {hh563схильність до чаклунства{x роблять їх природженими магами. Але для {hh575польоту{x їм доводиться бути легкими, і це позначається на силі та витривалості. Вони легко переносять шум вітру та інші гучні звуки, проте через крихку статуру часто {hh614хворіють{x. А їхнє тонке опорядження дуже {hh101вразливе{x до кислоти.
+
+Дорослі розумні аріали мають вражаючі сніжно-білі або світло-сірі крила і лише незначні риси птахів -- бліду шкіру, загострені нігті, гачкуватий ніс і величезні чорні зіниці. Існує гіпотеза, що в процесі розвитку або еволюції аріали проходять шлях від напівдикої пташиної до гуманоїдної форми, майже невідмінної від людей. Як відбувається це перетворення і яка історія цього еволюційного процесу -- поки лишається загадкою.
+
+Аріали воліють мовчати про походження своєї раси, історичну батьківщину і взагалі про будь-які традиції та закони свого суспільства. Напівзабуті перекази говорять, що в глибині Південних гір є загублене місто, населене напіврозумними крилатими істотами -- {hh2065аараккокра{x. На жаль, жодній картографічній експедиції ще не вдалося повернутися з тих країв живою, тож підтвердити або спростувати звʼязок аріалів і аараккокра поки що неможливо.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>50</manaBonus>

--- a/races/centaur.xml
+++ b/races/centaur.xml
@@ -22,7 +22,16 @@
     <keyword l="en">centaurs</keyword>
     <keyword l="ru">кентавр кентавра кентавры</keyword>
     <keyword l="ua">кентавр кентавриця кентаври</keyword>
-    <text l="en"></text>
+    <text l="en">Centaurs are a race that arose from the excessively active love of humans for horses. Or the other way around -- horses for humans. Appearance: the lower half is equine (tail, hooves, four legs), the upper half is human. Centaurs are considerably larger and stronger, but rather unwieldy. Tough, they {hh101endure{x cold well. What they lack in high intellectual and moral qualities they make up for with tribal wisdom, attractiveness, and sturdy hooves.
+
+They have no particular fondness for magic, but make use of the ancient tongue {hh2041Arcady{x. They are serious competition for satyrs in wine-drinking and other pleasant excesses. By nature centaurs are trusting and straightforward, and so become easy prey for {hh729charming{x spells. They fear electrical discharges (lightning). From childhood they learn to handle spears and shoot a bow.
+
+Trousers and shoes designed for two-legged races will not, of course, fit centaurs, but they can wear horseshoes. In the city of {hh1423Anon{x there is a blacksmith named Zholob who will not only forge horseshoes for a (not-so-)modest fee, but will also {hh1366shoe{x you. The properties of horseshoes depend on level, so it makes sense to buy new ones from time to time. Over the horse body, centaurs can wear barding. Good barding can be found in the {hh1850Prairies{x}.
+
+Centaurs possess an innate ability to strike {hh876two blows{x with their hooves. They know how to deliver a sudden, painful {hh869rear hoof{x kick to the head of anyone who sneaks up from behind with the intent to {hh620snap their neck{x or {hh782knock them out{x. They can {hh227carry{x other characters on their backs. All four-hoofed creatures have a much lower chance of falling to the ground when a {hh2021combat skill{x fails.
+
+%SA% %H% {hh1002ask{x
+</text>
     <text l="ru">Кентавры -- раса, произошедшая от чрезмерной активной любви людей к лошадям. Или наоборот -- лошадей к людям. Внешний вид: нижняя половина -- лошадиная (хвост, копыта, четыре ноги), верхняя -- человеческая. Кентавры значительно больше и сильнее, но довольно неповоротливы. Выносливы, хорошо {hh101переносят{x холода. Отсутствие высоких умственно-моральных качеств компенсируют племенной мудростью, привлекательностью и крепкими копытами.
 
 К магии особого влечения не испытывают, но пользуются колдовством древнего языка {hh2041Аркади{x. Составляют серьезную конкуренцию сатирам в винораспитии и других приятных излишествах. По природе кентавры доверчивы и бесхитростны, а потому становятся легкой жертвой для {hh729очаровывающих{x заклинаний. Боятся электрических разрядов (молний). С детства учатся владеть копьями и стрелять из лука.
@@ -33,7 +42,16 @@
 
 %SA% %H% {hh1002попросить{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Кентаври -- раса, що виникла з надмірно активної любові людей до коней. Або навпаки -- коней до людей. Зовнішній вигляд: нижня половина -- коняча (хвіст, копита, чотири ноги), верхня -- людська. Кентаври значно більші й сильніші, але доволі неповороткі. Витривалі, добре {hh101переносять{x холоди. Відсутність високих розумово-моральних якостей компенсують племінною мудрістю, привабливістю й міцними копитами.
+
+До магії особливого потягу не відчувають, але користуються чаклунством давньої мови {hh2041Аркаді{x. Складають серйозну конкуренцію сатирам у виновипиванні та інших приємних надмірностях. За природою кентаври довірливі й безхитрісні, а тому стають легкою здобиччю для {hh729зачаровуючих{x заклинань. Бояться електричних розрядів (блискавок). З дитинства вчаться володіти списами і стріляти з лука.
+
+Штани й черевики, призначені для двоногих рас, на кентаврів, звісно, не налізуть, зате вони можуть носити підкови. У місті {hh1423Анон{x є коваль Жолоб, який не тільки виготовить підкови за (не)скромну платню, але й {hh1366підкує{x. Властивості підков залежать від рівня, тому має сенс час від часу купувати нові. На кінське тіло кентаври можуть надягати попони. Гарні попони можна знайти в {hh1850Преріях{x}.
+
+Кентаври мають вроджену здатність завдавати {hh876два удари{x копитами. Вміють несподівано і боляче дати {hh869заднім копитом{x по лобі тому, хто підкрадається ззаду з метою {hh620звернути шию{x або {hh782приспати{x. Можуть {hh227возити{x на собі інших персонажів. У всіх чотирикопитних набагато менша ймовірність при невдалому використанні {hh2021бойової навички{x впасти на землю.
+
+%SA% %H% {hh1002попросити{x
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>1000</maxAlign>

--- a/races/cloud giant.xml
+++ b/races/cloud giant.xml
@@ -26,14 +26,24 @@
     <keyword l="en">&apos;cloud giants&apos;</keyword>
     <keyword l="ru">облачные великаны</keyword>
     <keyword l="ua">хмарні велетні</keyword>
-    <text l="en"></text>
+    <text l="en">Cloud giants resemble enormous humans, standing roughly three metres tall. Their facial features are quite handsome and sharply defined. The skin of cloud giants ranges in colour from milky white with a bluish tint to the colour of a blue sky. Their hair is often silver-white or bronze, their eyes bright blue.
+
+Cloud giants are wiser and far stronger than humans, but fall well short of other races in agility. They love music, fine clothing, and jewellery. In combat, cloud giants love to swing enormous maces and can find and hurl {hh218boulders{x at their opponents.
+
+Their gaseous nature grants them the ability to {hh575fly{x, lets them slip more easily from {hh852nets{x, and makes them less vulnerable to cutting weapons -- but easily vulnerable to lightning. It is said that great mages of antiquity could muddle the minds of certain cloud giants and bend them to their will, then imprison them in sealed vessels -- copper lamps, for instance...
+</text>
     <text l="ru">Облачные великаны напоминают огромных людей, ростом около трех метров. Черты лица -- довольно красивые и четко очерченные. Кожа облачных великанов варьируется по цвету от молочно-белой с голубоватым оттенком до цвета голубого неба. Цвет волос зачастую серебристо-белый или бронзовый, глаза -- ярко-голубые. 
 
 Облачные великаны мудрее и гораздо сильнее людей, но сильно уступают другим расам в ловкости. Они любят музыку, изящную одежду и драгоценности. В бою облачные великаны любят махать огромными булавами, умеют находить и швырять в противника {hh218камни{x.
 
 Их газообразная форма дарует им способность к {hh575полету{x, позволяет легче выпутываться из {hh852сетей{x и делает их менее уязвимыми к режущему оружию, но легко уязвимыми для молний. Говорят, что великим магам древности удавалось заморочить разум и покорить некоторых облачных великанов, а затем заточить в запечатанных сосудах -- например, медных лампах...
 </text>
-    <text l="ua"></text>
+    <text l="ua">Хмарні велетні нагадують величезних людей заввишки близько трьох метрів. Риси обличчя -- досить гарні й чітко окреслені. Шкіра хмарних велетнів варіюється за кольором від молочно-білої з блакитнуватим відтінком до кольору блакитного неба. Колір волосся найчастіше срібно-білий або бронзовий, очі -- яскраво-блакитні.
+
+Хмарні велетні мудріші й набагато сильніші за людей, але значно поступаються іншим расам у спритності. Вони люблять музику, вишуканий одяг і коштовності. У бою хмарні велетні люблять махати величезними булавами і вміють знаходити та жбурляти в противника {hh218каміння{x.
+
+Їхня газоподібна форма дарує їм здатність до {hh575польоту{x, дозволяє легше вивільнятися з {hh852мереж{x і робить їх менш вразливими до ріжучої зброї, але легко вразливими для блискавок. Кажуть, що великим магам давнини вдавалося заморочити розум і підкорити деяких хмарних велетнів, а потім ув'язнити у запечатаних посудинах -- наприклад, мідних лампах...
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>-20</manaBonus>

--- a/races/dark-elf.xml
+++ b/races/dark-elf.xml
@@ -26,12 +26,18 @@
     <keyword l="en">&apos;dark elf&apos; &apos;dark elves&apos; dark-elf dark-elves darkelf darkelves</keyword>
     <keyword l="ru">т-элф т-эльф &apos;темная эльфийка&apos; &apos;темные эльфы&apos; &apos;темный эльф&apos;</keyword>
     <keyword l="ua">темні ельфи</keyword>
-    <text l="en"></text>
+    <text l="en">Unlike their Light kindred, Dark Elves prefer magic to archery. Over long centuries of scholarship they have grown weaker and lost their former agility, but have become considerably more intelligent and developed a high {hh563art of sorcery{x. Their skin is slightly paler than that of Light Elves, and their hair is raven-black. Dark Elves see perfectly in {hh830darkness{x and move {hh703silently{x. They chose the ancient People of Darkness, Ellery Ahe, as their unseen mentors, embraced the ways of Evil, and began using a modified form of that ancient tongue, {hh2040ahenn{x. As with most kindred races, iron is {hh101bane{x to them. Only the {hh858secret of the Sidhe{x, revealed to them in dreams, can offer protection against that metal.
+
+After the great racial wars, which you can read about in the {hh2088Library{x, the elves were driven from their lands. Some went underground and later evolved into roksirs and drow. Those who remained, now called the High Elves, founded a new domain in the north of Thera -- {hh1429Arcadia{x. For the sake of survival they have partly made peace with old feuds, yet even now they live apart, ruled by two Houses of the Sidhe, the Dark and the Light.
+</text>
     <text l="ru">В отличие от своих Светлых собратьев, Темные эльфы предпочитают магию стрельбе из лука. За долгие столетия изыскания они ослабли и потеряли былую ловкость, но значительно поумнели и развили высокое {hh563искусство колдовства{x. Их кожа чуть бледнее, чем у Светлых эльфов, а волосы цвета вороного крыла. Темные эльфы прекрасно {hh830видят в темноте{x и {hh703бесшумно{x передвигаются. Они избрали древний Народ Тьмы, Эллери Ахе, своими незримыми наставниками, приняли пути Зла и начали пользоваться видоизмененной формой их древнего наречия, {hh2040ахэнн{x(ahenn). Как и для большинства родственных рас, железо для них {hh101пагубно{x. И лишь {hh858секрет Сидхов{x, являющийся им в снах, способен защитить от этого металла.
 
 После великих расовых войн, о которых можно прочесть в {hh2088Библиотеке{x, эльфы были вытеснены со своих земель. Некоторые ушли под землю и позже эволюционировали в роксиров и дроу. Оставшиеся, ныне называемые Высшими, основали новый домен на севере Тэры -- {hh1429Аркадию{x. Ради выживания они частично смирились с былыми междоусобицами, но и поныне живут раздельно, под управлением двух Домов Сидхов, Темного и Светлого.
 </text>
-    <text l="ua"></text>
+    <text l="ua">На відміну від своїх Світлих братів, Темні ельфи надають перевагу магії перед стрільбою з лука. За довгі століття вишукувань вони ослабли і втратили колишню спритність, зате значно поумнішали й розвинули високе {hh563мистецтво чаклунства{x. Їхня шкіра трохи бліда, ніж у Світлих ельфів, а волосся кольору вороняча крила. Темні ельфи чудово {hh830бачать у темряві{x і {hh703безшумно{x пересуваються. Вони обрали давній Народ Темряви, Еллері Аге, своїми незримими наставниками, прийняли шляхи Зла і почали користуватися видозміненою формою їхнього давнього наріччя, {hh2040ахенн{x. Як і для більшості споріднених рас, залізо для них {hh101згубне{x. І лише {hh858таємниця Сідхів{x, що являється їм уві сні, здатна захистити від цього металу.
+
+Після великих расових воєн, про які можна прочитати в {hh2088Бібліотеці{x, ельфи були витіснені зі своїх земель. Деякі пішли під землю і згодом еволюціонували в роксирів та дроу. Ті, що залишилися, нині звані Вищими, заснували новий домен на півночі Тери -- {hh1429Аркадію{x. Заради виживання вони частково примирилися зі старими міжусобицями, але й досі живуть окремо, під управлінням двох Домів Сідхів, Темного і Світлого.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>20</manaBonus>

--- a/races/drow.xml
+++ b/races/drow.xml
@@ -23,14 +23,24 @@
     <keyword l="en">&apos;black elf&apos; &apos;black elves&apos; black-elf &apos;drow elf&apos; &apos;drow elves&apos;</keyword>
     <keyword l="ru">дроу &apos;мужчина дроу&apos; &apos;женщина дроу&apos;</keyword>
     <keyword l="ua">дроу &apos;чоловік дроу&apos; &apos;жінка дроу&apos;</keyword>
-    <text l="en"></text>
+    <text l="en">Drow are distant relatives of elves who split from them many centuries ago. Like rockseers, the drow descended underground, where they made their home, losing the right to call themselves High Elves but gaining many new abilities. Drow skin is dark, ranging from coal-black to dark grey. Their hair is white, their ears pointed, their eyes bright iridescent colours.
+
+Drow are far more agile but less tough than humans. They venerate the spider-faced goddess {hh171Lloth{x, hating the light and all living things that populate the surface. Drow love {hh837poisons{x and {hh101resist{x their effects well, but are vulnerable to mithril. Drow are masters of blades and whips.
+
+Like the Dark Elves, drow use a modified form of the dialect {hh2040ahenn{x. They are very cunning and treacherous. Their culture has no room for honour or friendship -- from childhood they learn rivalry and the struggle for power.
+</text>
     <text l="ru">Дроу -- дальние родственники эльфов, отколовшиеся от них много веков назад. Как и роксиры, дроу спустились под землю, где и основали свой дом, потеряв право называться Высшими эльфами, но приобретя много новых умений. Кожа у дроу темная, варьируется от угольно-черной до темно-серой. Волосы белые, уши острые, глаза -- ярких радужных цветов. 
 
 Дроу гораздо более ловкие, но менее выносливые, чем люди. Они почитают пауколикую богиню {hh171Ллот{x, ненавидя свет и все живое, населяющее поверхность. Дроу обожают {hh837яды{x и хорошо {hh101сопротивляются{x его воздействию, но уязвимы к мифрилу. Дроу мастерски владеют клинками и хлыстами.
 
 Как и Темные Эльфы, дроу пользуются видоизмененной формой наречия {hh2040ахэнн{x. Они очень коварны и хитры. В их культуре нет места чести и дружбе, они с детства учатся соперничеству и борьбе за власть.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Дроу -- далекі родичі ельфів, що відкололися від них багато століть тому. Як і роксири, дроу спустилися під землю, де й заснували свій дім, втративши право називатися Вищими ельфами, але набувши багато нових умінь. Шкіра у дроу темна, варіюється від вугільно-чорної до темно-сірої. Волосся біле, вуха гострі, очі -- яскравих веселкових кольорів.
+
+Дроу набагато спритніші, але менш витривалі, ніж люди. Вони шанують павукоподібну богиню {hh171Ллот{x, ненавидячи світло і все живе, що населяє поверхню. Дроу обожнюють {hh837отрути{x і добре {hh101чинять опір{x їхньому впливу, але вразливі до міфрилу. Дроу майстерно володіють клинками та батогами.
+
+Як і Темні Ельфи, дроу користуються видозміненою формою наріччя {hh2040аґенн{x. Вони дуже підступні й хитрі. В їхній культурі немає місця честі й дружбі -- з дитинства вони вчаться суперництву й боротьбі за владу.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>10</manaBonus>

--- a/races/duergar.xml
+++ b/races/duergar.xml
@@ -23,12 +23,18 @@
     <keyword l="en">&apos;dark dwarf&apos; duergars</keyword>
     <keyword l="ru">дуэргар дуэргары дуэргарша &apos;темные карлики&apos;</keyword>
     <keyword l="ua">дуергар дуергари дуергарка &apos;темні карлики&apos;</keyword>
-    <text l="en"></text>
+    <text l="en">Duergar (also known as gray dwarves or dark dwarves) came to this world from {hh1854the Underdark{x. Duergar are very strong, agile, and hardy creatures, but solitude and irritability have greatly dulled their intellect. Centuries spent in rotten half-darkness have granted them {hh101resistance{x to disease. But, like their kin on the surface, they hate water and fear acid.
+
+Duergar are slightly shorter than humans, with dull gray skin and a bald head adorned with stubbornly disheveled white beard. Their black eyes, usually full of malice and contempt, frequently fill with blood, sending duergar into a {hh829berserk{x frenzy. They love axes and are skilled at working with {hh714lockpicks{x and locks. Duergar make excellent thieves and ninjas, but other warrior classes suit them well too.
+</text>
     <text l="ru">Дуэргары (они же серые дварфы или темные карлики) пришли в этот мир из {hh1854Подземья{x. Дуэргары -- очень сильные, ловкие и выносливые создания, но одиночество и раздражительность сильно притупили их интеллект. Века, проведенные в гнилом полумраке, даровали им {hh101устойчивость{x к болезням. Но, как и их родичи с поверхности, они ненавидят воду и боятся кислоты.
 
 Дуэргары совсем немного ниже людей, у них тускло-серая кожа и лысая башка, украшенная упрямо всклокоченной белой бородой. Черные глаза, обычно наполненные злобой и презрением, частенько наливаются кровью, вводя дуэргаров в состояние {hh829берсерка{x. Они обожают топоры и хорошо умеют разбираться в {hh714отмычках{x и замках. Из дуэргаров получаются прекрасные воры и ниндзи, но и другие воинские классы им тоже хорошо даются.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Дуергари (вони ж сірі дварфи або темні карлики) прийшли до цього світу з {hh1854Підземʼя{x. Дуергари -- дуже сильні, спритні та витривалі створіння, але самотність і роздратованість сильно притупили їхній інтелект. Століття, проведені в гнилому напівмороці, даровали їм {hh101стійкість{x до хвороб. Але, як і їхні родичі з поверхні, вони ненавидять воду і бояться кислоти.
+
+Дуергари трохи нижчі за людей, у них тьмяно-сіра шкіра та лиса голова, прикрашена вперто скуйовдженою білою бородою. Чорні очі, зазвичай сповнені злоби та презирства, часто наливаються крівʼю, вводячи дуергарів у стан {hh829берсерка{x. Вони обожнюють сокири і добре розбираються в {hh714відмичках{x та замках. З дуергарів виходять чудові злодії та ніндзі, але й інші воїнські класи їм теж добре даються.
+</text>
   </help>
   <hpBonus>25</hpBonus>
   <manaBonus>-10</manaBonus>

--- a/races/dwarf.xml
+++ b/races/dwarf.xml
@@ -26,14 +26,24 @@
     <keyword l="en">dwarves</keyword>
     <keyword l="ru">дварфы</keyword>
     <keyword l="ua">дварфи</keyword>
-    <text l="en"></text>
+    <text l="en">Dwarves are stocky, short-statured, and usually bearded humanoid creatures. Some mistakenly call them gnomes, driving the actual {hh168gnome{x race to fury. Dwarves are dwarves! BARUK KHAZAD!!!
+
+Dwarves are strong and incredibly hardy. Want to know how much -- offer a dwarf as much gold as he can carry. They have a cantankerous but greedy disposition and easily fall into {hh829rage{x. Not as agile as humans, dwarves nevertheless accumulate wisdom over their long lives. They make decent priests and excel at warrior classes.
+
+Long years at underground forges have developed in them {hh830infravision{x and fire resistance, but they are completely unaccustomed to bad weather on the surface: cold and thunderstorms with rain. Because of this dwarves {hh101fear{x lightning and have the buoyancy of an axe. {hh784Axes{x, however, are greatly respected by the dwarf race -- and other weapons too, which dwarves are remarkably skilled at forging and {hh804improving{x.
+</text>
     <text l="ru">Дварфы -- это коренастые, низкорослые и обычно бородатые человекоподобные существа. Некоторые ошибочно называют их гномами, доводя до бешенства настоящую расу {hh168гномов{x (gnomes). Дварфы -- это дварфы! БАРУК КАЗАД!!!
 
 Дварфы сильны и невероятно выносливы. Хочешь узнать насколько -- предложи дварфу взять столько золота, сколько он унесет. Характер имеют вредный, но жадный, легко впадают в {hh829ярость{x. Не столь ловкие как люди, дварфы однако в течении долгой жизни накапливают мудрость. Из них получаются неплохие священники, и им хорошо даются воинские классы.
 
 Долгие годы в пещерных кузнях развили в них {hh830инфразрение{x и сопротивляемость к огню, но они совершенно не привычны к плохой погоде на поверхности: холоду и грозе с дождем. Из-за этого дварфы {hh101боятся{x молний и имеют плавучесть топора. {hh784Топоры{x, впрочем, весьма уважаемы расой дварфов -- да и другие оружия дварфы замечательно умеют ковать и {hh804улучшать{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Дварфи -- це кремезні, низькорослі й зазвичай бородаті людиноподібні істоти. Дехто помилково називає їх гномами, доводячи до шаленства справжню расу {hh168гномів{x. Дварфи -- це дварфи! БАРУК КАЗАД!!!
+
+Дварфи сильні та неймовірно витривалі. Хочеш дізнатися наскільки -- запропонуй дварфу взяти стільки золота, скільки він зможе понести. Характер мають шкідливий, але жадібний, легко впадають у {hh829лють{x. Не такі спритні, як люди, дварфи однак протягом довгого життя накопичують мудрість. З них виходять непогані священники, і їм добре даються воїнські класи.
+
+Довгі роки в печерних кузнях розвинули в них {hh830інфразір{x та опір вогню, але вони зовсім не звикли до поганої погоди на поверхні: холоду та грози з дощем. Через це дварфи {hh101бояться{x блискавок і мають плавучість сокири. {hh784Сокири{x, втім, дуже шановані расою дварфів -- та й іншу зброю дварфи чудово вміють кувати та {hh804покращувати{x.
+</text>
   </help>
   <hpBonus>30</hpBonus>
   <maxAlign>1000</maxAlign>

--- a/races/elf.xml
+++ b/races/elf.xml
@@ -23,7 +23,14 @@
     <keyword l="en">elf elves</keyword>
     <keyword l="ru">перворожденные &apos;светлые эльфы&apos; &apos;светлый эльф&apos; эльф эльфийка эльфы</keyword>
     <keyword l="ua">первородні &apos;світлі ельфи&apos; &apos;світлий ельф&apos; ельф ельфійка ельфи</keyword>
-    <text l="en"></text>
+    <text l="en">Elves are the Firstborn race, who by the will of {hh1565Varda{x were the first to set foot on the lands of Thera. They are beautiful, intelligent, and agile, but yield to humans in strength and endurance. Elves are tall, their step as light as the wind, and long fair hair barely covers their pointed ears.
+
+In ancient times, elves despised the hordes of strangers who came later and overran their beloved forests. A great war broke out, but the elves lost and were forced to retreat far to the north. In the new kingdom they founded, {hh1429Arcadia{x, they coexist in a fragile, suspicious neutrality with their brethren, the Dark Elves. It is said that somewhere on the lands of Thera another secret city of the elves lies lost -- Malatar...
+
+They fear iron, and only {hh858the secret of the Sidhe{x, which comes to them in dreams, can protect them from that harmful metal. Their {hh703tread{x is so light that they are almost impossible to hear, and at night it is hard to hide from them. The {hh810bow{x in their hands is a deadly weapon that never misses, and the ancient words of the elven tongue {hh2044Quenya{x can make their archery truly {hh624lethal{x. Elves excel at fencing with long, slender swords.
+
+Elves have walked the path of Light since time immemorial, but do not be deceived -- they will not extend a hand to a troll or an uruk-hai. They are haughty enough to sometimes ignore their allies. They are the most ancient. Is their path still long?...
+</text>
     <text l="ru">Эльфы -- Перворожденная раса, волею {hh1565Варды{x первыми ступившая на земли Тэры. Они прекрасны собой, умны и ловки, но уступают людям в силе и выносливости. Росту эльфы высокого, поступь их легка как ветер, а длинные светлые волосы едва прикрывают заостренные уши.
 
 В древности эльфам были ненавистны орды чужаков, которые пришли позднее и заполонили их любимые леса. Грянула великая война, но эльфы проиграли и были вынуждены отступить далеко на север. В основанном ими новом королевстве, {hh1429Аркадии{x, они сосуществуют в хрупком недоверчивом нейтралитете со своими братьями, Темными эльфами. Говорят, что где-то на просторах Тэры затерян еще один тайный город эльфов, Малатар...
@@ -32,7 +39,14 @@
 
 Эльфы испокон веков идут по пути Света, но не стоит обольщаться -- они не протянут руку помощи троллю или урук-хаю. Они достаточно надменны, чтобы иногда игнорировать своих союзников. Они -- самые древние. Долог ли еще их путь?...
 </text>
-    <text l="ua"></text>
+    <text l="ua">Ельфи -- Перворождена раса, яка з волі {hh1565Варди{x першою ступила на землі Тери. Вони прекрасні собою, розумні й спритні, але поступаються людям у силі та витривалості. Ростом ельфи високі, хода легка як вітер, а довге світле волосся ледь прикриває загострені вуха.
+
+У давнину ельфам були ненависні орди чужаків, що прийшли пізніше й заполонили їхні улюблені ліси. Вибухнула велика війна, але ельфи програли і були змушені відступити далеко на північ. У заснованому ними новому королівстві, {hh1429Аркадії{x, вони співіснують у крихкому недовірливому нейтралітеті зі своїми братами, Темними ельфами. Кажуть, що десь на просторах Тери загубилося ще одне таємне місто ельфів, Малатар...
+
+Вони бояться заліза, і лише {hh858секрет Сідхів{x, що являється їм уві сні, здатний захистити від згубного металу. {hh703Хода{x їхня настільки легка, що їх майже неможливо почути, і вночі від них важко сховатися. {hh810Лук{x у їхніх руках -- небезпечна зброя, що б'є без промаху, а давні слова ельфійської мови {hh2044квенья{x можуть зробити їхню стрільбу справді {hh624смертоносною{x. Ельфи чудово фехтують довгими тонкими мечами.
+
+Ельфи здавна ідуть шляхом Світла, але не треба тішитися -- вони не простягнуть руку допомоги тролеві або урук-хаю. Вони досить зарозумілі, щоб іноді ігнорувати своїх союзників. Вони -- найдавніші. Чи ще довгий їхній шлях?...
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>30</manaBonus>

--- a/races/faery.xml
+++ b/races/faery.xml
@@ -23,12 +23,18 @@
     <keyword l="en">faeries faery fairy</keyword>
     <keyword l="ru">фаэри феи фейри фея</keyword>
     <keyword l="ua">феї фей фея фаері</keyword>
-    <text l="en"></text>
+    <text l="en">Faeries are tiny, sparkling creatures with wings, the native inhabitants of the lands of {hh1429Arcadia{x. Being magical creatures by nature, they are very intelligent and possess enormous {hh563aptitude for spells{x. Faeries easily deflect energy and light-based attacks. That said, faeries are very weak and fragile, and therefore easily succumb to poison and disease.
+
+Every faerie has access to the magic of their race -- {hh554faerie fire{x and {hh790faerie fog{x. In combat, faeries can {hh750blink{x: escaping an opponent's attacks with rapid teleports. Faeries make excellent mages and decent hybrid classes -- for example, paladins and anti-paladins.
+</text>
     <text l="ru">Феи -- крохотные искристые существа с крылышками, исконные жители земель {hh1429Аркадии{x. Будучи изначально магическими существами, они очень умны и обладают огромной {hh563склонностью к заклинаниям{x. Феи легко отражают энергетические и световые атаки. Впрочем, феи очень слабенькие и хрупкие, а потому легко поддаются ядам и болезням. 
 
 Любой фее доступна магия их расы -- {hh554огонь фей{x и {hh790туман фей{x. А в бою феи умеют {hh750мерцат{xь: быстрыми телепортами уходить от атак противника. Из фей получаются отличные маги и неплохие гибридные классы -- например, паладины и анти-паладины.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Феї -- крихітні іскристі істоти з крилами, корінні мешканці земель {hh1429Аркадії{x. Будучи від природи магічними істотами, вони дуже розумні й мають величезну {hh563схильність до заклинань{x. Феї легко відбивають енергетичні й світлові атаки. Втім, феї дуже слабенькі й крихкі, тому легко піддаються отруті й хворобам.
+
+Будь-якій феї доступна магія їхньої раси -- {hh554вогонь фей{x і {hh790туман фей{x. А в бою феї вміють {hh750мерехтіти{x: швидкими телепортами уникати атак противника. З фей виходять чудові маги і непогані гібридні класи -- наприклад, паладини й антипаладини.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>50</manaBonus>

--- a/races/felar.xml
+++ b/races/felar.xml
@@ -23,14 +23,24 @@
     <keyword l="en">felars</keyword>
     <keyword l="ru">фелар феларина фелары</keyword>
     <keyword l="ua">фелар фелариня фелари</keyword>
-    <text l="en"></text>
+    <text l="en">The ancestors of felars were great cats with eyes that burned in the dark. For centuries the felar race lived in slavery under sorcerers. The greedy sorcerers kept felars away from books, fearing that the furry servants would grow smarter and slip out of their control. And so intellectual growth passed the race by entirely. But agility -- that cats have in abundance -- they make excellent ninjas and thieves, and all cats know how to {hh703sneak{x silently.
+
+Felar fur is thick and highly flammable, so they {hh101fear{x fire, but handle cold well. They dislike water too, as they swim poorly and risk drowning. Due to natural agility and hereditary memory they are masters of unarmed combat. They don't like {hh167dogs{x, which is why in a fight the fur flies with particular ferocity.
+
+Unlike everyone else, the goddess Bast gives felars no leeway for killing felines -- at the very first offence, the {hh969Avenger{x will come for you!
+</text>
     <text l="ru">Предками феларов были огромные кошки с горящими во тьме глазами. На протяжении веков раса феларов находилась в рабстве у колдунов. Жадные колдуны не допускали феларов к чтению книг, боясь, что мохнатые слуги поумнеют и выйдут из-под контроля. Так вот и прошел интеллектуальный рост мимо расы. Зато ловкости кошкам не занимать -- из них выходят отличные ниндзи и воры, и все кошки умеют бесшумно {hh703красться{x.
 
 Шерсть у феларов густая и легковоспламеняемая, поэтому они {hh101боятся{x огня, зато хорошо переносят холод. И воду тоже недолюбливают, так как плавают плохо и рискуют утонуть. Из-за природной ловкости и наследственной памяти в совершенстве владеют рукопашным боем. Не любят {hh167собак{x, отчего в драке у них клочки по закоулочками летят с особой силой.
 
 Феларам в отличие от всех остальных богиня Баст не дает никаких поблажек на убийство кошачьих -- при первой же провинности за тобой придет {hh969Мститель{x!
 </text>
-    <text l="ua"></text>
+    <text l="ua">Предками феларів були величезні коти з очима, що горіли в темряві. Протягом століть раса феларів перебувала в рабстві у чаклунів. Жадібні чаклуни не допускали феларів до книжок, боячись, що волохаті слуги розумнішають і вийдуть з-під контролю. Ось так інтелектуальне зростання й оминуло расу стороною. Зате спритності кішкам не позичати -- з них виходять відмінні ніндзя і злодії, і всі коти вміють безшумно {hh703красти{x.
+
+Шерсть у феларів густа і легкозаймиста, тому вони {hh101бояться{x вогню, зате добре переносять холод. Та й воду не люблять, бо плавають погано і ризикують потонути. Через природну спритність і спадкову памʼять досконало володіють рукопашним боєм. Не люблять {hh167собак{x, через що у бійці шерсть із суперника летить по кутках із особливою силою.
+
+Феларам на відміну від усіх інших богиня Баст не дає жодних поблажок на вбивство котячих -- за першу-ліпшу провину за тобою прийде {hh969Месник{x!
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <hunts registry="race">mouse rat fish</hunts>

--- a/races/githyanki.xml
+++ b/races/githyanki.xml
@@ -24,12 +24,18 @@
     <keyword l="en">githyanki</keyword>
     <keyword l="ru">гитианки</keyword>
     <keyword l="ua">гітіанки</keyword>
-    <text l="en"></text>
+    <text l="en">The warlike race of githyanki inhabits the mysterious and hard-to-reach expanses of the {hh2048Astral{x. They are far more agile than humans, and reasonably clever, but have a more fragile build. They have yellow skin and an elongated skull with pointed ears and teeth. Githyanki hair is crimson or black, as are their eyes.
+
+Silver plays an important role in githyanki culture, and by spending their entire lives in ritual duels with silver swords they develop {hh101resistance{x to that material. Their inclination toward Evil makes them vulnerable to light and holy power. They make excellent warriors, thieves, and ninjas, though other classes suit them just fine too.
+</text>
     <text l="ru">Воинственная раса гитианки населяет таинственные и труднодоступные пространства {hh2048Астрала{x. Они гораздо более ловкие, чем люди, и довольно сообразительны, но строение тела имеют более хрупкое. У них желтая кожа и удлиненный череп с заостренными ушами и зубами. Волосы гитианки багрового или черного цвета, как и глаза.
 
 Серебро играет важную роль в культуре гитианки, и проводя всю жизнь в ритуальных поединках на серебряных мечах, они развивают {hh101сопротивляемость{x к этому материалу. А склонность ко Злу делает их уязвимыми к свету и святой силе. Из них выходят отличные воины, воры и ниндзи, но другие классы им тоже вполне по плечу.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Войовнича раса гітʼянкі населяє таємничі й важкодоступні простори {hh2048Астралу{x. Вони набагато спритніші за людей і доволі кмітливі, але будова тіла у них крихкіша. У них жовта шкіра й подовжений череп із загостреними вухами та зубами. Волосся гітʼянкі пурпурового або чорного кольору, як і очі.
+
+Срібло відіграє важливу роль у культурі гітʼянкі, і проводячи все життя в ритуальних поєдинках на срібних мечах, вони розвивають {hh101стійкість{x до цього матеріалу. А схильність до Зла робить їх вразливими до світла і священної сили. З них виходять чудові воїни, злодії й ніндзя, але й інші класи їм цілком до снаги.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>-300</maxAlign>

--- a/races/gnome.xml
+++ b/races/gnome.xml
@@ -21,12 +21,18 @@
     <keyword l="en">gnomes</keyword>
     <keyword l="ru">гном гномелла гномы</keyword>
     <keyword l="ua">гном гномела гноми</keyword>
-    <text l="en"></text>
+    <text l="en">Gnomes (not to be confused with dwarves) are small and wise creatures with pointed ears and large, deeply thoughtful eyes. Unlike dwarves, gnomes very rarely grow beards, but they take great care of their hair and often come up with breathtaking hairstyles.
+
+Gnomes are weaker than humans and {hh101vulnerable{x to energy attacks. On the other hand, like their underground kin, gnomes easily resist mental influence and are skilled at working with weapons and armour, {hh1110enhancing{x their properties. They learn faster than others and know the histories and {hh644legends{x of Dreamland to perfection, often remaining neutral in the eternal war between Good and Evil. Gnomes also master the art of reading {hh2145scrolls{x.
+</text>
     <text l="ru">Гномы (не путать с дварфами) -- маленькие и мудрые создания с заостренными ушами и большими, погруженными в глубокую задумчивость, глазами. В отличии от дварфов, гномы очень редко отращивают бороды, зато тщательно следят за волосами и частенько придумывают сногсшибательные прически. 
 
 Гномы слабее людей и {hh101уязвимы{x к энергетическим атакам. Зато, как и их подземные родичи, гномы легко сопротивляются ментальному воздействию и прекрасно умеют работать с оружием и доспехами, {hh1110улучшая{x их свойства. Они быстрее других учатся и в совершенстве знают истории и {hh644легенды{x Мира Мечты, часто сохраняя нейтралитет в извечной войне Добра и Зла. Гномы также в совершенстве владеют искусством чтения {hh2145свитков{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Гноми (не плутати з дварфами) -- маленькі й мудрі істоти із загостреними вухами і великими, заглибленими в глибоку задумливість очима. На відміну від дварфів, гноми дуже рідко відрощують бороди, натомість ретельно доглядають за волоссям і часто вигадують приголомшливі зачіски.
+
+Гноми слабші за людей і {hh101вразливі{x до енергетичних атак. Зате, як і їхні підземні родичі, гноми легко чинять опір ментальному впливу і чудово вміють працювати зі зброєю та обладунками, {hh1110покращуючи{x їхні властивості. Вони вчаться швидше за інших і досконало знають історії й {hh644легенди{x Світу Мрій, часто зберігаючи нейтралітет у вічній війні Добра і Зла. Гноми також досконало володіють мистецтвом читання {hh2145сувоїв{x.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>10</manaBonus>

--- a/races/half-elf.xml
+++ b/races/half-elf.xml
@@ -26,12 +26,18 @@
     <keyword l="en">&apos;half elves&apos;</keyword>
     <keyword l="ru">полуэльфы</keyword>
     <keyword l="ua">напівельфи</keyword>
-    <text l="en"></text>
+    <text l="en">Half-elves are the children of elves and someone else -- most often humans. They are not as intelligent as pureblooded elves, but slightly more agile and faster than humans. They can see in {hh830the dark{x and retain a knack for both elven dialects, {hh2044Quenya{x and {hh2040ahenn{x}.
+
+The fate of half-elves is unenviable -- they are often looked down on and called half-bloods by humans and elves alike. High Elves feel revulsion toward outsiders, going as far as open racism, and zealously guard their traditions and customs, so they despise and consider outcast the children of mixed marriages. As for humans, they are not overly fond of arrogant and pretentious elves, so they often make them targets of mockery.
+</text>
     <text l="ru">Полуэльфы -- дети эльфов и еще кого-нибудь. Чаще всего людей. Они не так умны, как чистокровные эльфы, но чуть ловчее и быстрее людей. Могут видеть в {hh830темноте{x и сохраняют склонность к обоим эльфийским наречиям, {hh2044квенья{x и {hh2040ахэнн{x.
 
 Судьба полуэльфов незавидна -- ведь их зачастую презирают и обзывают полукровками как люди, так и эльфы. Высшие эльфы испытывают отвращение к чужакам, доходя в этом до открытого расизма, и свято блюдут традиции и устои, поэтому презирают и считают изгоями детей от смешанных браков. Что же касается людей, то они не очень-то любят заносчивых и заумных эльфов, поэтому часто выбирают их мишенью насмешек.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Напівельфи -- діти ельфів і ще когось. Найчастіше людей. Вони не такі розумні, як чистокровні ельфи, але трохи спритніші й швидші за людей. Можуть бачити в {hh830темряві{x і зберігають схильність до обох ельфійських наріч, {hh2044квенья{x і {hh2040аґенн{x}.
+
+Доля напівельфів незавидна -- адже їх нерідко зневажають і обзивають напівкровками як люди, так і ельфи. Вищі ельфи відчувають відразу до чужинців, доходячи в цьому до відкритого расизму, і свято дотримуються традицій і устоїв, тому зневажають і вважають вигнанцями дітей від змішаних шлюбів. Що ж до людей, то вони не дуже-то люблять зарозумілих і заумних ельфів, тому часто обирають їх мішенню для насмішок.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>10</manaBonus>

--- a/races/hobbit.xml
+++ b/races/hobbit.xml
@@ -24,12 +24,18 @@
     <keyword l="en">hobbits</keyword>
     <keyword l="ru">хоббиты</keyword>
     <keyword l="ua">гобіти</keyword>
-    <text l="en"></text>
+    <text l="en">Hobbits are distant kin of humans, considered closer to them by blood than dwarves or elves. They are very short -- roughly half a human's height -- but sturdy and stocky. They dislike wearing shoes; their hard soles grow a coat of tough, curly fur. Coming to the lands of Thera, hobbits settled near the present-day capital, Midgaard. Their land, {hh2062the Shire{x, is guarded by battle-ready Shirriffs under the command of the Thain. The Shirriffs protect the peace and quiet of the Shire, for more than anything in the world hobbits cannot stand noise, clamour, and loud sounds in general.
+
+Hobbit faces are distinguished not by beauty but rather by good nature -- chubby-cheeked, bright-eyed, rosy. Being very kind by nature, hobbits {hh101resist{x dark magic well, but unfortunately are easily susceptible to {hh729charm{x. Hobbits love to make merry and eat well; many of them sport a respectable belly, yet they lack nothing in nimbleness. Any hobbit who needs to can {hh798hide{x and {hh703sneak{x so silently that no one will notice. A keen eye and steady hand let them throw {hh218stones{x with deadly accuracy. Hobbits are quite lucky, and their blows {hh47hit the mark{x more often than most. Hobbits make wonderful thieves, but other classes suit them just fine too.
+</text>
     <text l="ru">Хоббиты -- далекие сородичи людей, и считаются ближе им по крови, чем дварфы или эльфы. Росту они очень маленького, в пол-человека ростом, однако крепкие и кряжистые. Обувь носить не любят, их твердые ступни обрастают жесткой курчавой шерстью. Придя на просторы Тэры, хоббиты поселились неподалеку от нынешней столицы, Мидгаарда. Их земля, {hh2062Шир{x, охраняется боевитыми шириффами под руководством Тэйна. Шириффы оберегают тишину и покой в Хоббитании ведь больше всего на свете хоббиты не выносят шума, гама и вообще громких звуков.
 
 Лица хоббитов отличаются не красотой, а, скорее, добродушием -- щекастые, ясноглазые, румяные. Будучи очень добрыми по натуре, хоббиты хорошо {hh101сопротивляются{x темному волшебству, но к сожалению легко поддаются {hh729очарованию{x. Хоббиты очень любят повеселиться и хорошо покушать, многих из них украшает солидное брюшко, однако ловкости им не занимать. Любой хоббит, если нужно, сможет {hh798спрятаться{x и {hh703подкрасться{x так бесшумно, что его и не заметишь. Зоркий глаз и твердая рука позволяют им метко {hh218швыряться камнями{x. Хоббиты весьма удачливы, и их удары чаще других {hh47попадают в цель{x. Из хоббитов получаются замечательные воры, но и другие классы им вполне по плечу.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Гобіти -- далекі родичі людей, вважаються ближчими до них за кровʼю, ніж дварфи або ельфи. Ростом вони дуже маленькі -- з пів-людини заввишки, -- однак міцні та кряжисті. Взуття носити не люблять, їхні тверді ступні вкриваються жорсткою кучерявою шерстю. Прийшовши на простори Тери, гобіти оселилися неподалік від нинішньої столиці, Мідгаарда. Їхня земля, {hh2062Шир{x, охороняється войовничими ширрифами під керівництвом Тейна. Ширрифи оберігають тишу і спокій у Гобітанії, адже найбільше на світі гобіти не терплять галасу, гармидеру і взагалі гучних звуків.
+
+Обличчя гобітів вирізняються не красою, а радше добродушністю -- щокасті, яснооокі, рум'яні. Будучи дуже добрими за вдачею, гобіти добре {hh101чинять опір{x темному чаклунству, але на жаль легко піддаються {hh729зачаруванню{x. Гобіти дуже люблять веселитися і смачно поїсти; декого з них прикрашає солідне черевце, однак спритності їм не позичати. Будь-який гобіт, коли треба, зможе {hh798сховатися{x і {hh703підкрастися{x так безшумно, що його й не помітиш. Гостре oko і тверда рука дозволяють їм влучно {hh218жбурляти каміння{x. Гобіти дуже вдачливі, і їхні удари частіше за інших {hh47влучають у ціль{x. З гобітів виходять чудові злодії, але й інші класи їм цілком до снаги.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>1000</maxAlign>

--- a/races/human.xml
+++ b/races/human.xml
@@ -24,12 +24,18 @@
     <keyword l="en">humans</keyword>
     <keyword l="ru">люди</keyword>
     <keyword l="ua">люди</keyword>
-    <text l="en"></text>
+    <text l="en">Humans came to the Dreamland later than many other races, and at first glance possess no special skills or racial abilities. On the other hand, they are far better than others at adapting to their surroundings and improve their {hh1359skill proficiency{x faster than anyone else. The human race needs 250 fewer experience points to gain a {hh14level{x than all other races.
+
+Humans can pursue any class -- from warrior to vampire. They possess none of the vulnerabilities or weaknesses of other races. Humans may join any clan, choose any {hh81Path{x, and any alignment -- evil, good, or neutral.
+</text>
     <text l="ru">Люди пришли в Мир Мечты позже многих других рас, и на первый взгляд не обладают никакими специальными умениями или расовыми способностями. Зато они гораздо лучше других умеют приспосабливаться к окружающим условиям и быстрее других улучшают {hh1359владение умениями{x. Расе людей для получения {hh14уровня{x нужно набрать на 250 очков меньше, чем всем остальным расам.
 
 Людям по плечу любой класс -- от воина до вампира. Они не обладают никакими уязвимостями или слабостями других рас. Люди могут вступать в любой клан, выбирать любой {hh81Путь{x и любую натуру -- злую, добрую, или соблюдение нейтралитета.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Люди прийшли до Світу Мрій пізніше за багатьох інших рас і на перший погляд не мають жодних спеціальних умінь чи расових здібностей. Зате вони набагато краще за інших вміють пристосовуватися до оточуючих умов і швидше за інших покращують {hh1359володіння вміннями{x. Расі людей для отримання {hh14рівня{x потрібно набрати на 250 очок менше, ніж всім іншим расам.
+
+Людям під силу будь-який клас -- від воїна до вампіра. Вони не мають жодних вразливостей чи слабкостей інших рас. Люди можуть вступати до будь-якого клану, обирати будь-який {hh81Шлях{x і будь-яку вдачу -- злу, добру або дотримання нейтралітету.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>1000</maxAlign>

--- a/races/kender.xml
+++ b/races/kender.xml
@@ -23,7 +23,14 @@
     <keyword l="en">kenders kendr</keyword>
     <keyword l="ru">кендер кендеры кендерша кендр</keyword>
     <keyword l="ua">кендер кендери кендерка кендр</keyword>
-    <text l="en"></text>
+    <text l="en">Kender are short in stature and resemble humans in appearance. They love to wear their long hair tied in a topknot at the back of the head. Kender ears are as pointed as those of elves, and their eyes glow with the liveliest curiosity and a burning love of adventure. Kender adore stories and know the {hh644legends{x and tales of Thera to perfection.
+
+The favourite weapon of kender is the hoopak, a special forked staff. But they also have an excellent affinity for other staves and spears. Accustomed to the din of large cities, they do not fear loud sounds, but cannot stand the cold. Kender are one of the most agile races, though they are not distinguished by great strength or endurance.
+
+Of all the races inhabiting the Dreamland, kender are among the least aggressive -- but perhaps the most irritating. Some even say that the very appearance of kender on the lands of Thera was an unfortunate mistake of the Gods, one that led to the arrival of {hh977Erevan Ilesere{x and the entire kender race. The location of the kender homeland, Kendermore, remains a secret to this day.
+
+Kender are the carriers of the great ideas "all property not mine is all mine" and "anything not nailed down and pried loose counts as fair game." They steal absolutely everything without any pangs of conscience. Pathological kleptomaniacs -- it is better not to invite them as guests. Or at least lock everything up in a safe first, then bury the safe deep in the garden. Hide {hh238the shovel{x too.
+</text>
     <text l="ru">Росту кендеры маленького, внешне похожи на людей. Длинные волосы они обожают собирать в хвост на затылке. Ушки у кендеров острые как у эльфов, а глаза светятся живейшим любопытством и горячей любовью к приключениям. Кендеры обожают истории и в совершенстве знают {hh644легенды{x и сказки Тэры.
 
 Любимое оружие кендеров -- хупак, специальный раздвоенный посох. Но и к другим посохам и копьям у них отличная склонность. Привычные к гулу больших городов, они не боятся громких звуков, но терпеть не могут холода. Кендеры -- одна из самых ловких рас, но не отличаются большой силой и выносливостью.
@@ -32,7 +39,14 @@
 
 Кендеры -- носители великих идей &quot;чужая собственность -- вся моя&quot; и &quot;все, что плохо прибито и можно оторвать, считается плохо лежащим&quot;. Крадут абсолютно все, не мучаясь никакими угрызениями совести. Патологические клептоманы -- в гости таких лучше не приглашать. Ну, или предварительно сложить все вещи в сейф, а сейф закопать в саду поглубже. {hh238Лопату{x тоже спрятать.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Кендери невисокого зросту і зовні схожі на людей. Довге волосся вони обожнюють збирати у хвіст на потилиці. Вуха у кендерів гострі як у ельфів, а очі світяться найжвавішою цікавістю і гарячою любовʼю до пригод. Кендери обожнюють історії і досконало знають {hh644легенди{x та казки Тери.
+
+Улюблена зброя кендерів -- гупак, спеціальний роздвоєний посох. Але й до інших посохів та списів у них чудова схильність. Звикші до гулу великих міст, вони не бояться гучних звуків, але терпіти не можуть холоду. Кендери -- одна з найспритніших рас, але не відрізняються великою силою і витривалістю.
+
+З усіх рас, що населяють Світ Мрій, кендери -- один із найменш агресивних, але, мабуть, один із найбільш дратівливих народів. Кажуть навіть, що сама поява кендерів на просторах Тери -- прикра помилка Богів, яка призвела до проникнення у світ {hh977Еревана Ілесіра{x і всієї раси кендерів. Місцезнаходження корінної території кендерів, Кендермора, і досі -- таємниця.
+
+Кендери -- носії великих ідей "чужа власність -- уся моя" і "все, що погано прибите і можна відірвати, вважається погано закладеним". Крадуть абсолютно все, не мучачись жодними докорами сумління. Патологічні клептомани -- в гості таких краще не запрошувати. Ну, або попередньо скласти все у сейф, а сейф закопати в саду якомога глибше. {hh238Лопату{x теж сховати.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>1000</maxAlign>

--- a/races/mawg.xml
+++ b/races/mawg.xml
@@ -23,12 +23,18 @@
     <keyword l="en">mawgs</keyword>
     <keyword l="ru">мавги челобака челобаки чес</keyword>
     <keyword l="ua">псюрі псюрень псюрка мавги</keyword>
-    <text l="en"></text>
+    <text l="en">The mawg -- or ches -- is half human, half dog, and its own best friend. In appearance it resembles a humanoid with certain canine features. In each individual these features manifest differently: for example, the presence of a tail, fur on the face and body, dog-like ears, and so on. Mawgs are stronger than humans -- wise, agile, and tough -- but not particularly clever. They are unlikely to make good mages, though most warrior classes suit them just fine.
+
+Mawgs possess an innate ability to sniff out {hh640tracks{x. They dislike {hh166felines{x, so in a fight fur flies from those with particular force. It is hard to {hh837poison{x mawgs or drown them, and everything {hh2130heals{x on them very quickly -- literally 'like on a dog'. However, because of their fur, they suffer, like felars, from {hh101vulnerability{x to fire. Mawgs are generally friendly and trusting, and therefore easily fall prey to {hh729charm{x.
+</text>
     <text l="ru">Челобака или чес -- наполовину человек, наполовину собака, сам себе лучший друг. Внешне напоминает человекоподобное существо с некоторыми чертами собаки. У каждой особи эти черты проявляются по-разному: например, наличием хвоста, шерсти на лице и теле, собачьих ушей и так далее. Челобаки -- сильнее людей, они мудрые, ловкие и живучие, но не особо сообразительные. Из них вряд ли выйдут хорошие маги, зато большинство воинских классов им вполне по плечу. 
 
 Челобаки обладают врожденной способностью вынюхивать {hh640следы{x. Не любят {hh166кошачьих{x, отчего в драке у них клочки по закоулочками летят с особой силой. {hh837Отравить{x или утопить челобак тяжело и {hh2130заживает{x на них все очень быстро -- буквально &apos;как на собаке&apos;. Однако из-за наличия шерсти они, как и фелары, страдают от {hh101уязвимости{x к огню. Челобаки, как правило, дружелюбны и доверчивы, а потому легко поддаются {hh729очарованию{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Чесобака, або чес -- наполовину людина, наполовину собака, сам собі найкращий друг. Зовні нагадує людиноподібну істоту з деякими рисами собаки. У кожної особини ці риси проявляються по-різному: наприклад, наявністю хвоста, шерсті на обличчі й тілі, собачих вух тощо. Чесобаки сильніші за людей -- мудрі, спритні й живучі, але не надто кмітливі. З них навряд чи вийдуть хороші маги, зате більшість воїнських класів їм цілком до снаги.
+
+Чесобаки мають вроджену здатність вишнюхувати {hh640сліди{x. Не люблять {hh166котячих{x, через що в бою у тих клапті літають з особливою силою. {hh837Отруїти{x або втопити чесобак важко, і {hh2130гоїться{x на них все дуже швидко -- буквально &apos;як на собаці&apos;. Однак через наявність шерсті вони, як і фелари, страждають від {hh101вразливості{x до вогню. Чесобаки, як правило, дружелюбні й довірливі, а тому легко піддаються {hh729зачаруванню{x.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>-10</manaBonus>

--- a/races/rockseer.xml
+++ b/races/rockseer.xml
@@ -23,12 +23,18 @@
     <keyword l="en">rockseers</keyword>
     <keyword l="ru">&apos;пещерные эльфы&apos; &apos;пещерный эльф&apos; роксир роксира роксиры</keyword>
     <keyword l="ua">&apos;печерні ельфи&apos; &apos;печерний ельф&apos; роксір роксіра роксіри</keyword>
-    <text l="en"></text>
+    <text l="en">Rockseers are a race of elves living underground in stone caves. Their hair and skin have long lost all pigment, turning pale or grey like the surrounding rock. Over centuries of dwelling among stone, the cave elves developed interesting traits -- they learned to {hh647seep{x through rock and closed doors, or conversely to {hh870merge with the stone{x, gaining {hh101protection{x from piercing and slashing strikes, though at the cost of greatly {hh705slowing down{x and losing agility.
+ 
+Over long centuries of seclusion they forgot {hh2044Quenya{x, the tongue of the High Elves, and resolved to stay neutral in the elves' quarrels with Evil. In return they preserved resistance to {hh729charm{x and further sharpened {hh830infravision{x in the cave darkness. Rockseers despise tree roots that gnaw and crumble their beloved rocks, and they are vulnerable to anything made of wood -- except magical {hh121staves{x, which they wield to perfection.
+</text>
     <text l="ru">Роксиры -- раса эльфов, живущих под землей в каменных пещерах. Их волосы и кожа давно потеряла пигментацию, став белесой или серой, как окружающие скалы. За века обитания среди скал пещерные эльфы развили интересные свойства -- они научились {hh647просачиваться{x сквозь камень и закрытые двери или, наоборот, {hh870сливаться с камнями{x, получая {hh101защиту{x от колющих и рассекающих ударов, но в то же время сильно {hh705замедляясь{x и теряя проворность.
  
 За долгие века затворничества они забыли {hh2044квенью{x, язык Светлых эльфов и решили соблюдать нейтралитет в их разборках со Злом. Зато они сохранили сопротивляемость к {hh729очарованию{x и еще больше развили {hh830инфразрение{x в пещерной темноте. Роксирам ненавистны древесные корни, точащие и разрушающие их любимые скалы, и они уязвимы ко всему, что изготовлено из дерева. Кроме магических {hh121жезлов{x, которыми они владеют в совершенстве.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Роксири -- раса ельфів, що живуть під землею в камʼяних печерах. Їхнє волосся і шкіра давно втратили пігментацію, ставши білястою або сірою, як навколишні скелі. За століття проживання серед скель печерні ельфи розвинули цікаві властивості -- вони навчилися {hh647просочуватися{x крізь камінь і зачинені двері або, навпаки, {hh870зливатися зі скелями{x, отримуючи {hh101захист{x від колючих і рубаючих ударів, але водночас сильно {hh705сповільнюючись{x та втрачаючи спритність.
+ 
+За довгі віки затворництва вони забули {hh2044квенью{x, мову Світлих ельфів, і вирішили дотримуватися нейтралітету в їхніх сутичках зі Злом. Натомість зберегли стійкість до {hh729зачарування{x і ще більше розвинули {hh830інфразір{x у печерній темряві. Роксирам ненависне коріння дерев, що точить і руйнує їхні улюблені скелі, і вони вразливі до всього, що виготовлено з дерева. Крім магічних {hh121жезлів{x, якими вони володіють досконало.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>20</manaBonus>

--- a/races/satyr.xml
+++ b/races/satyr.xml
@@ -21,14 +21,24 @@
     <keyword l="en">satyrs</keyword>
     <keyword l="ru">сатир сатиры сатирша</keyword>
     <keyword l="ua">сатир сатири сатирка</keyword>
-    <text l="en"></text>
+    <text l="en">Satyrs are half-human, half-goat creatures with horns and hairy haunches ending in a pair of sturdy hooves that let satyrs kick harder than most races.
+
+Satyrs are not the wisest of races, but they are nimble and tough, making them quite decent thieves. Thanks to the low blood content in their alcohol, satyrs handle {hh614disease{x well -- though they had best bathe only when sober. That is, never. In the struggles of Good and Evil, satyrs prefer to remain neutral. Or rather, they couldn't care less.
+
+As native forest dwellers, they do not fear trees but use their help for {hh546camouflage{x. In the forest a satyr can hide so completely that you can't see him at all... And then he'll {yJUMP OUT{x from {hh689ambush{x!
+</text>
     <text l="ru">Сатиры -- полулюди-полукозы с рогами и шерстистыми ляжками, оканчивающимися парой крепких копыт, позволяющих сатирам пинаться больнее иных рас.
 
 Сатиры -- не очень мудрая, зато проворная и живучая раса, поэтому из них получаются весьма неплохие воры. Благодаря малому количеству крови в их алкоголе, сатиры хорошо переносят {hh614болезни{x, но вот купаться им лучше только трезвыми. То есть, никогда. В разборках Добра и Зла сатиры предпочитают сохранять нейтралитет. А точнее, им плевать.
 
 Как коренные жители лесов, они не боятся деревьев, а пользуются их помощью для {hh546маскировки{x. Среди леса сатир может замаскироваться так, что его совсем не видно... А потом как из {hh689засады{x {yВЫПРЫГНЕТ!{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Сатири -- напівлюди-напівкози з рогами та вовнистими стегнами, що закінчуються парою міцних копит, якими сатири лупцюють боляче -- будь-яким іншим расам таке й не снилось.
+
+Сатири -- не надто мудра, зате спритна і живуча раса, тому з них виходять дуже непогані злодії. Завдяки малій кількості крові в їхньому алкоголі, сатири добре переносять {hh614хвороби{x -- але купатися їм краще тільки тверезими. Тобто ніколи. У протистоянні Добра і Зла сатири воліють зберігати нейтралітет. А точніше, їм байдуже.
+
+Як корінні мешканці лісів, вони не бояться дерев, а користуються їхньою допомогою для {hh546маскування{x. У лісі сатир може замаскуватися так, що його зовсім не видно... А потім -- як {yВИСТРИБНЕ{x з {hh689засідки{x!
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>150</maxAlign>

--- a/races/storm giant.xml
+++ b/races/storm giant.xml
@@ -23,12 +23,18 @@
     <keyword l="en">&apos;storm giants&apos; stormgiant</keyword>
     <keyword l="ru">&apos;грозовой великан&apos; &apos;штормовая великанша&apos; &apos;штормовой гигант&apos; &apos;штормовой великан&apos; &apos;штормовые великаны&apos; штвел</keyword>
     <keyword l="ua">&apos;грозовий велетень&apos; &apos;штормова велетка&apos; &apos;штормовий гігант&apos; &apos;штормовий велетень&apos; &apos;штормові велетні&apos; штвел</keyword>
-    <text l="en"></text>
+    <text l="en">Storm giants are the largest of the giants inhabiting the Dreamland. Their height exceeds three metres. In appearance they resemble well-built humans of gigantic proportions. The skin of storm giants is pale and varies in shade from pale green to violet. Green skin often comes paired with dark-green hair and emerald eyes, while giants with violet skin may sport blue-black hair and lilac eyes.
+
+They are far stronger and more enduring than humans, but quite slow, even though they move {hh575through the air{x. They are intelligent, fond of music and the fine arts. Storm giants are lords of the tempest -- they are resistant to lightning strikes and can {hh650call lightning{x down on the heads of their enemies. Like cloud giants, they are {hh101vulnerable{x to mental influence, and their inclination toward Good makes them more susceptible to dark magic. They are skilled with two-handed weapons, preferring swords.
+</text>
     <text l="ru">Штормовые великаны -- самые крупные из великанов, населяющих Мир Мечты. Их рост превышает три метра. Внешне они напоминают хорошо сложенных людей гигантских размеров. Кожа штормовых великанов бледная и варьируется по оттенкам от бледно- зеленой до фиолетовой. Зеленая кожа часто идет в сочетании с темно-зелеными волосами и изумрудного цвета глазами, а у гигантов с фиолетовой кожей можно встретить иссиня-черные волосы и лиловые глаза.
 
 Они гораздо сильнее и выносливее людей, но весьма медлительны, хоть и перемещаются {hh575по воздуху{x. Умны, любят музыку и изящные искусства. Штормовые великаны -- повелители грозы, они устойчивы к ударам молний, и умеют {hh650призывать молнии{x на головы своих противников. Как и облачные гиганты, они {hh101уязвимы{x к ментальным воздействиям, а склонность к Добру делает их более подверженными темной магии. Хорошо владеют двуручным оружием, предпочитая мечи.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Штормові велетні -- найбільші з велетнів, що населяють Світ Мрій. їхній зріст перевищує три метри. Зовні вони нагадують добре складених людей гігантських розмірів. Шкіра штормових велетнів бліда і варіюється за відтінками від блідо-зеленої до фіолетової. Зелена шкіра часто поєднується з темно-зеленим волоссям та смарагдовими очима, а в велетнів із фіолетовою шкірою можна зустріти іссиня-чорне волосся і ліловані очі.
+
+Вони значно сильніші й витриваліші за людей, але доволі повільні, хоча й переміщуються {hh575повітрям{x. Розумні, люблять музику й образотворче мистецтво. Штормові велетні -- повелителі грози: вони стійкі до ударів блискавок і вміють {hh650кликати блискавки{x на голови своїх противників. Як і хмарні велетні, вони {hh101вразливі{x до ментального впливу, а схильність до Добра робить їх більш сприйнятливими до темної магії. Добре володіють дворучною зброєю, надаючи перевагу мечам.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <manaBonus>-20</manaBonus>

--- a/races/svirfnebli.xml
+++ b/races/svirfnebli.xml
@@ -23,12 +23,18 @@
     <keyword l="en">&apos;deep gnome&apos; svirfneblin</keyword>
     <keyword l="ru">&apos;глубинные гномы&apos; &apos;мужчина свирфнеблин&apos; &apos;подземные гномы&apos; свирфнеблин свирфы &apos;женщина свирфнеблин&apos;</keyword>
     <keyword l="ua">&apos;глибинні гноми&apos; &apos;чоловік свірфнеблі&apos; &apos;підземні гноми&apos; свірфнеблі &apos;жінка свірфнеблі&apos;</keyword>
-    <text l="en"></text>
+    <text l="en">Svirfnebli, also known as deep gnomes, came to the Dream World after the passage to the {hh1854Underdark{x was opened. They are small in stature, often bald. Their skin is an earthy grey, and on their homely faces sharp, alert ears and a bulbous nose stand out sharply. Centuries spent underground working with stone have made svirfnebli {hh101vulnerable{x to light. They are less agile but more hardy than their surface kin, and see perfectly in {hh830darkness{x.
+
+In intellect and wisdom svirfnebli yield to few, and they possess good resistance to mental attacks. They make excellent mages and clerics, learn faster than others, and have mastered {hh1110item magic{x. In the struggles of Good and Evil, svirfnebli prefer to remain neutral. They favour axes over all other weapons.
+</text>
     <text l="ru">Свирфы, они же подземные гномы, пришли в Мир Мечты после того, как был открыт путь в {hh1854Подземье{x. Они маленького роста, частенько лысые. Их кожа землисто-серого цвета, а на некрасивых лицах резко выделяются острые настороженные уши и нос картошкой. Века, проведенные в подземельях за работой с камнем, сделали свирфов {hh101уязвимыми{x к свету. Они менее ловкие, но более выносливые, чем их родичи с поверхности, и прекрасно видят в {hh830темноте{x.
 
 Умом и мудростью свирфы уступают немногим и обладают хорошей сопротивляемостью к ментальным атакам. Из них получаются прекрасные маги и клерики, они учатся быстрее других и в совершенстве владеют {hh1110предметной магией{x. В разборках Добра и Зла свирфы предпочитают сохранять нейтралитет. Топоры они предпочитают остальным видам оружия.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Свірфнеблі, вони ж підземні гноми, прийшли до Світу Мрій після того, як було відкрито шлях до {hh1854Підземʼя{x. Вони невисокі на зріст, нерідко лисі. Їхня шкіра землисто-сірого кольору, а на негарних обличчях різко виділяються гострі насторожені вуха та ніс-картоплина. Століття, проведені в підземеллях за роботою з каменем, зробили свірфнеблі {hh101вразливими{x до світла. Вони менш спритні, але витриваліші за своїх родичів із поверхні, і чудово бачать у {hh830темряві{x.
+
+Розумом і мудрістю свірфнеблі поступаються небагатьом і мають добру опірність до ментальних атак. З них виходять чудові маги й кліріки, вони навчаються швидше за інших і досконало володіють {hh1110предметною магією{x. У протистоянні Добра і Зла свірфнеблі воліють зберігати нейтралітет. Із зброї надають перевагу сокирам.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>150</maxAlign>

--- a/races/troll.xml
+++ b/races/troll.xml
@@ -26,14 +26,24 @@
     <keyword l="en">trolls</keyword>
     <keyword l="ru">тролли троллиха тролль</keyword>
     <keyword l="ua">тролі</keyword>
-    <text l="en"></text>
+    <text l="en">Deep in mountain caves, hiding from outside eyes for centuries, troll society formed -- known only through fragments of fairy tales and myths. After their long seclusion the trolls decided to crawl out of their lairs and join the other races living in the cities.
+ 
+Trolls are clumsy and not particularly sharp-witted, but they compensate with strength, tribal wisdom, and the resilience of mountain stone. These green-skinned, fanged creatures survive when other races can no longer manage: they {hh2130regenerate{x hit points faster than others and can even recover {hh541rotting{x wounds. Burning through their thick hide is best done with fire and acid. Trolls are cold-blooded, and their flesh is inedible even to predators.
+
+A natural inclination toward Evil has developed in trolls {hh101resistance{x to dark magic, and the clubs with which trolls have beaten each other since their claws were young grant them resistance to heavy blows. Trolls make excellent shaman-priests and practically invulnerable warriors.
+</text>
     <text l="ru">Глубоко в горных пещерах, веками скрываясь от чужих взглядов, сформировалось общество троллей, известное лишь по обрывкам сказок и мифов. После долгого затворничества тролли решили выползти из своих убежищ и присоединится к другим расам, живущим в городах.
  
 Тролли неуклюжи и не особо сообразительны, но компенсируют это силой, племенной мудростью и стойкостью горных камней. Эти зеленокожие и клыкастые твари выживают тогда, когда для других рас это уже не представляется возможным: они быстрее других {hh2130регенерируют{x здоровье и способны восстанавливать даже {hh541гниющие{x раны. Прожечь их толстую шкуру лучше всего получается огнем и кислотой. Тролли -- холоднокровные, а их плоть несъедобна даже для хищников. 
 
 Природная склонность ко Злу развила в троллях {hh101сопротивляемость{x к темной магии, а дубины, которыми тролли мутузят друг друга с младых когтей, даруют им сопротивляемость к тяжелым ударам. Из троллей получаются отличные шаманы-священники и практически неуязвимые воины.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Глибоко в гірських печерах, ховаючись від чужих поглядів упродовж століть, сформувалося суспільство тролів, відоме лише з уривків казок та міфів. Після довгого затворництва тролі вирішили виповзти зі своїх схованок і приєднатися до інших рас, що живуть у містах.
+ 
+Тролі незграбні й не надто кмітливі, але компенсують це силою, племінною мудрістю та стійкістю гірських каменів. Ці зеленошкірі й іклаті створіння виживають тоді, коли для інших рас це вже неможливо: вони швидше за інших {hh2130регенерують{x здоровʼя і здатні відновлювати навіть {hh541гниючі{x рани. Прожерти їхню товсту шкіру найкраще вдається вогнем та кислотою. Тролі -- холоднокровні, а їхня плоть неїстівна навіть для хижаків.
+
+Природна схильність до Зла розвинула в тролів {hh101стійкість{x до темної магії, а дубини, якими тролі мутузять одне одного з малих кігтів, дарують їм стійкість до важких ударів. З тролів виходять відмінні шамани-священники і практично невразливі воїни.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>-300</maxAlign>

--- a/races/urukhai.xml
+++ b/races/urukhai.xml
@@ -23,12 +23,18 @@
     <keyword l="en">uruk-hai urukhai</keyword>
     <keyword l="ru">урук-хаи &apos;урук-хай хыр&apos; &apos;урук-хай лядь&apos; урукхай</keyword>
     <keyword l="ua">урук-хаї &apos;урук-хай штрик&apos; &apos;урук-хай хурва&apos; урукхаї</keyword>
-    <text l="en"></text>
+    <text l="en">Uruk-hai are a new step in the evolutionary development of orcs. They are taller and larger than humans, long fangs protrude from their jaws, and their deep-set, malevolent eyes frequently go bloodshot from fits of battle {hh829rage{x. Uruk-hai boast impressive strength and endurance, and run faster than humans.
+
+From childhood they handle nearly all weapon types with skill. They have little grasp of magic and prefer warrior classes. Not being especially quick-witted, uruk-hai were once easily swayed by powerful sorcerers and carried out their orders. To this day uruk-hai are easily subjected to mental {hh101influence{x, and their affinity with Evil makes them vulnerable to holy and light attacks.
+</text>
     <text l="ru">Урукхаи -- новая ступень в эволюционном развитии орков. Они выше и больше людей, из пасти торчат длинные клыки, а глубоко посаженные злые буркалы часто наливаются кровью от припадков боевой {hh829ярости{x. Урукхаи отличаются завидной силой и выносливостью, а бегают быстрее людей. 
 
 С детства великолепно владеют почти всеми видами оружия. Магию недопонимают и предпочитают воинские классы. Не будучи особо сообразительными, урукхаи раньше часто подпадали под влияния могучих волшебников, исполняя их приказы. И по сей день урукхаи легко поддаются ментальным {hh101воздействиям{x, а их сродство со Злом делает их уязвимыми для святых и световых атак.
 </text>
-    <text l="ua"></text>
+    <text l="ua">Урук-хаї -- нова сходинка в еволюційному розвитку орків. Вони вищі й більші за людей, з пащ стирчать довгі іклаї, а глибоко посаджені злі буркала часто наливаються кровʼю від нападів бойової {hh829люті{x. Урук-хаї відрізняються завидною силою і витривалістю, а бігають швидше людей.
+
+Змалечку чудово володіють майже всіма видами зброї. Магії не розуміють і надають перевагу воїнським класам. Не відрізняючись особливою кмітливістю, урук-хаї раніше часто підпадали під вплив могутніх чарівників і виконували їхні накази. І донині урук-хаї легко піддаються ментальним {hh101впливам{x, а їхня спорідненість зі Злом робить їх уразливими до святих і світлових атак.
+</text>
   </help>
   <hpBonus>20</hpBonus>
   <maxAlign>-300</maxAlign>

--- a/religions/ahuramazda.xml
+++ b/religions/ahuramazda.xml
@@ -5,7 +5,19 @@
   <ethos></ethos>
   <flags>cult</flags>
   <help id="982" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CAhuramazda{x is the all-knowing creator dwelling in endless light, and the giver of all that is good. Ahuramazda is depicted in the image of the Faravahar -- a winged guardian angel in a tall hat with a full beard. In his infinite wisdom he inspires the righteous and punishes the wicked. Followers of the cult of Ahuramazda believe that daily struggle against evil in this world is not enough -- the day of the Last Judgment, Frashkard, will come, when the Great One shall transform the world and cleanse it of corruption once and for all.
+
+%A% =Paths:= {WLight{x, {BReason{x
+%A% =Gifts:= in battle the mark of Ahuramazda grants you {hh711inspiration{x, {hh758banishes evil{x
+and {hh794dispels{x demons and undead.
+%A% =Restrictions:= only the {hh33non-evil{x 
+%A% =Sacrifices:= Ahuramazda prefers magical items with spells
+  of healing and blessing. Will be pleased by the corpse of a non-good creature.
+
+After the fall of {hh1837Thalos{x the cult of Ahuramazda gained special power -- his prophets can be found in {hh1838New Thalos{x to this day.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CАхурамазда{x -- всеведущий творец, пребывающий в бесконечном свете, и податель всего благого. Ахурамазду изображают в образе Фаравахара -- крылатого ангела-хранителя в высокой шапке и с окладистой бородой. В своей бесконечной мудрости он вдохновляет праведников и карает нечестивцев. Последователи культа Ахурамазды верят, что ежедневной борьбы со злом в этом мире недостаточно -- наступит день Страшного Суда, Фрашкард, когда Великий преобразит мир и окончательно очистит его от скверны.
 
 %A% =Пути:= {WСвет{x, {BРазум{x
@@ -19,7 +31,19 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАхурамазда{x -- всезнаючий творець, що перебуває в нескінченному світлі, і подавець усього доброго. Ахурамазду зображують в образі Фаравахара -- крилатого ангела-охоронця у високому капелюсі з окладистою бородою. У своїй нескінченній мудрості він надихає праведників і карає нечестивців. Послідовники культу Ахурамазди вірять, що щоденної боротьби зі злом у цьому світі недостатньо -- настане день Страшного Суду, Фрашкард, коли Великий перетворить світ і остаточно очистить його від скверни.
+
+%A% =Шляхи:= {WСвітло{x, {BРозум{x
+%A% =Дари:= у бою знак Ахурамазди дарує тобі {hh711наснагу{x, {hh758виганяє зло{x
+та {hh794розвіює{x демонів і нежить.
+%A% =Обмеження:= тільки {hh33не-злі{x 
+%A% =Жертвоприношення:= Ахурамазда надає перевагу чарівним предметам із заклинаннями
+  зцілення та благословення. Зрадіє трупу не-доброї істоти.
+
+Після загибелі {hh1837Талосу{x культ Ахурамазди набув особливої сили -- його пророків можна знайти в {hh1838Новому Талосі{x і досі.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/alala.xml
+++ b/religions/alala.xml
@@ -9,7 +9,17 @@
     <keyword l="en">alala</keyword>
     <keyword l="ru">алала</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CAlala{x is the goddess of the deafening battle cry that inspires warriors to courage and great deeds in combat. Alala keeps her distance from her mad uncle {hh966Ares{x, god of war and bloodshed -- his companions repel her, and her chief mission is to help warriors across the world find bravery and overcome fear. Alala is depicted as a young female warrior with an encouraging smile on her lips, and the followers of her cult wander the expanse of Thera teaching the art of the battle cry.
+
+%A% =Paths:= {RFury{x
+%A% =Gifts:= in battle Alala's tattoo will let out a particularly mighty {hh860battle cry{x, which
+can sometimes {hh606stun{x your enemies
+%A% =Sacrifices:= Alala will be pleased by any weapon.
+  
+Alala's companions were last seen beyond the northern plains, in a small town called {hh1860Ofcol{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CАлала{x -- богиня оглушительного боевого клича, вдохновляющего воинов на храбрость и подвиги в сражении. Алала держится в стороне от своего безумного дяди {hh966Ареса{x, бога войны и кровопролития, ей отвратительны его спутники, и ее главная миссия -- помочь воинам по всему миру обрести отвагу и победить страх. Алалу изображают в виде молодой воительницы с ободряющей улыбкой на устах, а последователи ее культа странствуют по просторам Тэры, обучая искусству боевого клича.
 
 %A% =Пути:= {RЯрость{x
@@ -21,7 +31,17 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАлала{x -- богиня оглушливого бойового кличу, що надихає воїнів на хоробрість і подвиги в битві. Алала тримається осторонь від свого шаленого дядька {hh966Ареса{x, бога війни та кровопролиття -- його супутники їй огидні, і її головна місія -- допомогти воїнам по всьому світу знайти відвагу та здолати страх. Алалу зображують у вигляді молодої воїтельки з підбадьорливою усмішкою на вустах, а послідовники її культу мандрують просторами Тери, навчаючи мистецтву бойового кличу.
+
+%A% =Шляхи:= {RЯрість{x
+%A% =Дари:= у бою татуювання Алали видасть особливо потужний {hh860бойовий клич{x, який
+іноді здатен {hh606оглушити{x твоїх противників
+%A% =Жертвоприношення:= Алала зрадіє будь-якій зброї.
+  
+Останнього разу супутників Алали бачили за рівнинами Півночі, у маленькому містечку під назвою {hh1860Офкол{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/allanon.xml
+++ b/religions/allanon.xml
@@ -8,7 +8,14 @@
     <keyword l="en">allanon</keyword>
     <keyword l="ru">алланон</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CAllanon{x -- god-ranger, the legendary leader of the ancient {hh1494Mercenaries{x. He is usually depicted as a slender youth bent over the ground, carefully studying tracks invisible to others. It is said that Allanon was so captivated by the process of {hh640tracking{x that he did not care much about the Mercenaries' material well-being and often forgot to demand payment for his services. Fortunately, subsequent generations of Mercenaries corrected his regrettable oversight. Allanon is patron of the {hh140ranger{x class and the shaggy race of born trackers, the {hh167dogboys{x. 
+
+%A% =Paths:= {YSociety{x (supreme god)
+%A% =Gifts:= Allanon's mark will let you instantly {hh925return{x to your mortal
+{x body upon death, sometimes accelerate the {hh640tracking{x process by transporting you to the target, {x and in battle will briefly {hh1108sharpen your vision{x and grant the ability of {hh590woodland combat{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CАлланон{x -- бог-следопыт, легендарный лидер {hh1494Наемников{x древности. Его обычно изображают в виде субтильного юноши, склонившегося над землей и тщательно изучающего незримые прочим следы. Говорят, что Алланона настолько захватывал процесс {hh640следопытства{x, что он не очень заботился о материальном благополучии Наемников и частенько забывал потребовать плату за свои услуги. К счастью, последующие поколения Наемников исправили его досадное упущение. Алланон покровительствует сословию {hh140рейнджеров{x и мохнатой расе прирожденных следопытов, {hh167челобак{x. 
 
 %A% =Пути:= {YОбщество{x (верховный бог)
@@ -17,7 +24,14 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАлланон{x -- бог-слідопит, легендарний лідер {hh1494Найманців{x давнини. Його зазвичай зображують у вигляді субтильного юнака, що схилився над землею і уважно вивчає сліди, незримі для інших. Кажуть, що Алланона настільки захоплював процес {hh640слідопитства{x, що він не дуже дбав про матеріальне благополуччя Найманців і часто забував вимагати плату за свої послуги. На щастя, наступні покоління Найманців виправили його прикре упущення. Алланон покровительствує стану {hh140рейнджерів{x і мохнатій расі природжених слідопитів, {hh167чолобак{x. 
+
+%A% =Шляхи:= {YСуспільство{x (верховний бог)
+%A% =Дари:= знак Алланона дозволить тобі миттєво {hh925повернутися{x до свого бренного
+{x тіла у разі смерті, іноді прискорить процес {hh640слідкування{x, переносячи тебе до цілі, {x а у бою ненадовго {hh1108загострить твій зір{x і дарує здатність {hh590лісового бою{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/ares.xml
+++ b/religions/ares.xml
@@ -6,7 +6,19 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="966" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CAres{x is the fierce god of the chaos of war and mad bloodshed, the avatar of battle fury and might. Unlike his sister {hh965Athena,{x goddess of clever warfare, Ares prefers war that is treacherous and bloody -- war for its own sake. In the battles of Ares he is often accompanied by his associates, the gods {hh978Phobos{x and {hh986Deimos,{x fear and dread. Followers of his cult depict Ares as a huge half-naked warrior with eyes burning with fury and a bloodied spear in his mighty hands. Ares is patron of the fierce race of {hh163urukhai{x.
+
+%A% =Paths:= {RFury{x
+%A% =Gifts:= in battle the mark of Ares will send you into a state of {hh829battle fury{x, and will also
+  briefly increase damage at the cost of defensive skills
+%A% =Restrictions:= only the {hh39strongest{x
+%A% =Sacrifices:= Ares likes to receive good weapons as sacrifice.
+  Of drinks, prefers wines.
+
+By tradition, adepts of Ares make pilgrimages to Mount {hh1864Olympus{x, where the god of war was last seen.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CАрес{x -- неистовый бог хаоса войны и безумного кровопролития, аватар боевой ярости и мощи. В отличие от своей сестры {hh965Афины,{x богини умной войны, Арес предпочитает войну коварную и кровавую, войну ради самой войны. В битвах Ареса часто сопровождают его сообщники, боги {hh978Фобос{x и {hh986Деймос,{x страх и ужас. Последователи его культа изображают Ареса в виде огромного полуобнаженного воина с горящими от ярости очами и окровавленным копьем в могучих руках. Покровительствует Арес неистовой расе {hh163урукхаев{x.
 
 %A% =Пути:= {RЯрость{x
@@ -20,7 +32,19 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАрес{x -- шалений бог хаосу війни та безумного кровопролиття, аватар бойової ярості та потужі. На відміну від своєї сестри {hh965Афіни,{x богині розумної війни, Арес надає перевагу війні підступній і кривавій -- війні заради самої війни. У битвах Ареса часто супроводжують його спільники, боги {hh978Фобос{x та {hh986Деймос,{x страх і жах. Послідовники його культу зображують Ареса у вигляді величезного напівголого воїна з палаючими від ярості очима та закривавленим списом у могутніх руках. Арес покровительствує шаленій расі {hh163урукхаїв{x.
+
+%A% =Шляхи:= {RЯрість{x
+%A% =Дари:= у бою знак Ареса введе тебе в стан {hh829бойової ярості{x, а також
+  ненадовго посилить пошкодження на шкоду вмінням оборони
+%A% =Обмеження:= тільки найбільш {hh39сильні{x
+%A% =Жертвоприношення:= Арес любить, коли йому в жертву приносять хорошу зброю.
+  З напоїв надає перевагу винам.
+
+За традицією, адепти Ареса здійснюють паломництва на гору {hh1864Олімп{x, де бога війни бачили востаннє.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/athena.xml
+++ b/religions/athena.xml
@@ -6,7 +6,18 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="965" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CAthena{x is the goddess of military cunning, invention, and progress. Unlike the mad {hh966Ares{x, Athena is averse to excessive bloodshed. She helps mortals wage war more efficiently, using strategy, wisdom, and advanced technology, which is why she is patron of the Society path rather than Fury. Followers of her cult depict Athena as a helmeted warrior maiden with a long spear, or in the form of an owl, symbol of wisdom.
+
+%A% =Paths:= {YSociety{x
+%A% =Gifts:= the mark of Athena will increase the effectiveness of your defensive skills,
+  and in battle will briefly teach you new defensive skills previously unknown to you
+%A% =Sacrifices:= Athena likes to receive good weapons
+  or armor as sacrifice. Of drinks, prefers wines.
+
+By tradition, followers of Athena's cult make pilgrimages to Mount {hh1864Olympus{x, where they offer praise to their wise patroness.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CАфина{x -- богиня военной хитрости, изобретательства и прогресса. В отличие от безумного {hh966Ареса{x, Афине претит излишнее кровопролитие. Она помогает смертным вести войну более организованно, используя стратегию, мудрость и высокие технологии, поэтому она покровительствует пути Общества, а не Ярости. Последователи ее культа изображают Афину в виде шлемоблещущей воительницы с длинным копьем или образе совы, символа мудрости.
 
 %A% =Пути:= {YОбщество{x
@@ -19,7 +30,18 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАфіна{x -- богиня військової хитрості, винахідництва та прогресу. На відміну від шаленого {hh966Ареса{x, Афіні огидне зайве кровопролиття. Вона допомагає смертним вести війну більш організовано, використовуючи стратегію, мудрість і передові технології, тому вона покровительствує шляху Суспільства, а не Ярості. Послідовники її культу зображують Афіну у вигляді шоломоблискучої воїтельки з довгим списом або в образі сови, символу мудрості.
+
+%A% =Шляхи:= {YСуспільство{x
+%A% =Дари:= знак Афіни збільшить ефективність твоїх захисних вмінь,
+  а в бою ненадовго навчить тебе нових, раніше незнайомих навичок захисту
+%A% =Жертвоприношення:= Афіна любить, коли їй у жертву приносять хорошу зброю
+  або броню. З напоїв надає перевагу винам.
+
+За традицією, поклонники культу Афіни здійснюють паломництва на гору {hh1864Олімп{x, де зносять хвалу своїй мудрій покровительці.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon armor recipe</items>

--- a/religions/atum-ra.xml
+++ b/religions/atum-ra.xml
@@ -8,7 +8,20 @@
     <keyword l="en">&apos;atum ra&apos;</keyword>
     <keyword l="ru">&apos;атум ра&apos;</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CAtum-Ra{x -- deity of the Sun, light, day, and order. It arose from primordial chaos and, in the view of its cult's followers, embodies the original and eternal unity of all that exists. Its two aspects -- Atum and Ra -- are likewise one, so it is usually depicted as an androgynous being with a falcon's head. Atum-Ra is the patron of holy {hh141paladins{x and all who make the world brighter by driving back the darkness.
+
+%A% =Paths:= {WLight{x, {wOrder{x
+%A% =Gifts:= in battle, Atum-Ra's mark grants you {hh639bless{x and calls down
+  {hh786divine wrath{x upon your foes
+%A% =Restrictions:= only {hh33lawful good{x
+%A% =Sacrifices:= Atum-Ra prefers magical items enchanted with spells of
+  healing and blessing. Loves offerings of light sources
+  or jewelry. Will rejoice at the corpse of a non-good creature.
+
+Rumor has it that Atum-Ra's avatar has taken form somewhere on Mount {hh1864Olympus{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CАтум-Ра{x -- божество Солнца, света, дня и порядка. Оно возникло из первичного хаоса и олицетворяет, по мнению последователей его культа, первоначальное и вечное единство всего сущего. Две сущности его -- Атум и Ра -- также едины, поэтому изображают его обычно в виде обоеполого существа с головой сокола. Атум-Ра покровительствует святым {hh141паладинам{x и всем, кто делает мир светлее, разгоняя тьму.
 
 %A% =Пути:= {WСвет{x, {wПорядок{x
@@ -23,7 +36,20 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАтум-Ра{x -- божество Сонця, світла, дня та порядку. Воно виникло з первісного хаосу і, на думку послідовників його культу, уособлює початкову і вічну єдність усього сущого. Дві його сутності -- Атум і Ра -- також єдині, тому його зазвичай зображають у вигляді двостатевої істоти з головою сокола. Атум-Ра покровительствує святим {hh141паладинам{x та усім, хто робить світ яскравішим, розганяючи пітьму.
+
+%A% =Шляхи:= {WСвітло{x, {wПорядок{x
+%A% =Дари:= у бою знак Атум-Ра дарує тобі {hh639благість{x і насилає
+  {hh786божественний гнів{x на твоїх ворогів
+%A% =Обмеження:= тільки {hh33законослухняні добрі{x
+%A% =Жертвоприношення:= Атум-Ра віддає перевагу чарівним предметам із закляттями
+  зцілення та благословення. Любить, коли йому в жертву приносять джерела
+  світла або ювелірні прикраси. Зрадіє трупу не-доброї істоти.
+
+За чутками, аватар Атум-Ра втілився десь на горі {hh1864Олімп{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>light jewelry</items>

--- a/religions/azazel.xml
+++ b/religions/azazel.xml
@@ -8,7 +8,26 @@
     <extra l="en"></extra>
     <extra l="ru">&apos;пламя азазеля&apos; желание желания</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">{CAzazel{x -- god of pride, ambition, lust for power and might. This fallen angel, once one of {hh1565Varda{x's helpers, favors none of the Eight Paths and forms alliances with no one. He tolerates no power over himself and craves to overthrow all other gods.
+
+Seeing his followers as instruments for gaining power and strength, Azazel welcomes in them the same ambitions he holds himself. For him it makes no difference who worships him -- mage, warrior, thief, or priest -- only the striving for might matters. Azazel approves of those who exploit others to gain power or even follow one of the Paths, as well as those who seek strength alone. 
+
+Azazel despises oath-breakers and is quite harsh with those followers who do not keep their promises, while welcoming cleverness in the interpretation of words. Though you cannot call him honest, he is always true to his word -- and fulfills his promises precisely, letter for letter. This does not, however, stop him from interpreting promises in his own favor.
+
+Followers of Azazel's cult depict their patron as a fearsome winged demon with shaggy ginger hair, a goat's head, and enormous cloven hooves. They say he sometimes wears a huge tasteless red tie.
+
+%A% =Gifts:= Azazel's mark will grant one of three wishes spoken in his
+  own secret tongue -- it will restore your health, and will curse your enemies
+  or strike them with hellfire. But woe to you if you wish at the wrong moment or
+  mispronounce the words! Azazel does not forgive mistakes... 
+%A% =Restrictions:= {hh33evil, non-chaotic{x only
+%A% =Sacrifices:= Azazel prefers magical items with curse spells
+  and corpses of good creatures. Of drinks, he prefers cola.
+
+An altar dedicated to Azazel was seen somewhere deep in {hh1842the Emerald Forest{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CАзазель{x -- бог гордыни, амбиций, жажды власти и могущества. Этот падший ангел, бывший когда-то одним из помощников {hh1565Варды{x, не благоволит ни одному из Восьми Путей и ни с кем не заключает союзов. Он не терпит никакой власти над собой и жаждет свергнуть всех остальных богов.
 
 Видя в своих последователях инструмент для обретения власти и силы, Азазель приветствует в них те же амбиции, что и у него. Для него нет разницы, кто поклоняется ему -- маг, воин, вор или жрец -- важно только стремление к могуществу. Азазель одобряет как тех, кто использует окружающих ради обретения власти или даже идут по одному из Путей, так и тех, кто ищет силу в одиночку. 
@@ -29,7 +48,26 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CАзазель{x -- бог гордині, амбіцій, жаги влади і могутності. Цей падший янгол, що колись був одним із помічників {hh1565Варди{x, не прихильний до жодного з Восьми Шляхів і ні з ким не укладає союзів. Він не терпить жодної влади над собою і прагне скинути всіх інших богів.
+
+Вбачаючи у своїх послідовниках інструмент для здобуття влади і сили, Азазель вітає в них ті самі амбіції, що й у нього. Для нього немає різниці, хто поклоняється йому -- маг, воїн, злодій чи священник -- важливе лише прагнення до могутності. Азазель схвалює як тих, хто використовує оточуючих заради здобуття влади або навіть іде одним із Шляхів, так і тих, хто шукає силу наодинці. 
+
+Азазель ненавидить клятвопорушників і вельми жорстокий до тих своїх послідовників, що не тримають обіцянок, водночас вітаючи спритність у трактуванні слів. Хоч його й не можна назвати чесним, він завжди вірний своєму слову -- і точно, буква в букву, виконує свої обіцянки. Утім, це аніскільки не заважає йому трактувати обіцянки на свою користь.
+
+Послідовники культу Азазеля зображують свого патрона у вигляді моторошного крилатого демона з рудим скуйовдженим волоссям, козячою головою і величезними роздвоєними копитами. Кажуть, іноді він носить величезну безсмакову червону краватку.
+
+%A% =Дари:= знак Азазеля виконає одне з трьох твоїх бажань, вимовлених
+  його власною таємною мовою -- відновить твоє здоровʼя, а противників
+  проклене або вразить пекельним полумʼям. Але горе тобі, якщо ти забажаєш не
+  вчасно або помилишся у вимові! Азазель не прощає помилок... 
+%A% =Обмеження:= тільки {hh33злі, нехаотичні{x
+%A% =Жертвоприношення:= Азазель надає перевагу чарівним предметам із заклинаннями
+  прокльонів і трупам добрих істот. З напоїв надає перевагу колі.
+
+Вівтар, присвячений Азазелю, бачили десь у глибині {hh1842Смарагдового Лісу{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/bast.xml
+++ b/religions/bast.xml
@@ -8,7 +8,16 @@
     <extra l="en">avenger feline</extra>
     <extra l="ru">&apos;древний дух&apos; кошачий мститель</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">{CBast{x -- the fluffy goddess of joy, warmth, and the hearth, bestower of beauty, love, and tenderness. Bast often wanders the world in her true form, and mortals believe that those she crosses paths with are simply fated for luck and well-being. Those mortals lucky enough to have seen her describe Bast as a huge snow-white cat with bright blue eyes. Naturally, Bast is a {hh166felarine{x and the devoted patron of her race. Do not confuse her with {hh1579Bastian{x -- that is an entirely different god.
+
+The goddess {hh969Bast{x loves all cats and protects them. Legend has it that those who dare to kill more than 50 felines in a lifetime will be struck by a terrible curse -- they will be hunted until rebirth by the ancient spirit of the feline =Avenger=...
+
+%A% =Gifts:= Bast's mark will shield your tender skin (or fur) from fire, 
+{x lend your movements {hh739feline swiftness{x. Bast will help a cat {x cornered, but if you dare to touch any creature of the feline family, {x her wrath will turn on you!
+%A% =Restrictions:= only {hh166felars{x, not allowed for {hh1494Hunters{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CБаст{x -- пушистая богиня радости, тепла и домашнего очага, дарительница красоты, любви и ласки. Баст часто бродит по миру в своем настоящем обличьи, и смертные верят, что те, кому она перейдет дорожку, просто обречены на удачу и благополучие. Те смертные, кому посчастливилось увидеть ее, описывают Баст как огромную снежно-белую кошку с ярко-голубыми глазами. Разумеется, Баст -- {hh166феларина{x и верная покровительница своей расы. Не перепутай ее с {hh1579Бастианом{x -- это совсем другой бог.
 
 Богиня {hh969Баст{x любит всех кошек и защищает их. По легенде на тех, кто посмеет убить более 50 кошачьих за жизнь, падет жуткое проклятие -- их станет до самого перерождения преследовать древний дух кошачьего =Мстителя=...
@@ -19,7 +28,16 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CБаст{x -- пухнаста богиня радості, тепла та домашнього вогнища, дарителька краси, кохання та ласки. Баст часто блукає світом у своєму справжньому вигляді, і смертні вірять, що тим, кому вона перейде дорогу, просто судилось щастя і благополуччя. Ті смертні, кому пощастило її побачити, описують Баст як величезну сніжно-білу кішку з яскраво-блакитними очима. Звісно, Баст -- {hh166фелара{x і вірна покровителька своєї раси. Не переплутай її з {hh1579Бастіаном{x -- це зовсім інший бог.
+
+Богиня {hh969Баст{x любить усіх кішок і захищає їх. За легендою, на тих, хто насмілиться вбити більш ніж 50 котячих за життя, впаде жахливе прокляття -- їх аж до самого переродження переслідуватиме давній дух котячого =Месника=...
+
+%A% =Дари:= знак Баст захистить твою ніжну шкіру (або хутро) від вогню, 
+{x надасть твоїм рухам {hh739котячої спритності{x. Баст допоможе кішці, {x загнаній у куток, але якщо ти насмілишся торкнутись будь-якої істоти котячого роду, {x її гнів звернеться на тебе!
+%A% =Обмеження:= тільки {hh166фелари{x, не можна {hh1494Мисливцям{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <books>true</books>

--- a/religions/bastian.xml
+++ b/religions/bastian.xml
@@ -8,7 +8,15 @@
     <keyword l="en"></keyword>
     <keyword l="ru">бастик</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CBastian{x is the goat-legged god of orgies, pleasure, and debauchery, patron of {hh159satyrs{x, wallower in the dirt and stirrer of trouble. Legend has it that Bastian was once a mortal man, hopelessly in love with the satyr goddess {hh1580Kradyu{x. The gods heard his prayers and turned him into a satyr. Upon reaching the heavens, Bastian became one of the patrons of {hh2097Chaos{x, bringing a touch of merry madness even into the celestial empyrean. Don't confuse him with {hh969Bast{x -- that is an entirely different goddess.
+
+%A% =Paths:= {MChaos{x
+%A% =Gifts:= in battle the mark of Bastian will belch a foul {hh696gas cloud{x
+{x or strike your enemies with a {hh865hangover acid blow{x. {x Oh yes, and it will also reward you with vulnerability to drowning. {x When you're drunk, you know, the sea isn't always ankle-deep.
+%A% =Restrictions:= only the {hh30non-lawful{x (naturally!)
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CБастиан{x -- козлоногий бог оргий, наслаждения и дебоширства, покровитель {hh159сатиров{x, валятель земли и нарушитель безобразий. Легенда гласит, что когда-то Бастиан был смертным человеком, безответно влюбленным в сатирскую богиню {hh1580Крадю{x. Боги услышали его молитвы и превратили в сатира. Попав на небо, Бастиан стал одним из покровителей {hh2097Хаоса{x, привнося частичку веселого безумия даже в небесные эмпиреи. Не перепутай его с {hh969Баст{x -- это совсем другая богиня.
 
 %A% =Пути:= {MХаос{x
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CБастіан{x -- козлоногий бог оргій, насолоди та дебошу, покровитель {hh159сатирів{x, валяльник землі та порушник безобразій. Легенда говорить, що колись Бастіан був смертною людиною, безнадійно закоханою в сатиричну богиню {hh1580Крадю{x. Боги почули його молитви і перетворили на сатира. Потрапивши на небо, Бастіан став одним із покровителів {hh2097Хаосу{x, привносячи дрібку веселого безумства навіть у небесні емпіреї. Не плутай його з {hh969Баст{x -- це зовсім інша богиня.
+
+%A% =Шляхи:= {MХаос{x
+%A% =Дари:= у бою знак Бастіана відригне смердючу {hh696газову хмару{x
+{x або вразить твоїх противників {hh865похмільно-кислотним ударом{x. {x Ах так, а ще нагородить тебе вразливістю до утоплення. {x Пʼяним, знаєш, море не завжди по коліно.
+%A% =Обмеження:= тільки {hh30не-законослухняні{x (звісно!)
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/cradya.xml
+++ b/religions/cradya.xml
@@ -8,7 +8,15 @@
     <keyword l="en">cradya</keyword>
     <keyword l="ru">крадя</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CKradya{x -- supreme goddess of fauna and all mute creatures, patron of {hh151centaurs{x, the {hh1456Lion Pride{x, and the {hh2097Circle of Chaos{x all at once. Here is what the legends say of her birth and life: &quot;One warm winter morning a {hh159satyr{x was born. Her mother didn't make it to the satyr maternity ward, so the satyr had to be born in a puddle of beer. And the taste of mother's milk was improved by the puddle. She grew up a very obedient horned girl, excelling at biology and brewing. And on quiet moonlit nights she would go to the zoo. On the way she encountered {hh144vampires{x. She would whack them over the head with plastic bottles. They would yelp and not bite her. Because she had no blood in her. Only beer. When she arrived at the zoo, she would leap on the hippos and pour beer down the elephants. Then the elephants would make a ruckus in the morning. And the keepers would wonder. What's gotten into them. Life passed her by, merrily. And she died as she had always dreamed -- in a single day. From cirrhosis of the liver. Like a true satyr worthy of her life. And ended up in the satyr paradise-{hh92wishlist{x.&quot;
+
+%A% =Paths:= {gNature{x (supreme goddess), {MChaos{x
+%A% =Gifts:= Kradya's mark will teach you to heal yourself with beer and wine, and in battle will lend
+{x extra strength to your {hh15pet{x and cause {hh909tongues to stumble{x {x -- your foe's or your own, however it turns out!
+%A% =Restrictions:= only {hh30non-lawful{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CКрадя{x -- верховная богиня фауны и тварей бессловесных, покровительница {hh151кентавров{x, {hh1456Прайда Львов{x и {hh2097Круга Хаоса{x одновременно. Вот что говорят о ее рождении и жизни легенды: &quot;Однажды теплым зимним утром родилась {hh159сатира{x. Ее мама не добежала до сатирского роддома, и поэтому сатире пришлось родиться в луже пива. И вкус материнского молока был улучшен лужей. Она росла очень послушной рогатой девочкой, успевала в предметах биологии и пивоварения. А тихими лунными ночами она ходила в зоопарк. По дороге она встречала {hh144вампиров{x. Она огревала их пластиковыми бутылками по голове. Они ойкали и не кусали ее. Потому что в ней не было крови. Только пиво. Когда она приходила в зоопарк, она прыгала на бегемотах и поила слонов пивом. Потом слоны поутру буянили. А смотрители удивлялись. Чего это они. Жизнь ее проходила мимо и весело. И умерла она как мечтала -- в один день. От цирроза печени. Как настоящая и достойная своей жизни сатира. И попала в сатирский рай-{hh92визлист{x.&quot;
 
 %A% =Пути:= {gПрирода{x (верховная богиня), {MХаос{x
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CКрадя{x -- верховна богиня фауни та безсловесних тварин, покровителька {hh151кентаврів{x, {hh1456Прайду Левів{x та {hh2097Кола Хаосу{x водночас. Ось що кажуть про її народження і життя легенди: &quot;Одного теплого зимового ранку народилася {hh159сатира{x. Її мама не добігла до сатирського пологового будинку, і тому сатирі довелось народитися в калюжі пива. І смак материнського молока був поліпшений калюжею. Вона росла дуже слухняною рогатою дівчинкою, встигала з біології та пивоваріння. А тихими місячними ночами ходила до зоопарку. По дорозі вона зустрічала {hh144вампірів{x. Вона гатила їх пластиковими пляшками по голові. Вони ойкали і не кусали її. Бо в ній не було крові. Тільки пиво. Коли вона приходила до зоопарку, вона стрибала на бегемотах і поїла слонів пивом. Потім слони вранці буянили. А доглядачі дивувались. Що це вони. Життя проходило повз неї і весело. І померла вона, як мріяла, -- за один день. Від цирозу печінки. Як справжня і гідна свого життя сатира. І потрапила до сатирського раю-{hh92вішліст{x.&quot;
+
+%A% =Шляхи:= {gПрирода{x (верховна богиня), {MХаос{x
+%A% =Дари:= знак Краді навчить тебе лікуватися пивом і вином, а у бою додасть
+{x додаткової сили твоєму {hh15домашньому улюбленцю{x і змусить {hh909заплутуватись язики{x {x -- ворога або твій власний, як вже вийде!
+%A% =Обмеження:= тільки {hh30не-законослухняні{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/deimos.xml
+++ b/religions/deimos.xml
@@ -9,7 +9,21 @@
     <keyword l="en"></keyword>
     <keyword l="ru">ужас</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">Deimos -- god of the paralyzing terror that comes with war and death. His cult's followers believe that on the fields of battle Deimos and his twin brother {hh978Phobos,{x god of fear, accompany the god of war {hh966Ares{x in his bloody harvest. The face of Deimos is so terrible that no likeness of him has survived across the millennia.
+
+%A% =Paths:= {DDarkness{x, {RRage{x
+%A% =Gifts:= in battle, Deimos's mark will immobilize your foes with the spell of {hh555scream{x
+  or {hh645paralyze{x them with horror. Ancient legend says that when followers
+  of Phobos and Deimos join forces, they can inflict truly devastating damage.
+%A% =Restrictions:= only {hh33non-good{x
+%A% =Sacrifices:= Deimos prefers magical items with combat magic, 
+  illusions, or enchantments. Among drinks he likes wines best. Deimos enjoys
+  being offered good weapons. Will rejoice at the corpse of a non-evil creature.
+
+One adventurer who miraculously survived the depths of the {hh1865Chapel Dungeons{x spoke of an encounter with a nameless HORROR. Their hair has been whiter than the first snow ever since...
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">Деймос -- бог парализующего ужаса перед лицом войны и смерти. Последователи его культа верят, что на полях сражений Деймос и его брат-близнец {hh978Фобос,{x бог страха, сопровождают бога войны {hh966Ареса{x в его кровавой жатве. Лик Деймоса настолько ужасен, что никаких его изображений на протяжении тысячелетий не сохранилось.
 
 %A% =Пути:= {DТьма{x, {RЯрость{x
@@ -25,7 +39,21 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">Деймос -- бог паралізуючого жаху перед лицем війни та смерті. Послідовники його культу вірять, що на полях битв Деймос і його брат-близнюк {hh978Фобос,{x бог страху, супроводжують бога війни {hh966Ареса{x у його кривавій жнив. Лик Деймоса такий жахливий, що жодного його зображення не збереглося протягом тисячоліть.
+
+%A% =Шляхи:= {DТемрява{x, {RЛють{x
+%A% =Дари:= у бою знак Деймоса знерухомить твоїх ворогів закляттям {hh555крику{x
+  або {hh645паралізує{x їх жахом. Стародавня легенда каже, що обʼєднавшись,
+  послідовники Фобоса і Деймоса зможуть завдати воістину жахливих пошкоджень.
+%A% =Обмеження:= тільки {hh33не-добрі{x
+%A% =Жертвоприношення:= Деймос віддає перевагу чарівним предметам з бойовою магією, 
+  примарами або чарами. З напоїв найбільше любить вино. Деймосу подобається,
+  коли йому в жертву приносять гарну зброю. Зрадіє трупу не-злої істоти.
+
+Один пригодник, що чудом вижив у глибинах {hh1865Підземель Каплиці{x, розповідав про зустріч із безіменним ЖАХОМ. Його волосся відтоді -- біліше першого снігу...
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/dwarkin.xml
+++ b/religions/dwarkin.xml
@@ -7,7 +7,19 @@
     <keyword l="en">corwin dwarkin dworkin universals</keyword>
     <keyword l="ru">дваркин дворкин корвин универсалы</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CDwarkin{x, also known as Corwin -- one of the most ancient gods of this world, an artist and creator, faithful ally of {hh1576Leo{x and {hh1565Varda{x. Dwarkin is associated with the striving for unattainable ideals and a perfectionism that borders on compulsion. Since time immemorial he labored painstakingly over the creation of a perfect world filled with harmony and beauty, yet time and again Chaos -- led by his wife {hh1578Tananda{x -- and the free will of the living thwarted his intentions, driving him to madness.
+
+At the end of the Second Epoch Dwarkin succeeded in breeding ideal beings, =universals=. To clear the world for their arrival he unleashed the terrible Cataclysm, which swept all living things from the face of Thera. But the ideal utopia of Dwarkin did not suit the free folk of this world, and over the centuries the universals gradually vanished, remaining only in the memory of their descendants. Dwarkin is patron to the race of {hh168gnomes{x and is himself often depicted as a mad little man with a painter's brush in his hands.
+
+NB: The universals have already vanished from the world, but in Midgaard a cave can still be found with a keeper of their memory.
+
+%A% =Paths:= {wOrder{x
+%A% =Gifts:= in battle Dwarkin's mark may briefly grant you the finest skills
+{x of other classes
+%A% =Restrictions:= {hh33non-chaotic neutral{x only
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CДворкин{x, также известный как Корвин -- один из древнейших богов этого мира, художник и творец, верный соратник {hh1576Лео{x и {hh1565Варды{x. Дворкина отождествляют со стремлением к недостижимым идеалам и перфекционизму, граничащему с компульсией. С незапамятных времен он кропотливо работал над созданием идеального мира, наполненного гармонией и совершенством, но снова и снова Хаос, ведомый его женой {hh1578Танандой{x, и свобода воли живущих переиначивали его намерения, сводя его с ума.
 
 В конце Второй Эпохи Дворкину удалось вывести идеальных существ, =универсалов=. Чтобы освободить просторы мира для их пришествия, он вызвал ужасный Катаклизм, который смел с лица Тэры всех живущих. Но идеальная утопия Дворкина оказалась не по душе свободным жителям этого мира, и по прошествии столетий, универсалы постепенно исчезли, оставшись лишь в памяти потомков. Дворкин покровительствует расе {hh168гномов{x, и его самого часто изображают в виде безумного карлика с малярной кистью в руках.
@@ -21,7 +33,19 @@ NB: Универсалы уже исчезли из мира, но в Мидга
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CДворкін{x, також відомий як Корвін -- один із найдавніших богів цього світу, художник і творець, вірний соратник {hh1576Лео{x і {hh1565Варди{x. Дворкіна ототожнюють із прагненням до недосяжних ідеалів і перфекціонізмом, що межує з компульсією. Із сивої давнини він скрупульозно працював над створенням ідеального світу, наповненого гармонією і досконалістю, але знову і знову Хаос, очолюваний його дружиною {hh1578Танандою{x, і свобода волі живих переінакшували його наміри, зводячи його з розуму.
+
+Наприкінці Другої Епохи Дворкіну вдалося вивести ідеальних істот, =універсалів=. Щоб звільнити простір світу для їхнього приходу, він викликав жахливий Катаклізм, який змів з лиця Тери всіх живих. Але ідеальна утопія Дворкіна не припала до серця вільним мешканцям цього світу, і з плином століть універсали поступово зникли, залишившись лише в памʼяті нащадків. Дворкін покровительствує расі {hh168гномів{x, і його самого часто зображують у вигляді божевільного карлика з малярним пензлем у руках.
+
+NB: Універсали вже зникли зі світу, але в Мідгаарді досі можна знайти печеру з охоронцем памʼяті про них.
+
+%A% =Шляхи:= {wПорядок{x
+%A% =Дари:= у бою знак Дворкіна може ненадовго дарувати тобі найкращі вміння
+{x інших класів
+%A% =Обмеження:= тільки {hh33нехаотичні нейтральні{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/ehrumen.xml
+++ b/religions/ehrumen.xml
@@ -12,7 +12,22 @@
     <keyword l="en">ehrumen</keyword>
     <keyword l="ru">демоны эхрумен</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CEhrumen{x -- a malevolent deity of demons from other dimensions, existing in the eternal Void beyond the Gates of Chaos. Ehrumen is the embodiment of entropy striving to annihilate all that exists, and followers of his demonic cult sow chaos and make bloody sacrifices in the hope of one day reuniting with their Lord. The magic of demon summoning is incredibly difficult to master. Throughout the history of the world, a handful of demons were summoned and tamed only by the ancient archmages of {hh1479Shalafi{x and, of course, the great {hh1578Tananda{x.
+
+%A% =Paths:= {MChaos{x, {DEvil{x
+%A% =Gifts:= in battle Ehrumen's mark will scorch your enemies with the bloodthirsty fire
+  of {hh642demons{x and summon you a mighty demon as a
+  {hh15companion{x. The demon will not obey your {hh1091commands{x, but will shower
+  your foes with combat spells of its own accord.
+%A% =Restrictions:= {hh33chaotic evil{x only
+%A% =Sacrifices:= Ehrumen prefers magical items with combat magic or 
+  necromancy. Ehrumen likes when you sacrifice good weapons.
+  A non-evil creature's corpse will please him.
+
+They say that in the depths of {hh1854the Underdark{x there hides an enclave of Ehrumen's worshippers, still hatching terrible plans to conquer our world.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CЭхрумен{x -- злобное божество демонов иных измерений, существующее в вечной Пустоте за Вратами Хаоса. Эхрумен -- воплощение энтропии, стремящейся изничтожить все сущее, и последователи его демонического культа сеют хаос и приносят кровавые жертвоприношения в надежде когда-нибудь воссоединиться со своим Господином. Магия призыва демонов неимоверно сложна для постижения. За всю историю мира горстку демонов удалось призвать и приручить лишь древним архимагам {hh1479Шалафи{x и, конечно же, Великой {hh1578Тананде{x.
 
 %A% =Пути:= {MХаос{x, {DЗло{x
@@ -29,7 +44,22 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CЕхрумен{x -- злобне божество демонів інших вимірів, що існує у вічній Порожнечі за Брамою Хаосу. Ехрумен -- втілення ентропії, що прагне знищити все суще, а послідовники його демонічного культу сіють хаос і приносять криваві жертви у надії колись возз'єднатися зі своїм Господом. Магія виклику демонів неймовірно складна для опанування. За всю історію світу жменьку демонів вдалося викликати і приручити лише давнім архімагам {hh1479Шалафі{x і, звісно, великій {hh1578Тананді{x.
+
+%A% =Шляхи:= {MХаос{x, {DЗло{x
+%A% =Дари:= у бою знак Ехрумена опалить твоїх противників кровожерним вогнем
+  {hh642демонів{x і покличе тобі могутнього демона в якості
+  {hh15помічника{x. Демон не послухається твоїх {hh1091наказів{x, але зате зможе засипати
+  противників бойовими заклинаннями за власним бажанням.
+%A% =Обмеження:= тільки {hh33хаотичні злі{x
+%A% =Жертвоприношення:= Ехрумен надає перевагу чарівним предметам із бойовою магією або 
+  некромантією. Ехрумену подобається, коли йому в жертву приносять гарну зброю.
+  Зрадіє трупу незлої істоти.
+
+Кажуть, що в глибинах {hh1854Підземʼя{x ховається анклав поклонників Ехрумена, які досі виношують жахливі плани по завоюванню нашого світу.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/enki.xml
+++ b/religions/enki.xml
@@ -6,7 +6,22 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="974" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CEnki{x is the god of boundless knowledge and wisdom, lord of the waters, creator of the invisible currents of magical energy that permeate our world. The power of Enki breathed magic into the things that surround us. He taught mages to {hh1110enchant items,{x to use {hh121staves and wands.{x Enki created the alphabet, writing, and speech -- he is the father of all civilization and culture. Followers of his cult depict Enki as a bearded water-spirit with a fish's tail. Enki's sacred number and secret ideogram is the number 40. Enki is the patron of the race of deep gnomes, the {hh150svirfnebli,{x and has long taught them the secrets of item magic.
+
+Rumor has it that somewhere deep within the {hh1836High Tower of Sorcery{x there is a hidden altar of Enki...
+
+%A% =Paths:= {BReason{x, {YSociety{x
+%A% =Gifts:= the mark of Enki will strengthen your {hh1110item magic{x, {hh603identify{x spell and knowledge of {hh1130the basics{x, 
+  teach you to masterfully wield staves, wands and scrolls, and increase their power
+%A% =Restrictions:= only the {hh40wisest{x
+%A% =Sacrifices:= Enki likes it when books, scrolls,
+  textbooks and spellbooks are sacrificed to him, as well as any magical items -- especially those with
+  item magic spells.
+
+Librarians and other keepers of knowledge often become adepts of Enki. One of his adepts can easily be found in the map shop of {hh1392Midgaard{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CЭнки{x -- бог бесконечного знания и мудрости, властелин вод, создатель незримых потоков магической энергии, пронизывающие наш мир. Сила Энки вдохнула магию в вещи, окружающие нас. Он научил магов {hh1110зачаровывать предметы,{x использовать {hh121посохи и жезлы.{x Энки создал алфавит, письменность и речь, он -- отец всей цивилизации и культуры. Последователи его культа изображают Энки в виде бородатого водяного с рыбьим хвостом. Священное число и тайная идеограмма имени Энки -- число 40. Покровительствует Энки расе глубинных гномов, {hh150свирфнеблинов,{x и издавна обучает их тайнам предметной магии.
 
 По слухам где-то в глубине {hh1836Высшей Башни Колдовства{x есть скрытый алтарь Энки...
@@ -23,7 +38,22 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CЕнкі{x -- бог безмежного знання та мудрості, владика вод, творець незримих потоків магічної енергії, що пронизують наш світ. Сила Енкі вдихнула магію у речі навколо нас. Він навчив магів {hh1110зачаровувати предмети,{x використовувати {hh121посохи та жезли.{x Енкі створив алфавіт, письменність і мову -- він батько всієї цивілізації та культури. Послідовники його культу зображують Енкі у вигляді бородатого водяника з рибʼячим хвостом. Священне число і таємна ідеограма імені Енкі -- число 40. Енкі покровительствує расі глибинних гномів, {hh150свірфнеблінів,{x і здавна навчає їх таємницям предметної магії.
+
+За чутками, десь у глибині {hh1836Вищої Вежі Чаклунства{x є прихований вівтар Енкі...
+
+%A% =Шляхи:= {BРозум{x, {YСуспільство{x
+%A% =Дари:= знак Енкі посилить твою {hh1110предметну магію{x, {hh603розпізнавання{x та знання {hh1130основ{x, 
+  навчить тебе майстерно володіти посохами, жезлами і сувоями та збільшить їхню силу
+%A% =Обмеження:= тільки найбільш {hh40мудрі{x
+%A% =Жертвоприношення:= Енкі подобається, коли йому в жертву приносять книги, сувої,
+  підручники та книги заклинань, а також будь-які чарівні предмети -- особливо з
+  заклинаннями предметної магії.
+
+Адептами Енкі часто стають бібліотекарі та інші охоронці знань. Одного з адептів легко знайти в крамниці мап {hh1392Мідгаарду{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <books>true</books>

--- a/religions/erevan ilesere.xml
+++ b/religions/erevan ilesere.xml
@@ -6,7 +6,20 @@
   <ethos>neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="977" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CErevan Ilesere{x -- deity of deception, cunning, and treachery, who came to us from the same distant world as the {hh968Raven Queen{x. In our world he is patron of {hh135thieves{x and the thieving {hh148kender{x and {hh169hobbits{x.
+
+This is a completely unpredictable deity who changes his appearance at will -- so opinions on what he (it?) looks like differ wildly. Followers of Erevan's cult consider him a dark elf of male sex whose height varies from one inch to two meters. Erevan invariably wears at least one green article of clothing, and his symbol is a star with asymmetric rays.
+
+%A% =Gifts:= In battle the tattoo will {hh657heal{x you and {hh739speed{x you, and may douse your enemies
+  with {hh746colorful sprays{x. Sometimes Erevan
+  unexpectedly possesses you and strikes your enemy from behind.
+%A% =Sacrifices:= Erevan Ilesere likes offerings only from stolen
+  goods. Of magical items he prefers those containing healing
+  and haste spells.
+%A% =Restrictions:= not for the {hh30lawful{x
+
+Learning anything about this cult from its mocking followers is rather difficult. One of the few officially registered organizations connected in some way with this deity is located in the city of Anon.
+</text>
     <text l="ru">{CЭреван Илесир{x -- божество обмана, хитрости и коварства, пришедший к нам из того же далекого мира, что и {hh968Королева Воронов{x. В нашем мире он покровительствует {hh135ворам{x и вороватым {hh148кендерам{x и {hh169хоббитам{x.
 
 Это полностью непредсказуемое божество, меняющее свой внешний вид, как ему заблагорассудится -- поэтому мнения о том, как он (оно?) выглядит, сильно расходятся. Последователи культа Эревана считают его темным эльфом мужского пола, чей рост варьируется от одного дюйма до двух метров. Эреван неизменно носит как минимум один зеленый предмет одежды, а его символ -- звезда с ассиметричными лучами.
@@ -21,7 +34,20 @@
 
 Узнать что-то об этом культе от его глумливых последователей довольно сложно. Одна из немногих официально зарегистрированных организаций, так или иначе связанных с этим божеством, расположена в городе Аноне.
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CЕреван Ілесір{x -- божество обману, хитрощів і підступності, що прийшов до нас із того ж далекого світу, що й {hh968Королева Воронів{x. У нашому світі він покровительствує {hh135злодіям{x і злодійкуватим {hh148кендерам{x і {hh169хоббітам{x.
+
+Це цілком непередбачуване божество, що змінює свій вигляд, як йому заманеться -- тому думки щодо того, як він (воно?) виглядає, дуже розходяться. Послідовники культу Еревана вважають його темним ельфом чоловічої статі, чий зріст варіюється від одного дюйма до двох метрів. Ереван незмінно носить принаймні один зелений предмет одягу, а його символ -- зірка з асиметричними променями.
+
+%A% =Дари:= У бою татуювання буде {hh657лікувати{x тебе і {hh739пришвидшувати{x, а противників
+  може обдати {hh746барвистими бризками{x. Іноді Ереван
+  несподівано вселяється в тебе і нишком завдає удару твоєму противнику.
+%A% =Жертвоприношення:= Ереван Ілесір любить підношення виключно з вкрадених
+  речей. З чарівних предметів надає перевагу тим, що містять заклинання лікування
+  і пришвидшення.
+%A% =Обмеження:= не для {hh30законослухняних{x
+
+Дізнатися щось про цей культ від його глузливих послідовників досить складно. Одна з небагатьох офіційно зареєстрованих організацій, так чи інакше повʼязаних з цим божеством, розташована в місті Анон.
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/eros.xml
+++ b/religions/eros.xml
@@ -5,7 +5,20 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="972" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CEros{x is the playful and flirtatious god of love and {hh1348sex,{x the embodiment of spring, renewal, and the exuberant procreation of all living things. Love knows no bounds -- Eros inspires men and women, goats and centaurs, brutish trolls and bearded dwarf ladies. In the Dreamland this god often accompanies many other gods and goddesses of the pantheon -- all those open to the call of spring and the body. His cult's devotees indulge in carnal pleasures wherever they please, and Eros is usually depicted as a smirking little angel with rosy cheeks and a plump bottom. 
+
+%A% =Paths:= {gNature{x, {MChaos{x
+%A% =Gifts:= in battle the mark of Eros will {hh657heal{x your wounds, and outside battle grants
+  accelerated life regeneration -- and, incidentally, vulnerability to {hh729charm{x.
+  And of course, Eros will strengthen your love {hh2025potions{x and {hh687charms{x.
+%A% =Restrictions:= only the {hh35most charming{x {M&lt;3{x
+%A% =Sacrifices:= Eros prefers magical items with spells
+  of the wound-healing group. Of drinks, loves wines most of all.
+
+Devotees of Eros's cult can be found everywhere -- love for one's neighbor even holds sway over {hh1866smurfs{x! 
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CЭрос{x -- игривый и кокетливый бог любви и {hh1348секса,{x воплощение весны, обновления и бурного размножения всего живого. Любовь не знает границ -- Эрос вдохновляет мужчин и женщин, козлов и кентавров, брутальных троллей и бородатых дварфинь. В Мире Мечты этот бог часто сопутствует многим другим богам и богиням пантеона -- всем, кто открыт зову весны и тела. Поклонники его культа предаются плотским утехам где попало, а изображают Эроса обычно в виде ехидного ангелочка с розовыми щечками и пухлой попкой. 
 
 %A% =Пути:= {gПрирода{x, {MХаос{x
@@ -20,7 +33,20 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CЕрос{x -- грайливий і кокетливий бог кохання та {hh1348сексу,{x втілення весни, оновлення та бурхливого розмноження всього живого. Любов не знає меж -- Ерос надихає чоловіків і жінок, кізок і кентаврів, брутальних тролів і бородатих дварфинь. У Світі Мрії цей бог часто супроводжує багатьох інших богів і богинь пантеону -- усіх, хто відкритий поклику весни та тіла. Поклонники його культу віддаються тілесним насолодам де попало, а Еросу зазвичай надають образу єхидного янголяти з рожевими щічками та пухлою сідницею. 
+
+%A% =Шляхи:= {gПрирода{x, {MХаос{x
+%A% =Дари:= у бою знак Еросу {hh657залікує{x твої рани, а поза боєм дарує
+  прискорене відновлення життя -- і, до того ж, вразливість до {hh729зачарування{x.
+  І, звісно, Ерос посилить твої любовні {hh2025зілля{x та {hh687чари{x.
+%A% =Обмеження:= тільки найбільш {hh35симпатичні{x {M&lt;3{x
+%A% =Жертвоприношення:= Ерос надає перевагу чарівним предметам із заклинаннями
+  групи зцілення ран. З напоїв найбільше любить вина.
+
+Поклонників культу Еросу можна знайти скрізь -- любов до ближнього підвладна навіть {hh1866смурфам{x! 
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/fili.xml
+++ b/religions/fili.xml
@@ -8,7 +8,15 @@
     <keyword l="en">fili</keyword>
     <keyword l="ru">фили</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CFili{x -- greedy god of {hh13money{x, profit, and gain, patron of {hh1056trade{x and the {hh146dwarf{x race. During the Third Epoch Fili served as treasurer and leader of the {hh1494Mercenaries{x Clan, multiplying their wealth and power beyond measure. Fili reformed the {hh1086banking system{x and created a single stable currency in use across all of Thera. He also launched a small and medium business lending program, allowing merchants across the world to run their trade better and avoid bankruptcy.
+
+%A% =Paths:= {YSociety{x
+%A% =Gifts:= Fili's mark will improve your {hh694trading skills{x, greatly reduce
+{x the cost of healer services, double gold rewards from {hh125questors{x, triple the profit
+{x from {hh1375sacrifices{x, and increase the chance and quality of {hh122random drops{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CФили{x -- жадный бог {hh13денег{x, наживы и прибыли, покровитель {hh1056торговли{x и расы {hh146дварфов{x. Во времена Третьей Эпохи Фили служил казначеем и главой Клана {hh1494Наемников{x, вне всякой меры умножив их богатство и могущество. Фили изменил {hh1086банковскую систему{x и создал единую устойчивую валюту, действующую по всему простору Тэры. Также он запустил программу кредитования мелкого и среднего бизнеса, позволив торговцам по всему миру лучше вести бизнес и предотвращать банкротство.
 
 %A% =Пути:= {YОбщество{x
@@ -17,7 +25,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CФілі{x -- жадібний бог {hh13грошей{x, наживи та прибутку, покровитель {hh1056торгівлі{x і раси {hh146дварфів{x. За часів Третьої Епохи Філі служив скарбником і головою Клану {hh1494Найманців{x, примноживши їхнє багатство і могутність понад міру. Філі реформував {hh1086банківську систему{x і створив єдину стійку валюту, що діє по всьому простору Тери. Також він запустив програму кредитування малого і середнього бізнесу, дозволивши торговцям по всьому світу краще вести справи і запобігати банкрутству.
+
+%A% =Шляхи:= {YСуспільство{x
+%A% =Дари:= знак Філі покращить твої {hh694навички торгівлі{x, значно здешевить
+{x платні послуги лікарів, подвоїть грошові нагороди від {hh125кветорів{x, потроїть прибуток
+{x від {hh1375жертвоприношення{x, а також збільшить шанс і якість {hh122рандомних випадань{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/godiva.xml
+++ b/religions/godiva.xml
@@ -10,7 +10,13 @@
     <keyword l="en">godiva</keyword>
     <keyword l="ru">годива</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CGodiva{x is the goddess of ancient legends and myths, keeper of secrets and the powerful mysteries of the past. Mortals know very little about this goddess. They say that at the dawn of the Third Epoch Godiva helped the terrible {hh1569Mephisto{x create the clan of {hh1500Phantoms{x and endowed its members with ancient knowledge of the anatomy of all races, the physics and chemistry of this world, as well as legends and lore about all the powerful {hh42artifacts{x, making the Phantoms invincible fighters and inevitable assassins.
+
+%A% =Gifts:= the mark of Godiva will shroud your {hh1015equipment{x in a phantom veil,
+{x impenetrable to outside eyes, and grant a spectral aura to your blade, {x so that no one can {hh812disarm{x you
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CГодива{x -- богиня древних легенд и мифов, хранительница секретов и могущественных тайн прошлого. Про эту богиню смертным известно совсем немногое. Говорят, что на заре Третьей Эпохи Годива помогла ужасному {hh1569Мефисто{x создать клан {hh1500Призраков{x и наделила его членов древними знаниями об анатомии всех рас, физике и химии этого мира, а также легендами и преданиями обо всех могущественных {hh42артефактах{x, сделав Призраков непобедимыми бойцами и неотвратимыми убийцами.
 
 %A% =Дары:= знак Годивы окутает твою {hh1015экипировку{x призрачным покрывалом,
@@ -18,7 +24,13 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CГодіва{x -- богиня давніх легенд і міфів, охоронниця таємниць і могутніх загадок минулого. Смертним відомо зовсім небагато про цю богиню. Кажуть, що на зорі Третьої Епохи Годіва допомогла жахливому {hh1569Мефісто{x створити клан {hh1500Привидів{x та наділила його членів давніми знаннями про анатомію всіх рас, фізику та хімію цього світу, а також легендами й переказами про всі могутні {hh42артефакти{x, зробивши Привидів непереможними бійцями та невідворотними вбивцями.
+
+%A% =Дари:= знак Годіви огорне твою {hh1015екіпіровку{x примарним покривалом,
+{x непроникним для сторонніх очей, і дарує примарну ауру твоєму клинку, {x щоб ніхто не зміг тебе {hh812роззброїти{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/goktengri.xml
+++ b/religions/goktengri.xml
@@ -9,7 +9,18 @@
     <keyword l="en">&apos;gok tengri&apos;</keyword>
     <keyword l="ru">&apos;гек тенгри&apos; &apos;гок тенгри&apos; гоктенгри</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CGoktengri{x -- ancient deity of martial honor. Since time immemorial, long before the {hh80Third Epoch{x and the arrival of the new gods, followers of the Goktengri cult -- warriors and nomads -- believed that above all else a fighter needs not combat skill but martial honor and discipline. Over millennia the influence of this cult spread far to the east, where its philosophy resonated with the caste of {hh136samurai.{x Goktengri has no form or image and cannot be depicted, so followers believe it is the infinite blue sky above our heads itself, accompanying us throughout life -- as does our honor.
+
+%A% =Paths:= {RFury{x
+%A% =Gifts:= Goktengri's mark will let you sometimes strike two extra
+  attacks in a fair fight
+%A% =Sacrifices:= Goktengri likes when you sacrifice to him
+  good weapons, enemy corpses, or gold
+
+Nomads who follow the Goktengri cult prefer the grassy wastes of the {hh1859northern plains{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CГек Тенгри{x -- древнее божество воинской чести. С незапамятных времен, задолго до {hh80Третьей Эпохи{x и пришествия новых богов, последователи культа Гек Тенгри, воины и кочевники, верили, что превыше всего для бойца не боевое умение, а воинская честь и дисциплина. На протяжении тысячелетий влияние этого культа распространилось далеко на восток, где его философия пришлась по душе сословию {hh136самураев.{x Гек Тенгри не имеет формы или образа, его нельзя изобразить, поэтому его последователи верят, что это само бесконечное голубое небо над нашими головами, сопровождающее нас на протяжении всей жизни -- как и наша честь.
 
 %A% =Пути:= {RЯрость{x
@@ -22,7 +33,18 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CГек Тенгрі{x -- давнє божество воїнської честі. Із сивої давнини, задовго до {hh80Третьої Епохи{x і приходу нових богів, послідовники культу Гек Тенгрі, воїни і кочівники, вірили, що понад усе для бійця важливі не бойове вміння, а воїнська честь і дисципліна. Упродовж тисячоліть вплив цього культу поширився далеко на схід, де його філософія припала до душі стану {hh136самураїв.{x Гек Тенгрі не має форми чи образу, його не можна зобразити, тому послідовники вірять, що це само нескінченне блакитне небо над нашими головами, яке супроводжує нас упродовж усього життя -- як і наша честь.
+
+%A% =Шляхи:= {RЯрість{x
+%A% =Дари:= знак Гек Тенгрі дозволить тобі іноді завдавати двох додаткових
+  ударів у чесному бою
+%A% =Жертвоприношення:= Гек Тенгрі подобається, коли йому в жертву приносять
+  гарну зброю, трупи ворогів або золото
+
+Кочівники, що слідують культу Гек Тенгрі, надають перевагу трав'янистим пустошам {hh1859північних рівнин{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/hauzer.xml
+++ b/religions/hauzer.xml
@@ -8,7 +8,15 @@
     <keyword l="en">hauzer</keyword>
     <keyword l="ru">хаузер</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CHauser{x is the Prince of eternal and all-consuming Darkness, keeper of the dark law of Power, and patron of {hh138anti-paladins{x. At the dawn of this world he was among the first to lead the armies of Evil in the struggle against Light, and he remains to this day one of the patrons of the {hh1485Cabal of Conquerors.{x Hauser is usually depicted as a grim black knight with an enormous two-handed flamberge blade.
+
+%A% =Paths:= {DDarkness{x, {wOrder{x
+%A% =Gifts:= in battle the mark of Hauser will {hh606stun{x your enemies and bind
+{x them in tough {hh852webbing{x
+%A% =Restrictions:= only the {hh33lawful evil{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CХаузер{x -- Князь извечной и всепоглощающей Тьмы, хранитель темного права Силы и покровитель {hh138анти-паладинов{x. На заре этого мира он одним из первых повел армии Зла на борьбу со Светом, и до сих пор остается одним из покровителей {hh1485Кабала Захватчиков.{x Хаузера обычно изображают в виде мрачного черного рыцаря с огромным двуручным клинком-фламбергом.
 
 %A% =Пути:= {DТьма{x, {wПорядок{x
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CХаузер{x -- Князь вічної та всепоглинаючої Пітьми, охоронець темного права Сили та покровитель {hh138анти-паладинів{x. На зорі цього світу він одним із перших повів армії Зла в боротьбу зі Світлом, і досі залишається одним із покровителів {hh1485Кабалу Загарбників.{x Хаузера зазвичай зображують у вигляді похмурого чорного лицаря з величезним дворучним клинком-фламберком.
+
+%A% =Шляхи:= {DПітьма{x, {wПорядок{x
+%A% =Дари:= у бою знак Хаузера {hh606оглушить{x твоїх противників і скує
+{x їх міцною {hh852павутиною{x
+%A% =Обмеження:= тільки {hh33законослухняні злі{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/hera.xml
+++ b/religions/hera.xml
@@ -6,7 +6,18 @@
   <ethos></ethos>
   <flags>cult</flags>
   <help id="970" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CHera{x -- goddess of hatred and curses, blinding mortals with rage and poisoning them with jealousy and envy. Legend holds that Hera was not always this way, but the endless string of her husband Zeus's adulteries poisoned her soul with jealousy and malice. One of Hera's most terrible creations is her frenzied son {hh966Ares,{x god of war and bloodshed. Mortals and other gods return Hera's hatred in kind; followers of her cult are rare, and temples of Hera -- heraions -- are nearly gone across the breadth of {hh224Thera{x.
+
+%A% =Gifts:= in battle Hera's mark will {hh548curse{x, {hh705slow{x, {hh831blind{x
+  and infect your enemies with {hh614plague{x
+%A% =Restrictions:= {hh33non-good{x only
+%A% =Sacrifices:= Hera prefers magical items with curse-group
+  spells. Of drinks, she likes wines best.
+
+One of the last heraions has survived at the site of the cult's origin on Mount {hh1864Olympus{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CГера{x -- богиня ненависти и проклятий, ослепляющая смертных гневом и отравляющая их ревностью и завистью. По легенде, Гера не всегда была такой, но бесконечная череда адюльтеров ее мужа, Зевса, отравила ее душу ревностью и злобой. Одно из самых страшных детищ Геры -- ее неистовый сын {hh966Арес,{x бог войны и кровопролития. Смертные и другие боги отвечают на ненависть Геры взаимностью, последователи ее культа редки, и храмов Геры, герейонов, на просторах {hh224Тэры{x почти не осталось.
 
 %A% =Дары:= в бою знак Геры {hh548проклянет{x, {hh705замедлит{x, {hh831ослепит{x
@@ -19,7 +30,18 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CГера{x -- богиня ненависті і прокльонів, що засліплює смертних гнівом і отруює їх ревнощами та заздрістю. За легендою, Гера не завжди була такою, але нескінченна низка адюльтерів її чоловіка Зевса отруїла її душу ревнощами і злобою. Одне з найстрашніших породінь Гери -- її несамовитий син {hh966Арес,{x бог війни і кровопролиття. Смертні та інші боги відповідають на ненависть Гери взаємністю, послідовники її культу нечисленні, і храмів Гери -- гереонів -- на просторах {hh224Тери{x майже не залишилося.
+
+%A% =Дари:= у бою знак Гери {hh548проклене{x, {hh705сповільнить{x, {hh831осліпить{x
+  і заразить {hh614чумою{x твоїх противників
+%A% =Обмеження:= тільки {hh33недобрі{x
+%A% =Жертвоприношення:= Гера надає перевагу чарівним предметам із заклинаннями
+  групи прокльонів. З напоїв найбільше любить вина.
+
+Один із останніх гереонів зберігся на місці виникнення культу на горі {hh1864Олімп{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/irlana.xml
+++ b/religions/irlana.xml
@@ -8,7 +8,15 @@
     <keyword l="en">irlana</keyword>
     <keyword l="ru">ирлана</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CIrlana{x -- goddess of flora, peace, and prosperity, patron of pacifists, musicians, hippies, and rastafarians. Irlana created and watches over the commune of the {hh1551Children of Flowers,{x offering shelter to all who live in revulsion of {hh32killing{x and bloodshed. Irlana is remembered by her followers as a slender {hh147arial{x teenager who looks at you and the world from beneath a long fringe with a questioning gaze. 
+
+%A% =Paths:= {gNature{x, {YGood{x
+%A% =Gifts:= in battle, Irlana's mark will heal your wounds with {hh777healing herbs{x and
+{x save you from certain death by {hh1347teleporting{x you to safety
+%A% =Restrictions:= only {hh3clanless{x or {hh1551Children of Flowers{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CИрлана{x -- богиня флоры, мира и процветания, покровительница пацифистов, музыкантов, хиппи и растаманов. Ирлана создала и покровительствует коммуне {hh1551Детей Цветов,{x даруя убежище всем живущим, кому противно {hh32смертоубийство{x и кровопролитие. Ирлана осталась в памяти своих последователей как худощавый {hh147ариал{x-подросток, вопросительно смотрящий на тебя и на мир из-под длинной челки. 
 
 %A% =Пути:= {gПрирода{x, {YДобро{x
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CІрлана{x -- богиня флори, миру та процвітання, покровителька пацифістів, музикантів, хіпі та растаманів. Ірлана заснувала і опікується комуною {hh1551Дітей Квітів,{x даруючи притулок усім живим, кому огидне {hh32вбивство{x і кровопролиття. Ірлана залишилась у памʼяті своїх послідовників як кволий підліток-{hh147аріал{x, що дивиться на тебе і на світ з-під довгої чілки з питальним поглядом. 
+
+%A% =Шляхи:= {gПрирода{x, {YДобро{x
+%A% =Дари:= у бою знак Ірлани загоїть твої рани {hh777цілющими травами{x і
+{x врятує від неминучої загибелі, {hh1347перенісши{x тебе в безпечне місце
+%A% =Обмеження:= тільки {hh3безкланові{x або {hh1551Діти Квітів{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/karmina.xml
+++ b/religions/karmina.xml
@@ -8,7 +8,15 @@
     <keyword l="en">karmina</keyword>
     <keyword l="ru">кармина</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CKarmina{x is the bloodthirsty goddess-patron of the ancient order of {hh144vampires{x. Few mortals have survived an encounter with her; only one description from an ancient chronicle survives: "I see a skinny, flat-nosed, bald girl with a strange expression on her face. Clear blue eyes peer from under a high forehead adorned with a strange scar. She smiles, and I catch a glint on her even, slightly pointed fangs. The tattered shroud she is wrapped in is stained with dirt and blood all mixed together. And then she suddenly stretches out her arm, gives me the fig and runs off laughing. Or rather rides off... on skis?!?!"
+
+%A% =Gifts:= the mark of Karmina will increase damage in vampire {hh836form{x, sate the {hh539thirst for blood{x and
+  increase damage from the {hh552bone dagger{x, and will also allow
+  you to sometimes drain blood for pure pleasure
+%A% =Restrictions:= only {hh144vampires{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CКармина{x -- кровожадная богиня-покровительница древнего сословия {hh144вампиров{x. Мало кто из смертных выжил после встречи с ней, сохранилось лишь одно описание из древней летописи: &quot;Я вижу худенькую, плосконосую и лысую девочку со странным выражением лица. Ясные голубые глаза глядят из-под высокого лба, на котором красуется странный шрам. Она улыбается, и я замечаю блик на ее ровных, слегка заостренных клыках. Рваный саван, в который она замотана, испачкан грязью и кровью вперемешку. И тут она внезапно вытягивает руку, показывает мне фигу и хохоча убегает. Точнее уезжает... на лыжах?!?!&quot;
 
 %A% =Дары:= знак Кармины усилит урон в {hh836форме{x вампира, утолит {hh539жажду крови{x и
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CКарміна{x -- кровожерлива богиня-покровителька давнього стану {hh144вампірів{x. Мало хто зі смертних вижив після зустрічі з нею; збереглося лише один опис із давнього літопису: "Я бачу худеньку, плосконосу і лису дівчинку зі дивним виразом обличчя. Ясні блакитні очі дивляться з-під високого чола, на якому красується дивний шрам. Вона посміхається, і я помічаю відблиск на її рівних, злегка загострених іклах. Драний саван, у який вона загорнута, заплямований брудом і кровʼю вперемішку. І тут вона раптово простягає руку, показує мені дулю та реготом тікає. Точніше відʼїжджає... на лижах?!?!"
+
+%A% =Дари:= знак Карміни посилить шкоду в {hh836формі{x вампіра, вгамує {hh539спрагу крові{x та
+  збільшить пошкодження від {hh552кістяного кинджала{x, а також дозволить
+  іноді ссати кров заради чистого задоволення
+%A% =Обмеження:= тільки {hh144вампіри{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/kind.xml
+++ b/religions/kind.xml
@@ -11,7 +11,14 @@
     <keyword l="en">kind</keyword>
     <keyword l="ru">кинд</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CKind{x is the goddess of intellect, spellweaving, and the high {hh563art of sorcery{x, keeper of the Order of Mages {hh1479Shalafi{x. Thanks to Kind's scholarly research into sorcery, mages gained the ability to {hh660concentrate magic{x to deal greater damage, and the stray dogs of {hh1392Midgaard{x, the fidoshki, acquired a semblance of reason. Kind is patron to {hh139witches{x and cave elves, the {hh164rox'irs{x -- and it is in this guise that her followers depict her.
+
+%A% =Paths:= {BReason{x
+%A% =Gifts:= in battle the mark of Kind can briefly raise the level of your spells
+%A% =Restrictions:= only the {hh38most intelligent{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CКинд{x -- богиня интеллекта, чароплетения и высокого {hh563колдовского искусства{x, хранительница Ордена магов {hh1479Шалафи{x. Благодаря научным изысканиям Кинд в области колдовства, волшебники получили способность {hh660концентрировать магию{x для нанесения большего урона, а бродячие собаки {hh1392Мидгаарда{x, фидошки, обрели подобие разума. Кинд покровительствует {hh139ведьмам{x и пещерным эльфам, {hh164роксирам{x -- и именно в таком обличьи ее изображают последователи.
 
 %A% =Пути:= {BРазум{x
@@ -20,7 +27,14 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CКінд{x -- богиня інтелекту, чароплетіння та високого {hh563чаклунського мистецтва{x, охоронниця Ордену магів {hh1479Шалафі{x. Завдяки науковим дослідженням Кінд у галузі чаклунства, чарівники отримали здатність {hh660концентрувати магію{x для завдання більшої шкоди, а бездомні собаки {hh1392Мідгаарду{x, фідошки, набули подоби розуму. Кінд покровительствує {hh139відьмам{x та печерним ельфам, {hh164роксірам{x -- і саме в такому образі її зображують послідовники.
+
+%A% =Шляхи:= {BРозум{x
+%A% =Дари:= у бою знак Кінд може ненадовго підвищити рівень твоїх заклинань
+%A% =Обмеження:= тільки {hh38найрозумніші{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/leo.xml
+++ b/religions/leo.xml
@@ -7,7 +7,15 @@
     <keyword l="en">leo</keyword>
     <keyword l="ru">лео</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CLeo{x -- supreme God of Order and balance, who together with his wife, {hh1565Varda{x, shaped our entire world from the Void. He granted free will to all living beings but bound them to follow {hh68the laws of the gods{x and {hh1529the laws of society{x; he created and took under his patronage the {hh1461Order of Rulers{x, and also wrote the first criminal code, later improved and expanded by his faithful followers. Leo is depicted as an ordinary human, for {hh145humans{x are his own children, whom he loves and protects despite all their flaws.
+
+%A% =Paths:= {wOrder{x (supreme god), {YSociety{x
+%A% =Gifts:= in battle, Leo's mark will {hh766bless{x your gear with protection against
+{x magical influence, and sometimes let you see invisible mages {x or servants of Evil 
+%A% =Restrictions:= only {hh33lawful neutral{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CЛео{x -- верховный Бог Порядка и равновесия, вместе со своей женой, {hh1565Вардой{x, создавший весь наш мир из Пустоты. Он даровал свободу воли всем живущим, но обязал их следовать {hh68законам богов{x и {hh1529законам общества{x, он создал и взял под свое покровительство {hh1461Орден Правителей{x, а также начертал первый уголовный кодекс, позднее улучшенный и дополненный его верными последователями. Лео изображают в виде простого человека, ведь {hh145люди{x -- его собственные чада, которых он любит и оберегает, несмотря на все их недостатки.
 
 %A% =Пути:= {wПорядок{x (верховный бог), {YОбщество{x
@@ -17,7 +25,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CЛео{x -- верховний Бог Порядку та рівноваги, який разом зі своєю дружиною, {hh1565Вардою{x, створив увесь наш світ із Порожнечі. Він дарував вільну волю всім живим, але зобовʼязав їх дотримуватись {hh68законів богів{x і {hh1529законів суспільства{x; він заснував і взяв під своє покровительство {hh1461Орден Правителів{x, а також написав перший кримінальний кодекс, згодом вдосконалений і доповнений його вірними послідовниками. Лео зображають у вигляді простої людини, адже {hh145люди{x -- його власні діти, яких він любить і оберігає попри всі їхні недоліки.
+
+%A% =Шляхи:= {wПорядок{x (верховний бог), {YСуспільство{x
+%A% =Дари:= у бою знак Лео {hh766благословить{x твої речі на захист від
+{x магічного впливу, і іноді дозволить побачити невидимих магів {x або служителів Зла 
+%A% =Обмеження:= тільки {hh33законослухняні нейтральні{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/lloth.xml
+++ b/religions/lloth.xml
@@ -8,7 +8,24 @@
     <extra l="en"></extra>
     <extra l="ru">&apos;богиня лот&apos; ллос лолс</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">{CLloth{x, also known as Lloss or Lolth, Lady of the Demonic Web -- a demoness-goddess of spiders and spider venom, patroness of the {hh149drow{x people.
+
+Lloth takes many forms -- from a giant black spider with the head of a drow to the most beautiful of dominatrix women. Born millennia ago in the spaces of Chaos, Lloth extended her dominion across many worlds. 
+
+The drow say that Lloth and the {hh968Raven Queen{x are not rivals but are two sides of Darkness and Chaos, two faces of the Great Void, and two ends of the Infinite Spiral. 
+
+%A% =Paths:= {DDarkness{x, {MChaos{x
+%A% =Gifts:= in battle Lloth's mark will summon a swarm of venomous spiders that increase
+  your damage and hit points depending on their number. If an enemy kills a spider, the
+  goddess's blight will strike them; if you kill it -- the spider's energy will restore your strength.
+%A% =Restrictions:= non-lawful drow and dark elves only
+%A% =Sacrifices:= Lloth has no preferences and equally desires the death of any
+  creature, including her own followers
+
+The most famous temple of Lloth in Thera is located in the {hh1406City of Drow{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CЛлот{x, также известная как Ллос или Лолс, Владычица Демонических Тенет -- демоница-богиня пауков и паучьего яда, покровительница народа {hh149дроу{x.
 
 Ллос принимает много обличий -- от гигантского черного паука с головой дроу до прекраснейшей женщины-доминатрикс. Рожденная тысячелетия назад в пространствах Хаоса, Ллос распространила свою власть во множестве миров. 
@@ -27,7 +44,24 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CЛлот{x, також відома як Ллос або Лолс, Владарка Демонічних Тенет -- демониця-богиня павуків і павучої отрути, покровителька народу {hh149дроу{x.
+
+Ллот приймає безліч обличь -- від гігантського чорного павука з головою дроу до найпрекраснішої жінки-домінатрикс. Народжена тисячоліття тому в просторах Хаосу, Ллот поширила свою владу в безлічі світів. 
+
+Дроу кажуть, що Ллот і {hh968Королева Воронів{x -- не суперниці одна одній, але суть два боки Темряви і Хаосу, два обличчя Великої Порожнечі, і два кінці Нескінченної Спіралі. 
+
+%A% =Шляхи:= {DТемрява{x, {MХаос{x
+%A% =Дари:= у бою знак Ллот покличе безліч отруйних павуків, що збільшать
+  твою шкоду і здоровʼя залежно від своєї кількості. Якщо ворог уб'є павука, його
+  спіткає бич богині, а якщо ти -- енергія павука відновить твої сили.
+%A% =Обмеження:= тільки незаконослухняні дроу і темні ельфи
+%A% =Жертвоприношення:= Ллот не має жодних уподобань і однаково бажає смерті
+  будь-яким істотам, включно зі своїми послідовниками
+
+Найвідоміший храм Ллот на просторах Тери розташований у {hh1406Місті Дроу{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/mephisto.xml
+++ b/religions/mephisto.xml
@@ -8,7 +8,15 @@
     <keyword l="en">mephisto</keyword>
     <keyword l="ru">мефисто</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CMephisto{x -- a heartless god of pain, cruelty, and torture, patron of the {hh158githyanki{x people. Legend has it he fought on the side of the {hh1485Cabal of Invaders{x in the Second Epoch, but the suffering the Invaders brought was never enough for him. Together with {hh1586Godiva{x he founded the clan of the most ruthless killers -- the {hh1500Phantoms.{x Mephisto is depicted as a massive horned demon with four clawed limbs.
+
+%A% =Paths:= {DDarkness{x, {RRage{x
+%A% =Gifts:= in battle, Mephisto's mark will deal {hh724harm{x to your foes and make
+{x them {hh541rot alive{x, screaming in pain
+%A% =Restrictions:= only {hh33non-good{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CМефисто{x -- бессердечный бог боли, жестокости и пыток, покровитель народа {hh158гитианки{x. По легенде он сражался на стороне {hh1485Кабала Захватчиков{x во Второй Эпохе, но ему стало недостаточно приносимой Захватчиками боли и страданий. Вместе с {hh1586Годивой{x он основал клан самых безжалостных убийц -- {hh1500Призраков.{x Мефисто изображают в образе огромного рогатого демона с четырьмя когтистыми лапами.
 
 %A% =Пути:= {DТьма{x, {RЯрость{x
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CМефісто{x -- бездушний бог болю, жорстокості та катувань, покровитель народу {hh158гітʼянкі{x. За легендою, він воював на боці {hh1485Кабалу Загарбників{x у Другу Епоху, але болю і страждань, що їх несли Загарбники, йому виявилось замало. Разом із {hh1586Годівою{x він заснував клан найбезжальніших убивць -- {hh1500Примар.{x Мефісто зображають у вигляді величезного рогатого демона з чотирма кігтистими лапами.
+
+%A% =Шляхи:= {DТемрява{x, {RЛють{x
+%A% =Дари:= у бою знак Мефісто завдасть {hh724шкоди{x твоїм ворогам і змусить
+{x їх {hh541гнити живцем{x, волаючи від болю
+%A% =Обмеження:= тільки {hh33не-добрі{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/mihail.xml
+++ b/religions/mihail.xml
@@ -8,7 +8,16 @@
     <keyword l="en">mihail</keyword>
     <keyword l="ru">михаил</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CMikhail{x -- god of magical might and arcane enhancement. Legend holds that Mikhail was the master of magic and leader of the {hh1479Shalafi{x Order during the Second Epoch of this world. In those times mages wielded enormous power, using magic solely to advance their own authority and well-being, bringing death and destruction to all living things. This exhausted the patience of the god {hh1584Tirna{x, who cast down the Tower of Shalafi and reduced it to ash. Yet in the memory of mortals Mikhail remained a truly awe-inspiring archmage. He is remembered as the creator of many powerful enchantments and spells that enhance the physical abilities of wizards. Mikhail is patron of {hh134sorcerers{x and the magical race of {hh155faeries.{x
+
+%A% =Paths:= {BMind{x
+%A% =Gifts:= Mikhail's mark will raise the level of your {hh1126teleportation magic{x and
+{x {hh1111enhancement{x spells, and in battle will occasionally {hh918transform{x your body
+%A% =Restrictions:= {hh30non-chaotic{x {hh134sorcerers{x, {hh139witches{x, {hh143necromancers{x, {hh133clerics{x and
+{x {hh138anti-paladins{x only
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CМихаил{x -- бог волшебного могущества и магического усиления. По легенде, Михаил был повелителем магии и лидером Ордена {hh1479Шалафи{x во Вторую Эпоху этого мира. В те времена маги обладали огромной силой, используя магию только для достижения собственной власти и благополучия, неся смерть и разрушение всему живому. Это переполнило чашу терпения бога {hh1584Тирны{x, и он низверг Башню Шалафи, обратив ее в пепел. Но в памяти смертных Михаил остался наводящим трепет архимагом. Его запомнили как создателя множества могущественных чар и заклятий, усиливающих телесные способности волшебников. Покровительствует Михаил {hh134колдунам{x и волшебной расе {hh155фей.{x
 
 %A% =Пути:= {BРазум{x
@@ -19,7 +28,16 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CМихаїл{x -- бог чарівної могутності і магічного посилення. За легендою, Михаїл був повелителем магії і лідером Ордену {hh1479Шалафі{x в Другу Епоху цього світу. У ті часи маги мали величезну силу, використовуючи магію виключно для досягнення власної влади і добробуту, несучи смерть і руйнування всьому живому. Це переповнило чашу терпіння бога {hh1584Тирни{x, і він скинув Вежу Шалафі, перетворивши її на попіл. Але в памʼяті смертних Михаїл залишився справді грізним архімагом. Його памʼятають як творця безлічі могутніх чарів і заклинань, що посилюють тілесні здібності чаклунів. Покровительствує Михаїл {hh134чаклунам{x і чарівній расі {hh155фей.{x
+
+%A% =Шляхи:= {BРозум{x
+%A% =Дари:= знак Михаїла підніме рівень твоєї {hh1126транспортної магії{x і заклинань
+{x {hh1111посилення{x, а у бою зрідка {hh918перетворить{x твоє тіло
+%A% =Обмеження:= тільки {hh30нехаотичні{x {hh134чаклуни{x, {hh139відьми{x, {hh143некроманти{x, {hh133клерики{x і
+{x {hh138анти-паладіни{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/nofate.xml
+++ b/religions/nofate.xml
@@ -7,7 +7,15 @@
     <keyword l="en">nofate</keyword>
     <keyword l="ru">нофейт</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CNoFate{x -- supreme god of academic knowledge, science, and the entire path of Mind. He is a dispassionate and omnipotent demiurge who orders energy, matter, and time, but takes little interest in the fate of mortals. Over countless eons he has painstakingly altered and rebuilt the fabric of our reality, bringing universal good and colossal cataclysms in equal measure. NoFate is usually depicted as a man with serenely closed eyes. NoFate's symbol is {hh996beetles{x, and they often accompany him in legend. NoFate is the patron of {hh153cloud giants{x.
+
+%A% =Paths:= {BMind{x (supreme god), {wOrder{x
+%A% =Gifts:= in battle, NoFate's mark will summon a pair of fearsome beetles to your aid
+  (depends on level)
+%A% =Restrictions:= only {hh33true neutral{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CНоФейт{x -- верховный бог академического познания, науки, и всего пути Разума. Это бесстрастный и всемогущий демиург, упорядочивающий энергию, материю и время, но не очень-то заботящийся о судьбах смертных. На протяжении бессчетных эонов он кропотливо менял и перестраивал ткань нашей реальности, принося в равной степени вселенское благо и колоссальные катаклизмы. Изображают НоФейт обычно в виде мужчины с безмятежно закрытыми глазами. Символ НоФейт -- {hh996жуки{x, и они часто сопровождают его в легендах. Покровительствует НоФейт {hh153облачным гигантам{x.
 
 %A% =Пути:= {BРазум{x (верховный бог), {wПорядок{x
@@ -17,7 +25,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CНоФейт{x -- верховний бог академічного пізнання, науки та всього шляху Розуму. Це безпристрасний і всемогутній деміург, що упорядковує енергію, матерію і час, але мало дбає про долі смертних. Протягом незліченних еонів він ретельно змінював і перебудовував тканину нашої реальності, приносячи однаковою мірою вселенське благо і колосальні катаклізми. НоФейт зазвичай зображають у вигляді чоловіка з безтурботно заплющеними очима. Символ НоФейт -- {hh996жуки{x, і вони часто супроводжують його в легендах. Покровительствує НоФейт {hh153хмарним гігантам{x.
+
+%A% =Шляхи:= {BРозум{x (верховний бог), {wПорядок{x
+%A% =Дари:= у бою знак НоФейт покличе тобі на допомогу пару жахливих жуків
+  (залежить від рівня)
+%A% =Обмеження:= тільки {hh33справді нейтральні{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/odin.xml
+++ b/religions/odin.xml
@@ -8,7 +8,20 @@
     <keyword l="en">odin</keyword>
     <keyword l="ru">один водан вотан</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{COdin{x -- sage and shaman, god of war and victory, lord of Valhalla and leader of the fearsome Valkyries. He is identified with the Force of Law, and he aids all who defend right and law in battle. In time immemorial, before humans appeared, Odin was master of Asgard, and his world was bound to {hh224Thera{x. Together with the other Aesir he fought the titans of Chaos and held dominion over all that exists. {hh1565Varda{x and {hh1576Leo{x spared the old god's life, but severed the bond between the worlds -- now only Immortals can cross the rainbow bridge Bifrost and reach Asgard and Valhalla. Followers of Odin's cult believe he often travels the world in the guise of a humble, unremarkable old man in a pointed hat, with a staff and a black patch over one eye. Odin is the patron of valkyries and of the winged race of {hh147arials{x.
+
+%A% =Paths:= {wOrder{x, {BMind{x
+%A% =Gifts:= in battle, Odin's mark will smite your foes with {hh849blue flame{x and a {hh564wall of blades{x
+%A% =Restrictions:= only {hh30non-chaotic{x {hh33neutral{x
+%A% =Sacrifices:= Odin prefers magical items enchanted with spells
+  of the healing or detection group. 
+
+Like many old gods, Odin sometimes visited in his physical form on Mount {hh1864Olympus{x.
+
+%SA% %H% {hh81Eight Paths{x
+
+P.S. A rather annoying little dog is named in honor of Odin (Wotan); every year on Valentine's Day it interferes with adventurers trying to complete {hh2124Sven's{x mission.
+</text>
     <text l="ru">{CОдин{x -- мудрец и шаман, бог войны и победы, господин Вальгаллы и предводитель грозных Валькирий. Его отождествляют с Силой Закона, и он помогает всем, кто защищает право и закон в бою. В незапамятные времена, еще до появления людей, Один был хозяином Асгарда, и его мир был сопряжен с {hh224Тэрой{x. Вместе с другими Асами он сражался с титанами Хаоса и повелевал всем сущим. {hh1565Варда{x и {hh1576Лео{x сохранили жизнь старому богу, но разорвали связь миров -- теперь лишь Бессмертные могут пройти через радужный мост Биврест и попасть в Асгард и Вальгаллу. Последователи культа Одина верят, что он часто путешествует по миру в обличьи скромного непримечательного старца в остроконечной шляпе, с посохом и черной повязкой на одном из глаз. Один покровительствует валькириям и крылатой расе {hh147ариалов{x.
 
 %A% =Пути:= {wПорядок{x, {BРазум{x
@@ -23,7 +36,20 @@
 
 P.S. В честь Одина (Вотана) названа одна надоедливая собачонка, которая каждый год в День Влюбленных мешает приключенцам выполнять миссию {hh2124Свенов{x.
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CОдін{x -- мудрець і шаман, бог війни та перемоги, господар Вальгалли і ватажок грізних Валькірій. Його ототожнюють із Силою Закону, і він допомагає всім, хто захищає право і закон у бою. У незапамʼятні часи, ще до появи людей, Одін був господарем Асгарду, і його світ був повʼязаний із {hh224Терою{x. Разом з іншими Асами він воював із титанами Хаосу і правив усім сущим. {hh1565Варда{x та {hh1576Лео{x зберегли життя старому богу, але розірвали звʼязок між світами -- тепер лише Безсмертні можуть пройти крізь веселковий міст Біврест і потрапити до Асгарду та Вальгалли. Послідовники культу Одіна вірять, що він часто мандрує світом в образі скромного непоказного старця в гостроверхому капелюсі, з посохом і чорною пов'язкою на одному оці. Одін покровительствує валькіріям і крилатій расі {hh147аріалів{x.
+
+%A% =Шляхи:= {wПорядок{x, {BРозум{x
+%A% =Дари:= у бою знак Одіна вразить твоїх ворогів {hh849блакитним полумʼям{x та {hh564стіною клинків{x
+%A% =Обмеження:= тільки {hh30не-хаотичні{x {hh33нейтральні{x
+%A% =Жертвоприношення:= Одін віддає перевагу чарівним предметам із закляттями
+  групи зцілення ран або виявлення. 
+
+Подібно до багатьох старих богів, Одін іноді навідувався у своїй тілесній іпостасі на гору {hh1864Олімп{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+
+P.S. На честь Одіна (Вотана) названо одного настирливого песика, який щороку в День Закоханих заважає пригодникам виконувати місію {hh2124Свенів{x.
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/phobos.xml
+++ b/religions/phobos.xml
@@ -6,7 +6,21 @@
   <ethos></ethos>
   <flags>cult</flags>
   <help id="978" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CPhobos{x -- god of ice-cold fear and the bloody madness of war. His cult's followers believe that on the fields of battle Phobos and his twin brother {hh986Deimos,{x god of terror, accompany the god of war {hh966Ares{x in his bloody harvest. Phobos is depicted as a nightmarish monster with a lion's head, fanged jaws, and blazing crimson eyes.
+
+%A% =Paths:= {MChaos{x, {RRage{x
+%A% =Gifts:= in battle, Phobos's mark will send {hh740fear{x upon your foes and warp
+  their {hh651minds{x. Ancient legend says that when followers of Phobos and Deimos
+  join forces, they can inflict truly devastating damage.
+%A% =Restrictions:= only {hh33non-good{x
+%A% =Sacrifices:= Phobos prefers magical items with combat magic, illusions,
+  or enchantments. Phobos likes being offered good weapons.
+  Among drinks he prefers wines.
+
+Legend has it that the illithids, known in the common tongue as mind flayers, are the most ancient followers of Phobos's cult. The remnants of this dreadful race are said to lurk somewhere in the depths of the {hh1856Sewers{x...
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CФобос{x -- бог леденящего страха и кровавого безумия войны. Последователи его культа верят, что на полях сражений Фобос и его брат-близнец {hh986Деймос,{x бог ужаса, сопровождают бога войны {hh966Ареса{x в его кровавой жатве. Изображают Фобоса в виде кошмарного чудовища с головой льва, клыкастой пастью и пылающими алыми буркалами.
 
 %A% =Пути:= {MХаос{x, {RЯрость{x
@@ -22,7 +36,21 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CФобос{x -- бог крижаного страху та кривавого безумства війни. Послідовники його культу вірять, що на полях битв Фобос і його брат-близнюк {hh986Деймос,{x бог жаху, супроводжують бога війни {hh966Ареса{x у його кривавій жнив. Фобоса зображають у вигляді кошмарного чудовиська з левʼячою головою, іклуватою пащею та палаючими яскраво-червоними очима.
+
+%A% =Шляхи:= {MХаос{x, {RЛють{x
+%A% =Дари:= у бою знак Фобоса нашле {hh740страх{x на твоїх ворогів і спотворить
+  їхній {hh651розум{x. Стародавня легенда каже, що обʼєднавшись,
+  послідовники Фобоса і Деймоса зможуть завдати воістину жахливих пошкоджень.
+%A% =Обмеження:= тільки {hh33не-добрі{x
+%A% =Жертвоприношення:= Фобос віддає перевагу чарівним предметам з бойовою магією, примарами
+  або чарами. Фобосу подобається, коли йому в жертву приносять гарну зброю.
+  З напоїв віддає перевагу вину.
+
+За легендою, найдавнішими послідовниками культу Фобоса є раса іллітидів, яких на загальній мові називають пожирачами мозку. Кажуть, що залишки цього моторошного племені ховаються десь у глибинах {hh1856Каналізації{x...
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/prometheus.xml
+++ b/religions/prometheus.xml
@@ -6,7 +6,19 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="971" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CPrometheus{x is the blacksmith god, giver of fire, and creator of the crafts. After the Supreme Goddess {hh1565Varda{x brought elves into our world, it was he who helped Father {hh1576Leo{x mold the second mortal race, humans, from clay and endow them with reason. Prometheus stands apart from the great confrontation of the Eight Principles; helping people concerns him far more than divine intrigues. Because of this the other gods dislike him and sometimes visit punishments upon him.
+
+%A% =Gifts:= the mark of Prometheus will periodically {hh273repair{x and clean your
+  armor of {hh2168corrosion{x, and in battle will fire a {hh625fireball{x at your enemy.
+  The mark of Prometheus also helps with {hh273repairs{x and crafting items by {hh195artisans{x.
+%A% =Sacrifices:= Prometheus prefers magical items with spells
+  of item magic. Prometheus likes to receive books,
+  scrolls, textbooks and spellbooks as sacrifice, as well as good weapons.
+
+According to legend, the old gods of {hh1864Olympus{x imprisoned Prometheus, but one of his followers helped his patron escape and took his place in the prison cell.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CПрометей{x -- бог-кузнец, даритель огня и создатель ремесел. После того как Верховная Богиня {hh1565Варда{x привела в наш мир эльфов, именно он помог Отцу {hh1576Лео{x создать из глины вторую смертную расу, людей, и наделить их разумом. Прометей стоит в стороне от великого противоборства Восьми Начал, помощь людям заботит его гораздо больше, чем божественные перипетии. Поэтому остальные боги недолюбливают его и иногда насылают на него кары.
 
 %A% =Дары:= знак Прометея будет периодически {hh273чинить{x и чистить от {hh2168коррозии{x твои
@@ -20,7 +32,19 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CПрометей{x -- бог-коваль, дарувальник вогню та творець ремесел. Після того як Верховна Богиня {hh1565Варда{x привела до нашого світу ельфів, саме він допоміг Батькові {hh1576Лео{x створити з глини другу смертну расу, людей, і наділити їх розумом. Прометей стоїть осторонь великого протистояння Восьми Начал -- допомога людям цікавить його набагато більше, ніж божественні перипетії. Тому решта богів недолюблює його і іноді насилає на нього кари.
+
+%A% =Дари:= знак Прометея буде час від часу {hh273лагодити{x і чистити від {hh2168корозії{x твої
+  обладунки, а в бою вистрілить у твого противника {hh625вогняною кулею{x.
+  Також знак Прометея допомагає при {hh273ремонті{x та виготовленні речей {hh195ремісниками{x.
+%A% =Жертвоприношення:= Прометей надає перевагу чарівним предметам із заклинаннями
+  предметної магії. Прометею подобається, коли йому в жертву приносять книги,
+  сувої, підручники та книги заклинань, а також хорошу зброю.
+
+За легендою, старі боги {hh1864Олімпу{x ув'язнили Прометея, але один із його послідовників допоміг своєму патрону втекти та зайняв його місце у тюремній камері.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>scroll weapon furniture spellbook recipe parchment</items>

--- a/religions/raven queen.xml
+++ b/religions/raven queen.xml
@@ -9,7 +9,23 @@
     <extra l="en">crow &apos;crow queen&apos; queen</extra>
     <extra l="ru"></extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">{CRaven Queen{x -- goddess of winter, cold fate, and grim death magic. Legend has it she was born in another world as a mortal sorceress, taken in by evil gods as their companion and apprentice. Trained in drawing power from the souls of the dead, the future Queen managed to raise a rebellion against an evil deity and cast it down, though she lost her body in the process. The other gods of the pantheon feared her and prevented her from becoming mistress of the dead. But before long the Raven Queen expanded her influence. She gained dominion over fate by defeating the spider goddess {hh171Lloth{x, and dominion over cold, seized from the winter god of her former pantheon.
+
+She came to the Dreamland at the height of her power and might and became the patron of {hh143necromancy{x and {hh152dark elves{x. Her cult's followers depict the Queen as a black sorceress with a raven's head.
+
+The Queen's sign (a feather) is especially active in the {hh1027winter months{x.
+
+%A% =Paths:= {DDarkness{x
+%A% =Gifts:= in battle, the Raven Queen's mark will {hh548curse{x, {hh705slow{x, and
+  drain life from your foes with the {hh827Hand of Undeath{x
+%A% =Restrictions:= only {hh33evil{x
+%A% =Sacrifices:= the Raven Queen loves magical items enchanted with spells of
+  curses or necromancy. Will rejoice at the corpse of a non-evil creature. 
+
+Necromancers who follow the Raven Queen's cult often lurk in the darkness of the {hh1854Underdark{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CКоролева Воронов{x -- богиня зимы, холодной судьбы и мрачной магии смерти. По легенде она была рождена в ином мире смертной колдуньей, принятой злыми богами в качестве своей спутницы и ученицы. Обученная использованию силы из душ умерших, будущая Королева смогла поднять восстание против злого божества и низвергнуть его, хотя и потеряла свое тело. Другие боги пантеона боялись ее и помешали ей стать повелительницей мертвых. Но вскоре Королева Воронов смогла расширить свое влияние. Она получила власть над судьбой, победив паучью богиню {hh171Ллот{x, и власть над холодом, отобранную у бога зимы своего бывшего пантеона.
 
 В Мир Мечты она пришла в расцвете своей силы и могущества и стала покровительницей {hh143некромантии{x и {hh152темных эльфов{x. Последователи ее культа изображают Королеву в виде черной колдуньи с головой ворона.
@@ -27,7 +43,23 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CКоролева Воронів{x -- богиня зими, холодної долі та похмурої магії смерті. За легендою, вона народилась в іншому світі смертною чаклункою, прийнятою злими богами як супутниця та учениця. Навчившись черпати силу з душ померлих, майбутня Королева змогла підняти повстання проти злого божества і скинути його, хоча й втратила своє тіло. Інші боги пантеону боялись її і завадили їй стати повелителькою мертвих. Але невдовзі Королева Воронів змогла розширити свій вплив. Вона здобула владу над долею, перемігши павучу богиню {hh171Ллот{x, і владу над холодом, відібрану у бога зими свого колишнього пантеону.
+
+У Світ Мрій вона прийшла на піку своєї сили та могутності і стала покровителькою {hh143некромантії{x та {hh152темних ельфів{x. Послідовники її культу зображають Королеву у вигляді чорної чаклунки з головою ворона.
+
+Знак Королеви (пір'їна) особливо активний у {hh1027зимові місяці{x.
+
+%A% =Шляхи:= {DТемрява{x
+%A% =Дари:= у бою знак Королеви Воронів {hh548проклене{x, {hh705сповільнить{x і
+  висмокче життя з твоїх ворогів {hh827Рукою Умертвія{x
+%A% =Обмеження:= тільки {hh33злі{x
+%A% =Жертвоприношення:= Королева Воронів любить чарівні предмети із закляттями
+  проклять або некромантії. Зрадіє трупу не-злої істоти. 
+
+Некроманти, послідовники культу Королеви Воронів, часто ховаються у мороці {hh1854Підземʼя{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/razer.xml
+++ b/religions/razer.xml
@@ -7,7 +7,14 @@
     <keyword l="en">razer</keyword>
     <keyword l="ru">разер</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CRazer{x -- god of furious, scorching light that burns away darkness, the legendary King of {hh1466Knights{x who united the armies of Light and the warriors of {hh1471Fury{x for war against the hordes of the Invaders during the First and Second Epochs of this world. Razer is usually depicted as a mature man in a crown and gleaming golden armor, poised for hand-to-hand combat. Razer's first commandment: &quot;Good must have fists.&quot; He is patron of the Order of Knights and all who are willing to sacrifice themselves in the eternal and irreconcilable struggle against Evil.
+
+%A% =Paths:= {WLight{x, {RFury{x
+%A% =Gifts:= in battle Razer's mark will incinerate your foes with {hh761a ray of truth{x
+%A% =Restrictions:= {hh33good{x only
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CРазер{x -- бог яростного, обжигающего света, испепеляющего тьму, легендарный Король {hh1466Рыцарей{x, объединивший армии Света и воинов {hh1471Ярости{x на войну с полчищами Захватчиков во времена Первой и Второй Эпох этого мира. Разера обычно изображают в виде зрелого мужчины в короне и сияющих золотых доспехах, в стойке рукопашного боя. Первая заповедь Разера: &quot;Добро должно быть с кулаками.&quot; Он покровительствует Ордену Рыцарей и всем, кто готов пожертвовать собой в извечной и непримиримой борьбе со Злом.
 
 %A% =Пути:= {WСвет{x, {RЯрость{x
@@ -16,7 +23,14 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CРазер{x -- бог лютого, випалюючого світла, що нищить пітьму, легендарний Король {hh1466Лицарів{x, який обʼєднав армії Світла і воїнів {hh1471Ярості{x на війну з полчищами Загарбників у часи Першої і Другої Епох цього світу. Разера зазвичай зображують у вигляді зрілого чоловіка в короні та виблискуючих золотих обладунках, у стійці рукопашного бою. Перша заповідь Разера: &quot;Добро має бути з кулаками.&quot; Він покровительствує Ордену Лицарів і всім, хто готовий пожертвувати собою у вічній і непримиренній боротьбі зі Злом.
+
+%A% =Шляхи:= {WСвітло{x, {RЯрість{x
+%A% =Дари:= у бою знак Разера спопелить твоїх противників {hh761променем істини{x
+%A% =Обмеження:= тільки {hh33добрі{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/ruffina.xml
+++ b/religions/ruffina.xml
@@ -8,14 +8,24 @@
     <keyword l="en">ruffina rufina</keyword>
     <keyword l="ru">коза руффина руфина</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CRuffina{x -- {hh159satyr{x goddess of creation from chaos, who arrived in the world at the twilight of the Third Epoch and almost immediately took up the mantle from the retiring {hh1577Dwarkin{x and {hh1584Tirna{x. With her arrival the Fourth Epoch begins its count -- a time of brief withering and the gradual rebirth of the world toward the heights of its former glory. Ruffina is patron to chaotic-neutral characters who, like her, are free of the dogmas of good or evil and understand that chaos is a source of inspiration. Legend has it that her mother was a certain {hh151centauress{x and her father a unicorn from the Forgotten Dungeons, which is why an unusually long tail is attached to her ginger satyric um... body.
+
+=Paths=: {BMind{x, {MChaos{x =Gifts=: in battle Ruffina's mark will utter one of the words in {hh234ancient tongues{x =Restrictions=: {hh33chaotic-neutral{x only
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CРуфина{x -- {hh159сатирская{x богиня созидания из хаоса, пришедшая в мир на закате Третьей Эпохи и почти сразу принявшая эстафету от уходивших на покой {hh1577Дворкина{x и {hh1584Тирны{x. С ее прихода начинает отсчет Четвертая Эпоха, во время которой произошло кратковременное увядание и постепенное возрождение мира к вершинам былой славы. Руфина покровительствует хаотически-нейтральным персонажам, так же, как она сама, свободным от догм добра или зла и понимающим, что хаос -- это источник вдохновения. По легенде, ее матерью была некая {hh151кентавра{x, а отцом -- единорог из Забытых Подземелий, из-за чего к ее рыжему сатирскому эм... телу крепится необычно длинный хвост.
 
 =Пути=: {BРазум{x, {MХаос{x =Дары=: в бою знак Руфины изречет одно из слов на {hh234древних языках{x =Ограничения=: только {hh33хаотично-нейтральные{x
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CРуфіна{x -- {hh159сатирська{x богиня творення з хаосу, що прийшла у світ на заході Третьої Епохи і майже одразу прийняла естафету від {hh1577Дворкіна{x і {hh1584Тирни{x, що відходили на спокій. З її приходом починає відлік Четверта Епоха, під час якої сталося короткочасне в'янення і поступове відродження світу до вершин колишньої слави. Руфіна покровительствує хаотично-нейтральним персонажам, так само як і вона сама, вільним від догм добра чи зла і тим, хто розуміє, що хаос -- це джерело натхнення. За легендою, її матірʼю була якась {hh151кентавра{x, а батьком -- єдиноріг із Забутих Підземель, через що до її рудого сатиричного гм... тіла кріпиться незвично довгий хвіст.
+
+=Шляхи=: {BРозум{x, {MХаос{x =Дари=: у бою знак Руфіни вимовить одне зі слів на {hh234давніх мовах{x =Обмеження=: тільки {hh33хаотично-нейтральні{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/seth.xml
+++ b/religions/seth.xml
@@ -9,7 +9,20 @@
     <extra l="en"></extra>
     <extra l="ru">сэт</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">{CSeth{x -- god of rage, sandstorms, war and death, destruction and chaos, the Scourge of All That Is, who razes cities and peoples to ash. Legend holds that Seth bred the race of dragons to command them and lead their armies to the ruin of all living things. But {hh1576Leo{x granted dragons reason and free will, and {hh974Enki{x breathed magic into them, and since then the dragons decide for themselves which side to fight on. Followers of the Seth cult depict him as a black dragon with the head of a donkey, a red mane, and bloodshot eyes.
+
+%A% =Paths:= {MChaos{x, {DEvil{x
+%A% =Gifts:= in battle the mark of Seth will sear your foes with {hh658fire{x or {hh664lightning{x
+  breath (depending on the number of foes) and grant you {hh565the strength of a dragon{x,
+  increasing your damage, strength, and accuracy.
+%A% =Restrictions:= only {hh30non-lawful{x {hh33non-good{x
+%A% =Sacrifices:= Seth prefers magical items with spells
+  from the school of battle magic.
+
+Driven from Dragon Peak and stripped of dominion over the draconian race, the last priests of the Seth cult took refuge in the darkness of {hh1856the Underdark{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CСет{x -- бог ярости, песчаных бурь, войны и смерти, разрушения и хаоса, Бич Сущего, испепеляющий города и народы. По легенде, Сет вывел расу драконов, чтобы повелевать ими и вести их армии на погибель всему живому. Но {hh1576Лео{x даровал драконам разум и свободу воли, а {hh974Энки{x вдохнул в них магию, и с тех пор драконы сами решают, на чьей стороне сражаться. Поклонники культа Сета изображают его в виде черного дракона с головой осла, красной гривой и кровавыми буркалами.
 
 %A% =Пути:= {MХаос{x, {DЗло{x
@@ -24,7 +37,20 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CСет{x -- бог люті, піщаних бур, війни і смерті, руйнування і хаосу, Бич Сущого, що спалює міста і народи. За легендою, Сет вивів расу драконів, щоб владарювати ними і вести їхні армії на загибель усьому живому. Але {hh1576Лео{x дарував драконам розум і вільну волю, а {hh974Енкі{x вдихнув у них магію, і відтоді дракони самі вирішують, на чиєму боці битися. Поклонники культу Сета зображують його у вигляді чорного дракона з головою осла, червоною гривою і кривавими баньками.
+
+%A% =Шляхи:= {MХаос{x, {DЗло{x
+%A% =Дари:= у бою знак Сета обпалить твоїх противників {hh658вогняним{x або {hh664електричним{x
+  диханням (залежно від кількості противників) і дарує тобі {hh565силу дракона{x,
+  збільшуючи шкоду, силу і точність.
+%A% =Обмеження:= тільки {hh30не-законослухняні{x {hh33не-добрі{x
+%A% =Жертвоприношення:= Сет надає перевагу чарівним предметам із заклинаннями
+  групи бойової магії.
+
+Вигнані з Піку Драконів і позбавлені влади над расою дракоників, останні жерці культу Сета сховалися у пітьмі {hh1856Підземʼя{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/shamash.xml
+++ b/religions/shamash.xml
@@ -8,7 +8,20 @@
     <extra l="en">resurrection</extra>
     <extra l="ru">воскрешение</extra>
     <extra l="ua"></extra>
-    <text l="en"></text>
+    <text l="en">{CShamash{x -- god of justice, the day-and-night cycle, judge of the dead, keeper of nature's circle, the laws of evolution and survival. He grants new life and frees souls from the bonds of flesh, he blesses sprouting seeds and rots the bodies of the fallen, he takes the living and raises the dead. Followers of his cult depict Shamash as an old man in a turban, seated upon the Throne of Life.
+
+%A% =Paths:= {wOrder{x, {gNature{x
+%A% =Gifts:= Shamash's mark will ease your bodily suffering after {hh12death{x,
+  and sometimes will even miraculously spare you from certain doom in battle -- especially in
+  fights against monsters
+%A% =Restrictions:= {hh30non-chaotic{x only
+%A% =Sacrifices:= Shamash prefers magical items with healing and protective
+  spells, as well as good armor and any corpses.
+
+In our reality, followers of Shamash are nearly gone. Legends say some were spotted in {hh1446Thalos{x shortly before the city's destruction.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CШамаш{x -- бог справедливости, цикла дня и ночи, судья мертвых, хранитель круговорота природы, законов эволюции и выживания. Он дарует новую жизнь и освобождает от оков плоти, он благословляет ростки и истлевает тела павших, он забирает живых и воскрешает мертвых. Последователи его культа изображают Шамаша в виде старца в тюрбане, восседающего на Троне Жизни.
 
 %A% =Пути:= {wПорядок{x, {gПрирода{x
@@ -23,7 +36,20 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CШамаш{x -- бог справедливості, циклу дня і ночі, суддя мертвих, охоронець кругообігу природи, законів еволюції та виживання. Він дарує нове життя і звільняє від кайданів плоті, він благословляє паростки і тлить тіла полеглих, він забирає живих і воскрешає мертвих. Послідовники його культу зображують Шамаша у вигляді старця в тюрбані, що сидить на Троні Життя.
+
+%A% =Шляхи:= {wПорядок{x, {gПрирода{x
+%A% =Дари:= знак Шамаша полегшить твої тілесні страждання після {hh12смерті{x,
+  а іноді навіть чудом позбавить тебе від неминучої загибелі в бою -- особливо в
+  сутичках проти чудовиськ
+%A% =Обмеження:= тільки {hh30нехаотичні{x
+%A% =Жертвоприношення:= Шамаш надає перевагу чарівним предметам із заклинаннями
+  лікування та захисної магії, а також гарній броні та будь-яким трупам.
+
+У нашій реальності адептів Шамаша залишилося зовсім мало. За легендами, деяких послідовників цього культу бачили в {hh1446Талосі{x незадовго до руйнування міста.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>armor</items>

--- a/religions/siebele.xml
+++ b/religions/siebele.xml
@@ -8,7 +8,22 @@
     <keyword l="en">kibela</keyword>
     <keyword l="ru">сибель</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CSiebele{x -- goddess of nature's wild fury and its fearsome power. Siebele is revered as the embodiment of the Great Mother Nature, and she often serves as a symbol of the feminine principle.
+
+The priests and priestesses of Siebele's cult despise human anthill societies; they offer their Mother terrifying sacrifices, begging her to send floods and earthquakes upon cities so that new forests may grow in their place. Siebele is depicted as a stern queen in a turreted crown, hurtling madly on a golden chariot drawn by lions. Naturally, Siebele is the patron of {hh192druids{x.
+
+%A% =Paths:= {gNature{x
+%A% =Gifts:= in a forest fight, Siebele's mark will ensnare the foe with {hh835tree roots{x;
+  near water -- {hh553drown{x them; against multiple foes
+  it will unleash a {hh796hurricane{x upon them, and in all other cases -- strike
+  with the power of Earth, hitting men with particular force
+%A% =Sacrifices:= Siebele prefers magical items enchanted with spells of
+  nature and enhancement. She will rejoice at the corpse of a non-neutral creature.
+
+Siebele's shrines can be found in the depths of Thera's ancient forests -- for instance, in {hh1862Haon Dor{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CКибела{x -- богиня буйства природы и ее грозной силы. Кибелу почитают как олицетворение Великой Матери-Природы, и она часто выступает символом женского начала.
 
 Жрецам и жрицам культа Кибелы ненавистны людские общества-муравейники, они приносят своей Матери ужасающие жертвоприношения, прося наслать на города потопы и землетрясения, дабы вырастить на их месте новые леса. Кибелу изображают суровой царицей в зубчатой короне, бешено несущейся на золотой колеснице, запряженной львами. Разумеется, Кибела покровительствует {hh192друидам{x.
@@ -25,7 +40,22 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CСіебела{x -- богиня буйства природи та її грізної сили. Сіебелу шанують як уособлення Великої Матері-Природи, і вона часто виступає символом жіночого начала.
+
+Жреці та жриці культу Сіебели ненавидять людські суспільства-мурашники, вони приносять своїй Матері жахливі жертвоприношення, просячи наслати на міста повені й землетруси, щоб на їхньому місці виросли нові ліси. Сіебелу зображають суворою царицею в зубчастій короні, що несамовито мчить на золотій колісниці, запряженій левами. Звісно, Сіебела покровительствує {hh192друїдам{x.
+
+%A% =Шляхи:= {gПрирода{x
+%A% =Дари:= у лісовому бою знак Сіебели обплете ворога {hh835деревʼяним корінням{x;
+  у бою біля води -- {hh553потопить{x його; проти кількох ворогів
+  нашле на них {hh796ураган{x, а в усіх інших випадках -- вдарить
+  силою Землі, з особливою потугою вражаючи чоловіків
+%A% =Жертвоприношення:= Сіебела віддає перевагу чарівним предметам із закляттями
+  природи та підсилення. Зрадіє трупу не-нейтральної істоти.
+
+Капища Сіебели можна знайти у глибинах стародавніх лісів Тери -- наприклад, у {hh1862Хаон Дорі{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/taiphoen.xml
+++ b/religions/taiphoen.xml
@@ -8,7 +8,14 @@
     <keyword l="en">taiphoen</keyword>
     <keyword l="ru">тайфоэн</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CTaiphoen{x -- goddess of dark might and death that stalks in the shadows. Legend holds that in the ancient age of this world she led the hordes of the {hh1485Invaders{x against the destruction of Good. Her mortal form perished alongside countless others in the terrible Cataclysm at the end of the Second Epoch, but she was reborn from Darkness in the shape of the Phantom Dragoness who brings sudden death. Taiphoen encourages {hh32killing{x (PK), watches over the balance of power in the world, and is the patron of {hh135thieves{x, {hh132ninjas{x, and the Cabal of Invaders. She favors the race of {hh154dark dwarves{x and sometimes travels in the guise of a duergar woman.
+
+%A% =Paths:= {DDarkness{x (supreme goddess), {YSociety{x
+%A% =Gifts:= Taiphoen's mark makes {hh1123sudden death{x skills more inescapable
+%A% =Restrictions:= only {hh33evil{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CТайфоэн{x -- богиня темного могущества и смерти, крадущейся в тенях. По легенде, во времена древности этого мира она вела за собой полчища {hh1485Захватчиков{x на уничтожение Добра. Ее смертная ипостась сгинула вместе с мириадами других в ужасном Катаклизме в конце Второй Эпохи, но она возродилась из Тьмы в образе приносящей внезапную гибель Призрачной Драконицы. Тайфоэн поощряет {hh32смертоубийство{x (PK), следит за балансом могущества в мире и покровительствует {hh135ворам{x, {hh132ниндзям{x и Кабалу Захватчиков. Она благоволит расе {hh154темных карликов{x и иногда путешествует в обличьи дуэргарши.
 
 %A% =Пути:= {DТьма{x (верховная богиня), {YОбщество{x
@@ -17,7 +24,14 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CТайфоен{x -- богиня темної могутності та смерті, що крадеться в тінях. За легендою, у давнину цього світу вона вела за собою полчища {hh1485Загарбників{x на знищення Добра. Її смертна іпостась загинула разом із безліччю інших у жахливому Катаклізмі наприкінці Другої Епохи, але вона відродилась із Темряви у вигляді Примарної Дракониці, що несе раптову загибель. Тайфоен заохочує {hh32вбивство{x (PK), стежить за балансом могутності у світі та покровительствує {hh135злодіям{x, {hh132ніндзя{x та Кабалу Загарбників. Вона благоволить расі {hh154темних карликів{x і часом подорожує в подобі дуергарки.
+
+%A% =Шляхи:= {DТемрява{x (верховна богиня), {YСуспільство{x
+%A% =Дари:= знак Тайфоен робить уміння {hh1123раптової смерті{x більш невідворотними
+%A% =Обмеження:= тільки {hh33злі{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/tananda.xml
+++ b/religions/tananda.xml
@@ -8,7 +8,15 @@
     <keyword l="en">tananda</keyword>
     <keyword l="ru">тананда</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CTananda{x -- supreme goddess of Chaos, improvisation, and spectacular self-expression, wife of {hh1577Dvorkin{x and patron of the Barons and Baronesses of the {hh2097Circle of Chaos{x. {hh1576Leo{x gave the living free will, but it is thanks to Tananda that our world gained true freedom of Path and infinite choice. Incredibly eccentric, Tananda appeared before her devotees in a thousand guises. She is usually depicted as an impossibly attractive and passionate woman with stunning curves, golden skin, and light-green hair. In her wanderings she was often accompanied by crowds of noisy imps, porcelain dogs, and a tame albino hippo. Even the race she chose to patronize was eccentric enough -- the green-skinned mountain {hh157trolls{x -- and she granted them resistance to charm. Tananda departed from our world at the end of the First Epoch, but she lives on forever in the loving memory of millions. Her inconsolable devotees raised a {hh1846temple{x to her in the {hh1392capital{x, but somehow -- perhaps as Tananda's parting prank -- the temple ended up in two places at once, in Midgaard and New Thalos. Will she ever return? Who knows...
+
+%A% =Paths:= {MChaos{x (supreme goddess)
+%A% =Gifts:= in battle, Tananda's mark may cast almost any spell.
+{x Which one? Oh, does it matter!
+%A% =Restrictions:= only {hh30chaotic{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CТананда{x -- верховная богиня Хаоса, импровизации и феерического самовыражения, жена {hh1577Дворкина{x и покровительница Баронов и Баронесс {hh2097Круга Хаоса{x. {hh1576Лео{x дал живущим свободу воли, но благодаря Тананде наш мир обрел истинную свободу Пути и бесконечность выбора. Невероятно эксцентричная, Тананда представала перед поклонниками в тысяче обличий. Изображают ее обычно в виде невероятно привлекательной и страстной женщины с восхитительными формами, золотистой кожей и светло-зелеными волосами. В странствиях ее часто сопровождали толпы шумных чертенят, фарфоровые собачки и ручной бегемот-альбинос. Даже расу для покровительства она выбрала весьма эксцентричную -- зеленокожих горных {hh157троллей{x -- и даровала им сопротивляемость к очарованию. Тананда ушла из нашего мира в конце Первой Эпохи, но навсегда осталась в любящей памяти миллионов живущих. Безутешные поклонники воздвигли ей {hh1846храм{x в {hh1392столице{x, но каким-то чудом -- а, может, в качестве прощальной шалости Тананды -- храм оказался в двух местах одновременно, в Мидгаарде и Новом Талосе. Вернется ли она когда-нибудь? Кто знает...
 
 %A% =Пути:= {MХаос{x (верховная богиня)
@@ -18,7 +26,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CТананда{x -- верховна богиня Хаосу, імпровізації та феєричного самовираження, дружина {hh1577Дворкіна{x та покровителька Баронів і Баронес {hh2097Кола Хаосу{x. {hh1576Лео{x дав живим свободу волі, але завдяки Тананді наш світ здобув справжню свободу Шляху і нескінченність вибору. Неймовірно ексцентрична, Тананда поставала перед шанувальниками в тисячі обличь. Зазвичай її зображають у вигляді неймовірно привабливої і пристрасної жінки з чудовими формами, золотистою шкірою та світло-зеленим волоссям. У мандрах її часто супроводжували натовпи галасливих чортенят, порцелянові собачки та ручний бегемот-альбінос. Навіть расу для покровительства вона обрала вельми ексцентричну -- зеленошкірих гірських {hh157тролів{x -- і дарувала їм стійкість до чарів. Тананда пішла з нашого світу наприкінці Першої Епохи, але назавжди залишилась у люблячій памʼяті мільйонів живих. Безутішні шанувальники спорудили їй {hh1846храм{x у {hh1392столиці{x, але якимось дивом -- а, може, на прощання Тананда пожартувала -- храм опинився одночасно у двох місцях, у Мідгаарді та Новому Талосі. Чи повернеться вона колись? Хто знає...
+
+%A% =Шляхи:= {MХаос{x (верховна богиня)
+%A% =Дари:= у бою знак Тананди може зчаклувати майже будь-яке заклинання.
+{x Яке? Ах, та яка різниця!
+%A% =Обмеження:= тільки {hh30хаотичні{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/teshub.xml
+++ b/religions/teshub.xml
@@ -5,7 +5,21 @@
   <ethos></ethos>
   <flags>cult</flags>
   <help id="988" level="-1" type="ReligionHelp">
-    <text l="en"></text>
+    <text l="en">{CTeshub{x is the god of storms and tempests, master of lightning. His sacred animals are the bull and the cow, which is why followers of his cult often depict Teshub in a chariot drawn by bulls, with a bundle of lightning bolts in his hands. Teshub is the mortal enemy of {hh967Set{x and the entire race of dragons, and according to legend once defeated the terrible dragon of antiquity, Illuyanka, in battle.
+
+Teshub is revered as the father of the {hh165storm giants{x, whom he protects.
+
+%A% =Paths:= {gNature{x
+%A% =Gifts:= in battle the mark of Teshub will strike a single enemy with {hh664lightning breath{x,
+  and several at once with {hh773chain lightning{x
+%A% =Sacrifices:= Teshub prefers magical items with combat or
+  nature spells. Will be pleased by the corpse of a non-neutral creature.
+  Teshub likes to receive good weapons as sacrifice. 
+
+Adepts of Teshub are drawn to places steeped in the magical power of the elements -- such as {hh1867Canyon of Elements{x.
+
+%SA% %H% {hh81Eight Paths{x
+</text>
     <text l="ru">{CТешуб{x -- бог грозы и штормов, хозяин молний. Его священные животные -- бык и корова, отчего последователи его культа часто изображают Тешуба в колеснице, запряженной быками, с пучком молний в руках. Тешуб -- смертельный враг {hh967Сета{x и всей расы драконов, и по преданию когда-то победил в сражении ужасного дракона древности, Иллуянку.
 
 Тешуба почитают как отца {hh165штормовых великанов{x, которым он покровительствует.
@@ -21,7 +35,21 @@
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CТешуб{x -- бог грози та штормів, господар блискавок. Його священні тварини -- бик і корова, тому послідовники його культу часто зображують Тешуба у колісниці, запряженій биками, з пучком блискавок у руках. Тешуб -- смертельний ворог {hh967Сета{x та всієї раси драконів, і за переказом колись переміг у сутичці жахливого дракона давнини, Іллуянку.
+
+Тешуба шанують як батька {hh165штормових велетнів{x, яким він покровительствує.
+
+%A% =Шляхи:= {gПрирода{x
+%A% =Дари:= у бою знак Тешуба вразить одиночного противника {hh664подихом блискавок{x,
+  а кількох одразу -- {hh773ланцюгом блискавок{x
+%A% =Жертвоприношення:= Тешуб надає перевагу чарівним предметам з бойовими або
+  природними заклинаннями. Зрадіє трупу не-нейтральної істоти.
+  Тешуб любить, коли йому в жертву приносять хорошу зброю. 
+
+Адептів Тешуба вабить до місць, насичених магічною силою елементів -- наприклад, {hh1867Каньйон Стихій{x.
+
+%SA% %H% {hh81Вісім Шляхів{x
+</text>
   </help>
   <likes>
     <items>weapon recipe</items>

--- a/religions/tirna.xml
+++ b/religions/tirna.xml
@@ -11,7 +11,14 @@
     <keyword l="en">teelak tirna</keyword>
     <keyword l="ru">тилак тирна</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CTirna{x -- patron god of those who walk their own paths without joining any clan. During the Second Epoch he was known under the name Tilak, and for many centuries helped {hh1577Dwarkin{x and other gods develop and build our world from the void. Tirna is a patient shepherd of the sentient races, a teacher of civilizations and architect of cities. Mortals remember with gratitude many of his gifts and innovations -- especially in the development of our society, the {hh3clans and orders{x of this world. Tirna is patron of the race of half-bloods and outcasts, the {hh162half-elves{x.
+
+%A% =Gifts:= in battle Tirna's mark may briefly teach you one of the secret
+{x clan skills
+%A% =Restrictions:= only a clanless character can become a follower of Tirna
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CТирна{x -- бог-покровитель тех, кто идет иными путями, не вступая ни в какой клан. Во времена Второй Эпохи он был известен под именем Тилака, и много столетий помогал {hh1577Дворкину{x и другим богам развивать и строить наш мир из пустоты. Тирна -- терпеливый пастырь разумных рас, учитель цивилизаций и архитектор городов. Смертные с благодарностью вспоминают многие его дары и нововведения -- особенно в области развития нашего общества, {hh3кланов и орденов{x этого мира. Тирна покровительствует расе полукровок и изгоев, {hh162полуэльфов{x.
 
 %A% =Дары:= в бою знак Тирны может ненадолго обучить тебя одному из тайных
@@ -20,7 +27,14 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CТирна{x -- бог-покровитель тих, хто іде своїми шляхами, не вступаючи до жодного клану. За часів Другої Епохи він був відомий під іменем Тілака, і багато століть допомагав {hh1577Дворкіну{x та іншим богам розвивати і будувати наш світ із порожнечі. Тирна -- терплячий пастир розумних рас, учитель цивілізацій і архітектор міст. Смертні з вдячністю згадують багато його дарів і нововведень -- особливо в галузі розвитку нашого суспільства, {hh3кланів і орденів{x цього світу. Тирна покровительствує расі напівкровок і вигнанців, {hh162напівельфів{x.
+
+%A% =Дари:= у бою знак Тирни може ненадовго навчити тебе одному з таємних
+{x кланових умінь
+%A% =Обмеження:= стати послідовником Тирни зможе тільки позаклановий
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/turlok.xml
+++ b/religions/turlok.xml
@@ -9,7 +9,16 @@
     <keyword l="en">turlok</keyword>
     <keyword l="ru">турлок</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CTurlok{x -- supreme god of battlefield valor, dueling, and martial mastery, patron of {hh142warriors{x. Legend holds he was an unmatched swordsman and one of the first leaders of the {hh1471Battlerage{x clan during the First and Second Epochs. Turlok is depicted either as a mighty warrior with two crossed blades, or as a furious tiger, his sacred form.
+
+%A% =Paths:= {RRage{x (supreme god)
+%A% =Gifts:= in battle, Turlok's mark will briefly increase the effectiveness of many of your
+{x {hh2021combat skills{x: raise the chance of landing extra attacks or a
+  {hh693critical hit{x, boost damage from {hh807kicks{x, and so on
+%A% =Restrictions:= only {hh142warriors{x, {hh136samurai{x, {hh140rangers{x, and {hh132ninjas{x
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CТурлок{x -- верховный бог доблести на поле сражений, дуэлей и боевого мастерства, покровитель {hh142воинов{x. По легенде он был непревзойденным фехтовальщиком и одним из первых лидеров клана {hh1471Баттлрейджеров{x во времена Первой и Второй эпох. Изображают Турлока или в образе могучего воина с двумя скрещенными клинками, или в образе яростного тигра, его священной ипостаси.
 
 %A% =Пути:= {RЯрость{x (верховный бог)
@@ -20,7 +29,16 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CТурлок{x -- верховний бог доблесті на полі бою, дуелей та бойової майстерності, покровитель {hh142воїнів{x. За легендою, він був неперевершеним фехтувальником і одним із перших лідерів клану {hh1471Батлрейджерів{x за часів Першої та Другої епох. Турлока зображають або у вигляді могутнього воїна з двома схрещеними клинками, або у вигляді лютого тигра -- його священної іпостасі.
+
+%A% =Шляхи:= {RЛють{x (верховний бог)
+%A% =Дари:= у бою знак Турлока ненадовго підвищить ефективність багатьох твоїх
+{x {hh2021бойових умінь{x: збільшить шанс завдати додаткові атаки або
+  {hh693критичний удар{x, посилить шкоду від {hh807ударів ногою{x і так далі
+%A% =Обмеження:= тільки {hh142воїни{x, {hh136самураї{x, {hh140рейнджери{x та {hh132ніндзя{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>

--- a/religions/varda.xml
+++ b/religions/varda.xml
@@ -10,7 +10,15 @@
     <keyword l="en">varda</keyword>
     <keyword l="ru">варда</keyword>
     <keyword l="ua"></keyword>
-    <text l="en"></text>
+    <text l="en">{CVarda{x -- Mother of all Gods and of the Dream World at large. Together with her husband {hh1576Leo{x, she created our world from the eternal void and breathed life into it. Varda loves and cares for all of us, offering kindness and gentle starlight. The high {hh156elves{x, whom Varda first brought into our world, call her Elbereth, the eternal Queen of Stars, and depict her as an infinitely beautiful woman with a tender maternal smile on her delicate lips.
+
+%A% =Paths:= {WLight{x (supreme goddess), {gNature{x 
+%A% =Gifts:= in battle Varda's mark will envelop you in protective {hh760stardust{x,
+{x and for elves she will help temporarily shed the vulnerability to iron.
+%A% =Restrictions:= {hh33good{x only
+
+%SA% %H% {hh81Eight Paths{x, {hh80epochs{x
+</text>
     <text l="ru">{CВарда{x -- Мать всех Богов и Мира Мечты, в целом. Вместе со своим мужем {hh1576Лео{x, она создала наш мир из вечной пустоты и вдохнула в него жизнь. Варда любит и заботится обо всех нас, дарит нам доброту и ласковый звездный свет. Высшие {hh156эльфы{x, которых Варда первыми привела в наш мир, называют ее Элберет, предвечная Королева Звезд, и изображают ее в виде бесконечно прекрасной женщины с нежной материнской улыбкой на тонких устах.
 
 %A% =Пути:= {WСвет{x (верховная богиня), {gПрирода{x 
@@ -20,7 +28,15 @@
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
-    <text l="ua"></text>
+    <text l="ua">{CВарда{x -- Мати всіх Богів і Світу Мрій загалом. Разом зі своїм чоловіком {hh1576Лео{x вона створила наш світ з вічної порожнечі і вдихнула в нього життя. Варда любить і піклується про всіх нас, дарує нам доброту і лагідне зоряне світло. Вищі {hh156ельфи{x, яких Варда першими привела в наш світ, звуть її Елберет, одвічна Королева Зірок, і зображують її у вигляді нескінченно прекрасної жінки з ніжною материнською усмішкою на тонких устах.
+
+%A% =Шляхи:= {WСвітло{x (верховна богиня), {gПрирода{x 
+%A% =Дари:= у бою знак Варди огорне тебе захисним {hh760зоряним пилом{x,
+{x а ельфам вона допоможе тимчасово позбутися вразливості до заліза.
+%A% =Обмеження:= тільки {hh33добрі{x
+
+%SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
+</text>
   </help>
   <likes>
     <items></items>


### PR DESCRIPTION
Completes EN+UA for 125 RU-only help bodies (spells, skills, commands, races, religions) to full three-language coverage. Translated from RU against a locked glossary; {hh<id> links, %markers% and colour codes preserved verbatim, line structure mirrored, ASCII punctuation, UA apostrophe, no script-mixing. Automated QC per article: {hh-id and marker multisets match RU, XML well-formed, only empty en/ua tags filled. Overnight help-corpus pass -- translation batch. Review before deploy (plug reload most).