### PR TITLE
Add scales, soap, and bouquet object behaviors

### DIFF
--- a/behaviors/bouquet.xml
+++ b/behaviors/bouquet.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Сложи цветы в каркас -- и они составятся в красивый букет, который можно понюхать.</description>
+  <help id="364" level="-1" type="BehaviorHelp">
+    <keyword l="en">bouquet</keyword>
+    <keyword l="ru">букет</keyword>
+    <keyword l="ua">букет</keyword>
+    <text l="en">Drop flowers into an empty bouquet frame and they arrange themselves into a named bouquet -- take them back out and it falls apart into a bare frame again. {hh1084Smell{x a finished bouquet to drink in its scent.
+</text>
+    <text l="ru">Сложи цветы в пустой каркас -- и они сами собой составятся в красивый букет; вынь их обратно, и останется голый каркас. {hh1084Понюхай{x готовый букет, чтобы насладиться его ароматом.
+</text>
+    <text l="ua">Склади квіти в порожній каркас -- і вони самі складуться в гарний букет; вийми їх назад, і лишиться голий каркас. {hh1084Понюхай{x готовий букет, щоб насолодитися його ароматом.
+</text>
+  </help>
+  <id>101</id>
+  <nameRus>букет||а|у||ом|е</nameRus>
+  <props>null</props>
+  <target>obj</target>
+</behavior>

--- a/behaviors/scales.xml
+++ b/behaviors/scales.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Весы показывают вес того, что на них кладут или с них снимают.</description>
+  <help id="362" level="-1" type="BehaviorHelp">
+    <keyword l="en">scales</keyword>
+    <keyword l="ru">весы</keyword>
+    <keyword l="ua">терези</keyword>
+    <text l="en">Put something onto a working pair of scales (or take it off) and the needle will swing to show the weight of whatever rests on them, measured in pounds. An empty pan keeps the needle on zero.
+</text>
+    <text l="ru">Положи что-нибудь на исправные весы (или сними обратно), и стрелка качнется, показывая вес того, что на них лежит, в фунтах. С пустой чашей стрелка стоит на нуле.
+</text>
+    <text l="ua">Поклади щось на справні терези (або зніми назад), і стрілка хитнеться, показуючи вагу того, що на них лежить, у фунтах. З порожньою чашею стрілка стоїть на нулі.
+</text>
+  </help>
+  <id>99</id>
+  <nameRus>вес|ы|ов|ам|ы|ами|ах</nameRus>
+  <props>null</props>
+  <target>obj</target>
+</behavior>

--- a/behaviors/soap.xml
+++ b/behaviors/soap.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description>Мылом можно смыть с себя или с кого-то другого посторонние запахи -- духи или пролитую жидкость.</description>
+  <help id="363" level="-1" type="BehaviorHelp">
+    <keyword l="en">soap</keyword>
+    <keyword l="ru">мыло</keyword>
+    <keyword l="ua">мило</keyword>
+    <text l="en">%FMT% {yuse{x _%OBJ%_
+%FMT% {yuse{x _%OBJ%_ _%CHAR%_
+
+Soap lathers away unwanted scents -- a spilled liquid or a dab of perfume -- so that nobody can {hh1084smell{x them on you anymore. Use it on yourself, or scrub down someone else.
+</text>
+    <text l="ru">%FMT% {yиспользовать{x _%OBJ%_
+%FMT% {yиспользовать{x _%OBJ%_ _%CHAR%_
+
+Мыло смывает посторонние запахи -- пролитую жидкость или капельку духов, -- так что больше никто не сможет их на тебе {hh1084унюхать{x. Используй его на себя или хорошенько намыль кого-нибудь другого.
+</text>
+    <text l="ua">%FMT% {yвикористати{x _%OBJ%_
+%FMT% {yвикористати{x _%OBJ%_ _%CHAR%_
+
+Мило змиває сторонні запахи -- пролиту рідину чи краплю парфумів, -- тож більше ніхто не зможе їх на тобі {hh1084занюхати{x. Скористайся ним на себе або добряче намиль когось іншого.
+</text>
+  </help>
+  <id>100</id>
+  <nameRus>мыло</nameRus>
+  <props>null</props>
+  <target>obj</target>
+</behavior>


### PR DESCRIPTION
Iteration-2 behaviors card: three new `target=obj` DefaultBehavior definitions with trilingual help articles.

- **scales** (id 99, help 362) -- needle shows the weight on the pan when items are put on / taken off.
- **soap** (id 100, help 363) -- washes off lingering scents (the `perfume` and `poured liquid` affects).
- **bouquet** (id 101, help 364) -- arranges a flower frame into a named bouquet as flowers go in, and lets it be smelled.

Help ids 362-364 and behavior ids 99-101 verified free on live. Fenia trigger bodies + area attachments deploy alongside (dreamland_fenia / dreamland_areas).