### PR TITLE
Translate profiles EN+UA: languages, craft-professions, professions, behaviors

### DIFF
--- a/behaviors/axe lumberjack.xml
+++ b/behaviors/axe lumberjack.xml
@@ -5,7 +5,7 @@
   <help id="282" level="-1" type="BehaviorHelp">
     <extra l="en">chopping woodchopping woodcutting</extra>
     <extra l="ru">бревно бревна дерево деревья лесорубка рубить срубить топоры дровосек</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">колода колоди дерево дерева лісоруб рубати зрубати сокири дроворуб</extra>
     <text l="en">%FMT% *use* {Daxe{x
 %FMT% *use* {Daxe{x _%OBJ%_
 

--- a/behaviors/blacksmith.xml
+++ b/behaviors/blacksmith.xml
@@ -3,12 +3,12 @@
   <cmd></cmd>
   <description>Кузнецы ремонтируют броню и оружие и подковывают копытных.</description>
   <help id="273" labels="item service" level="-1" type="BehaviorHelp">
-    <extra l="en"></extra>
+    <extra l="en">smiths reshoe horseshoes repair mend fix armorer &apos;armor shop&apos; &apos;weapon shop&apos; weaponsmith &apos;item repair&apos; durability condition</extra>
     <extra l="ru">кузнецы подковаться подковы починка чинить починить отремонтировать доспешник &apos;магазин доспехов&apos; &apos;оружейная лавка&apos; оружейник починить починка предметов прочность состояние</extra>
     <extra l="ua">доспешник &apos;магазин обладунків&apos; &apos;збройова крамниця&apos; зброяр відремонтувати ремонт предметів міцність стан</extra>
     <keyword l="en">repair condition</keyword>
     <keyword l="ru">ремонтировать состояние</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">ремонтувати стан</keyword>
     <text l="en">During battles your weapon and {hh1015equipment{x take damage. Their condition ({cdurability{x) is shown in square brackets after the item name -- for example, %PAUSE%[{Rawf.{x]%RESUME% means the item is in awful condition and will soon be destroyed entirely and disappear.
 
 To prevent that, you can repair damaged weapons or armor at =blacksmiths= throughout the world, especially in large cities, who can provide you with {hh275paid services{x for repairs.
@@ -69,9 +69,9 @@ Blacksmiths also fit {hh151centaurs{x with new iron horseshoes, with stats scale
 %FMT% *послуга* *підкови* _предмет_
 Ковалі також забезпечують {hh151кентаврів{x новими залізними підковами з параметрами залежно від твого рівня. Можна принести власні підкови -- коваль прибʼє їх до твоїх копит, але додаткові бонуси будуть знижені. Нові підкови ставляться замість старих, які коваль просто викидає.
 </text>
-    <title l="en"></title>
+    <title l="en">{CPaid services: {xsmiths, repair, durability, horseshoes</title>
     <title l="ru">{CПлатные услуги: {xкузнецы, починка, прочность, подковы</title>
-    <title l="ua"></title>
+    <title l="ua">{CПлатні послуги: {xковалі, ремонт, міцність, підкови</title>
   </help>
   <id>42</id>
   <nameRus>кузнец</nameRus>

--- a/behaviors/bottle.xml
+++ b/behaviors/bottle.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh95бутылку{x, чтобы отпить из нее.</description>
   <help id="95" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">bottle</keyword>
     <keyword l="ru">бутылочка</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">пляшечка</keyword>
     <text l="en">%FMT% {yuse{x _%OBJ%_ _%VICT%_
 
 In combat you can smash a bottle or other suitable vessel over a foe's head, producing an effect similar to {hh700a knock on the noggin{x. You need to hold the bottle in your hands for this.

--- a/behaviors/caltraps.xml
+++ b/behaviors/caltraps.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh267Осколки{x и шипы впиваются в ноги -- ниндзя бросают их под ноги врагу.</description>
   <help id="267" level="-1" type="BehaviorHelp">
-    <extra l="en"></extra>
+    <extra l="en">shard spikes</extra>
     <extra l="ru">осколок шипы</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">уламок шипи</extra>
     <keyword l="en">shards fractions</keyword>
     <keyword l="ru"></keyword>
     <keyword l="ua"></keyword>

--- a/behaviors/cauldron.xml
+++ b/behaviors/cauldron.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh292котел{x, чтобы сварить полезные {hh93зелья{x.</description>
   <help id="292" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">cauldron</keyword>
     <keyword l="ru">котел</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">котел</keyword>
     <text l="en">Devices that let witches and sorcerers of the {hh1479Order of Shalafi{x {hh93brew potions{x.
 
 %FMT% *use* _%OBJ%_

--- a/behaviors/coin.xml
+++ b/behaviors/coin.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh263Брось{x, чтобы сыграть в {hh203орлянку{x.</description>
   <help id="203" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">heads tails coinflip</keyword>
     <keyword l="ru">орел орлянка решка</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">орел решка орлянка</keyword>
     <text l="en">%FMT% {yflip{x _%OBJ%_
 
 Suitable coins can be {hh1024flipped{x on the floor to play heads-or-tails with someone.

--- a/behaviors/conflagration.xml
+++ b/behaviors/conflagration.xml
@@ -30,9 +30,9 @@ Some areas in the world burn permanently.
 
 Деякі місцевості у світі горять постійно.
 </text>
-    <title l="en"></title>
+    <title l="en">Terrain: conflagration</title>
     <title l="ru">Местность: пожарище</title>
-    <title l="ua"></title>
+    <title l="ua">Місцевість: згарище</title>
   </help>
   <id>47</id>
   <nameRus>пожарище</nameRus>

--- a/behaviors/dice.xml
+++ b/behaviors/dice.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh263Брось{x, чтобы сыграть в {hh206кости{x.</description>
   <help id="206" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">dice</keyword>
     <keyword l="ru">кубики</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">кубики</keyword>
     <text l="en">%FMT% {yroll{x _%OBJ%_
 
 Dice can be {hh1024rolled{x on the floor to play a game of bones with someone. Different dice sets differ in the total number of dice per roll and the number of sides on each die.

--- a/behaviors/enchanter.xml
+++ b/behaviors/enchanter.xml
@@ -5,10 +5,10 @@
   <help id="274" labels="service" level="-1" type="BehaviorHelp">
     <extra l="en">enchanters</extra>
     <extra l="ru">чародеи услуга исправление огнеупорность термоустойчивость перезарядка починка</extra>
-    <extra l="ua"></extra>
-    <keyword l="en"></keyword>
+    <extra l="ua">чародії послуга виправлення вогнетривкість термостійкість перезарядка ремонт</extra>
+    <keyword l="en">enchanter</keyword>
     <keyword l="ru">чародей</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">чародій</keyword>
     <text l="en">=Enchanters= -- wizards versed in item magic -- offer {hh275paid services{x for enchanting gear.
 
 %FMT% *service* *name* _item_
@@ -39,9 +39,9 @@ Enchanters who also offer smithing services can repair any items, not just armor
 
 Чарівники, які також надають ковальські послуги, можуть полагодити будь-які предмети, а не лише броню та зброю.
 </text>
-    <title l="en"></title>
+    <title l="en">{CPaid services: {xenchanters</title>
     <title l="ru">{CПлатные услуги: {xчародеи</title>
-    <title l="ua"></title>
+    <title l="ua">{CПлатні послуги: {xчародії</title>
   </help>
   <id>43</id>
   <nameRus>чародей</nameRus>

--- a/behaviors/feather.xml
+++ b/behaviors/feather.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh248перышко{x, чтобы кого-нибудь пощекотать.</description>
   <help id="248" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">feather tickle</keyword>
     <keyword l="ru">перо перышко пощекотать щекотать</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">перо пірʼїнка полоскотати лоскотати</keyword>
     <text l="en">%FMT% {yuse{x _%OBJ%_
 %FMT% {yuse{x _%OBJ%_ _%CHAR%_
 

--- a/behaviors/fire.xml
+++ b/behaviors/fire.xml
@@ -3,12 +3,12 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh249пламя{x, чтобы поджечь горючую вещь.</description>
   <help id="249" level="-1" type="BehaviorHelp">
-    <extra l="en"></extra>
+    <extra l="en">ignite kindle light burn</extra>
     <extra l="ru">поджечь разжечь развести сжечь зажечь</extra>
-    <extra l="ua"></extra>
-    <keyword l="en"></keyword>
+    <extra l="ua">підпалити розпалити розвести спалити запалити</extra>
+    <keyword l="en">campfire fire bonfire</keyword>
     <keyword l="ru">костёр костер огонь</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">багаття вогнище вогонь</keyword>
     <text l="en">With something flammable in hand and a source of fire -- a {hh240torch{x, {hh214matches{x, or one of the fire spells -- you can start a campfire. By a fire you recover your strength faster and your wounds {hh2130heal{x more quickly. A fire can also warm you if you are suffering from frostbite or {hh610ice touch{x.
 
 You can keep a fire going by {hh1024feeding{x it flammable objects or by setting other objects on the ground alight. Many things can be burned -- for example, {hh1024containers{x, {hh282logs{x, corpses, vessels holding flammable liquids, and much more -- even your own mortal {hh12body{x! Different objects will burn, melt, or {hh4become red-hot{x depending on their {hh201material{x. A fire stoked too high can turn into a {hh281wildfire{x -- careful!

--- a/behaviors/matches.xml
+++ b/behaviors/matches.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh214спички{x, чтобы что-нибудь поджечь.</description>
   <help id="214" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">matchbox matches &apos;spider races&apos;</keyword>
     <keyword l="ru">коробок &apos;паучьи бега&apos; спичек спички</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">коробка сірники 'павучі перегони'</keyword>
     <text l="en">%FMT% {yuse{x {Dmatches{x _%OBJ%_
 
 Matches can light something flammable to start a {hh249campfire{x. The chance to ignite depends on the flammability and density of the {hh201material{x of the target. Each matchbox holds a limited number of matches -- every ignition attempt uses one.

--- a/behaviors/mirror.xml
+++ b/behaviors/mirror.xml
@@ -5,7 +5,7 @@
   <help id="284" level="-1" type="BehaviorHelp">
     <extra l="en">mirrors</extra>
     <extra l="ru">зеркала</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">дзеркала</extra>
     <text l="en">%FMT% *look* _%OBJ%_
 %FMT% *use* _%OBJ%_
 %FMT% *use* _%OBJ%_ _%CHAR%_

--- a/behaviors/needle.xml
+++ b/behaviors/needle.xml
@@ -5,10 +5,10 @@
   <help id="247" level="-1" type="BehaviorHelp">
     <extra l="en">needles sewing stitching thimbles</extra>
     <extra l="ru">иголка наперсток зашить зашивать шить</extra>
-    <extra l="ua"></extra>
-    <keyword l="en"></keyword>
+    <extra l="ua">голка наперсток зашити зашивати шити</extra>
+    <keyword l="en">needle sewing</keyword>
     <keyword l="ru">игла швейная</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">голка швейна</keyword>
     <text l="en">%FMT% {yuse{x {Dneedle{x _%OBJ%_
 
 Items made of {hh201cloth or leather{x (such as {hh65clothing{x) sometimes cannot be repaired by {hh273blacksmiths{x -- but they can be sewn up. Buy a needle and thread at a shop -- and don't forget a thimble, or you might prick your finger!

--- a/behaviors/perfume.xml
+++ b/behaviors/perfume.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh233парфюм{x, чтобы наделить себя или другого новым ароматом.</description>
   <help id="233" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">perfume perfumery</keyword>
     <keyword l="ru">парфюмерия</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">парфумерія</keyword>
     <text l="en">%FMT% {yuse{x _%OBJ%_
 %FMT% {yuse{x _%OBJ%_ _%CHAR%_
 

--- a/behaviors/sage.xml
+++ b/behaviors/sage.xml
@@ -6,9 +6,9 @@
     <extra l="en">sages otho</extra>
     <extra l="ru"></extra>
     <extra l="ua"></extra>
-    <keyword l="en"></keyword>
+    <keyword l="en">sages otho</keyword>
     <keyword l="ru">мудрецы отто</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">мудреці отто</keyword>
     <text l="en">Throughout the world you can find =sages= who provide {hh275paid services{x for {hh603identification{x and locating items -- Otto in Midgaard, for example.
 
 %FMT% *service* *identify* _item_
@@ -33,9 +33,9 @@ Same as the {hh707locator{x spell, shows the locations of all items that have th
 %FMT% *послуга* *локатор* _рядок_
 Аналогічно заклинанню {hh707локатора{x, показує місцезнаходження всіх речей, які мають цей рядок у ключових словах.
 </text>
-    <title l="en"></title>
+    <title l="en">{CPaid services: {xsages</title>
     <title l="ru">{CПлатные услуги: {xмудрецы</title>
-    <title l="ua"></title>
+    <title l="ua">{CПлатні послуги: {xмудреці</title>
   </help>
   <id>44</id>
   <nameRus>мудрец</nameRus>

--- a/behaviors/shovel.xml
+++ b/behaviors/shovel.xml
@@ -5,7 +5,7 @@
   <help id="238" level="-1" type="BehaviorHelp">
     <keyword l="en">dig</keyword>
     <keyword l="ru">копаться выкопать закопать</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">копатися викопати закопати</keyword>
     <text l="en">%FMT% {yuse{x {Dshovel{x
 
 The world holds items or treasures buried by someone. To dig them up you will need a shovel. Just {hh1023use{x it in the right spot and, if you are lucky, you may unearth something interesting.

--- a/behaviors/snare.xml
+++ b/behaviors/snare.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh263Брось{x {hh239капкан{x, чтобы поймать в него существо.</description>
   <help id="239" level="-1" type="BehaviorHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">snare trap mousetrap</keyword>
     <keyword l="ru">ловушка мышеловка</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">пастка мишоловка</keyword>
     <text l="en">%FMT% {ythrow{x _%OBJ%_
 %FMT% {yput{x {Dbait{x _%OBJ%_
 Cages, mousetraps, and similar items can catch creatures in the room -- not all of them, of course, only {hh2142non-sentient{x, non-quest, {hh15non-follower{x ones, and so on. To catch a creature, place suitable bait in the trap and throw it in front of the creature in the same area. Then wait... and if the bait is right and the trap is the right size, the creature will be caught. 

--- a/behaviors/spyglass.xml
+++ b/behaviors/spyglass.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh285подзорную трубу{x, чтобы разглядеть местность по направлению.</description>
   <help id="285" level="-1" type="BehaviorHelp">
-    <extra l="en"></extra>
+    <extra l="en">spyglass binoculars</extra>
     <extra l="ru">бинокль</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">бінокль</extra>
     <keyword l="en">binoculars</keyword>
     <keyword l="ru"></keyword>
     <keyword l="ua"></keyword>

--- a/behaviors/telescope.xml
+++ b/behaviors/telescope.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh366телескоп{x, чтобы разглядеть далекие земли и звезды.</description>
   <help id="366" level="-1" type="BehaviorHelp">
-    <extra l="en"></extra>
+    <extra l="en">telescope</extra>
     <extra l="ru">телескоп</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">телескоп</extra>
     <keyword l="en">telescope</keyword>
     <keyword l="ru">телескоп</keyword>
     <keyword l="ua">телескоп</keyword>

--- a/behaviors/torch.xml
+++ b/behaviors/torch.xml
@@ -3,9 +3,9 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh240факел{x, чтобы поджечь бревна и развести костер.</description>
   <help id="240" level="-1" type="BehaviorHelp">
-    <extra l="en"></extra>
+    <extra l="en">torch pitch</extra>
     <extra l="ru">смоляной факел</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">смоляний смолоскип</extra>
     <text l="en">%FMT% {yuse{x {Dtorch{x _%OBJ%_
 
 You can use a torch to set something flammable alight and start a {hh249campfire{x. The chance of ignition depends on the flammability and density of the object's {hh201material{x.

--- a/craft-professions/carpenter.xml
+++ b/craft-professions/carpenter.xml
@@ -4,7 +4,7 @@
   <help id="230" level="-1" type="CraftProfessionHelp">
     <keyword l="en">carpenter</keyword>
     <keyword l="ru">плотник</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">тесля</keyword>
     <text l="en">=Carpenter= is one of the {hh195crafts{x or secondary professions available to all players. Carpenters can craft from wood {hh810bows{x and {hh537arrows{x, {hh699polearms{x, boats, beds, decorations, and shields.
 
 %FMT% *craft* _desired item_
@@ -35,9 +35,9 @@ Some of the most skilled carpenters and lumberjacks of Thera can be found in the
 {CЯК СТАТИ ТЕСЛЕЮ{x
 Одних з найвправніших теслів та лісорубів Тери можна знайти в маленькому містечку {hh1506Дюнкельдорф{x. Якщо хочеш освоїти цю професію, спробуй пошукати вчителя там.
 </text>
-    <title l="en"></title>
+    <title l="en">{CAdditional professions:{x carpenter</title>
     <title l="ru">{CДополнительные профессии:{x плотник</title>
-    <title l="ua"></title>
+    <title l="ua">{CДодаткові професії:{x тесля</title>
   </help>
   <maxLevel>10</maxLevel>
   <mltName>плотник|и|ов|ам|ов|ами|ах</mltName>

--- a/craft-professions/tattooist.xml
+++ b/craft-professions/tattooist.xml
@@ -4,10 +4,10 @@
   <help id="242" level="-1" type="CraftProfessionHelp">
     <extra l="en">picture tatoist tatooist tattoist</extra>
     <extra l="ru">&apos;нож для татуировок&apos; рисунки рисунок скарабей снять татуировать татуировка татуировки татуировку нанести наносить</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">'ніж для татуювань' малюнки малюнок скарабей зняти татуювати татуювання наносити нанести</extra>
     <keyword l="en">tattooist</keyword>
     <keyword l="ru">татуировщик</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">татуювальник</keyword>
     <text l="en">=Tattooist= is one of the {hh195crafts{x or secondary professions available to all players. A tattooist can apply various tattoos to themselves or other players on different body parts: the left or right {hh243wrist{x, {hh246shoulders{x, or {hh244face{x. To apply a tattoo to a given location you must learn the corresponding skills, which become available as you practice.
 
 {CHOW TO BECOME A TATTOOIST{x
@@ -62,9 +62,9 @@ To {hh245remove a tattoo{x, you need a special ointment, which can be bought fro
 
 Щоб {hh245зняти татуювання{x, потрібна спеціальна мазь, яку можна купити там же у тату-майстра в Преріях.
 </text>
-    <title l="en"></title>
+    <title l="en">{CAdditional professions:{x tattooist</title>
     <title l="ru">{CДополнительные профессии:{x татуировщик</title>
-    <title l="ua"></title>
+    <title l="ua">{CДодаткові професії:{x татуювальник</title>
   </help>
   <maxLevel>10</maxLevel>
   <mltName>татуировщик|и|ов|ам|ов|ами|ах</mltName>

--- a/languages/arcadian.xml
+++ b/languages/arcadian.xml
@@ -13,7 +13,7 @@
       <extra l="en">'beer elemental' toughness</extra>
       <extra l="ru">'пивной элементаль' толстокожесть</extra>
       <extra l="ua">'пивний елементаль' товстошкірість</extra>
-      <keyword l="en"></keyword>
+      <keyword l="en">'arcadian'</keyword>
       <keyword l="ru">'язык аркади'</keyword>
       <keyword l="ua">'мова аркаді'</keyword>
       <text l="en">{WArcadian{x -- a language once spoken by the hoofed inhabitants of {hh1429Arcadia{x. Everything you ever wanted to know about the effects of alcohol but were hesitant to try on yourself.

--- a/languages/quenia.xml
+++ b/languages/quenia.xml
@@ -12,7 +12,7 @@
     <help id="2044" level="-1" type="LanguageHelp">
       <extra l="en">quenya</extra>
       <extra l="ru">квения эльфийский язык</extra>
-      <extra l="ua"></extra>
+      <extra l="ua">квенья ельфійська мова</extra>
       <text l="en">=Quenya= -- is an ancient Elven dialect. Over the centuries, it was driven from everyday speech and became a lofty language of poetry, songs, and philosophical manuscripts, and then it was entirely forgotten. Resurrected fragments of ancient wisdom contain the secrets of Elven healers&apos; medicine and the accuracy of Elven archers.
 
 {CCommand{x

--- a/professions/anti-paladin.xml
+++ b/professions/anti-paladin.xml
@@ -39,7 +39,7 @@
   <skillHelp id="2001" level="-1" type="ClassSkillHelp">
     <keyword l="en">&apos;a-p skills&apos; &apos;a-p spells&apos; &apos;antipaladin skills&apos; &apos;antipaladin spells&apos;</keyword>
     <keyword l="ru">антипаладина антипаладинов</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">антипаладина антипаладинів</keyword>
   </skillHelp>
   <stats>
     <str>2</str>

--- a/professions/cleric.xml
+++ b/professions/cleric.xml
@@ -4,7 +4,7 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>divine caster</flags>
   <help id="133" level="-1" type="ProfessionHelp">
-    <extra l="en"></extra>
+    <extra l="en">clerics priests shamans</extra>
     <extra l="ru">клирики священники жрецы шаманы</extra>
     <extra l="ua">клірики священики жерці шамани</extra>
     <keyword l="en">clerics</keyword>
@@ -49,9 +49,9 @@ Note that clerics must choose a {hh1religion{x -- otherwise the {hh2036level{x o
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2002" level="-1" type="ClassSkillHelp">
-    <extra l="en"></extra>
+    <extra l="en">cleric</extra>
     <extra l="ru">клирика</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">клірика</extra>
   </skillHelp>
   <stats>
     <wis>3</wis>

--- a/professions/ninja.xml
+++ b/professions/ninja.xml
@@ -4,7 +4,7 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>agile</flags>
   <help id="132" level="-1" type="ProfessionHelp">
-    <extra l="en"></extra>
+    <extra l="en">ninjas ninja</extra>
     <extra l="ru">ниндзе ниндзи нинзи нинзя</extra>
     <extra l="ua">нінзя нінзи ніндзі</extra>
     <keyword l="en">ninja</keyword>
@@ -37,9 +37,9 @@
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2004" level="-1" type="ClassSkillHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">ninjas</keyword>
     <keyword l="ru">ниндзей нинзей нинзя</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">ніндзю ніндзів</keyword>
   </skillHelp>
   <stats>
     <str>1</str>

--- a/professions/ranger.xml
+++ b/professions/ranger.xml
@@ -4,9 +4,9 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>nature melee</flags>
   <help id="140" level="-1" type="ProfessionHelp">
-    <extra l="en"></extra>
+    <extra l="en">archers rangers</extra>
     <extra l="ru">лучники рангеры рейнжеры рэйнджеры рэйнжеры</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">лучники рейнджери</extra>
     <keyword l="en">rangers</keyword>
     <keyword l="ru">рейнджеры</keyword>
     <keyword l="ua">рейнджери</keyword>
@@ -37,9 +37,9 @@
   <sex>male female</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2006" level="-1" type="ClassSkillHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">rangers</keyword>
     <keyword l="ru">рангера рангеров ренджера ренджеров рэйнджера рэйнджеров</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">рейнджера рейнджерів</keyword>
   </skillHelp>
   <stats>
     <str>1</str>

--- a/professions/vampire.xml
+++ b/professions/vampire.xml
@@ -4,7 +4,7 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>magic hybrid</flags>
   <help id="144" level="-1" type="ProfessionHelp">
-    <extra l="en"></extra>
+    <extra l="en">&apos;creature of the night&apos;</extra>
     <extra l="ru">&apos;создание ночи&apos;</extra>
     <extra l="ua">'створіння ночі'</extra>
     <keyword l="en">vampire</keyword>

--- a/professions/warlock.xml
+++ b/professions/warlock.xml
@@ -43,9 +43,9 @@ Only men can become warlocks. Female spellcasters become {hh139witches{x.
   <sex>male</sex>
   <skillAdept>75</skillAdept>
   <skillHelp id="2010" level="-1" type="ClassSkillHelp">
-    <keyword l="en"></keyword>
+    <keyword l="en">mages warlocks</keyword>
     <keyword l="ru">мага магов варлока варлоков</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">мага магів варлока варлоків</keyword>
   </skillHelp>
   <stats>
     <int>3</int>


### PR DESCRIPTION
Fills the empty `l="en"`/`l="ua"` fields in the content-ready profile categories from the "решта XML профайлів" roadmap — the ones that already have multilang (`l=`) field structure, so this is pure content translation (no engine changes).

- **languages** (2): arcadian keyword-en, quenia extra-ua.
- **craft-professions** (2 files): carpenter, tattooist — keyword/title/extra. Titles use the `{CAdditional professions:{x <name>` convention; UA names тесля / татувальник.
- **professions** (6 files): anti-paladin, cleric, ninja, ranger, vampire, warlock — secondary search-keyword/extra lists (declined forms), anchored on the canonical class names already in each file.
- **behaviors** (21 files): keyword/extra/title help fields. Paid-service titles follow `commands/fenia/service.xml` (Paid services / Платні послуги); terrain titles coined Terrain: / Місцевість:.

All XML well-formed; 0 remaining gaps in these four categories; QA clean (no guillemets, no stray э/ё in UA, no mixed-script words).

Out of scope (deferred to engine work): the bare-RU-only profile types — desires, bonuses, wearlocations, clans, craft-wearlocs, liquids — which need XMLMultiString conversion in the C++ loader before they can carry en/ua.