### PR TITLE
help 18 (movetype): fix EN token sneak->slink, fill UA/EN metadata

### DIFF
--- a/helps/help.xml
+++ b/helps/help.xml
@@ -697,19 +697,19 @@ The command separator *|* lets you enter several commands on one line, or define
   <node id="18" labels="move" level="-1" type="Help">
     <extra l="en">crawl slink</extra>
     <extra l="ru">красться ползти &apos;про перемещение&apos;</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">крастися повзти &apos;про переміщення&apos;</extra>
     <keyword l="en">movetype</keyword>
     <keyword l="ru">&apos;типы перемещения&apos;</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">&apos;типи переміщення&apos;</keyword>
     <text l="en">{CNORMAL MOVEMENT{x
 %A% =very fast:= for example, {hh1078running via speedwalks{x or {hh1025fleeing{x from combat
 %A% =at a normal pace:= simply {hh1022walk{x, {hh2128swim{x, {hh227ride{x or {hh575fly{x in one of the directions
 
 {CCAUTIOUS MOVEMENT{x 
-%FMT% _direction_ {ysneak{x
+%FMT% _direction_ {yslink{x
 %FMT% _direction_ {ycrawl{x
 
-Slowly and carefully sneak or crawl in the desired direction. For example {ynorth sneak{x or {yeast crawl{x
+Slowly and carefully slink or crawl in the desired direction. For example {ynorth slink{x or {yeast crawl{x
  
 In some zones you may encounter {hh241traps{x, and your speed of movement determines whether you fall into them or not. 
 </text>
@@ -737,9 +737,9 @@ In some zones you may encounter {hh241traps{x, and your speed of movement determ
  
 У деяких зонах можна натрапити на {hh241пастки{x, і від твоєї швидкості переміщення залежить, потрапиш ти в них чи ні. 
 </text>
-    <title l="en"></title>
+    <title l="en">{CMovement: {xmovement types, speed</title>
     <title l="ru">{CПеремещение: {xтипы перемещения, скорость</title>
-    <title l="ua"></title>
+    <title l="ua">{CПереміщення: {xтипи переміщення, швидкість</title>
   </node>
   <node id="19" labels="item" level="0" type="Help">
     <extra l="en">cabinets</extra>


### PR DESCRIPTION
EN body documented `sneak` as the careful-move command -- but that is the stealth skill; the engine movetype command is `slink` (per movetypes.cpp). Corrected the %FMT% line, example, and prose to `slink`. Filled the empty `extra l=ua`, `keyword l=ua`, `title l=en`, `title l=ua`. The UA body's повзти/крастися are made functional by the companion movetypes UA-alias change (dreamland_code #592).