### PR TITLE
Add amix behavior for the wonderworker Amix

### DIFF
--- a/behaviors/amix.xml
+++ b/behaviors/amix.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Чудотворец: за квестовые очки уничтожает вещи с неснимаемым проклятием, а также бесплатно сводит надетые татуировки, которые не являются знаком веры персонажа.</description>
+  <id>97</id>
+  <nameRus>чудотворец</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>


### PR DESCRIPTION
Defines the `amix` behavior (id 97, target mob) for mob 31057 (wonderworker Amix in Anon).

Amix migrates from prototype triggers to a behavior. The behavior destroys items with an uncurseable curse for 200 qp (ported faithfully) and adds a new free service: removing a worn tattoo that is not the character's current faith sign (covers the joke/world tattoos that can be worn on the religion slot but never removed). Fenia triggers live in dreamland_fenia (behaviors/amix/*).