### PR TITLE
Add help articles for 10 role-mob behaviors

### DIFF
--- a/behaviors/adept.xml
+++ b/behaviors/adept.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="257" level="110" type="BehaviorHelp">
+    <extra l="en">adept acolyte healer buffs newbie</extra>
+    <extra l="ru">адепт послушник лекарь баффы новичок</extra>
+    <extra l="ua">адепт послушник лікар баффи новачок</extra>
+    <text l="en">An adept looks after the young and after its own: from time to time it cures ailments, heals wounds and lays helpful blessings on newbies and fellow clan members nearby. A clan adept tends only its clan's own territory.</text>
+    <text l="ru">Адепт заботится о юных и о своих: время от времени он снимает недуги, лечит раны и накладывает полезные благословения на новичков и соклановцев поблизости. Клановый адепт хлопочет только на территории своего клана.</text>
+    <text l="ua">Адепт піклується про юних і про своїх: час від часу він знімає недуги, лікує рани й накладає корисні благословення на новачків і соклановців поблизу. Клановий адепт порається лише на території свого клану.</text>
   </help>
   <id>30</id>
   <nameRus>адепт</nameRus>

--- a/behaviors/bank.xml
+++ b/behaviors/bank.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="269" level="102" type="BehaviorHelp">
+    <extra l="en">bank banker deposit withdraw balance account</extra>
+    <extra l="ru">банк банкир вклад снять баланс счет</extra>
+    <extra l="ua">банк банкір вклад зняти баланс рахунок</extra>
+    <text l="en">At a bank you can deposit your coin, withdraw it and check your balance -- the same account you reach from any {hh268atm{x. Money kept in the bank is not lost on death, nor to thieves. Here the *deposit*, *withdraw* and *balance* commands do their work.</text>
+    <text l="ru">В банке можно положить деньги на счет, снять их и проверить баланс -- тот же счет, к которому ты обращаешься из любого {hh268банкомата{x. Деньги в банке не пропадут ни при смерти, ни от воров. Здесь работают команды *deposit*, *withdraw* и *balance*.</text>
+    <text l="ua">У банку можна покласти гроші на рахунок, зняти їх і перевірити баланс -- той самий рахунок, до якого ти звертаєшся з будь-якого {hh268банкомата{x. Гроші в банку не пропадуть ні при смерті, ні від злодіїв. Тут працюють команди *deposit*, *withdraw* і *balance*.</text>
   </help>
   <id>41</id>
   <nameRus>банк</nameRus>

--- a/behaviors/clan guard.xml
+++ b/behaviors/clan guard.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="259" level="-1" type="BehaviorHelp">
+    <extra l="en">clan guard guardian territory intruder</extra>
+    <extra l="ru">клановый охранник страж территория чужак</extra>
+    <extra l="ua">клановий охоронець вартовий територія чужак</extra>
+    <text l="en">A clan guard keeps its clan's territory: clan members and their pets it lets pass, but strangers and stray creatures it drives off or cuts down where they stand. On clan ground only your own clan's guards will suffer you.</text>
+    <text l="ru">Клановый охранник стережет территорию своего клана: соклановцев и их питомцев он пропускает, а чужаков и забредших тварей прогоняет или рубит на месте. На клановой земле терпят тебя лишь охранники твоего клана.</text>
+    <text l="ua">Клановий охоронець стереже територію свого клану: соклановців і їхніх улюбленців він пропускає, а чужаків і приблудних тварин проганяє або рубає на місці. На клановій землі терплять тебе лише охоронці твого клану.</text>
   </help>
   <id>32</id>
   <nameRus>клановый охранник</nameRus>

--- a/behaviors/cult adept.xml
+++ b/behaviors/cult adept.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="261" level="110" type="BehaviorHelp">
+    <extra l="en">cult adept preacher proselyte religion faith</extra>
+    <extra l="ru">адепт культа проповедник религия вера</extra>
+    <extra l="ua">адепт культу проповідник релігія віра</extra>
+    <text l="en">A cult adept preaches its faith to the godless: answer its call and it will bring you into its cult. Not ready? Say no, and read up on religion first. Each cult adept serves a single god.</text>
+    <text l="ru">Адепт культа проповедует свою веру безбожникам: откликнись на зов -- и он введет тебя в свой культ. Не готов? Скажи 'нет' и сперва почитай про религию. Каждый адепт культа служит одному богу.</text>
+    <text l="ua">Адепт культу проповідує свою віру безбожникам: відгукнись на поклик -- і він введе тебе у свій культ. Не готовий? Скажи 'ні' й спершу почитай про релігію. Кожен адепт культу служить одному богові.</text>
   </help>
   <id>34</id>
   <nameRus>адепт культа</nameRus>

--- a/behaviors/golem.xml
+++ b/behaviors/golem.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="253" level="-1" type="BehaviorHelp">
+    <extra l="en">golem construct creation servant recharge</extra>
+    <extra l="ru">голем конструкт создание слуга подзарядка</extra>
+    <extra l="ua">голем конструкт створіння слуга підзарядка</extra>
+    <text l="en">A golem is a construct that obeys its creator and no one else. In time it fades -- some hours before it crumbles it will warn you; to recharge it, give it the very material it was made from. The sturdiest golems will even rescue their master in a fight.</text>
+    <text l="ru">Голем -- конструкт, что подчиняется своему создателю и никому больше. Со временем он угасает: за несколько часов до разрушения он предупредит тебя; чтобы перезарядить его, дай ему тот самый материал, из которого он создан. Самые крепкие големы даже спасают хозяина в бою.</text>
+    <text l="ua">Голем -- конструкт, що підкоряється своєму творцеві й нікому іншому. З часом він згасає: за кілька годин до руйнування він попередить тебе; щоб перезарядити його, дай йому той самий матеріал, з якого його створено. Найміцніші големи навіть рятують господаря в бою.</text>
   </help>
   <id>27</id>
   <nameRus>голем</nameRus>

--- a/behaviors/healer.xml
+++ b/behaviors/healer.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="254" level="-1" type="BehaviorHelp">
+    <extra l="en">healer heal cure wounds poison blindness</extra>
+    <extra l="ru">лекарь лечение исцеление раны яд слепота</extra>
+    <extra l="ua">лікар лікування зцілення рани отрута сліпота цілитель</extra>
+    <text l="en">A healer will mend your wounds and lift your ailments for a fee -- healing, and cures for poison, blindness, curse and worse. Look over what is on offer and pay in coin; it is cheaper than dying and far faster than resting.</text>
+    <text l="ru">Лекарь за плату залечит твои раны и снимет недуги -- лечение, а также исцеление от яда, слепоты, проклятия и худшего. Посмотри, что он предлагает, и плати монетой; это дешевле смерти и куда быстрее отдыха.</text>
+    <text l="ua">Лікар за плату залікує твої рани й зніме недуги -- лікування, а також зцілення від отрути, сліпоти, прокляття й гіршого. Подивись, що він пропонує, і плати монетою; це дешевше за смерть і значно швидше за відпочинок.</text>
   </help>
   <id>28</id>
   <nameRus>лекарь</nameRus>

--- a/behaviors/jailer.xml
+++ b/behaviors/jailer.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="258" level="-1" type="BehaviorHelp">
+    <extra l="en">jailer jail prison guard warden</extra>
+    <extra l="ru">тюремщик тюрьма темница стража надзиратель</extra>
+    <extra l="ua">тюремник вʼязниця темниця варта наглядач</extra>
+    <text l="en">A jailer keeps the law: newcomers and lost souls it packs off to the temple, but a marked criminal it claps in manacles and hauls to a cell. Serve your time or find your own way out -- but expect no mercy at the gate.</text>
+    <text l="ru">Тюремщик блюдет закон: новичков и заблудшие души он отправляет в храм, а помеченного преступника заковывает в кандалы и волочет в камеру. Отсиди свое или ищи выход сам -- но пощады у ворот не жди.</text>
+    <text l="ua">Тюремник пильнує закон: новачків і заблуканих душ він відправляє до храму, а позначеного злочинця заковує в кайдани й тягне до камери. Відсидь своє або шукай вихід сам -- але помилування біля воріт не чекай.</text>
   </help>
   <id>31</id>
   <nameRus>тюремщик</nameRus>

--- a/behaviors/money changer.xml
+++ b/behaviors/money changer.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="260" level="-1" type="BehaviorHelp">
+    <extra l="en">money changer exchange gold silver coin</extra>
+    <extra l="ru">валютчик обмен золото серебро монета</extra>
+    <extra l="ua">валютник обмін золото срібло монета міняйло</extra>
+    <text l="en">A money changer swaps gold for silver and silver for gold: just give it the sum you want changed and it will hand you back the equal worth. Handy when a shop wants small coin and your purse holds nothing but gold.</text>
+    <text l="ru">Валютчик меняет золото на серебро и обратно: просто дай ему сумму для обмена, и он вернет тебе равную стоимость. Удобно, когда лавка просит серебро, а в кошельке одно золото.</text>
+    <text l="ua">Валютник міняє золото на срібло й навпаки: просто дай йому суму для обміну, і він поверне тобі рівну вартість. Зручно, коли крамниця просить срібло, а в гаманці саме золото.</text>
   </help>
   <id>33</id>
   <nameRus>валютчик</nameRus>

--- a/behaviors/suave moose.xml
+++ b/behaviors/suave moose.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="256" level="-1" type="BehaviorHelp">
+    <extra l="en">suave moose polite elk courteous gift</extra>
+    <extra l="ru">вежливый лось учтивый подарок попросить</extra>
+    <extra l="ua">ввічливий лось чемний подарунок попросити</extra>
+    <text l="en">The suave moose is a beast of impeccable manners. Ask it politely -- in plain words -- for what you would like, and it may well oblige you. Rudeness gets you nowhere; a well-turned request earns you a gift.</text>
+    <text l="ru">Вежливый лось -- существо безупречных манер. Попроси его учтиво, словами, о том, что тебе нужно -- и, глядишь, он уважит. Хамством ничего не добьешься; складная просьба приносит подарок.</text>
+    <text l="ua">Ввічливий лось -- створіння бездоганних манер. Попроси його чемно, словами, про те, що тобі потрібно -- і, дивись, він уважить. Хамством нічого не доборешся; доладне прохання приносить подарунок.</text>
   </help>
   <id>29</id>
   <nameRus>ввічливий лось</nameRus>

--- a/behaviors/templeperson.xml
+++ b/behaviors/templeperson.xml
@@ -3,6 +3,12 @@
   <cmd></cmd>
   <description></description>
   <help id="262" level="-1" type="BehaviorHelp">
+    <extra l="en">templeperson temple attendant priest religion faith</extra>
+    <extra l="ru">храмовник храм жрец религия вера</extra>
+    <extra l="ua">храмовник храм жрець релігія віра</extra>
+    <text l="en">A templeperson tends those who hold no faith: it will ask whether you wish to speak of religion, and if you say yes, guide you to choose a god. Answer yes or no as you please -- faith here is never forced upon anyone.</text>
+    <text l="ru">Храмовник печется о тех, у кого нет веры: он спросит, желаешь ли ты поговорить о религии, и, если скажешь 'да', поможет выбрать бога. Отвечай 'да' или 'нет' по своей воле -- веру здесь силой никому не навязывают.</text>
+    <text l="ua">Храмовник дбає про тих, хто не має віри: він спитає, чи бажаєш ти поговорити про релігію, і, якщо скажеш 'так', допоможе обрати бога. Відповідай 'так' чи 'ні' на власний розсуд -- віру тут силою нікому не навʼязують.</text>
   </help>
   <id>35</id>
   <nameRus>храмовник</nameRus>


### PR DESCRIPTION
Fills the empty `BehaviorHelp` bodies for the ten role-mob behaviors that shipped with a help node but no text: adept, bank, clan guard, cult adept, golem, healer, jailer, money changer, suave moose, templeperson.

Each gets EN/RU/UA `<extra>` lookup synonyms and a `<text>` body describing what the mob/room actually does for players. Bodies are grounded in each behavior's Fenia implementation (e.g. money changer's gold/silver swap, golem's creator-binding + material recharge, jailer's temple-send vs. manacle logic, bank's deposit/withdraw/balance). `bank` cross-links the `atm` help (id 268).

Existing help IDs only -- no new IDs, no collision risk. Hot-reloadable via plugin reload.