### PR TITLE
Add config/flagmessages.json: extra_flags fully translated (UA)

### DIFF
--- a/config/flagmessages.json
+++ b/config/flagmessages.json
@@ -1,0 +1,48 @@
+// Per-language flag-table messages (bits.conf Variant 2).
+//
+// Shape: { "<table>": { "<flag>": { "ua": "...", "en": "...", "ru": "..." } } }
+//
+// Only "ua" is normally needed:
+//   - EN falls back to the flag's bit name (already English) unless you add an
+//     "en" override for a snake_case/ugly name.
+//   - RU falls back to the in-binary bits.conf message; add "ru" only to change it.
+// A value is a message pad (the "stem|case1|case2|..." Flexer form bits.conf
+// uses; a plain string means "no declension").
+//
+// RULE: add a table here only once every flag has "ua" -- a partially filled
+// table makes a UA viewer see UA + RU mush, worse than the table being absent.
+{
+    "extra_flags": {
+        "glow":         { "ua": "сяє" },
+        "hum":          { "ua": "гуде" },
+        "dark":         { "ua": "темне" },
+        "water_stand":  { "ua": "не тоне" },
+        "evil":         { "ua": "диявольське" },
+        "invis":        { "ua": "невидиме" },
+        "magic":        { "ua": "магічне" },
+        "nodrop":       { "ua": "не кинути" },
+        "bless":        { "ua": "священне" },
+        "anti_good":    { "ua": "не для добрих" },
+        "anti_evil":    { "ua": "не для злих" },
+        "anti_neutral": { "ua": "не для нейтральних" },
+        "noremove":     { "ua": "не зняти" },
+        "inventory":    { "ua": "інвентар" },
+        "nopurge":      { "ua": "незнищенне" },
+        "rot_death":    { "ua": "гниє з трупом" },
+        "vis_death":    { "ua": "видиме привидам" },
+        "nosac":        { "ua": "не пожертвувати" },
+        "nonmetal":     { "ua": "неметал" },
+        "nolocate":     { "ua": "недоступне локаторам" },
+        "melt_drop":    { "ua": "зникає на землі" },
+        "had_timer":    { "ua": "був таймер" },
+        "sell_extract": { "ua": "зникне при продажу" },
+        "nofind":       { "ua": "недоступне пошуку" },
+        "burn_proof":   { "ua": "вогнетривке" },
+        "nouncurse":    { "ua": "незнімне прокляття" },
+        "nosell":       { "ua": "не для продажу" },
+        "noident":      { "ua": "не опізнати" },
+        "nosavedrop":   { "ua": "не зберігається" },
+        "deleted":      { "ua": "видалене" },
+        "noenchant":    { "ua": "не зачарувати" }
+    }
+}


### PR DESCRIPTION
Per-language flag-table messages (bits.conf Variant 2), consumed by dreamland_code's FlagMessageStore (#608/#609).

First table: **extra (item) flags**, all 31 entries with a `ua` value. EN derives from the bits.conf bit name, RU from the in-binary message, so only `ua` is stored.

**Rule** (in the file header): a table is added only once *every* flag has `ua` — a partially filled table shows a UA viewer UA + RU mush, which is worse than the table being absent (consistent RU).

Verified locally: `stat` of a glow/hum/nodrop/bless item renders pure Ukrainian under `config lang ua`, bit names under `en`, binary RU under `ru`.