### PR TITLE
help: perception documents trap-sensing

### DIFF
--- a/generic-skills/perception.xml
+++ b/generic-skills/perception.xml
@@ -19,11 +19,17 @@
     <extra l="en">perception</extra>
     <extra l="ru">восприятие</extra>
     <extra l="ua">сприйняття</extra>
-    <text l="en">The ability to sense hidden exits and secret passages. 
+    <text l="en">The ability to sense hidden exits and secret passages.
+
+The same sharp eye catches danger underfoot: a character with this skill spots a {hh655trap{x set by a thief or ninja -- the tripwire shows itself when you look around the room -- and treads around hidden snares, pits and deadly tiles without springing them, much as a {hh896detect trap{x spell lets its caster do.
 </text>
-    <text l="ru">Умение почувствовать скрытые выходы и тайные ходы. 
+    <text l="ru">Умение почувствовать скрытые выходы и тайные ходы.
+
+Тот же острый глаз замечает опасность под ногами: обладатель этого навыка различает {hh655ловушку{x, расставленную вором или ниндзя -- растяжка выдает себя, стоит тебе оглядеть комнату -- и обходит скрытые силки, ямы и смертельные плиты, не приводя их в действие, подобно тому как это делает {hh896обнаружение ловушек{x.
 </text>
-    <text l="ua">Здатність відчувати приховані виходи та таємні проходи. 
+    <text l="ua">Здатність відчувати приховані виходи та таємні проходи.
+
+Те саме гостре око помічає небезпеку під ногами: власник цієї навички розрізняє {hh655пастку{x, розставлену крадієм чи ніндзя -- розтяжка виказує себе, щойно ти озирнеш кімнату -- і обходить приховані сильця, ями та смертельні плити, не приводячи їх у дію, подібно до того як це робить {hh896виявлення пасток{x.
 </text>
   </help>
   <name l="en">perception</name>


### PR DESCRIPTION
Documents the new perception trap-sense (dreamland_fenia#109 / dreamland_fenia_public#15): the skill now lets thieves/druids spot a set trap in the room description and avoid set/falling/death traps. Cross-links settraps (655) and detect trap (896); keeps the hidden-exits text. Interim wording -- neighbour-room warnings come with the passive auto-affect engine work.