### PR TITLE
Add municipality behavior definition; tattooists need a craft license

### DIFF
--- a/behaviors/municipality.xml
+++ b/behaviors/municipality.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>В ратуше можно получить или продлить ремесленную лицензию.</description>
+  <help id="361" labels="craft" level="-1" type="BehaviorHelp">
+    <extra l="en">license licence craft license town hall</extra>
+    <extra l="ru">лицензия лицензию лицензии лицензией ремесленная лицензия ратуша</extra>
+    <extra l="ua">ліцензія ліцензію ліцензії реміснича ліцензія ратуша</extra>
+    <keyword l="en">license</keyword>
+    <keyword l="ru">лицензия</keyword>
+    <keyword l="ua">ліцензія</keyword>
+    <text l="en">A =craft license= lets you practice your {hh195craft{x. Every crafter of level 10 or higher -- carpenter, blacksmith or tattooist alike -- needs a valid license to work.
+
+The license is sold and renewed at the Midgaard town hall. It costs {Y10 gold per level{x, with a small surcharge for each rebirth, and stays valid for 30 real-world days. Step up to the secretary's window and {y{hcsay yes{x to buy or extend it.
+
+Without a valid license your crafting will simply not work.
+</text>
+    <text l="ru">=Ремесленная лицензия= позволяет заниматься своим {hh195ремеслом{x. Любому ремесленнику 10го уровня и выше -- будь то плотник, кузнец или татуировщик -- нужна действующая лицензия.
+
+Лицензию продают и продлевают в ратуше Мидгаарда. Стоит она {Y10 золотых за уровень{x, с небольшой надбавкой за каждое перевоплощение, и действует 30 дней реального времени. Подойди к окошку секретарши и {y{hcскажи да{x, чтобы купить или продлить.
+
+Без действующей лицензии ремесло просто не сработает.
+</text>
+    <text l="ua">=Реміснича ліцензія= дозволяє займатися своїм {hh195ремеслом{x. Будь-якому ремісникові 10го рівня і вище -- чи то тесля, чи коваль, чи татуювальник -- потрібна чинна ліцензія.
+
+Ліцензію продають і продовжують у ратуші Мідгаарда. Коштує вона {Y10 золотих за рівень{x, з невеликою надбавкою за кожне переродження, і діє 30 днів реального часу. Підійди до віконця секретарки і {y{hcскажи так{x, щоб купити або продовжити.
+
+Без чинної ліцензії ремесло просто не спрацює.
+</text>
+    <title l="en">Craft: craft license</title>
+    <title l="ru">{CРемесло: {xремесленная лицензия</title>
+    <title l="ua">{CРемесло: {xреміснича ліцензія</title>
+  </help>
+  <id>98</id>
+  <nameRus>ратуша</nameRus>
+  <props>null
+</props>
+  <target>mob</target>
+</behavior>

--- a/craft-professions/tattooist.xml
+++ b/craft-professions/tattooist.xml
@@ -11,7 +11,7 @@
     <text l="en">=Tattooist= is one of the {hh195crafts{x or secondary professions available to all players. A tattooist can apply various tattoos to themselves or other players on different body parts: the left or right {hh243wrist{x, {hh246shoulders{x, or {hh244face{x. To apply a tattoo to a given location you must learn the corresponding skills, which become available as you practice.
 
 {CHOW TO BECOME A TATTOOIST{x
-To learn this profession, find a {hh235tattoo master{x and follow his instructions. You will need a =knife= and =ink= to apply tattoos. Any dagger with the =for tattoos= flag can serve as a tattooing knife -- use {hh603identify{x or the site's search tool to find one.
+To learn this profession, find a {hh235tattoo master{x and follow his instructions. You will need a =knife= and =ink= to apply tattoos. Any dagger with the =for tattoos= flag can serve as a tattooing knife -- use {hh603identify{x or the site's search tool to find one. Like every {hh195craft{x, a tattooist of level 10 or higher needs a valid {hh361craft license{x, sold at the Midgaard town hall.
 
 {CTYPES OF TATTOOS{x
 There are several tattoo designs you can apply -- one for each of the {hh81Eight Paths{x and their pairs with neighbors -- and each grants unique bonuses: improved stats, accuracy, damage, hit points, mana, improved skills, and so on. Basic supplies and simple designs can be purchased directly from the teacher; more complex ones will have to be farmed from suitable sentient enemies across Thera.
@@ -29,7 +29,7 @@ To {hh245remove a tattoo{x, you need a special ointment, which can be bought fro
     <text l="ru">=Татуировщик= -- одно из доступных всем игрокам {hh195ремесел{x или дополнительных профессий. Татуировщик умеет наносить себе или другим игрокам разные татуировки на различные части тела: левое или правое {hh243запястье{x, {hh246плечи{x или {hh244лицо{x. Для нанесения татуировки на то или иное место нужно разучить соответствующие навыки, которые становятся доступны по мере использования.
 
 {CКАК СТАТЬ ТАТУИРОВЩИКОМ{x
-Для того, чтобы выучиться этой профессии, найди {hh235тату-мастера{x и следуй его инструкциям. Для нанесения татуировок понадобятся =нож= и =чернила=. Ножом для татуировок может служить любой кинжал с флагом =для татуировок= -- используй {hh603опознание{x или поисковик на сайте, чтобы найти.
+Для того, чтобы выучиться этой профессии, найди {hh235тату-мастера{x и следуй его инструкциям. Для нанесения татуировок понадобятся =нож= и =чернила=. Ножом для татуировок может служить любой кинжал с флагом =для татуировок= -- используй {hh603опознание{x или поисковик на сайте, чтобы найти. Как и для любого {hh195ремесла{x, татуировщику 10го уровня и выше нужна действующая {hh361ремесленная лицензия{x, которую продают в ратуше Мидгаарда.
 
 {CКАКИЕ БЫВАЮТ ТАТУИРОВКИ{x
 Есть несколько рисунков татуировок, которые можно наносить -- по одному на каждый из {hh81Восьми Путей{x и их пары с соседями -- и каждый из них дает какие-то уникальные бонусы: улучшенные параметры, точность, урон, здоровье, мана, улучшенные умения и так далее. Базовые расходные материалы и простые рисунки можно приобрести прямо у учителя, более сложные придется выбивать из подходящих разумных противников на просторах Тэры.
@@ -47,7 +47,7 @@ To {hh245remove a tattoo{x, you need a special ointment, which can be bought fro
     <text l="ua">=Татуювальник= -- одне з {hh195ремесел{x або додаткових професій, доступних усім гравцям. Татуювальник вміє наносити собі або іншим гравцям різні татуювання на різні частини тіла: ліве або праве {hh243запʼястя{x, {hh246плечі{x або {hh244обличчя{x. Для нанесення татуювання на те чи інше місце потрібно вивчити відповідні навички, які стають доступні в міру використання.
 
 {CЯК СТАТИ ТАТУЮВАЛЬНИКОМ{x
-Щоб навчитися цієї професії, знайди {hh235тату-майстра{x і слідуй його інструкціям. Для нанесення татуювань знадобляться =ніж= і =чорнило=. Ножем для татуювань може служити будь-який кинджал з прапором =для татуювань= -- використовуй {hh603опізнання{x або пошуковик на сайті, щоб знайти.
+Щоб навчитися цієї професії, знайди {hh235тату-майстра{x і слідуй його інструкціям. Для нанесення татуювань знадобляться =ніж= і =чорнило=. Ножем для татуювань може служити будь-який кинджал з прапором =для татуювань= -- використовуй {hh603опізнання{x або пошуковик на сайті, щоб знайти. Як і для будь-якого {hh195ремесла{x, татуювальнику 10го рівня і вище потрібна чинна {hh361реміснича ліцензія{x, яку продають у ратуші Мідгаарда.
 
 {CЯКІ БУВАЮТЬ ТАТУЮВАННЯ{x
 Є кілька малюнків татуювань, які можна наносити -- по одному на кожен з {hh81Восьми Шляхів{x та їхніх пар із сусідами -- і кожен з них дає якісь унікальні бонуси: покращені параметри, точність, шкода, здоровʼя, мана, покращені вміння тощо. Базові витратні матеріали та прості малюнки можна придбати прямо у вчителя, складніші доведеться здобувати з відповідних розумних противників на просторах Тери.


### PR DESCRIPTION
Definition for the `municipality` mob behavior (the town-hall craft-license desk, mob 3142 -- see dreamland_fenia#138): target mob, nameRus, description, and a 3-language help (id 361) explaining craft licenses.

Also updates the tattooist profession help -- tattooists of level 10+ now need a craft license like every other crafter (the exemption was dropped in the Fenia PR).