### PR TITLE
Translate standalone help fields EN+UA: religion, clan, group, quest

### DIFF
--- a/helps/clan.xml
+++ b/helps/clan.xml
@@ -3,7 +3,7 @@
   <node id="2" labels="clan" level="0" type="Help">
     <keyword l="en">&apos;clan prices&apos;</keyword>
     <keyword l="ru">&apos;клановые цены&apos;</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">&apos;кланові ціни&apos;</keyword>
     <text l="en">{RWARNING: {WAdding shops and clan pets is no longer possible. Extra exits and portals -- no more than three per clan. Instead of an arms race there is now equality.{x
 
 Clan leadership (leaders and recruiters) can purchase additional perks for their clan territories in exchange for quest points:
@@ -46,17 +46,17 @@ The parameters of all rooms, items, or creatures are approved by the Gods.
 
 Параметри всіх кімнат, предметів або істот затверджуються Богами.
 </text>
-    <title l="en"></title>
+    <title l="en">Prices for improving clan territories</title>
     <title l="ru">Цены на благоустройство клановых территорий</title>
-    <title l="ua"></title>
+    <title l="ua">Ціни на облаштування кланових територій</title>
   </node>
   <node id="3" labels="clan" level="-1" type="Help">
     <extra l="en">bank clan clanguard clanmembers clanpower commands diplomacy invitation leadership leave levels members petition power ranks recruiter guard</extra>
     <extra l="ru">банк дипломатия иерархия клана клангвард кланхолл кланов клановики клановый команды лидер недоверие отношения перемирие петиция покинуть приглашение ранги рекрутер руководство список святыня территория уровень устав внеклановый война &apos;вступить в клан&apos; &apos;вступление в клан&apos; &apos;выйти из клана&apos; звание звания охранник стражник</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">банк дипломатія ієрархія клану клангвард кланхол кланів кланівники клановий команди лідер недовіра відносини перемирʼя петиція покинути запрошення ранги рекрутер керівництво список святиня територія рівень статут позаклановий війна &apos;вступити в клан&apos; &apos;вступ до клану&apos; &apos;вийти з клану&apos; звання охоронець вартовий</extra>
     <keyword l="en">clans</keyword>
     <keyword l="ru">кланы</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">клани</keyword>
     <text l="en">Clans or Orders are special organisations of players who share common goals.
 The main clans each embody one of the {hh81Eight Paths{x.
 
@@ -368,8 +368,8 @@ For clan leadership: %H% {hh2clan prices{x
 %SA% команду *клан допомога* і всі її підкоманди
 Для керівництва кланів: %H% {hh2кланові ціни{x
 </text>
-    <title l="en"></title>
+    <title l="en">Clans and Orders</title>
     <title l="ru">Кланы и Ордена</title>
-    <title l="ua"></title>
+    <title l="ua">Клани та Ордени</title>
   </node>
 </Help>

--- a/helps/group.xml
+++ b/helps/group.xml
@@ -3,10 +3,10 @@
   <node id="121" labels="item" level="-1" type="Help">
     <extra l="en">brandish pills potions quaff recite scrolls staves &apos;using magic items&apos; vials wands zap</extra>
     <extra l="ru">глотать &apos;использование волшебных предметов&apos; лекарство &apos;магические предметы&apos; осушить пилюли поразить посохи пузырек снадобье снадобья свитки таблетки жезлы взмахнуть зачитать зелья &apos;читать свиток&apos;</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">ковтати &apos;використання чарівних предметів&apos; ліки &apos;магічні предмети&apos; осушити пігулки вразити посохи пузирок зілля настій сувої таблетки жезли змахнути зачитати настої &apos;читати сувій&apos;</extra>
     <keyword l="en">&apos;magical items&apos;</keyword>
     <keyword l="ru">&apos;волшебные предметы&apos;</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">&apos;чарівні предмети&apos;</keyword>
     <text l="en">Magic items are artefacts with limited charges of some magic or prayers. By using these items you can cast spells on yourself or your opponents. Before using magic items it is strongly advisable to first {hh603identify{x them -- or use the {hh65search engine{x on the website.
 
 Magic items come in the following types:
@@ -88,17 +88,17 @@ Staves and wands may contain multiple charges. When the charges run out, these m
 
 Посохи і жезли можуть містити кілька зарядів. Коли заряди вичерпаються, ці чарівні предмети стають марними. Однак чарівники і відьми знають секрет повторного заряджання жезлів і посохів (вміння {hh600перезарядка{x).
 </text>
-    <title l="en"></title>
+    <title l="en">Magical items</title>
     <title l="ru">Волшебные предметы</title>
-    <title l="ua"></title>
+    <title l="ua">Чарівні предмети</title>
   </node>
   <node id="122" labels="fight item" level="-1" type="Help">
     <extra l="en">average random &apos;weapon types&apos;</extra>
     <extra l="ru">клановое оружием оружия первичное рандомы случайное случайные &apos;список оружия&apos; &apos;среднее повреждение&apos; &apos;средние повреждения&apos; &apos;типы оружия&apos; владение вооружение вооружения</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">кланове зброєю зброї первинне рандоми випадкове випадкові &apos;список зброї&apos; &apos;середнє пошкодження&apos; &apos;середні пошкодження&apos; &apos;типи зброї&apos; володіння озброєння озброєння</extra>
     <keyword l="en">weapons</keyword>
     <keyword l="ru">оружие</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">зброя</keyword>
     <text l="en">A weapon increases your damage in combat and lets you use special combat skills. Weapons are divided into *types.* Every weapon has a base stat called *average damage* -- the higher the average, the more damage you can deal.
 
 Every weapon requires the skill to wield it. Each weapon type has its own skill. The higher the skill, the more often you will hit your opponent and the more damage you will deal. The skill with each weapon type also governs your combat and defensive abilities -- for example, the {hh576parry{x or {hh812disarm{x skills. In addition, the chance for defensive skills depends on the weapon type you and your opponent are carrying.
@@ -246,8 +246,8 @@ a випадкові параметри додаються до наявних. 
 можна викликати за допомогою заклинань, а от {hh1494Мисливці{x одразу отримують свою зброю в
 комплекті з {hh906жакетом{x при вступі в клан.
 </text>
-    <title l="en"></title>
+    <title l="en">Weapons and their types</title>
     <title l="ru">Оружие и его типы</title>
-    <title l="ua"></title>
+    <title l="ua">Зброя та її типи</title>
   </node>
 </Help>

--- a/helps/quest.xml
+++ b/helps/quest.xml
@@ -3,10 +3,10 @@
   <node id="123" labels="quest" level="-1" type="Help">
     <extra l="en">&apos;quest types&apos;</extra>
     <extra l="ru">&apos;божественный квест&apos; &apos;квесты виды&apos; &apos;личный квест&apos; &apos;типы квестов&apos; &apos;типы заданий&apos; задания</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">&apos;божественний квест&apos; &apos;квести види&apos; &apos;особистий квест&apos; &apos;типи квестів&apos; &apos;типи завдань&apos; завдання</extra>
     <keyword l="en">quests</keyword>
     <keyword l="ru">квесты</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">квести</keyword>
     <text l="en">Quests come in many varieties, require different efforts, and offer different rewards. The following =types of quests= exist:
 
 {CFOR BEGINNERS:{x
@@ -40,17 +40,17 @@
 %A% Божественні глобальні квести (подробиці публікуються в повідомленнях *квестнота* або оголошуються по каналу *квестканал*).
 %A% Божественні персональні/особисті квести конкретним гравцям
 </text>
-    <title l="en"></title>
+    <title l="en">Types of tasks and quests</title>
     <title l="ru">Типы заданий и квестов</title>
-    <title l="ua"></title>
+    <title l="ua">Типи завдань і квестів</title>
   </node>
   <node id="124" labels="quest" level="-1" type="Help">
-    <extra l="en"></extra>
+    <extra l="en">&apos;area quests&apos; &apos;zone tasks&apos; &apos;area tasks&apos; lost</extra>
     <extra l="ru">&apos;квесты в зонах&apos; потеряла &apos;задание зоны&apos; &apos;задания локация&apos; &apos;задания в зонах&apos;</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">&apos;квести в зонах&apos; загубила &apos;завдання зони&apos; &apos;завдання локація&apos; &apos;завдання в зонах&apos;</extra>
     <keyword l="en">&apos;area quests&apos;</keyword>
     <keyword l="ru">&apos;задания зон&apos;</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">&apos;завдання зон&apos;</keyword>
     <text l="en">In some {hh998zones{x you can receive individual quests if you pay close
 attention to what is happening around you. Sometimes a hero is explicitly
 asked for help, and sometimes you have to figure things out on your own.
@@ -132,17 +132,17 @@ Here are a few examples to get you started:
 
 %SA% %H% {hh127типи квестів{x, %H% {hh1368команда квест{x
 </text>
-    <title l="en"></title>
+    <title l="en">{CQuests:{x Area tasks</title>
     <title l="ru">{CКвесты:{x Задания в зонах</title>
-    <title l="ua"></title>
+    <title l="ua">{CКвести:{x Завдання в зонах</title>
   </node>
   <node id="125" labels="quest" level="-1" type="Help">
     <extra l="en">mermaid qps qpt &apos;quest points&apos; &apos;quest scroll&apos; study</extra>
     <extra l="ru">купэ &apos;квест поинты&apos; квестеры квестора квесторы &apos;квестовые единицы&apos; &apos;квестовые очки&apos; квесты познание русалка &apos;свиток познания&apos; задание</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">купе &apos;квест поінти&apos; квестери квестора квестори &apos;квестові одиниці&apos; &apos;квестові очки&apos; квести пізнання русалка &apos;сувій пізнання&apos; завдання</extra>
     <keyword l="en">questors</keyword>
     <keyword l="ru">квестора задания</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">квестора завдання</keyword>
     <text l="en">Personal quests can be obtained from =questors=, who reside in most major
 cities such as {hh1392Midgaard{x, {hh1446Old Midgaard{x, {hh2071Valley of the Titans{x, {hh1423Anon{x, {hh1838New Thalos{x, {hh1505Solace{x, {hh2054Greater Gerighelm{x and a few other places. The command {y{hcwhere questor{x will help you find one in the city.
 
@@ -183,17 +183,17 @@ For more information about quest items use %H% {hh126reward{x. For information a
 
 %SA% %H% {hh50будівництво{x, {hh11Милості Богів{x
 </text>
-    <title l="en"></title>
+    <title l="en">{CQuests:{x Questor tasks, quest points</title>
     <title l="ru">{CКвесты:{x Задания квесторов, квестовые очки</title>
-    <title l="ua"></title>
+    <title l="ua">{CКвести:{x Завдання квесторів, квестові очки</title>
   </node>
   <node id="126" labels="quest" level="-1" type="Help">
     <extra l="en">bag girth hero &apos;quest items&apos; questweapon ring weapon</extra>
     <extra l="ru">дорожная героя кольцо квестовая квестовое &apos;квестовые предметы&apos; квестовый награда награды &apos;оружие героя&apos; пояс сумка</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">дорожня героя кільце квестова квестове &apos;квестові предмети&apos; квестовий нагорода нагороди &apos;зброя героя&apos; пояс сумка</extra>
     <keyword l="en">quest rewards</keyword>
     <keyword l="ru">квестовые вещи</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">квестові речі</keyword>
     <text l="en">From {hh125questors{x you can purchase various services and items for quest points.
 
 One of the most popular goods are {Cquest items:{x
@@ -266,17 +266,17 @@ You can sew {hh19pockets{x onto the quest bag for convenient item sorting.
 
 %SA% %H% {hh125завдання квестора{x, %H% {hh1368команда квест{x
 </text>
-    <title l="en"></title>
+    <title l="en">{CQuests:{x Quest items and other rewards</title>
     <title l="ru">{CКвесты:{x Квестовые вещи и другие награды</title>
-    <title l="ua"></title>
+    <title l="ua">{CКвести:{x Квестові речі та інші нагороди</title>
   </node>
   <node id="127" labels="quest" level="-1" type="Help">
     <extra l="en">&apos;quest types&apos;</extra>
     <extra l="ru">&apos;банду геть&apos; &apos;кусочек бытия&apos; &apos;кусочек души&apos; &apos;квесты виды&apos; листовка похищения &apos;поиск королевских вещей&apos; &apos;помощь жертвам ограблений&apos; &apos;сбор потерянных вещей&apos; &apos;виды персональных заданий&apos; &apos;засады и похищения&apos; проповедники ханжа ханжи</extra>
-    <extra l="ua"></extra>
-    <keyword l="en"></keyword>
+    <extra l="ua">&apos;банду геть&apos; &apos;шматочок буття&apos; &apos;шматочок душі&apos; &apos;квести види&apos; листівка викрадення &apos;пошук королівських речей&apos; &apos;допомога жертвам пограбувань&apos; &apos;збір загублених речей&apos; &apos;види персональних завдань&apos; &apos;засідки і викрадення&apos; проповідники ханжа ханжі</extra>
+    <keyword l="en">&apos;task types&apos;</keyword>
     <keyword l="ru">&apos;виды заданий&apos;</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">&apos;види завдань&apos;</keyword>
     <text l="en">Questors in the Dream World can give you the following types of quests:
 
 {C%A%{x {WAssassination{x: eliminate an unwanted element disrupting the balance of power or having
@@ -376,17 +376,17 @@ You can sew {hh19pockets{x onto the quest bag for convenient item sorting.
 
 {hh2127Новачкам{x найскладніших типів завдань не дають, але деякі квести можуть бути легкими або складними просто через свою природу. Рекомендуємо починати кар'єру квестовика з простих завдань, таких як пошук королівських речей або лікування. Потім пробувати свої сили у вбивстві і так далі. Завдання по позбавленню від банд підходять тим, хто прагне набрати багато {hh14досвіду{x.
 </text>
-    <title l="en"></title>
+    <title l="en">{CQuests:{x Kinds of questor personal tasks</title>
     <title l="ru">{CКвесты:{x Виды персональных заданий квесторов</title>
-    <title l="ua"></title>
+    <title l="ua">{CКвести:{x Види персональних завдань квесторів</title>
   </node>
   <node id="128" labels="quest" level="-1" type="Help">
     <extra l="en">globals gquests info</extra>
     <extra l="ru">гквест &apos;глобальный квест&apos; глобалы инфо квестканал глобалквест</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">гквест &apos;глобальний квест&apos; глобали інфо квестканал глобалквест</extra>
     <keyword l="en">&apos;global quests&apos;</keyword>
     <keyword l="ru">&apos;глобальные квесты&apos;</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">&apos;глобальні квести&apos;</keyword>
     <text l="en">=Global quests= are a fun competition in which players race to rid our
 world of some threat. Type {y{hcgquest{x to read the instructions during
 a global, see the statistics, and much more.
@@ -432,17 +432,17 @@ may be rather modest. The main thing is victory.
 отримує цінну нагороду, тоді як приз за виконання дрібних етапів квесту
 може бути досить мізерним. Головне -- перемога.
 </text>
-    <title l="en"></title>
+    <title l="en">{CQuests:{x Global quests</title>
     <title l="ru">{CКвесты:{x Глобальные квесты</title>
-    <title l="ua"></title>
+    <title l="ua">{CКвести:{x Глобальні квести</title>
   </node>
   <node id="129" labels="quest" level="-1" type="Help">
-    <extra l="en"></extra>
+    <extra l="en">boss lair chief</extra>
     <extra l="ru">логово шефа</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">лігво шефа</extra>
     <keyword l="en">gangsters</keyword>
     <keyword l="ru">бандиты гангстеры</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">бандити гангстери</keyword>
     <text l="en">Gangsters is one of the most interesting {hh128global quests{x.
 
 Lately there have been too few {hh1461Rulers{x -- bandits have sensed the opportunity and begun pushing in everywhere, creating pockets of organised crime in the most unexpected places. As it turns out, absolutely everyone suffers from this. The particularly aggrieved local residents tip off Hassan, reporting exactly where they encountered the criminals.
@@ -473,17 +473,17 @@ Since it is impossible to return to the bandit hideout after the quest ends, the
 
 Оскільки потрапити назад до бандитського лігва після закінчення квесту неможливо, Боги переносять трупи персонажів, що там лежать, до вівтарів, а інші речі -- до {hh2141Бюро Знахідок{x.
 </text>
-    <title l="en"></title>
+    <title l="en">{CGlobal quests:{x Gangsters</title>
     <title l="ru">{CГлобальные квесты:{x Гангстеры</title>
-    <title l="ua"></title>
+    <title l="ua">{CГлобальні квести:{x Гангстери</title>
   </node>
   <node id="130" labels="quest" level="-1" type="Help">
     <extra l="en">bubbles global locusts</extra>
     <extra l="ru">футбольные глобал мячи пузыри пузырь саранча</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">футбольні глобал мʼячі пузирі пузир сарана</extra>
     <keyword l="en">invasion</keyword>
     <keyword l="ru">нашествие</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">навала</keyword>
     <text l="en">Invasion is a {hh128global quest{x in which heroes must rid the world of one threat or another -- for example, ravenous locusts, multicoloured bubbles, or a sudden ice-over.
 
 For example, locusts spread across all places where they can feed on vegetation (looking for them under the mayor's bed is probably not worth it). Locusts and the like are visible via the *where* command -- the main thing is not to be lazy, keep running around and searching.
@@ -496,17 +496,17 @@ For example, locusts spread across all places where they can feed on vegetation 
 
 Наприклад, сарана розбредається по всіх місцях, де можна поживитися рослинністю (шукати її під ліжком мера, мабуть, не варто). Сарану та Ко видно по команді *де* -- головне не ледарювати, бігати і шукати.
 </text>
-    <title l="en"></title>
+    <title l="en">{CGlobal quests:{x Invasion</title>
     <title l="ru">{CГлобальные квесты:{x Нашествие</title>
-    <title l="ua"></title>
+    <title l="ua">{CГлобальні квести:{x Навала</title>
   </node>
   <node id="131" labels="quest" level="-1" type="Help">
-    <extra l="en"></extra>
+    <extra l="en">&apos;rainbow shield&apos;</extra>
     <extra l="ru">&apos;радужный щит&apos;</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">&apos;райдужний щит&apos;</extra>
     <keyword l="en">rainbow</keyword>
     <keyword l="ru">радуга</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">райдуга</keyword>
     <text l="en">Rainbow is a {hh128global quest{x. The participants' task is to gather together as many pieces of the rainbow scattered across the world as possible. The quest winner receives special protection -- a =rainbow shield=.
 
 To see more detailed instructions, type {y{hcgquest info{x during the quest.
@@ -519,8 +519,8 @@ To see more detailed instructions, type {y{hcgquest info{x during the quest.
 
 Щоб побачити докладніші інструкції, напиши {y{hcгквест інфо{x під час квесту.
 </text>
-    <title l="en"></title>
+    <title l="en">{CGlobal quests:{x Rainbow</title>
     <title l="ru">{CГлобальные квесты:{x Радуга</title>
-    <title l="ua"></title>
+    <title l="ua">{CГлобальні квести:{x Райдуга</title>
   </node>
 </Help>

--- a/helps/religion.xml
+++ b/helps/religion.xml
@@ -3,10 +3,10 @@
   <node id="1" labels="religion" level="-1" type="Help">
     <extra l="en">adepts atheism atheist faith gods marks</extra>
     <extra l="ru">адепты атеист атеизм бога боги богов божества божество древние &apos;древние боги&apos; &apos;на челе&apos; религии культы смена своей вера выбор знаки культов твоей выбрать религию культа</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">адепти атеїст атеїзм бога боги богів божества божество древні &apos;древні боги&apos; &apos;на чолі&apos; релігії культи зміна своєї віра вибір знаки культів твоєї вибрати релігію культа</extra>
     <keyword l="en">cults religions</keyword>
     <keyword l="ru">культы религии религия</keyword>
-    <keyword l="ua"></keyword>
+    <keyword l="ua">культи релігії релігія</keyword>
     <text l="en">In the World of Dreams many deities coexist -- old and new, come from distant
 worlds and born right here. Most gods patronise one of the
 {hh81Eight Paths{x, but there are also deities that stand apart.
@@ -241,8 +241,8 @@ For details on each god see the help article, for example: {hchelp teshub{x.
 
 %SA% %H% {hh1375вівтар{x, {hh1375жертвувати{x
 </text>
-    <title l="en"></title>
+    <title l="en">Religions and cults</title>
     <title l="ru">Религии и культы</title>
-    <title l="ua"></title>
+    <title l="ua">Релігії та культи</title>
   </node>
 </Help>


### PR DESCRIPTION
Fills empty EN/UA in the four small/topical standalone help files (`dreamland_world/helps/`) — titles, keyword/extra search terms. No text-body gaps in these four (those live in anatolia/immort/help.xml, tackled separately). All monolingual per language, ASCII punctuation, UA ʼ, no э/ё, no mixed-script; help-node edits only (no new IDs -> no collision risk). Quoted phrases match the files' existing `&apos;` convention.

Deploys via `plug reload most` (hot-reload, no reboot). Remaining help work (help.xml 307 short + 2 prose; anatolia 29 short + 20 lore bodies; immort 19 short + 44 mechanics bodies) is separate.