### PR TITLE
i18n: UA class names for all 13 professions

### DIFF
--- a/professions/anti-paladin.xml
+++ b/professions/anti-paladin.xml
@@ -33,6 +33,7 @@
   <mltName>анти-паладин|ы|ов|ам|ов|ам|ах</mltName>
   <points>300</points>
   <rusName>анти-паладин||а|у|а|ом|е</rusName>
+  <uaName>анти-паладин||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2001" level="-1" type="ClassSkillHelp">

--- a/professions/cleric.xml
+++ b/professions/cleric.xml
@@ -45,6 +45,7 @@ Note that clerics must choose a {hh1religion{x -- otherwise the {hh2036level{x o
   <mltName>клерик|и|ов|ам|ов|ами|ах</mltName>
   <points>0</points>
   <rusName>клерик||а|у|а|ом|е</rusName>
+  <uaName>клірик||а|у|а|ом|у</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2002" level="-1" type="ClassSkillHelp">

--- a/professions/druid.xml
+++ b/professions/druid.xml
@@ -51,6 +51,7 @@ To use their powers, druids must choose a {hh1religion{x -- and only gods of the
   <mltName>друид|ы|ов|ам|ов|ам|ах</mltName>
   <points>300</points>
   <rusName>друид||а|у|а|ом|е</rusName>
+  <uaName>друїд||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="193" level="-1" type="ClassSkillHelp">

--- a/professions/necromancer.xml
+++ b/professions/necromancer.xml
@@ -30,6 +30,7 @@
   <mltName>некромант|ы|ов|ам|ов|ами|ах</mltName>
   <points>200</points>
   <rusName>некромант||а|у|а|ом|е</rusName>
+  <uaName>некромант||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2003" level="-1" type="ClassSkillHelp">

--- a/professions/ninja.xml
+++ b/professions/ninja.xml
@@ -33,6 +33,7 @@
   <mltName>ниндзя</mltName>
   <points>300</points>
   <rusName>ниндзя</rusName>
+  <uaName>ніндзя</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2004" level="-1" type="ClassSkillHelp">

--- a/professions/paladin.xml
+++ b/professions/paladin.xml
@@ -36,6 +36,7 @@ Of course, paladins must choose a {hh1religion{x -- otherwise the {hh2036level{x
   <mltName>паладин|ы|ов|ам|ов|ам|ах</mltName>
   <points>400</points>
   <rusName>паладин||а|у|а|ом|е</rusName>
+  <uaName>паладин||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2005" level="-1" type="ClassSkillHelp">

--- a/professions/ranger.xml
+++ b/professions/ranger.xml
@@ -33,6 +33,7 @@
   <mltName>рейнджер|ы|ов|ам|ов|ами|ах</mltName>
   <points>200</points>
   <rusName>рейнджер||а|у|а|ом|е</rusName>
+  <uaName>рейнджер||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2006" level="-1" type="ClassSkillHelp">

--- a/professions/samurai.xml
+++ b/professions/samurai.xml
@@ -33,6 +33,7 @@
   <mltName>самура|и|ев|ям|ев|ями|ях</mltName>
   <points>500</points>
   <rusName>самура|й|я|ю|я|ем|е</rusName>
+  <uaName>самура|й|я|ю|я|єм|ї</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2007" level="-1" type="ClassSkillHelp">

--- a/professions/thief.xml
+++ b/professions/thief.xml
@@ -30,6 +30,7 @@
   <mltName>вор|ы|ов|ам|ов|ами|ах</mltName>
   <points>0</points>
   <rusName>вор||а|у|а|ом|е</rusName>
+  <uaName>краді|й|я|ю|я|єм|ї</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2008" level="-1" type="ClassSkillHelp">

--- a/professions/vampire.xml
+++ b/professions/vampire.xml
@@ -39,6 +39,7 @@ Every young vampire must undergo a one-time initiation ritual with the Master of
   <mltName>вампир|ы|ов|ам|ов|ами|ах</mltName>
   <points>300</points>
   <rusName>вампир||а|у|а|ом|е</rusName>
+  <uaName>вампір||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2009" level="-1" type="ClassSkillHelp">

--- a/professions/warlock.xml
+++ b/professions/warlock.xml
@@ -39,6 +39,7 @@ Only men can become warlocks. Female spellcasters become {hh139witches{x.
   <mltName>колдун|ы|ов|ам|ов|ами|ах</mltName>
   <points>300</points>
   <rusName>колдун||а|у|а|ом|е</rusName>
+  <uaName>чаклун||а|у|а|ом|і</uaName>
   <sex>male</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2010" level="-1" type="ClassSkillHelp">

--- a/professions/warrior.xml
+++ b/professions/warrior.xml
@@ -36,6 +36,7 @@ Warriors get the most out of defensive {hh2021combat{x and {hh1127weapon{x skill
   <mltName>воин|ы|ов|ам|ов|ами|ах</mltName>
   <points>0</points>
   <rusName>воин||а|у|а|ом|е</rusName>
+  <uaName>воїн||а|у|а|ом|і</uaName>
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2011" level="-1" type="ClassSkillHelp">

--- a/professions/witch.xml
+++ b/professions/witch.xml
@@ -33,6 +33,7 @@
   <mltName>ведьм|ы||ам||ами|ах</mltName>
   <points>200</points>
   <rusName>ведьм|а|ы|е|у|ой|е</rusName>
+  <uaName>відьм|а|и|і|у|ою|і</uaName>
   <sex>female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2012" level="-1" type="ClassSkillHelp">


### PR DESCRIPTION
Adds `<uaName>` (UA Flexer declension pad) to each profession XML, from the Kit-locked CLASSES.md table. Consumed by the engine change in dreamland_code (class name display by config lang).