### PR TITLE
help: craft proficiency caps at level 10 (general craft help + tattooist)

### DIFF
--- a/craft-professions/tattooist.xml
+++ b/craft-professions/tattooist.xml
@@ -11,7 +11,7 @@
     <text l="en">=Tattooist= is one of the {hh195crafts{x or secondary professions available to all players. A tattooist can apply various tattoos to themselves or other players on different body parts: the left or right {hh243wrist{x, {hh246shoulders{x, or {hh244face{x. To apply a tattoo to a given location you must learn the corresponding skills, which become available as you practice.
 
 {CHOW TO BECOME A TATTOOIST{x
-To learn this profession, find a {hh235tattoo master{x and follow his instructions. You will need a =knife= and =ink= to apply tattoos. Any dagger with the =for tattoos= flag can serve as a tattooing knife -- use {hh603identify{x or the site's search tool to find one. Like every {hh195craft{x, a tattooist of level 10 or higher needs a valid {hh361craft license{x, sold at the Midgaard town hall.
+To learn this profession, find a {hh235tattoo master{x and follow his instructions. You will need a =knife= and =ink= to apply tattoos. Any dagger with the =for tattoos= flag can serve as a tattooing knife -- use {hh603identify{x or the site's search tool to find one. Like every {hh195craft{x, a tattooist at level 10 (the maximum) needs a valid {hh361craft license{x, sold at the Midgaard town hall.
 
 {CTYPES OF TATTOOS{x
 There are several tattoo designs you can apply -- one for each of the {hh81Eight Paths{x and their pairs with neighbors -- and each grants unique bonuses: improved stats, accuracy, damage, hit points, mana, improved skills, and so on. Basic supplies and simple designs can be purchased directly from the teacher; more complex ones will have to be farmed from suitable sentient enemies across Thera.
@@ -29,7 +29,7 @@ To {hh245remove a tattoo{x, you need a special ointment, which can be bought fro
     <text l="ru">=Татуировщик= -- одно из доступных всем игрокам {hh195ремесел{x или дополнительных профессий. Татуировщик умеет наносить себе или другим игрокам разные татуировки на различные части тела: левое или правое {hh243запястье{x, {hh246плечи{x или {hh244лицо{x. Для нанесения татуировки на то или иное место нужно разучить соответствующие навыки, которые становятся доступны по мере использования.
 
 {CКАК СТАТЬ ТАТУИРОВЩИКОМ{x
-Для того, чтобы выучиться этой профессии, найди {hh235тату-мастера{x и следуй его инструкциям. Для нанесения татуировок понадобятся =нож= и =чернила=. Ножом для татуировок может служить любой кинжал с флагом =для татуировок= -- используй {hh603опознание{x или поисковик на сайте, чтобы найти. Как и для любого {hh195ремесла{x, татуировщику 10го уровня и выше нужна действующая {hh361ремесленная лицензия{x, которую продают в ратуше Мидгаарда.
+Для того, чтобы выучиться этой профессии, найди {hh235тату-мастера{x и следуй его инструкциям. Для нанесения татуировок понадобятся =нож= и =чернила=. Ножом для татуировок может служить любой кинжал с флагом =для татуировок= -- используй {hh603опознание{x или поисковик на сайте, чтобы найти. Как и для любого {hh195ремесла{x, татуировщику 10го (максимального) уровня нужна действующая {hh361ремесленная лицензия{x, которую продают в ратуше Мидгаарда.
 
 {CКАКИЕ БЫВАЮТ ТАТУИРОВКИ{x
 Есть несколько рисунков татуировок, которые можно наносить -- по одному на каждый из {hh81Восьми Путей{x и их пары с соседями -- и каждый из них дает какие-то уникальные бонусы: улучшенные параметры, точность, урон, здоровье, мана, улучшенные умения и так далее. Базовые расходные материалы и простые рисунки можно приобрести прямо у учителя, более сложные придется выбивать из подходящих разумных противников на просторах Тэры.
@@ -47,7 +47,7 @@ To {hh245remove a tattoo{x, you need a special ointment, which can be bought fro
     <text l="ua">=Татуювальник= -- одне з {hh195ремесел{x або додаткових професій, доступних усім гравцям. Татуювальник вміє наносити собі або іншим гравцям різні татуювання на різні частини тіла: ліве або праве {hh243запʼястя{x, {hh246плечі{x або {hh244обличчя{x. Для нанесення татуювання на те чи інше місце потрібно вивчити відповідні навички, які стають доступні в міру використання.
 
 {CЯК СТАТИ ТАТУЮВАЛЬНИКОМ{x
-Щоб навчитися цієї професії, знайди {hh235тату-майстра{x і слідуй його інструкціям. Для нанесення татуювань знадобляться =ніж= і =чорнило=. Ножем для татуювань може служити будь-який кинджал з прапором =для татуювань= -- використовуй {hh603опізнання{x або пошуковик на сайті, щоб знайти. Як і для будь-якого {hh195ремесла{x, татуювальнику 10го рівня і вище потрібна чинна {hh361реміснича ліцензія{x, яку продають у ратуші Мідгаарда.
+Щоб навчитися цієї професії, знайди {hh235тату-майстра{x і слідуй його інструкціям. Для нанесення татуювань знадобляться =ніж= і =чорнило=. Ножем для татуювань може служити будь-який кинджал з прапором =для татуювань= -- використовуй {hh603опізнання{x або пошуковик на сайті, щоб знайти. Як і для будь-якого {hh195ремесла{x, татуювальнику 10го (максимального) рівня потрібна чинна {hh361реміснича ліцензія{x, яку продають у ратуші Мідгаарда.
 
 {CЯКІ БУВАЮТЬ ТАТУЮВАННЯ{x
 Є кілька малюнків татуювань, які можна наносити -- по одному на кожен з {hh81Восьми Шляхів{x та їхніх пар із сусідами -- і кожен з них дає якісь унікальні бонуси: покращені параметри, точність, шкода, здоровʼя, мана, покращені вміння тощо. Базові витратні матеріали та прості малюнки можна придбати прямо у вчителя, складніші доведеться здобувати з відповідних розумних противників на просторах Тери.

--- a/helps/help.xml
+++ b/helps/help.xml
@@ -6210,7 +6210,7 @@ The required tool is also described in the recipe. Most carpenter blueprints nee
 In addition, every craft profession requires a =license=, which can be purchased at the Midgaard town hall once you have the profession. The license lasts a month of real time, and its cost depends on your level.
 
 {CPROFESSION LEVELS{x
-Craft professions have their own levels and their own experience scale. The recipes you can use and the quality of products depend on the profession level. If you keep crafting the same thing, or work on recipes too easy for you, you will earn less experience.
+Craft professions have their own levels and their own experience scale. The maximum proficiency level in any craft is 10. The recipes you can use and the quality of products depend on the profession level. If you keep crafting the same thing, or work on recipes too easy for you, you will earn less experience.
 </text>
     <text l="ru">Впридачу к основному {hh28классу{x, в нашем мире можно обзавестись дополнительной профессией или =ремеслом=. На текущий момент есть такие ремесла:
 %A% {hh242Тату-мастера{x: наносят улучшающие параметры татуировки вдобавок к экипировке
@@ -6235,7 +6235,7 @@ Craft professions have their own levels and their own experience scale. The reci
 Кроме того, для всех ремесленных профессий понадобится =лицензия=, которую можно приобрести в ратуше Мидгаарда при наличии самой профессии. Лицензия выдается на месяц реального времени, а ее стоимость зависит от твоего уровня.
 
 {CУРОВНИ ПРОФЕССИИ{x
-У крафтовых профессий есть свои уровни и своя шкала опыта до уровня. От уровня профессии зависит сложность рецептов, которые можно использовать, и качество продуктов. Если все время мастерить одно и то же или делать слишком легкие рецепты, опыта получишь меньше.
+У крафтовых профессий есть свои уровни и своя шкала опыта до уровня. Максимальный уровень мастерства в любом ремесле -- 10. От уровня профессии зависит сложность рецептов, которые можно использовать, и качество продуктов. Если все время мастерить одно и то же или делать слишком легкие рецепты, опыта получишь меньше.
 </text>
     <text l="ua">На додаток до основного {hh28класу{x, у нашому світі можна обзавестися додатковою професією чи =ремеслом=. Наразі доступні такі ремесла:
 %A% {hh242Тату-майстри{x: наносять татуювання, що поліпшують параметри понад екіпірування
@@ -6260,7 +6260,7 @@ Craft professions have their own levels and their own experience scale. The reci
 Крім того, для всіх ремісничих професій знадобиться =ліцензія=, яку можна придбати в ратуші Мідгаарда за наявності самої професії. Ліцензія видається на місяць реального часу, а її вартість залежить від твого рівня.
 
 {CРІВНІ ПРОФЕСІЇ{x
-Крафтові професії мають свої рівні та свою шкалу досвіду до рівня. Від рівня професії залежить складність рецептів, які можна використовувати, і якість продуктів. Якщо весь час робити одне й те ж або працювати над занадто легкими рецептами, досвіду отримаєш менше.
+Крафтові професії мають свої рівні та свою шкалу досвіду до рівня. Максимальний рівень майстерності в будь-якому ремеслі -- 10. Від рівня професії залежить складність рецептів, які можна використовувати, і якість продуктів. Якщо весь час робити одне й те ж або працювати над занадто легкими рецептами, досвіду отримаєш менше.
 </text>
     <title l="en">Crafting, making items</title>
     <title l="ru">Крафт, создание предметов</title>


### PR DESCRIPTION
Bug (Elis): a tattooist stuck at level 10 saw no indication it's the cap. General craft help id 195 now states the max proficiency level in any craft is 10 (EN/RU/UA); the tattooist help's 'level 10 or higher' becomes 'level 10 (the maximum)'. Pairs with the score fix in dreamland_code #611. Loads on next reboot.