### PR TITLE
settraps: grant to ninjas; help 655/896 for detect trap

### DIFF
--- a/clan-skills/detect trap.xml
+++ b/clan-skills/detect trap.xml
@@ -19,15 +19,21 @@
   <help id="896" level="-1" type="SkillHelp">
     <text l="en">%FMT% *%SPELL%* 
 		    
-While under the influence of this spell, the Hunter easily detects traps set by others and avoids them.
+While under this spell the Hunter senses {hh241traps{x set by others -- the {hh655tripwires{x of thieves and ninjas, and the pits and snares of the wild -- and steps around them without springing the mechanism, leaving them armed for less wary travellers.
+
+The spell also warns of any active trap in a neighbouring room: a set trap, a hidden pitfall, a deadly cloud, even a lethal {hh241death tile{x. A death tile can only be avoided, not disarmed, so heed the warning -- walking into molten rock or a yawning void will kill the Hunter all the same.
 </text>
     <text l="ru">%FMT% *%SPELL%* 
 		    
-Находясь под действием этого заклинания, Охотник с легкостью обнаруживает установленные кем-то ловушки и избегает их.
+Под действием этого заклинания Охотник чует расставленные другими {hh241ловушки{x -- {hh655растяжки{x воров и ниндзя, ямы и силки дикой природы -- и обходит их, не приводя в действие механизм, оставляя взведенными для менее осторожных путников.
+
+Заклинание также предупреждает о любой действующей ловушке в соседней комнате: о расставленной ловушке, скрытой яме, ядовитом облаке и даже о смертельной {hh241ловушке-западне{x. Смертельную западню можно только обойти, но не обезвредить, так что прислушивайся к предупреждению -- шаг в расплавленный камень или зияющую пустоту все равно убьет Охотника.
 </text>
     <text l="ua">%FMT% *%SPELL%* 
 		    
-Перебуваючи під дією цього заклинання, Мисливець з легкістю виявляє встановлені кимось пастки і уникає їх.
+Під дією цього закляття Мисливець чує розставлені іншими {hh241пастки{x -- {hh655розтяжки{x крадіїв та ніндзя, ями й сильця дикої природи -- і обходить їх, не приводячи в дію механізм, лишаючи зведеними для менш обережних подорожніх.
+
+Закляття також попереджає про будь-яку діючу пастку в сусідній кімнаті: про розставлену пастку, приховану яму, отруйну хмару й навіть про смертельну {hh241пастку-западню{x. Смертельну западню можна лише обійти, але не знешкодити, тож зважай на попередження -- крок у розплавлений камінь чи у зяючу порожнечу все одно вбʼє Мисливця.
 </text>
   </help>
   <mana>200</mana>

--- a/generic-skills/settraps.xml
+++ b/generic-skills/settraps.xml
@@ -11,13 +11,18 @@
       <maximum>100</maximum>
       <rating>1</rating>
     </node>
+    <node name="ninja">
+      <level>59</level>
+      <maximum>100</maximum>
+      <rating>1</rating>
+    </node>
   </classes>
   <command type="DefaultSkillCommand">
     <argtype>undef</argtype>
     <cat>class</cat>
-    <hint l="en">(thieves) set a trap</hint>
-    <hint l="ru">(воры) установить ловушку</hint>
-    <hint l="ua">(злодії) встановити пастку</hint>
+    <hint l="en">(thieves, ninjas) set a trap</hint>
+    <hint l="ru">(воры, ниндзя) установить ловушку</hint>
+    <hint l="ua">(крадії, ніндзя) встановити пастку</hint>
     <name l="en">settraps</name>
     <name l="ru">ловушка</name>
     <name l="ua">пастка</name>
@@ -26,26 +31,32 @@
   <dammsg mg="f">ловушка</dammsg>
   <group registry="skillGroup">adventure</group>
   <help id="655" level="-1" type="SkillHelp">
-    <extra l="en">dart trap traps poisoned thieves</extra>
-    <extra l="ru">дротик ловушка ловушки отравленный воровская</extra>
-    <extra l="ua">дротик пастка пастки отруєний злодійська</extra>
+    <extra l="en">dart trap traps poisoned thieves ninjas</extra>
+    <extra l="ru">дротик ловушка ловушки отравленный воровская ниндзя</extra>
+    <extra l="ua">дротик пастка пастки отруєний злодійська ніндзя</extra>
     <text l="en">%FMT% *%CMD%*
 
-Professional thieves can set traps deadly for their enemies. The thieves&apos; trap will shoot a {hh837poisoned{x dart at characters in your {hh32PC-range{x or creatures that follow you.
+Professional thieves and ninjas can set traps deadly for their enemies. Such a trap will shoot a {hh837poisoned{x dart at characters in your {hh32PC-range{x or creatures that follow you.
 
 The way you {hh18move{x into the room matters: stepping in carefully, sneaking or crawling, gives you a chance to spot the tripwire and avoid the dart, while barging in at speed does not.
+
+A foe under a {hh896detect trap{x spell senses the tripwire and steps around it, leaving the trap armed for the next to pass.
 </text>
     <text l="ru">%FMT% *%CMD%*
 
-Профессиональные воры могут расставлять смертельные для их врагов ловушки. Воровская ловушка выстрелит {hh837отравленным{x дротиком в персонажей в твоем {hh32ПК-интервале{x или существ, которые идут за тобой по следу.
+Профессиональные воры и ниндзя могут расставлять смертельные для их врагов ловушки. Такая ловушка выстрелит {hh837отравленным{x дротиком в персонажей в твоем {hh32ПК-интервале{x или существ, которые идут за тобой по следу.
 
 Важно, как ты {hh18входишь{x в комнату: осторожный шаг, крадучись или ползком, дает шанс заметить растяжку и уклониться от дротика, а влетевшего на всем ходу ловушка не пощадит.
+
+Враг под действием {hh896обнаружения ловушек{x чует растяжку и обходит ее, оставляя ловушку взведенной для следующего.
 </text>
     <text l="ua">%FMT% *%CMD%*
 
-Професійні злодії можуть розставляти смертельні для їхніх ворогів пастки. Злодійська пастка вистрілить {hh837отруєним{x дротиком у персонажів у твоєму {hh32ПК-інтервалі{x або істот, які йдуть за тобою по сліду.
+Професійні крадії та ніндзя можуть розставляти смертельні для їхніх ворогів пастки. Така пастка вистрілить {hh837отруєним{x дротиком у персонажів у твоєму {hh32ПК-інтервалі{x або істот, які йдуть за тобою по сліду.
 
 Важливо, як ти {hh18заходиш{x до кімнати: обережний крок, крадучись чи поповзом, дає шанс помітити розтяжку й ухилитися від дротика, а того, хто влетів на всьому ходу, пастка не помилує.
+
+Ворог під дією {hh896виявлення пасток{x чує розтяжку й обходить її, лишаючи пастку зведеною для наступного.
 </text>
   </help>
   <mana>200</mana>


### PR DESCRIPTION
Pairs with dreamland_fenia#105 and dreamland_fenia_public#11.

- `generic-skills/settraps.xml` — ninja gains **settraps** (level 59, parity with thief); command hint + help 655 keywords mention ninjas; help 655 notes that a foe under detect trap foils the trap. Fixed the UA class name to the locked `крадії`.
- `clan-skills/detect trap.xml` — rewrote help 896 to match the now-working mechanic: the hunter steps around set/falling traps and is warned of any active trap in a neighbouring room; a death tile must be avoided, not disarmed.

Activates on `plug reload most` / next reboot.