### PR TITLE
Add baker/beggar/vagabond behavior definitions

### DIFF
--- a/behaviors/baker.xml
+++ b/behaviors/baker.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Пекарь: подкармливает голодных новичков свежим хлебом и зазывает покупателей.</description>
+  <id>94</id>
+  <nameRus>пекарь</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>

--- a/behaviors/beggar.xml
+++ b/behaviors/beggar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Нищий: выпрашивает монеты, благодарит за подаяние, зовет на помощь в драке.</description>
+  <id>95</id>
+  <nameRus>нищий</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>

--- a/behaviors/vagabond.xml
+++ b/behaviors/vagabond.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Бродяга-пьяница: пьет, поет, попрошайничает и задирает прохожих.</description>
+  <id>96</id>
+  <nameRus>бродяга</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>


### PR DESCRIPTION
Three shared NPC-flavor behavior definitions (ids 94/95/96, target mob) for generalizing Midgaard's bespoke `midgaard.are/common` NPC flavor across the world. Trigger bodies live in dreamland_fenia behaviors/{baker,beggar,vagabond}; mobs are attached in dreamland_areas. Combined drunk+tramp into one `vagabond` behavior per Kit.