### PR TITLE
Add fido and janitor mob behavior definitions

### DIFF
--- a/behaviors/fido.xml
+++ b/behaviors/fido.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Падальщик: пожирает трупы существ, лежащие на земле.</description>
+  <id>82</id>
+  <nameRus>падальщик</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>

--- a/behaviors/janitor.xml
+++ b/behaviors/janitor.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Уборщик: подбирает с пола мусор и пустые бутылки.</description>
+  <id>83</id>
+  <nameRus>уборщик</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>


### PR DESCRIPTION
Behavior defs (ids 82/83) for the onSpec triggers migrating C++ spec_fido / spec_janitor. No help node. Inert until attached + triggers posted at the migration reboot.