### PR TITLE
Backfill behavior help articles (EN/RU/UA) for 34 behaviors

### DIFF
--- a/behaviors/ashes.xml
+++ b/behaviors/ashes.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>{hh1023Используй{x, чтобы скорбно посыпать голову {hh280пеплом{x.</description>
   <help id="280" level="-1" type="BehaviorHelp">
+    <extra l="en">ashes ash mourning grief</extra>
+    <extra l="ru">пепел скорбь траур посыпать</extra>
+    <extra l="ua">попіл скорбота траур посипати</extra>
+    <text l="en">%FMT% *use* {Dashes{x
+
+Use ashes to mournfully sprinkle them over your head -- an ancient gesture of grief and repentance. No mechanical effect; pure roleplay of sorrow.</text>
+    <text l="ru">%FMT% *использовать* {Dпепел{x
+
+Используй пепел, чтобы скорбно посыпать им голову -- древний жест горя и покаяния. Никакой механической пользы, чистый отыгрыш скорби.</text>
+    <text l="ua">%FMT% *використати* {Dпопіл{x
+
+Використай попіл, щоб скорботно посипати ним голову -- прадавній жест горя і покаяння. Жодної механічної користі, чистий відіграш скорботи.</text>
   </help>
   <id>46</id>
   <nameRus>пепел</nameRus>

--- a/behaviors/atm.xml
+++ b/behaviors/atm.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>В {hh268банкомате{x можно положить деньги на счет и снять их обратно.</description>
   <help id="268" level="102" type="BehaviorHelp">
+    <extra l="en">atm bank machine deposit withdraw</extra>
+    <extra l="ru">банкомат счет вклад снять</extra>
+    <extra l="ua">банкомат рахунок вклад зняти</extra>
+    <text l="en">%FMT% *use* {Datm{x
+
+At an atm you can deposit money into your account and withdraw it again. Money in the bank is not lost on death, and you can withdraw it at any atm in the world.</text>
+    <text l="ru">%FMT% *использовать* {Dбанкомат{x
+
+В банкомате можно положить деньги на счет и снять их обратно. Деньги на счету не потеряешь при смерти, а снять их можно у любого банкомата мира.</text>
+    <text l="ua">%FMT% *використати* {Dбанкомат{x
+
+У банкоматі можна покласти гроші на рахунок і зняти їх назад. Гроші на рахунку не втратиш при смерті, а зняти їх можна в будь-якому банкоматі світу.</text>
   </help>
   <id>40</id>
   <nameRus>банкомат</nameRus>

--- a/behaviors/babayaga.xml
+++ b/behaviors/babayaga.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Баба Яга выдает плату за прожитые жизни -- ремортные бонусы за очки жизни, с возможностью возврата.</description>
   <help id="359" level="-1" type="BehaviorHelp">
+    <extra l="en">baba yaga witch remort life points</extra>
+    <extra l="ru">баба яга ведьма реморт очки жизни</extra>
+    <extra l="ua">баба яга відьма реморт очки життя</extra>
+    <text l="en">Baba Yaga trades you remort bonuses in exchange for life points -- the currency you earn by living out your lives. Ask her, and she will lay out what each bonus costs; a bonus taken can also be given back.</text>
+    <text l="ru">Баба Яга выдает плату за прожитые жизни: за очки жизни она даст тебе ремортные бонусы -- постоянные надбавки твоему герою. Спроси ее, и она распишет цену каждого; взятый бонус можно и вернуть обратно.</text>
+    <text l="ua">Баба Яга видає плату за прожиті життя: за очки життя вона дасть тобі ремортні бонуси -- постійні надбавки твоєму героєві. Спитай її, і вона розпише ціну кожного; взятий бонус можна й повернути назад.</text>
   </help>
   <id>80</id>
   <nameRus>Баба Яга</nameRus>

--- a/behaviors/bell.xml
+++ b/behaviors/bell.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh295колокольчик{x, чтобы мелодично позвонить.</description>
   <help id="295" level="-1" type="BehaviorHelp">
+    <extra l="en">bell ring chime</extra>
+    <extra l="ru">колокольчик звонить звон</extra>
+    <extra l="ua">дзвіночок дзвонити дзвін</extra>
+    <text l="en">%FMT% *use* {Dbell{x
+
+Use a bell to ring it melodiously -- a soft, cheerful sound carries through the room. Flavour only: a signal, a summons, or just a merry jingle.</text>
+    <text l="ru">%FMT% *использовать* {Dколокольчик{x
+
+Используй колокольчик, чтобы мелодично позвонить -- негромкий веселый звук разносится по комнате. Флейвор: сигнал, зов или просто радостный перезвон.</text>
+    <text l="ua">%FMT% *використати* {Dдзвіночок{x
+
+Використай дзвіночок, щоб мелодійно подзвонити -- неголосний веселий звук розноситься кімнатою. Флейвор: сигнал, поклик чи просто радісний передзвін.</text>
   </help>
   <id>60</id>
   <nameRus>колокольчик</nameRus>

--- a/behaviors/bloodthirst.xml
+++ b/behaviors/bloodthirst.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Вещь с {hh288кровожадностью{x в бою жаждет вражеской крови.</description>
   <help id="288" level="-1" type="BehaviorHelp">
+    <extra l="en">bloodthirst bloodthirsty thirst blood</extra>
+    <extra l="ru">кровожадность кровожадный жажда крови</extra>
+    <extra l="ua">кровожерність кровожерний жага крові</extra>
+    <text l="en">A weapon or item with bloodthirst craves enemy blood in battle: the more blood its wielder spills, the more eagerly it serves. A passive property -- it shows itself on its own in combat.</text>
+    <text l="ru">Оружие или вещь с кровожадностью в бою жаждет вражеской крови: чем больше крови проливает владелец, тем охотнее она служит. Пассивное свойство -- проявляется само во время сражения.</text>
+    <text l="ua">Зброя чи річ із кровожерністю в бою жадає ворожої крові: що більше крові проливає власник, то охочіше вона служить. Пасивна властивість -- проявляється сама під час битви.</text>
   </help>
   <id>53</id>
   <nameRus>кровожадность</nameRus>

--- a/behaviors/blueprint.xml
+++ b/behaviors/blueprint.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>По {hh252чертежу{x ремесленник изготовит описанную в нем вещь.</description>
   <help id="252" level="-1" type="BehaviorHelp">
+    <extra l="en">blueprint schematic craft recipe</extra>
+    <extra l="ru">чертеж схема ремесло рецепт</extra>
+    <extra l="ua">креслення схема ремесло рецепт</extra>
+    <text l="en">%FMT% *use* {Dblueprint{x
+
+From a blueprint a skilled craftsman can make the item it describes, given the right {hh294components{x and tools. Use a blueprint to read what it lets you create and from what.</text>
+    <text l="ru">%FMT% *использовать* {Dчертеж{x
+
+По чертежу умелый ремесленник изготовит описанную в нем вещь, если у него есть нужные {hh294компоненты{x и инструмент. Используй чертеж, чтобы прочесть, что и из чего он позволяет создать.</text>
+    <text l="ua">%FMT% *використати* {Dкреслення{x
+
+За кресленням умілий ремісник виготовить описану в ньому річ, якщо має потрібні {hh294компоненти{x та інструмент. Використай креслення, щоб прочитати, що і з чого воно дозволяє створити.</text>
   </help>
   <id>24</id>
   <nameRus>чертеж</nameRus>

--- a/behaviors/bucket.xml
+++ b/behaviors/bucket.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>{hh1023Используй{x ведро на копытную тварь, чтобы ее {hh5087подоить{x.</description>
   <help id="365" level="-1" type="BehaviorHelp">
+    <extra l="en">bucket pail milk milking</extra>
+    <extra l="ru">ведро подоить молоко доить</extra>
+    <extra l="ua">відро подоїти молоко доїти</extra>
+    <text l="en">%FMT% *use* {Dbucket{x _%VICT%_
+
+Use a bucket on a hoofed creature to {hh5087milk{x it. From cows, goats and the like you can draw milk this way -- if the beast does not mind.</text>
+    <text l="ru">%FMT% *использовать* {Dведро{x _%VICT%_
+
+Используй ведро на копытную тварь, чтобы ее {hh5087подоить{x. С коров, коз и им подобных самок так можно набрать молока -- если тварь не против.</text>
+    <text l="ua">%FMT% *використати* {Dвідро{x _%VICT%_
+
+Використай відро на копитну тварину, щоб її {hh5087подоїти{x. З корів, кіз і подібних самиць так можна набрати молока -- якщо тварина не проти.</text>
   </help>
   <id>102</id>
   <nameRus></nameRus>

--- a/behaviors/component.xml
+++ b/behaviors/component.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Из {hh294крафтовых компонентов{x состоят все вещи и материалы.</description>
   <help id="294" level="-1" type="BehaviorHelp">
+    <extra l="en">component components material crafting</extra>
+    <extra l="ru">компонент компоненты материал крафт</extra>
+    <extra l="ua">компонент компоненти матеріал крафт</extra>
+    <text l="en">Crafting components are what all the world's items and materials are made of. Break an item down in a {hh293cuisinart{x to get its components; gather the right components per a {hh252blueprint{x to make something new.</text>
+    <text l="ru">Крафтовые компоненты -- то, из чего состоят все вещи и материалы мира. Разобрав вещь в {hh293кузинатре{x, получишь ее компоненты; собрав нужные компоненты по {hh252чертежу{x, изготовишь новую вещь.</text>
+    <text l="ua">Крафтові компоненти -- те, з чого складаються всі речі й матеріали світу. Розібравши річ у {hh293кузинатрі{x, отримаєш її компоненти; зібравши потрібні компоненти за {hh252кресленням{x, виготовиш нову річ.</text>
   </help>
   <id>59</id>
   <nameRus>крафтовый компонент</nameRus>

--- a/behaviors/cuisinart.xml
+++ b/behaviors/cuisinart.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh293кузинатру{x, чтобы раздробить вещь на {hh294компоненты{x.</description>
   <help id="293" level="-1" type="BehaviorHelp">
+    <extra l="en">cuisinart grinder shredder disassemble</extra>
+    <extra l="ru">кузинатра дробилка разобрать разбор</extra>
+    <extra l="ua">кузинатра дробарка розібрати розбір</extra>
+    <text l="en">%FMT% *use* {Dcuisinart{x _%OBJ%_
+
+Use a cuisinart on an item to shatter it into {hh294components{x -- raw material for crafting. Not every item can be broken down.</text>
+    <text l="ru">%FMT% *использовать* {Dкузинатра{x _%OBJ%_
+
+Используй кузинатру на вещь, чтобы раздробить ее на {hh294компоненты{x -- сырье для крафта. Не всякая вещь поддается разбору.</text>
+    <text l="ua">%FMT% *використати* {Dкузинатра{x _%OBJ%_
+
+Використай кузинатру на річ, щоб роздробити її на {hh294компоненти{x -- сировину для крафту. Не кожна річ піддається розбору.</text>
   </help>
   <id>58</id>
   <nameRus>кузинатра</nameRus>

--- a/behaviors/deathtrap.xml
+++ b/behaviors/deathtrap.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Вошедшего в комнату с некоторой вероятностью убивает на месте.</description>
   <help id="360" level="-1" type="BehaviorHelp">
+    <extra l="en">deathtrap death trap lethal room</extra>
+    <extra l="ru">смертельная ловушка смерть комната</extra>
+    <extra l="ua">смертельна пастка смерть кімната</extra>
+    <text l="en">A room with a deathtrap kills whoever enters, with some chance, on the spot -- no fight, no warning. Tread such places with the utmost care, and never drag a corpse or drop your gear where it may be lost forever.</text>
+    <text l="ru">Комната со смертельной ловушкой с некоторой вероятностью убивает вошедшего на месте -- без боя и предупреждения. Ходи в такие места с крайней осторожностью и не тащи труп и не бросай вещи там, где они пропадут навсегда.</text>
+    <text l="ua">Кімната зі смертельною пасткою з певною ймовірністю вбиває того, хто увійшов, на місці -- без бою й попередження. Ходи в такі місця вкрай обережно й не тягни труп і не кидай речі там, де вони пропадуть назавжди.</text>
   </help>
   <id>81</id>
   <nameRus>смертельная ловушка</nameRus>

--- a/behaviors/fishka.xml
+++ b/behaviors/fishka.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh297Фишки{x казино обращаются в ничто за пределами зоны.</description>
   <help id="297" level="-1" type="BehaviorHelp">
+    <extra l="en">chip chips casino token</extra>
+    <extra l="ru">фишка фишки казино жетон</extra>
+    <extra l="ua">фішка фішки казино жетон</extra>
+    <text l="en">Casino chips are the local gaming currency. Outside their own zone they crumble to nothing, so you must spend them where you won them.</text>
+    <text l="ru">Фишки казино -- местная игровая валюта. За пределами своей зоны они обращаются в ничто, так что тратить их надо там же, где выиграл.</text>
+    <text l="ua">Фішки казино -- місцева ігрова валюта. За межами своєї зони вони обертаються на ніщо, тож витрачати їх треба там само, де виграв.</text>
   </help>
   <id>61</id>
   <nameRus>фишка</nameRus>

--- a/behaviors/fountain.xml
+++ b/behaviors/fountain.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>Из {hh264фонтана{x можно напиться того, чем он наполнен.</description>
   <help id="264" level="-1" type="BehaviorHelp">
+    <extra l="en">fountain drink well spring</extra>
+    <extra l="ru">фонтан пить источник напиться</extra>
+    <extra l="ua">фонтан пити джерело напитися</extra>
+    <text l="en">%FMT% *use* {Dfountain{x
+
+From a fountain you can drink whatever fills it -- water, wine, or something worse. What exactly flows in a fountain is usually clear from its description.</text>
+    <text l="ru">%FMT% *использовать* {Dфонтан{x
+
+Из фонтана можно напиться того, чем он наполнен -- водой, вином или чем похуже. Что именно течет в фонтане, обычно ясно из его описания.</text>
+    <text l="ua">%FMT% *використати* {Dфонтан{x
+
+З фонтана можна напитися того, чим він наповнений -- водою, вином чи чимось гіршим. Що саме тече у фонтані, зазвичай ясно з його опису.</text>
   </help>
   <id>36</id>
   <nameRus>фонтан</nameRus>

--- a/behaviors/katana.xml
+++ b/behaviors/katana.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh353Катана{x, выкованная самураем лично для себя -- чужих рук не признает.</description>
   <help id="353" level="-1" type="BehaviorHelp">
+    <extra l="en">katana samurai sword</extra>
+    <extra l="ru">катана самурай меч</extra>
+    <extra l="ua">катана самурай меч</extra>
+    <text l="en">A katana forged by a {hh351samurai{x for himself will not suffer another's hand: an outsider cannot wield it properly. To its own master it serves true and keen.</text>
+    <text l="ru">Катана, выкованная {hh351самураем{x лично для себя, не признает чужих рук: чужак не сможет как следует ею владеть. Своему хозяину она служит верно и остро.</text>
+    <text l="ua">Катана, викувана {hh351самураєм{x особисто для себе, не визнає чужих рук: чужак не зможе як слід нею володіти. Своєму господарю вона служить вірно й гостро.</text>
   </help>
   <id>74</id>
   <nameRus>катана самурая</nameRus>

--- a/behaviors/koschei.xml
+++ b/behaviors/koschei.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Кощей Бессмертный выменивает постоянные ремортные бонусы на квестовые победы.</description>
   <help id="358" level="-1" type="BehaviorHelp">
+    <extra l="en">koschei deathless remort quest bonus</extra>
+    <extra l="ru">кощей бессмертный реморт квест бонус</extra>
+    <extra l="ua">кощій безсмертний реморт квест бонус</extra>
+    <text l="en">Koschei the Deathless trades permanent remort bonuses for quest victories: bring him proof of your triumphs and he will graft a lasting boon onto your hero. His prices are steep, but his gifts do not fade.</text>
+    <text l="ru">Кощей Бессмертный выменивает постоянные ремортные бонусы на квестовые победы: принеси ему доказательства своих триумфов, и он привьет твоему герою прочную надбавку. Цены его высоки, но дары не тускнеют.</text>
+    <text l="ua">Кощій Безсмертний виміняє постійні ремортні бонуси на квестові перемоги: принеси йому докази своїх тріумфів, і він прищепить твоєму героєві тривку надбавку. Ціни його високі, та дари не тьмяніють.</text>
   </help>
   <id>79</id>
   <nameRus>Кощей</nameRus>

--- a/behaviors/lust room.xml
+++ b/behaviors/lust room.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>В этой местности персонажи испытывают странные желания.</description>
   <help id="283" level="-1" type="BehaviorHelp">
+    <extra l="en">lust desire spring aromas</extra>
+    <extra l="ru">вожделение желание ароматы весны</extra>
+    <extra l="ua">жага бажання аромати весни</extra>
+    <text l="en">In such a place -- thick with the aromas of spring -- characters are gripped by strange desires. The air itself stirs the blood; what you do with the urge is your own affair.</text>
+    <text l="ru">В этой местности, полной ароматов весны, персонажей охватывают странные желания. Сам воздух будоражит кровь; а что делать с этим порывом -- дело твое.</text>
+    <text l="ua">У цій місцевості, повній ароматів весни, персонажів охоплюють дивні бажання. Саме повітря бентежить кров; а що робити з цим поривом -- справа твоя.</text>
   </help>
   <id>49</id>
   <nameRus>ароматы весны</nameRus>

--- a/behaviors/master samurai.xml
+++ b/behaviors/master samurai.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Мастер самурай учит ковать катану и выкупает смерти за квесточки.</description>
   <help id="351" level="-1" type="BehaviorHelp">
+    <extra l="en">master samurai katana forge teach</extra>
+    <extra l="ru">мастер самурай катана ковка учить</extra>
+    <extra l="ua">майстер самурай катана кування вчити</extra>
+    <text l="en">The master samurai teaches a worthy warrior to forge his own {hh353katana{x -- a blade that will answer to no other hand. He will also buy back your battlefield deaths for quest points, sparing you the sting of a lost life.</text>
+    <text l="ru">Мастер самурай учит достойного воина ковать собственную {hh353катану{x -- клинок, что не признает чужой руки. Также он выкупает за квестовые очки твои смерти в бою, избавляя от горечи потерянной жизни.</text>
+    <text l="ua">Майстер самурай навчає гідного воїна кувати власну {hh353катану{x -- клинок, що не визнає чужої руки. Також він викуповує за квестові очки твої смерті в бою, позбавляючи гіркоти втраченого життя.</text>
   </help>
   <id>72</id>
   <nameRus>мастер самурай</nameRus>

--- a/behaviors/master vampire.xml
+++ b/behaviors/master vampire.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Мастер вампир инициирует молодых вампиров.</description>
   <help id="352" level="-1" type="BehaviorHelp">
+    <extra l="en">master vampire initiate embrace</extra>
+    <extra l="ru">мастер вампир инициация посвящение</extra>
+    <extra l="ua">майстер вампір ініціація посвячення</extra>
+    <text l="en">The master vampire initiates the young of his kind: he leads a fledgling through the rite of embrace and teaches the powers of the night. Seek him if you would take your first steps as a true vampire.</text>
+    <text l="ru">Мастер вампир инициирует молодых сородичей: он проводит новообращенного через обряд посвящения и обучает силам ночи. Ищи его, если хочешь сделать первые шаги настоящим вампиром.</text>
+    <text l="ua">Майстер вампір ініціює молодих родичів: він проводить новонаверненого через обряд посвячення й навчає силам ночі. Шукай його, якщо хочеш зробити перші кроки справжнім вампіром.</text>
   </help>
   <id>73</id>
   <nameRus>мастер вампир</nameRus>

--- a/behaviors/money.xml
+++ b/behaviors/money.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh265Деньги{x нашего мира -- золото и серебро в твоем кошельке.</description>
   <help id="265" level="-1" type="BehaviorHelp">
+    <extra l="en">money gold silver coins</extra>
+    <extra l="ru">деньги золото серебро монеты</extra>
+    <extra l="ua">гроші золото срібло монети</extra>
+    <text l="en">The money of our world is the gold and silver in your purse. One gold coin is worth a hundred silver; with them you buy goods, services, and clan benefits.</text>
+    <text l="ru">Деньги нашего мира -- золото и серебро в твоем кошельке. Одна золотая монета стоит сотни серебряных; на них покупают товары, услуги и клановые блага.</text>
+    <text l="ua">Гроші нашого світу -- золото й срібло в твоєму гаманці. Одна золота монета варта сотні срібних; на них купують товари, послуги та кланові блага.</text>
   </help>
   <id>37</id>
   <nameRus>деньги</nameRus>

--- a/behaviors/questreward.xml
+++ b/behaviors/questreward.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh291Квестовая награда{x подстраивается под своего владельца.</description>
   <help id="291" level="-1" type="BehaviorHelp">
+    <extra l="en">quest reward hero prize</extra>
+    <extra l="ru">квестовая награда герой приз</extra>
+    <extra l="ua">квестова нагорода герой приз</extra>
+    <text l="en">A hero's quest reward adapts to its owner -- its stats grow along with them, so the prize stays useful even many levels later.</text>
+    <text l="ru">Квестовая награда героя подстраивается под своего владельца -- ее характеристики растут вместе с ним, так что подарок остается полезным и через много уровней.</text>
+    <text l="ua">Квестова нагорода героя підлаштовується під свого власника -- її характеристики ростуть разом із ним, тож подарунок лишається корисним і через багато рівнів.</text>
   </help>
   <id>56</id>
   <nameRus>квестовая награда героя</nameRus>

--- a/behaviors/roulette croupier.xml
+++ b/behaviors/roulette croupier.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Крупье запускает рулетку, принимает ставки на разные исходы и выдает выигрыши.</description>
   <help id="356" level="-1" type="BehaviorHelp">
+    <extra l="en">croupier roulette dealer bets</extra>
+    <extra l="ru">крупье рулетка ставки выигрыш</extra>
+    <extra l="ua">крупʼє рулетка ставки виграш</extra>
+    <text l="en">The croupier runs the {hh357roulette table{x: he takes your bets on numbers, colour and odd-or-even, spins the wheel, and pays out the winners. The house, of course, keeps its edge.</text>
+    <text l="ru">Крупье заведует {hh357столом рулетки{x: принимает ставки на числа, цвет и чет-нечет, крутит колесо и выдает выигрыши. Заведение, разумеется, своего не упустит.</text>
+    <text l="ua">Крупʼє завідує {hh357столом рулетки{x: приймає ставки на числа, колір і парне-непарне, крутить колесо й видає виграші. Заклад, певна річ, свого не впустить.</text>
   </help>
   <id>77</id>
   <nameRus>крупье</nameRus>

--- a/behaviors/roulette table.xml
+++ b/behaviors/roulette table.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh357стол рулетки{x, чтобы сделать ставку и крутануть колесо.</description>
   <help id="357" level="-1" type="BehaviorHelp">
+    <extra l="en">roulette table wheel bet</extra>
+    <extra l="ru">рулетка стол ставка колесо</extra>
+    <extra l="ua">рулетка стіл ставка колесо</extra>
+    <text l="en">%FMT% *use* {Droulette table{x
+
+Use a roulette table to place a bet and spin the wheel. The {hh356croupier{x announces the outcome and pays out -- you can bet on numbers, colour, and odd-or-even.</text>
+    <text l="ru">%FMT% *использовать* {Dстол рулетки{x
+
+Используй стол рулетки, чтобы сделать ставку и крутануть колесо. {hh356Крупье{x объявит исход и выдаст выигрыш -- ставить можно на числа, цвет и чет-нечет.</text>
+    <text l="ua">%FMT% *використати* {Dстіл рулетки{x
+
+Використай стіл рулетки, щоб зробити ставку й крутнути колесо. {hh356Крупʼє{x оголосить результат і видасть виграш -- ставити можна на числа, колір і парне-непарне.</text>
   </help>
   <id>78</id>
   <nameRus>стол рулетки</nameRus>

--- a/behaviors/set amazon.xml
+++ b/behaviors/set amazon.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh5081набор амазонки{x.</description>
   <help id="5081" level="-1" type="BehaviorHelp">
+    <extra l="en">set amazon pieces collection</extra>
+    <extra l="ru">набор амазонки части комплект</extra>
+    <extra l="ua">набір амазонки частини комплект</extra>
+    <text l="en">This item is part of the amazon set -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор амазонки' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір амазонки' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>70</id>
   <nameRus>набор амазонки</nameRus>

--- a/behaviors/set ashigaru.xml
+++ b/behaviors/set ashigaru.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh298набор асигару{x.</description>
   <help id="298" level="-1" type="BehaviorHelp">
+    <extra l="en">set ashigaru pieces collection</extra>
+    <extra l="ru">набор асигару части комплект</extra>
+    <extra l="ua">набір асигару частини комплект</extra>
+    <text l="en">This item is part of the ashigaru set -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор асигару' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір асигару' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>62</id>
   <nameRus>набор асигару</nameRus>

--- a/behaviors/set berserker.xml
+++ b/behaviors/set berserker.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh5079набор берсерка{x.</description>
   <help id="5079" level="-1" type="BehaviorHelp">
+    <extra l="en">set berserker pieces collection</extra>
+    <extra l="ru">набор берсерка части комплект</extra>
+    <extra l="ua">набір берсерка частини комплект</extra>
+    <text l="en">This item is part of the berserker set -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор берсерка' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір берсерка' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>69</id>
   <nameRus>набор берсерка</nameRus>

--- a/behaviors/set defender.xml
+++ b/behaviors/set defender.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh5077набор защитника{x.</description>
   <help id="5077" level="-1" type="BehaviorHelp">
+    <extra l="en">set defender pieces collection</extra>
+    <extra l="ru">набор защитника части комплект</extra>
+    <extra l="ua">набір захисника частини комплект</extra>
+    <text l="en">This item is part of the defender set -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор защитника' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір захисника' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>68</id>
   <nameRus>набор защитника</nameRus>

--- a/behaviors/set fathers.xml
+++ b/behaviors/set fathers.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh5073отцовское наследство{x.</description>
   <help id="5073" level="-1" type="BehaviorHelp">
+    <extra l="en">set fathers legacy pieces collection</extra>
+    <extra l="ru">набор отцовское наследство части комплект</extra>
+    <extra l="ua">набір батьківський спадок частини комплект</extra>
+    <text l="en">This item is part of the the fathers' legacy -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'отцовское наследство' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'батьківський спадок' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>66</id>
   <nameRus>отцовское наследство</nameRus>

--- a/behaviors/set gloomstalker.xml
+++ b/behaviors/set gloomstalker.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh5083набор охотника тьмы{x.</description>
   <help id="5083" level="-1" type="BehaviorHelp">
+    <extra l="en">set gloomstalker pieces collection</extra>
+    <extra l="ru">набор охотника тьмы части комплект</extra>
+    <extra l="ua">набір мисливця пітьми частини комплект</extra>
+    <text l="en">This item is part of the gloomstalker set -- a matched set of 4 pieces. Collect and wear all 4 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор охотника тьмы' из 4 предметов. Собери и надень все 4 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір мисливця пітьми' із 4 предметів. Збери й надінь усі 4 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>71</id>
   <nameRus>набор охотника тьмы</nameRus>

--- a/behaviors/set hoplite.xml
+++ b/behaviors/set hoplite.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh299набор гоплита{x.</description>
   <help id="299" level="-1" type="BehaviorHelp">
+    <extra l="en">set hoplite pieces collection</extra>
+    <extra l="ru">набор гоплита части комплект</extra>
+    <extra l="ua">набір гопліта частини комплект</extra>
+    <text l="en">This item is part of the hoplite set -- a matched set of 2 pieces. Collect and wear all 2 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор гоплита' из 2 предметов. Собери и надень все 2 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір гопліта' із 2 предметів. Збери й надінь усі 2 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>63</id>
   <nameRus>набор гоплита</nameRus>

--- a/behaviors/set myrmidon.xml
+++ b/behaviors/set myrmidon.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh5075набор мирмидонянина{x.</description>
   <help id="5075" level="-1" type="BehaviorHelp">
+    <extra l="en">set myrmidon pieces collection</extra>
+    <extra l="ru">набор мирмидонянина части комплект</extra>
+    <extra l="ua">набір мірмідонянина частини комплект</extra>
+    <text l="en">This item is part of the myrmidon set -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'набор мирмидонянина' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'набір мірмідонянина' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>67</id>
   <nameRus>набор мирмидонянина</nameRus>

--- a/behaviors/set pixie.xml
+++ b/behaviors/set pixie.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh290доспехи пикси{x.</description>
   <help id="290" level="110" type="BehaviorHelp">
+    <extra l="en">set pixie pieces collection</extra>
+    <extra l="ru">набор пикси части комплект</extra>
+    <extra l="ua">набір піксі частини комплект</extra>
+    <text l="en">This item is part of the pixie armor -- a matched set of 5 pieces. Collect and wear all 5 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'доспехи пикси' из 5 предметов. Собери и надень все 5 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'обладунки піксі' із 5 предметів. Збери й надінь усі 5 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>55</id>
   <nameRus>доспехи пикси</nameRus>

--- a/behaviors/set wood nymph.xml
+++ b/behaviors/set wood nymph.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>{hh990Надень{x, чтобы собрать {hh301оберег древесных нимф{x.</description>
   <help id="301" level="-1" type="BehaviorHelp">
+    <extra l="en">set wood nymph dryad pieces collection</extra>
+    <extra l="ru">набор древесных нимф части комплект</extra>
+    <extra l="ua">набір деревних німф частини комплект</extra>
+    <text l="en">This item is part of the wood nymphs' charm -- a matched set of 3 pieces. Collect and wear all 3 together to assemble the set; once complete it grants its bonus. Wear only some pieces and you gain nothing extra.</text>
+    <text l="ru">Эта вещь -- часть набора 'оберег древесных нимф' из 3 предметов. Собери и надень все 3 вместе, чтобы собрать набор; собранный целиком, он дает свой бонус. Наденешь лишь часть -- ничего сверх не получишь.</text>
+    <text l="ua">Ця річ -- частина набору 'оберіг деревних німф' із 3 предметів. Збери й надінь усі 3 разом, щоб зібрати набір; зібраний цілком, він дає свій бонус. Надінеш лише частину -- нічого понад не отримаєш.</text>
   </help>
   <id>65</id>
   <nameRus>оберег древесных нимф</nameRus>

--- a/behaviors/synesthesia.xml
+++ b/behaviors/synesthesia.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Местности, вызывающие у посетителей синестезию.</description>
   <help id="289" level="110" type="BehaviorHelp">
+    <extra l="en">synesthesia senses cross blending</extra>
+    <extra l="ru">синестезия чувства смешение</extra>
+    <extra l="ua">синестезія чуття змішання</extra>
+    <text l="en">Localities that stir synesthesia in their visitors: senses cross and blend, so that colours are heard, sounds are tasted, and smells take on shape. A builder's tool for dreamlike, disorienting rooms.</text>
+    <text l="ru">Местности, вызывающие у посетителей синестезию: чувства смешиваются и перетекают одно в другое -- цвета слышны, звуки на вкус, запахи обретают форму. Инструмент строителя для сновидческих, сбивающих с толку комнат.</text>
+    <text l="ua">Місцевості, що викликають у відвідувачів синестезію: чуття змішуються й перетікають одне в одне -- кольори чутно, звуки на смак, запахи набувають форми. Інструмент будівничого для сновидних, спантеличливих кімнат.</text>
   </help>
   <id>54</id>
   <nameRus>синестезия</nameRus>

--- a/behaviors/tattoo picture.xml
+++ b/behaviors/tattoo picture.xml
@@ -3,6 +3,18 @@
   <cmd></cmd>
   <description>{hh1023Используй{x {hh5001рисунок{x на части тела, чтобы нанести {hh242татуировку{x.</description>
   <help id="5001" level="110" type="BehaviorHelp">
+    <extra l="en">tattoo picture design ink</extra>
+    <extra l="ru">рисунок татуировка нанести</extra>
+    <extra l="ua">малюнок татуювання нанести</extra>
+    <text l="en">%FMT% *use* {Dpicture{x _%BODY%_
+
+Use a tattoo picture on a body part to apply a {hh242tattoo{x there. Different pictures give different tattoos; the spot matters too.</text>
+    <text l="ru">%FMT% *использовать* {Dрисунок{x _%BODY%_
+
+Используй рисунок на части тела, чтобы нанести на нее {hh242татуировку{x. Разные рисунки дают разные татуировки; место тоже имеет значение.</text>
+    <text l="ua">%FMT% *використати* {Dмалюнок{x _%BODY%_
+
+Використай малюнок на частині тіла, щоб нанести на неї {hh242татуювання{x. Різні малюнки дають різні татуювання; місце теж має значення.</text>
   </help>
   <id>26</id>
   <nameRus>рисунок татуировки</nameRus>

--- a/behaviors/teacher.xml
+++ b/behaviors/teacher.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description>Учителя тренируют твои параметры и помогают практиковать навыки.</description>
   <help id="279" level="-1" type="BehaviorHelp">
+    <extra l="en">teacher train practice trainer</extra>
+    <extra l="ru">учитель тренировать практика тренер</extra>
+    <extra l="ua">учитель тренувати практика тренер</extra>
+    <text l="en">Teachers train your basic stats and help you practise your skills and spells. Come with practice sessions and coin; a good teacher turns raw talent into mastery.</text>
+    <text l="ru">Учителя тренируют твои базовые параметры и помогают практиковать умения и заклинания. Приходи с сессиями практики и деньгами; хороший учитель превращает сырой талант в мастерство.</text>
+    <text l="ua">Учителі тренують твої базові параметри й допомагають практикувати вміння та закляття. Приходь із сесіями практики й грошима; добрий учитель перетворює сирий талант на майстерність.</text>
   </help>
   <id>45</id>
   <nameRus>учитель</nameRus>


### PR DESCRIPTION
Fills the empty `<help>` nodes (extra + text, all three languages) for 34 behaviors that had a help ID but no article body. Edits EXISTING help IDs only -> no new IDs, no collision risk, hot-reloadable (`plug reload most`, no reboot).

- **15 object behaviors**: ashes, atm, bell, bloodthirst, blueprint, bucket, component, cuisinart, fishka, fountain, katana, money, questreward, roulette table, tattoo picture -- each with a `%FMT% *use*` syntax line where active, grounded in the vetted `<description>` identify-hint.
- **9 mob/room behaviors**: babayaga, koschei, master samurai, master vampire, roulette croupier, teacher, deathtrap, lust room, synesthesia -- descriptive bodies from their migration mechanics.
- **10 equipment sets**: amazon, ashigaru, berserker, defender, fathers, gloomstalker, hoplite, myrmidon, pixie, wood nymph -- generic-but-accurate 'collect and wear all N pieces' text using each set's real piece count from props.

All monolingual per language, ASCII punctuation, UA ʼ, no э/ё, no mixed-script, one flowing paragraph after the syntax line (no hard breaks). {hh links reuse IDs already referenced in the deployed identify descriptions.

Remaining (separate): 10 role-mobs with no description (adept/bank/clan guard/cult adept/golem/healer/jailer/money changer/suave moose/templeperson -- need a document-or-internal decision); 24 NOHELP behaviors that need new live-allocated IDs + reboot; the 10 sets' specific per-set bonuses (this PR states the assembly mechanic, not the exact bonus).