### PR TITLE
Document spyglass range in behavior help

### DIFF
--- a/behaviors/spyglass.xml
+++ b/behaviors/spyglass.xml
@@ -11,15 +11,15 @@
     <keyword l="ua"></keyword>
     <text l="en">%FMT% *use* _%OBJ%_ _%DIR%_
 
-With a spyglass you can see distant terrain in a given direction.
+With a spyglass you peer in a chosen direction and make out the terrain a few rooms away. Put a number before the direction -- 2.north, 3.east -- to look that many rooms off; a bare direction looks as far as the glass reaches. A closed door or a screened-off passage blocks the view.
 </text>
     <text l="ru">%FMT% *использовать* _%OBJ%_ _%DIR%_
 
-С помощью подзорной трубы можно увидеть удаленную местность по направлению.
+С помощью подзорной трубы ты вглядываешься в выбранном направлении и различаешь местность на несколько комнат вперед. Поставь перед направлением число -- 2.север, 3.восток -- чтобы заглянуть на столько комнат вдаль; просто направление показывает так далеко, как позволяет труба. Закрытая дверь или скрытый проход преграждают обзор.
 </text>
-    <text l="ua">%FMT% *використовати* _%OBJ%_ _%DIR%_
+    <text l="ua">%FMT% *використовувати* _%OBJ%_ _%DIR%_
 
-За допомогою підзорної труби можна побачити віддалену місцевість у заданому напрямку.
+За допомогою підзорної труби ти вдивляєшся в обраному напрямку й розрізняєш місцевість на кілька кімнат уперед. Постав перед напрямком число -- 2.north, 3.east -- щоб зазирнути на стільки кімнат удалечінь; саме лише напрямок показує так далеко, як дозволяє труба. Зачинені двері чи прихований прохід затуляють огляд.
 </text>
   </help>
   <id>51</id>


### PR DESCRIPTION
Help 285 now explains the new spyglass range: `use <spyglass> [N.]dir` (e.g. 2.north) looks that many rooms off, a bare direction looks as far as the glass reaches, and closed/screened exits block the view. EN/RU/UA. Part of Trello card spyglasses/telescopes.