### PR TITLE
helps: document the movetype on-entry dodge for the 9 room-affect skills

### DIFF
--- a/clan-skills/evil spirit.xml
+++ b/clan-skills/evil spirit.xml
@@ -23,16 +23,23 @@
     <extra l="en">spirit spirits concentration concentrations darkness great evil tentacles</extra>
     <extra l="ru">дух духи сосредоточие средоточия тьмы великой злой злые щупальца</extra>
     <extra l="ua">дух духи зосередження зосередження темряви великої злої злі щупальця</extra>
-    <text l="en">Experience Invaders can summon an evil focus -- creepy tentacles, penetrating the minds of all non-friendly creatures to the Invader in the zone, dealing damage to them and driving them insane in the current {hh998location{x.</text>
+    <text l="en">Experience Invaders can summon an evil focus -- creepy tentacles, penetrating the minds of all non-friendly creatures to the Invader in the zone, dealing damage to them and driving them insane in the current {hh998location{x.
+
+The way you {hh18enter{x the haunted area matters: hurrying in at speed, quickly or at a run, gives a chance to slip past before the focus fixes on you, while creeping in slowly does not. This counts only on entry, not while you remain.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Опытные Захватчики способны призвать в текущую {hh998локацию{x средоточие Зла -- жуткие щупальца, проникающие в мозг всех не-дружественных Захватчику существ в зоне, нанося им повреждения и сводя их с ума.
+
+Важно, как ты {hh18входишь{x в одержимую местность: влетевшему на скорости, быстро или бегом, есть шанс проскользнуть прежде, чем средоточие вцепится в него, а крадущемуся медленно -- нет. Касается только момента входа, но не того, кто остался стоять.
 
 {RВНИМАНИЕ:{x Это {hh184ритуал{x, не прерывай процесс до полного завершения -- иначе заклинание сорвется.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
 Досвідчені Захоплювачі можуть викликати у поточній {hh998локації{x зосередження Зла -- моторошні щупальця, що проникають у мозок усіх не-дружніх до Захоплювача істот у зоні, завдаючи їм ушкодження і зводячи їх з розуму.
+
+Важливо, як ти {hh18заходиш{x до одержимої місцевості: тому, хто влетів на швидкості, швидко чи бігом, є шанс прослизнути, перш ніж зосередження вчепиться в нього, а тому, хто крадеться повільно, -- ні. Стосується лише моменту входу, але не того, хто лишився стояти.
 </text>
   </help>
   <mana>500</mana>

--- a/generic-skills/black death.xml
+++ b/generic-skills/black death.xml
@@ -19,18 +19,25 @@
   <help id="601" level="-1" type="SkillHelp">
     <text l="en">This spell allows you to cast a {hh614plague{x on a specific area -- everyone who is there has a chance to become infected. Does not affect players outside your {hh32PK-range{x.
     
-Victims who die from your plague miasmas will be credited to you -- in PK or in {hh125quests{x.</text>
+Victims who die from your plague miasmas will be credited to you -- in PK or in {hh125quests{x.
+
+The way you {hh18move{x through the miasma matters too: rushing through at speed, quickly or at a run, gives you a chance to pass with less exposure, while creeping along slowly does not help. This counts only as you enter, not while you linger.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание позволяет наложить {hh614чуму{x на определенную местность -- все, кто находятся там, имеют шанс заразиться. Не действует на игроков вне твоего {hh32ПК-диапазона{x.
 
 Умершие от твоих чумных миазмов жертвы засчитаются тебе -- в ПК или в {hh125квестах{x.
+
+Важно и то, как ты {hh18проходишь{x сквозь миазмы: проскочившему на скорости, быстро или бегом, есть шанс заразиться меньше, а крадущемуся медленно это не поможет. Касается только момента входа, но не того, кто остался стоять в заразе.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
 Це заклинання дозволяє накласти {hh614чуму{x на певну місцевість -- всі, хто перебувають там, мають шанс заразитися. Не діє на гравців поза твоїм {hh32ПК-діапазоном{x.
 
 Загиблі від твоїх чумних міазм жертви зараховуються тобі -- в ПК або в {hh125квестах{x.
+
+Важливо й те, як ти {hh18проходиш{x крізь міазми: тому, хто проскочив на швидкості, швидко чи бігом, є шанс заразитися менше, а тому, хто крадеться повільно, це не зарадить. Стосується лише моменту входу, але не того, хто лишився стояти в заразі.
 </text>
   </help>
   <mana>150</mana>

--- a/generic-skills/cursed lands.xml
+++ b/generic-skills/cursed lands.xml
@@ -33,14 +33,20 @@
     <text l="en">%FMT% *%SPELL%*
 
 This spell allows you to curse a certain room, preventing the use of {hh862recall{x and {hh1126transport{x abilities from this room.
+
+Beyond blocking escape, the cursed ground lashes out at those who {hh18enter{x it -- everyone stepping in risks {hh548a curse{x. Pressing through quickly, at speed or a run, gives a chance to shrug it off, while creeping in slowly does not. This counts only on entry, not while you remain.
 </text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание позволяет проклясть определенную комнату, предотвращая использование {hh862возврата{x и {hh1126транспортных{x умений из этой комнаты.
+
+Помимо запрета на бегство, проклятая земля бьет по входящим -- каждый, кто {hh18заходит{x, рискует получить {hh548проклятие{x. Проскочившему на скорости, быстро или бегом, есть шанс стряхнуть его, а крадущемуся медленно -- нет. Касается только момента входа, но не того, кто остался стоять.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
 Це заклинання дозволяє проклясти певну кімнату, запобігаючи використанню {hh862повернення{x і {hh1126транспортних{x умінь з цієї кімнати.
+
+Окрім заборони на втечу, проклята земля бʼє по тих, хто {hh18заходить{x -- кожен, хто ступає сюди, ризикує дістати {hh548прокляття{x. Тому, хто проскочив на швидкості, швидко чи бігом, є шанс струсити його, а тому, хто крадеться повільно, -- ні. Стосується лише моменту входу, але не того, хто лишився стояти.
 </text>
   </help>
   <mana>150</mana>

--- a/generic-skills/deadly venom.xml
+++ b/generic-skills/deadly venom.xml
@@ -22,18 +22,25 @@
     <extra l="ua">&apos;пари отрути&apos; &apos;отруйні пари&apos;</extra>
     <text l="en">This spell allows you to poison the area with toxic fumes -- everyone who is there may {hh837be poisoned{x. It does not affect players outside your {hh32PC-range{x.
 
-Victims who died from poisonous vapors will count towards you - in PK or in {hh125quests{x.</text>
+Victims who died from poisonous vapors will count towards you - in PK or in {hh125quests{x.
+
+The way you {hh18move{x through the fumes matters too: rushing through at speed, quickly or at a run, gives you a chance to breathe in less, while creeping along slowly does not help. This counts only as you enter, not while you linger.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание позволяет отравить местность ядовитыми испарениями -- все, кто находятся там, могут {hh837отравиться{x. Не действует на игроков вне твоего {hh32ПК-диапазона{x.
 
 Умершие от ядовитых паров жертвы засчитаются тебе -- в ПК или в {hh125квестах{x.
+
+Важно и то, как ты {hh18проходишь{x сквозь испарения: проскочившему на скорости, быстро или бегом, есть шанс вдохнуть меньше, а крадущемуся медленно это не поможет. Касается только момента входа, но не того, кто остался стоять в отраве.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
 Це заклинання дозволяє отруїти місцевість отруйними випарами -- всі, хто знаходяться там, можуть {hh837отруїтися{x. Не діє на гравців поза твоїм {hh32ПК-діапазоном{x.
 
 Жертви, які загинули від отруйних парів, будуть зараховані тобі -- в ПК або в {hh125квестах{x.
+
+Важливо й те, як ти {hh18проходиш{x крізь випари: тому, хто проскочив на швидкості, швидко чи бігом, є шанс вдихнути менше, а тому, хто крадеться повільно, це не зарадить. Стосується лише моменту входу, але не того, хто лишився стояти в отруті.
 </text>
   </help>
   <mana>150</mana>

--- a/generic-skills/lethargic mist.xml
+++ b/generic-skills/lethargic mist.xml
@@ -28,14 +28,22 @@
   <help id="622" level="-1" type="SkillHelp">
     <text l="en">%FMT% *%SPELL%*
 
-This spell allows you to fill the area with a lethargic mist which, upon {hh2035failed save{x, {hh705slows{x the movements of all present. It does not affect players outside your {hh32PVP range{x.</text>
+This spell allows you to fill the area with a lethargic mist which, upon {hh2035failed save{x, {hh705slows{x the movements of all present. It does not affect players outside your {hh32PVP range{x.
+
+The way you {hh18move{x through the area matters too: rushing through at speed, quickly or at a run, gives you a chance to pass with less exposure, while creeping along slowly does not help. This counts only as you enter, not while you linger in the mist.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание позволяет заполнить местность летаргическим туманом, который, при провале {hh2035спасброска{x, {hh705замедляет{x движения всех, кто там находится. Не действует на игроков вне твоего {hh32ПК-диапазона{x.
+
+Важно и то, как ты {hh18проходишь{x местность: проскочившему на скорости, быстро или бегом, есть шанс хватить тумана меньше, а крадущемуся медленно это не поможет. Касается только момента входа, но не того, кто остался стоять в тумане.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
-Це заклинання дозволяє заповнити місцевість летаргічним туманом, який, при провалі {hh2035спасброска{x, {hh705уповільнює{x рухи всіх, хто там знаходиться. Не діє на гравців поза вашим {hh32ПК-діапазоном{x.</text>
+Це заклинання дозволяє заповнити місцевість летаргічним туманом, який, при провалі {hh2035спасброска{x, {hh705уповільнює{x рухи всіх, хто там знаходиться. Не діє на гравців поза вашим {hh32ПК-діапазоном{x.
+
+Важливо й те, як ти {hh18проходиш{x місцевість: тому, хто проскочив на швидкості, швидко чи бігом, є шанс хапнути туману менше, а тому, хто крадеться повільно, це не зарадить. Стосується лише моменту входу, але не того, хто лишився стояти в тумані.
+</text>
   </help>
   <mana>150</mana>
   <name l="en">lethargic mist</name>

--- a/generic-skills/lightning ward.xml
+++ b/generic-skills/lightning ward.xml
@@ -23,7 +23,10 @@
 
 In the current battle, the ward will occasionally strike your opponents with lightning as long as you remain in the same area as the ward.
 
-Outside of battle, the ward acts as an alert system against characters in your {hh32ПК-range{x or creatures tracking you. As soon as one of them steps into the same area with you, the shield will deal damage, wake you up if you are asleep and start the fight. Then it will continue striking lightning in the ensuing battle.</text>
+Outside of battle, the ward acts as an alert system against characters in your {hh32ПК-range{x or creatures tracking you. As soon as one of them steps into the same area with you, the shield will deal damage, wake you up if you are asleep and start the fight. Then it will continue striking lightning in the ensuing battle.
+
+The way an enemy {hh18approaches{x matters: one who slips in carefully, sneaking or crawling, has a chance to pass unnoticed, while a reckless dash does not.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Оберег молний -- мощное защитное заклинание, которое срабатывает либо в текущем бою, либо при попытке противника войти в данную местность.
@@ -31,6 +34,8 @@ Outside of battle, the ward acts as an alert system against characters in your {
 В текущем бою оберег будет изредка поражать твоих противников молниями, пока ты находишься в той же местности, что и оберег.
 
 Вне боя оберег -- система сигнализации против персонажей в твоем {hh32ПК-интервале{x или существ, которые идут за тобой по следу. Как только кто-то из них зайдет в одну местность с тобой, щит нанесет им урон, разбудит тебя если ты спишь и начнет сражение. А после этого продолжит поливать молниями уже в бою.
+
+Важно, как противник {hh18приближается{x: проскользнувший осторожно, крадучись или ползком, имеет шанс пройти незамеченным, а летящего напролом оберег засечет.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
@@ -39,6 +44,8 @@ Outside of battle, the ward acts as an alert system against characters in your {
 У поточному бою оберіг час від часу вражатиме твоїх противників блискавками, поки ти перебуваєш в тій же місцевості, що й оберіг.
 
 Поза боєм оберіг -- система сигналізації проти персонажів у твоєму {hh32ПК-діапазоні{x або істот, які стежать за тобою по сліду. Як тільки хтось із них зайде в одну місцевість з тобою, щит завдасть їм шкоди, розбудить тебе, якщо ти спиш, і почне битву. А потім продовжить поливати блискавками вже в бою.
+
+Важливо, як противник {hh18наближається{x: той, хто прослизнув обережно, крадучись чи поповзом, має шанс пройти непоміченим, а того, хто летить напролом, оберіг засіче.
 </text>
   </help>
   <mana>150</mana>

--- a/generic-skills/narcotic mist.xml
+++ b/generic-skills/narcotic mist.xml
@@ -37,16 +37,22 @@
     <text l="en">%FMT% *%SPELL%*
 
 This spell allows you to cast a {hh741sleep{x enchantment over the area. Anyone who enters and fails the {hh2035saving throw{x will fall into a deep sleep.
+
+The way you {hh18move{x through the area matters too: rushing through at speed, quickly or at a run, gives you a chance to breathe in less, while creeping along slowly does not help. This counts only as you enter, not while you linger in the mist.
 </text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание позволяет наложить заклинание {hh741сна{x на данную местность.
 
 Чары срабатывают при заходе в местность и периодически на все подходящие цели в ней. Успех зависит от {hh2035спасброска{x, а для игроков в {hh32ПК{x -- еще и от дополнительных факторов, включая {hh38интеллект{x мага и {hh36телосложение{x жертвы. {hh28Ловкачей{x поймать в магическую ловушку сложнее.
+
+Важно и то, как ты {hh18проходишь{x местность: проскочившему на скорости, быстро или бегом, есть шанс надышаться меньше, а крадущемуся медленно это не поможет. Касается только момента входа, но не того, кто остался стоять в тумане.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
 Це заклинання дозволяє накласти заклинання {hh741сна{x на дану місцевість. Кожен, хто зайде туди і не зробить {hh2035рятунковий кидок{x, порине в глибокий сон.
+
+Важливо й те, як ти {hh18проходиш{x місцевість: тому, хто проскочив на швидкості, швидко чи бігом, є шанс надихатися менше, а тому, хто крадеться повільно, це не зарадить. Стосується лише моменту входу, але не того, хто лишився стояти в тумані.
 </text>
   </help>
   <mana>200</mana>

--- a/generic-skills/settraps.xml
+++ b/generic-skills/settraps.xml
@@ -31,14 +31,21 @@
     <extra l="ua">дротик пастка пастки отруєний злодійська</extra>
     <text l="en">%FMT% *%CMD%*
 
-Professional thieves can set traps deadly for their enemies. The thieves&apos; trap will shoot a {hh837poisoned{x dart at characters in your {hh32PC-range{x or creatures that follow you.</text>
+Professional thieves can set traps deadly for their enemies. The thieves&apos; trap will shoot a {hh837poisoned{x dart at characters in your {hh32PC-range{x or creatures that follow you.
+
+The way you {hh18move{x into the room matters: stepping in carefully, sneaking or crawling, gives you a chance to spot the tripwire and avoid the dart, while barging in at speed does not.
+</text>
     <text l="ru">%FMT% *%CMD%*
 
 Профессиональные воры могут расставлять смертельные для их врагов ловушки. Воровская ловушка выстрелит {hh837отравленным{x дротиком в персонажей в твоем {hh32ПК-интервале{x или существ, которые идут за тобой по следу.
+
+Важно, как ты {hh18входишь{x в комнату: осторожный шаг, крадучись или ползком, дает шанс заметить растяжку и уклониться от дротика, а влетевшего на всем ходу ловушка не пощадит.
 </text>
     <text l="ua">%FMT% *%CMD%*
 
 Професійні злодії можуть розставляти смертельні для їхніх ворогів пастки. Злодійська пастка вистрілить {hh837отруєним{x дротиком у персонажів у твоєму {hh32ПК-інтервалі{x або істот, які йдуть за тобою по сліду.
+
+Важливо, як ти {hh18заходиш{x до кімнати: обережний крок, крадучись чи поповзом, дає шанс помітити розтяжку й ухилитися від дротика, а того, хто влетів на всьому ходу, пастка не помилує.
 </text>
   </help>
   <mana>200</mana>

--- a/generic-skills/shocking trap.xml
+++ b/generic-skills/shocking trap.xml
@@ -24,14 +24,22 @@
     <extra l="en">shocking waves</extra>
     <extra l="ru">силовые волны</extra>
     <extra l="ua">силові хвилі</extra>
-    <text l="en">The force trap will deal energy damage and {hh120delay{x characters in your {hh32PK-interval{x or creatures that are following your trail.</text>
+    <text l="en">The force trap will deal energy damage and {hh120delay{x characters in your {hh32PK-interval{x or creatures that are following your trail.
+
+The way you {hh18move{x into the room matters: stepping in carefully, sneaking or crawling, gives you a chance to skirt the trap, while charging in at speed does not.
+</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Силовая ловушка нанесет энергетический урон и {hh120задержит{x персонажей в твоем {hh32ПК-интервале{x или существ, которые идут за тобой по следу.
+
+Важно, как ты {hh18входишь{x в комнату: осторожный шаг, крадучись или ползком, дает шанс обойти ловушку стороной, а влетевшего на всем ходу она не пощадит.
 </text>
     <text l="ua">%FMT% *%SPELL%*
 
-Силова пастка завдасть енергетичної шкоди і {hh120затримає{x персонажів у твоєму {hh32ПК-інтервалі{x або істот, які йдуть за тобою по сліду.</text>
+Силова пастка завдасть енергетичної шкоди і {hh120затримає{x персонажів у твоєму {hh32ПК-інтервалі{x або істот, які йдуть за тобою по сліду.
+
+Важливо, як ти {hh18заходиш{x до кімнати: обережний крок, крадучись чи поповзом, дає шанс обійти пастку стороною, а того, хто влетів на всьому ходу, вона не помилує.
+</text>
   </help>
   <mana>150</mana>
   <name l="en">shocking trap</name>


### PR DESCRIPTION
Player-facing help text (EN/RU/UA) for the 9 entry-triggered room affects that just gained a movetype-aware on-entry dodge (dreamland_fenia #104 / dreamland_code #594).

Each help now notes that how you enter matters: careful entry (slink/crawl) can avoid the **trap group** (settraps, shocking trap, lightning ward); fast entry (quickly/running) can pass with less exposure through the **gas/exposure group** (narcotic/lethargic mist, deadly venom, black death, cursed lands, evil spirit) — on entry only, not while standing. Links the {hh18 movetype article; cursed lands also documents its previously-undocumented on-entry curse ({hh548).

No new help IDs (edits only — no collision risk). Activation: needs `plug reload most` or a reboot (no immortal was online to hot-reload at write time).