### PR TITLE
help: perception trap sense is now a chance that trains

### DIFF
--- a/generic-skills/perception.xml
+++ b/generic-skills/perception.xml
@@ -21,15 +21,15 @@
     <extra l="ua">сприйняття</extra>
     <text l="en">The ability to sense hidden exits and secret passages.
 
-The same sharp eye catches danger underfoot: a character with this skill spots a {hh655trap{x set by a thief or ninja -- the tripwire shows itself when you look around the room -- and treads around hidden snares, pits and deadly tiles without springing them, much as a {hh896detect trap{x spell lets its caster do.
+The same sharp eye catches danger underfoot: a character with this skill has a chance to spot a {hh655trap{x set by a thief or ninja and to step around hidden snares, pits and deadly tiles without springing them. The keener the eye, the more often it works -- and the more you skirt danger, the sharper it grows. A {hh896detect trap{x spell does the same, but never misses.
 </text>
     <text l="ru">Умение почувствовать скрытые выходы и тайные ходы.
 
-Тот же острый глаз замечает опасность под ногами: обладатель этого навыка различает {hh655ловушку{x, расставленную вором или ниндзя -- растяжка выдает себя, стоит тебе оглядеть комнату -- и обходит скрытые силки, ямы и смертельные плиты, не приводя их в действие, подобно тому как это делает {hh896обнаружение ловушек{x.
+Тот же острый глаз замечает опасность под ногами: обладатель этого навыка имеет шанс различить {hh655ловушку{x, расставленную вором или ниндзя, и обойти скрытые силки, ямы и смертельные плиты, не приводя их в действие. Чем острее глаз, тем чаще это удается -- и чем больше ходишь по краю, тем глаз острее. Заклинание {hh896обнаружение ловушек{x делает то же самое, но без промаха.
 </text>
     <text l="ua">Здатність відчувати приховані виходи та таємні проходи.
 
-Те саме гостре око помічає небезпеку під ногами: власник цієї навички розрізняє {hh655пастку{x, розставлену крадієм чи ніндзя -- розтяжка виказує себе, щойно ти озирнеш кімнату -- і обходить приховані сильця, ями та смертельні плити, не приводячи їх у дію, подібно до того як це робить {hh896виявлення пасток{x.
+Те саме гостре око помічає небезпеку під ногами: власник цієї навички має шанс розрізнити {hh655пастку{x, розставлену крадієм чи ніндзя, і обійти приховані сильця, ями та смертельні плити, не приводячи їх у дію. Що гостріше око, то частіше це вдається -- і що більше ходиш по краю, то око гостріше. Закляття {hh896виявлення пасток{x робить те саме, але без промаху.
 </text>
   </help>
   <name l="en">perception</name>


### PR DESCRIPTION
Help 834 (en/ru/ua) reworded to match dreamland_fenia#134 / dreamland_fenia_public#19: perception is a chance to spot/avoid traps that scales with the skill and trains on use; 'detect trap' spell is the guaranteed version. Applies on next world reload/reboot.