### PR TITLE
Add EN and UA short/colour forms for all 50 liquids

### DIFF
--- a/liquids/absinthe.xml
+++ b/liquids/absinthe.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>зелен|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">green</color>
+  <color l="ru">зелен|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">зелен|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>4</thirst>
     <drunk>200</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>{gабсент|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{gabsinthe{x</shortDescr>
+  <shortDescr l="ru">{gабсент|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{gабсент||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/ale.xml
+++ b/liquids/ale.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">brown</color>
+  <color l="ru">коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">коричнев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{yэл|ь{x|я{x|ю{x|ь{x|ем{x|е{x</shortDescr>
+  <shortDescr l="en">{yale{x</shortDescr>
+  <shortDescr l="ru">{yэл|ь{x|я{x|ю{x|ь{x|ем{x|е{x</shortDescr>
+  <shortDescr l="ua">{yел|ь|ю|ю|ь|ем|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/amontillado.xml
+++ b/liquids/amontillado.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>золотист|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">golden</color>
+  <color l="ru">золотист|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">золотист|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>{yа{Yм{yо{Yнт{yи{Yл{yья{Yд{yо{x</shortDescr>
+  <shortDescr l="en">{yamontillado{x</shortDescr>
+  <shortDescr l="ru">{yа{Yм{yо{Yнт{yи{Yл{yья{Yд{yо{x</shortDescr>
+  <shortDescr l="ua">{yамонтильядо</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/aquavit.xml
+++ b/liquids/aquavit.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>140</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>аквавит||а|у||ом|е</shortDescr>
+  <shortDescr l="en">aquavit</shortDescr>
+  <shortDescr l="ru">аквавит||а|у||ом|е</shortDescr>
+  <shortDescr l="ua">аквавіт||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/beer.xml
+++ b/liquids/beer.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">amber</color>
+  <color l="ru">янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">бурштинов|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{ybeer{x</shortDescr>
+  <shortDescr l="ru">{yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yпив|о|а|у|о|ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/benedictine wine.xml
+++ b/liquids/benedictine wine.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>темно-красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">dark red</color>
+  <color l="ru">темно-красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">темно-червон|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>{rбенедиктинск|ое{x|ого{x|ому{x|ое{x|им{x|ом{x вин|о|а|у|о|ом|е</shortDescr>
+  <shortDescr l="en">{rbenedictine wine{x</shortDescr>
+  <shortDescr l="ru">{rбенедиктинск|ое{x|ого{x|ому{x|ое{x|им{x|ом{x вин|о|а|у|о|ом|е</shortDescr>
+  <shortDescr l="ua">{rбенедиктинськ|е|ого|ому|е|им|ому вин|о|а|у|о|ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/blood.xml
+++ b/liquids/blood.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">red</color>
+  <color l="ru">красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">червон|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>-1</thirst>
     <bloodlust>2</bloodlust>
     <hunger>-1</hunger>
   </desires>
-  <shortDescr>{Rкров|ь{x|и{x|и{x|ь{x|ью{x|и{x</shortDescr>
+  <shortDescr l="en">{Rblood{x</shortDescr>
+  <shortDescr l="ru">{Rкров|ь{x|и{x|и{x|ь{x|ью{x|и{x</shortDescr>
+  <shortDescr l="ua">{Rкров||і|і||ʼю|і</shortDescr>
   <sipSize>6</sipSize>
 </Liquid>

--- a/liquids/brandy.xml
+++ b/liquids/brandy.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="en">gold</color>
+  <color l="ru">золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="ua">золот|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>80</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>{Yбренди{x</shortDescr>
+  <shortDescr l="en">{Ybrandy{x</shortDescr>
+  <shortDescr l="ru">{Yбренди{x</shortDescr>
+  <shortDescr l="ua">{Yбренді</shortDescr>
   <sipSize>4</sipSize>
 </Liquid>

--- a/liquids/champagne.xml
+++ b/liquids/champagne.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="en">gold</color>
+  <color l="ru">золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="ua">золот|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>{Yшам{yпан{Yск|ое{x|ого{x|ому{x|ое{x|им{x|ом{x</shortDescr>
+  <shortDescr l="en">{Ychampagne{x</shortDescr>
+  <shortDescr l="ru">{Yшам{yпан{Yск|ое{x|ого{x|ому{x|ое{x|им{x|ом{x</shortDescr>
+  <shortDescr l="ua">{Yшампанськ|е|ого|ому|е|им|ому</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/chocolate.xml
+++ b/liquids/chocolate.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">brown</color>
+  <color l="ru">коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">коричнев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>7</thirst>
     <hunger>3</hunger>
   </desires>
-  <shortDescr>{yгоряч|ий|его|ему|ий|им|ем {yш{Dоколад|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{yhot chocolate{x</shortDescr>
+  <shortDescr l="ru">{yгоряч|ий|его|ему|ий|им|ем {yш{Dоколад|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yгаряч|ий|ого|ому|ий|им|ому шоколад||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/coffee.xml
+++ b/liquids/coffee.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>черн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">black</color>
+  <color l="ru">черн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">чорн|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
   </desires>
-  <shortDescr>{Dкофе{x</shortDescr>
+  <shortDescr l="en">{Dcoffee{x</shortDescr>
+  <shortDescr l="ru">{Dкофе{x</shortDescr>
+  <shortDescr l="ua">{Dкав|а|и|і|у|ою|і</shortDescr>
   <sipSize>6</sipSize>
 </Liquid>

--- a/liquids/coke.xml
+++ b/liquids/coke.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">brown</color>
+  <color l="ru">коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">коричнев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>9</thirst>
     <hunger>2</hunger>
   </desires>
-  <shortDescr>{Yко{yл|а{x|ы{x|е{x|у{x|ой{x|е{x</shortDescr>
+  <shortDescr l="en">{Ycoke{x</shortDescr>
+  <shortDescr l="ru">{Yко{yл|а{x|ы{x|е{x|у{x|ой{x|е{x</shortDescr>
+  <shortDescr l="ua">{Yкол|а|и|і|у|ою|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/cold chocolate.xml
+++ b/liquids/cold chocolate.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">brown</color>
+  <color l="ru">коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">коричнев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>3</full>
     <thirst>4</thirst>
     <hunger>4</hunger>
   </desires>
-  <shortDescr>{yш{Dоколад|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{ycold chocolate{x</shortDescr>
+  <shortDescr l="ru">{yш{Dоколад|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yшоколад||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/condensed milk.xml
+++ b/liquids/condensed milk.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>желтоват|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">yellowish</color>
+  <color l="ru">желтоват|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">жовтуват|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>3</full>
     <hunger>10</hunger>
   </desires>
-  <shortDescr>{yсгущенн|ое|ого|ому|ое|ым|ом {Wмолок|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Wcondensed milk{x</shortDescr>
+  <shortDescr l="ru">{yсгущенн|ое|ого|ому|ое|ым|ом {Wмолок|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yзгущен|е|ого|ому|е|им|ому {Wмоло|ко|ка|ку|ко|ком|ці</shortDescr>
   <sipSize>10</sipSize>
 </Liquid>

--- a/liquids/cordial.xml
+++ b/liquids/cordial.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>100</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>бальзам||а|у||ом|е</shortDescr>
+  <shortDescr l="en">cordial</shortDescr>
+  <shortDescr l="ru">бальзам||а|у||ом|е</shortDescr>
+  <shortDescr l="ua">бальзам||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/cranberry juice.xml
+++ b/liquids/cranberry juice.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">red</color>
+  <color l="ru">красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">червон|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>9</thirst>
     <hunger>2</hunger>
   </desires>
-  <shortDescr>{Rклюквенн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x сок||а|у||ом|е</shortDescr>
+  <shortDescr l="en">{Rcranberry juice{x</shortDescr>
+  <shortDescr l="ru">{Rклюквенн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x сок||а|у||ом|е</shortDescr>
+  <shortDescr l="ua">{Rжуравлинов|ий|ого|ому|ий|им|ому с|ік|оку|оку|ік|оком|оці</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/dark ale.xml
+++ b/liquids/dark ale.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>темн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">dark</color>
+  <color l="ru">темн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">темн|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{Dтемн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x эл|ь|я|ю|ь|ем|е</shortDescr>
+  <shortDescr l="en">{Ddark ale{x</shortDescr>
+  <shortDescr l="ru">{Dтемн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x эл|ь|я|ю|ь|ем|е</shortDescr>
+  <shortDescr l="ua">{Dтемн|ий|ого|ому|ий|им|ому ел|ь|ю|ю|ь|ем|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/dark beer.xml
+++ b/liquids/dark beer.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>темно-янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">dark amber</color>
+  <color l="ru">темно-янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">темно-бурштинов|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{Dтемн|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Ddark beer{x</shortDescr>
+  <shortDescr l="ru">{Dтемн|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Dтемн|е|ого|ому|е|им|ому пив|о|а|у|о|ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/elvish wine.xml
+++ b/liquids/elvish wine.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>зелен|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">green</color>
+  <color l="ru">зелен|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">зелен|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>{Gэльфийск|ое|ого|ому|ое|им|ом {gвин|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Gelvish wine{x</shortDescr>
+  <shortDescr l="ru">{Gэльфийск|ое|ого|ому|ое|им|ом {gвин|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Gельфійськ|е|ого|ому|е|им|ому вин|о|а|у|о|ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/firebreather.xml
+++ b/liquids/firebreather.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>оранжев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">orange</color>
+  <color l="ru">оранжев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">помаранчев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <thirst>4</thirst>
     <drunk>190</drunk>
   </desires>
-  <shortDescr>{Rперцовк|а{x|и{x|е{x|у{x|ой{x|е{x</shortDescr>
+  <shortDescr l="en">{Rfirebreather{x</shortDescr>
+  <shortDescr l="ru">{Rперцовк|а{x|и{x|е{x|у{x|ой{x|е{x</shortDescr>
+  <shortDescr l="ua">{Rперців|ка|ки|ці|ку|кою|ці</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/framboise.xml
+++ b/liquids/framboise.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">red</color>
+  <color l="ru">красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">червон|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>7</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{Rфрамбуаз||а|у||ом|е{x</shortDescr>
+  <shortDescr l="en">{Rframboise{x</shortDescr>
+  <shortDescr l="ru">{Rфрамбуаз||а|у||ом|е{x</shortDescr>
+  <shortDescr l="ua">{Rфрамбуаз||у|у||ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/grape juice.xml
+++ b/liquids/grape juice.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>лилов|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">purple</color>
+  <color l="ru">лилов|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">бузков|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>9</thirst>
     <hunger>3</hunger>
   </desires>
-  <shortDescr>{Mвиноградн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x {Bсок|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Mgrape juice{x</shortDescr>
+  <shortDescr l="ru">{Mвиноградн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x {Bсок|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Mвиноградн|ий|ого|ому|ий|им|ому с|ік|оку|оку|ік|оком|оці</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/icewine.xml
+++ b/liquids/icewine.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>пурпурн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">crimson</color>
+  <color l="ru">пурпурн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">пурпуров|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>6</thirst>
     <drunk>50</drunk>
     <hunger>1</hunger>
   </desires>
-  <shortDescr>{yайсвайн|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{yicewine{x</shortDescr>
+  <shortDescr l="ru">{yайсвайн|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yайсвайн||у|у||ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/ink.xml
+++ b/liquids/ink.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>черн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">black</color>
+  <color l="ru">черн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">чорн|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>0</full>
     <thirst>-2</thirst>
   </desires>
-  <shortDescr>{Dчернил|а{x|{x|ам{x|а{x|ами{x|ах{x</shortDescr>
+  <shortDescr l="en">{Dink{x</shortDescr>
+  <shortDescr l="ru">{Dчернил|а{x|{x|ам{x|а{x|ами{x|ах{x</shortDescr>
+  <shortDescr l="ua">{Dчорнил|о|а|у|о|ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/kefir.xml
+++ b/liquids/kefir.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>бел|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">white</color>
+  <color l="ru">бел|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">біл|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>9</thirst>
     <drunk>10</drunk>
     <hunger>3</hunger>
   </desires>
-  <shortDescr>{Wке{wф{Wир|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Wkefir{x</shortDescr>
+  <shortDescr l="ru">{Wке{wф{Wир|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Wкефір||у|у||ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/lemonade.xml
+++ b/liquids/lemonade.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>розов|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">pink</color>
+  <color l="ru">розов|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">рожев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>9</thirst>
     <hunger>2</hunger>
   </desires>
-  <shortDescr>{Mлимонад|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Mlemonade{x</shortDescr>
+  <shortDescr l="ru">{Mлимонад|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Mлимонад||у|у||ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/light beer.xml
+++ b/liquids/light beer.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>светло-янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">light amber</color>
+  <color l="ru">светло-янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">світло-бурштинов|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{Yс{yве{Yт{yл|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Ylight beer{x</shortDescr>
+  <shortDescr l="ru">{Yс{yве{Yт{yл|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Yсвітл|е|ого|ому|е|им|ому пив|о|а|у|о|ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/local specialty.xml
+++ b/liquids/local specialty.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>3</thirst>
     <drunk>151</drunk>
   </desires>
-  <shortDescr>самогон||а|у||ом|е</shortDescr>
+  <shortDescr l="en">moonshine</shortDescr>
+  <shortDescr l="ru">самогон||а|у||ом|е</shortDescr>
+  <shortDescr l="ua">самогон||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/mead.xml
+++ b/liquids/mead.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>медов|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">honey</color>
+  <color l="ru">медов|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">медов|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>8</thirst>
     <drunk>34</drunk>
     <hunger>2</hunger>
   </desires>
-  <shortDescr>{yмед|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{ymead{x</shortDescr>
+  <shortDescr l="ru">{yмед|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yмед||у|у||ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/milk.xml
+++ b/liquids/milk.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>бел|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">white</color>
+  <color l="ru">бел|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">біл|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>9</thirst>
     <hunger>3</hunger>
   </desires>
-  <shortDescr>{Wмолок|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Wmilk{x</shortDescr>
+  <shortDescr l="ru">{Wмолок|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Wмоло|ко|ка|ку|ко|ком|ці</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/non milk.xml
+++ b/liquids/non milk.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>желтоват|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">yellowish</color>
+  <color l="ru">желтоват|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">жовтуват|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>3</full>
     <hunger>10</hunger>
   </desires>
-  <shortDescr>{yне {Wмолок|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{ynon-milk{x</shortDescr>
+  <shortDescr l="ru">{yне {Wмолок|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yне {Wмоло|ко|ка|ку|ко|ком|ці</shortDescr>
   <sipSize>10</sipSize>
 </Liquid>

--- a/liquids/orange juice.xml
+++ b/liquids/orange juice.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>оранжев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">orange</color>
+  <color l="ru">оранжев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">помаранчев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>9</thirst>
     <hunger>3</hunger>
   </desires>
-  <shortDescr>{Yапе{Rльси{Yнов|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x сок||а|у||ом|е</shortDescr>
+  <shortDescr l="en">{Yorange juice{x</shortDescr>
+  <shortDescr l="ru">{Yапе{Rльси{Yнов|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x сок||а|у||ом|е</shortDescr>
+  <shortDescr l="ua">{Yапельсинов|ий|ого|ому|ий|им|ому с|ік|оку|оку|ік|оком|оці</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/red beer.xml
+++ b/liquids/red beer.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>красноват|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">reddish</color>
+  <color l="ru">красноват|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">червонуват|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>{rкрасн|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{rred beer{x</shortDescr>
+  <shortDescr l="ru">{rкрасн|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{rчервон|е|ого|ому|е|им|ому пив|о|а|у|о|ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/red wine.xml
+++ b/liquids/red wine.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>темно-красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">dark red</color>
+  <color l="ru">темно-красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">темно-червон|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>{rкрасн|ое{x|ого{x|ому{x|ое{x|ым{x|ом{x вин|о|а|у|о|ом|е</shortDescr>
+  <shortDescr l="en">{rred wine{x</shortDescr>
+  <shortDescr l="ru">{rкрасн|ое{x|ого{x|ому{x|ое{x|ым{x|ом{x вин|о|а|у|о|ом|е</shortDescr>
+  <shortDescr l="ua">{rчервон|е|ого|ому|е|им|ому вин|о|а|у|о|ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/root beer.xml
+++ b/liquids/root beer.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">brown</color>
+  <color l="ru">коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">коричнев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>9</thirst>
     <hunger>2</hunger>
   </desires>
-  <shortDescr>{Yнастойк|а|и|е|у|ой|е {yна корнях{x</shortDescr>
+  <shortDescr l="en">{Yroot beer{x</shortDescr>
+  <shortDescr l="ru">{Yнастойк|а|и|е|у|ой|е {yна корнях{x</shortDescr>
+  <shortDescr l="ua">{Yнастоян|ка|ки|ці|ку|кою|ці на корінні</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/rose wine.xml
+++ b/liquids/rose wine.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>розов|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">pink</color>
+  <color l="ru">розов|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">рожев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>{Mрозов|ое{x|ого{x|ому{x|ое{x|ым{x|ом{x вин|о|а|у|о|ом|е</shortDescr>
+  <shortDescr l="en">{Mrose wine{x</shortDescr>
+  <shortDescr l="ru">{Mрозов|ое{x|ого{x|ому{x|ое{x|ым{x|ом{x вин|о|а|у|о|ом|е</shortDescr>
+  <shortDescr l="ua">{Mрожев|е|ого|ому|е|им|ому вин|о|а|у|о|ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/rum.xml
+++ b/liquids/rum.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">amber</color>
+  <color l="ru">янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">бурштинов|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>4</thirst>
     <drunk>151</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>{yром|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{yrum{x</shortDescr>
+  <shortDescr l="ru">{yром|{x|а{x|у{x|{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{yром||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/sake.xml
+++ b/liquids/sake.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>саке</shortDescr>
+  <shortDescr l="en">sake</shortDescr>
+  <shortDescr l="ru">саке</shortDescr>
+  <shortDescr l="ua">саке</shortDescr>
   <sipSize>3</sipSize>
 </Liquid>

--- a/liquids/salt water.xml
+++ b/liquids/salt water.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>-2</thirst>
   </desires>
-  <shortDescr>солен|ая|ой|ой|ую|ой|ой вод|а|ы|е|у|ой|е</shortDescr>
+  <shortDescr l="en">salt water</shortDescr>
+  <shortDescr l="ru">солен|ая|ой|ой|ую|ой|ой вод|а|ы|е|у|ой|е</shortDescr>
+  <shortDescr l="ua">солон|а|ої|ій|у|ою|ій вод|а|и|і|у|ою|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/schnapps.xml
+++ b/liquids/schnapps.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>90</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>шнапс||а|у||ом|е</shortDescr>
+  <shortDescr l="en">schnapps</shortDescr>
+  <shortDescr l="ru">шнапс||а|у||ом|е</shortDescr>
+  <shortDescr l="ua">шнапс||у|у||ом|і</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/semidark beer.xml
+++ b/liquids/semidark beer.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">amber</color>
+  <color l="ru">янтарн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">бурштинов|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>beer</flags>
-  <shortDescr>полу-{Dтемн|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Dsemi-dark beer{x</shortDescr>
+  <shortDescr l="ru">полу-{Dтемн|ое|ого|ому|ое|ым|ом {yпив|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Dнапівтемн|е|ого|ому|е|им|ому пив|о|а|у|о|ом|і</shortDescr>
   <sipSize>12</sipSize>
 </Liquid>

--- a/liquids/sherry.xml
+++ b/liquids/sherry.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">red</color>
+  <color l="ru">красн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">червон|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>7</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>{Rшерри{x</shortDescr>
+  <shortDescr l="en">{Rsherry{x</shortDescr>
+  <shortDescr l="ru">{Rшерри{x</shortDescr>
+  <shortDescr l="ua">{Rхерес||у|у||ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/slime mold juice.xml
+++ b/liquids/slime mold juice.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>зелен|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">green</color>
+  <color l="ru">зелен|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">зелен|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>2</full>
     <thirst>-8</thirst>
     <hunger>1</hunger>
   </desires>
-  <shortDescr>{Gсок||а|у||ом|е из слизняков{x</shortDescr>
+  <shortDescr l="en">{Gslime mold juice{x</shortDescr>
+  <shortDescr l="ru">{Gсок||а|у||ом|е из слизняков{x</shortDescr>
+  <shortDescr l="ua">{Gс|ік|оку|оку|ік|оком|оці зі слизняків</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/swill.xml
+++ b/liquids/swill.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>мутн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">murky</color>
+  <color l="ru">мутн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">каламутн|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>-2</full>
     <thirst>-2</thirst>
   </desires>
-  <shortDescr>{yпомо|и{x|ев{x|ям{x|и{x|ями{x|ях{x</shortDescr>
+  <shortDescr l="en">{yswill{x</shortDescr>
+  <shortDescr l="ru">{yпомо|и{x|ев{x|ям{x|и{x|ями{x|ях{x</shortDescr>
+  <shortDescr l="ua">{yпоми|ї|їв|ям|ї|ями|ях</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>

--- a/liquids/tea.xml
+++ b/liquids/tea.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">brown</color>
+  <color l="ru">коричнев|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">коричнев|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
   </desires>
-  <shortDescr>{Yч{yа|й{x|я{x|ю{x|й{x|ем{x|е{x</shortDescr>
+  <shortDescr l="en">{Ytea{x</shortDescr>
+  <shortDescr l="ru">{Yч{yа|й{x|я{x|ю{x|й{x|ем{x|е{x</shortDescr>
+  <shortDescr l="ua">{Yча|й|ю|ю|й|єм|ї</shortDescr>
   <sipSize>6</sipSize>
 </Liquid>

--- a/liquids/valerian tincture.xml
+++ b/liquids/valerian tincture.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>желтоват|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">yellowish</color>
+  <color l="ru">желтоват|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">жовтуват|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>130</drunk>
   </desires>
-  <shortDescr>{gва{yле{gрь{yян{gк|а{x|и{x|е{x|у{x|ой{x|е{x</shortDescr>
+  <shortDescr l="en">{gvalerian tincture{x</shortDescr>
+  <shortDescr l="ru">{gва{yле{gрь{yян{gк|а{x|и{x|е{x|у{x|ой{x|е{x</shortDescr>
+  <shortDescr l="ua">{gвалеріан|ка|ки|ці|ку|кою|ці</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/vodka.xml
+++ b/liquids/vodka.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>130</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>водк|а|и|е|у|ой|е</shortDescr>
+  <shortDescr l="en">vodka</shortDescr>
+  <shortDescr l="ru">водк|а|и|е|у|ой|е</shortDescr>
+  <shortDescr l="ua">горіл|ка|ки|ці|ку|кою|ці</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/water.xml
+++ b/liquids/water.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="en">clear</color>
+  <color l="ru">прозрачн|ый|ого|ому|ый|ым|ом</color>
+  <color l="ua">прозор|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>10</thirst>
   </desires>
-  <shortDescr>вод|а|ы|е|у|ой|е</shortDescr>
+  <shortDescr l="en">water</shortDescr>
+  <shortDescr l="ru">вод|а|ы|е|у|ой|е</shortDescr>
+  <shortDescr l="ua">вод|а|и|і|у|ою|і</shortDescr>
   <sipSize>16</sipSize>
 </Liquid>

--- a/liquids/whisky.xml
+++ b/liquids/whisky.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="en">gold</color>
+  <color l="ru">золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="ua">золот|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>5</thirst>
     <drunk>120</drunk>
   </desires>
   <flags>liquor</flags>
-  <shortDescr>{Yв{yи{Yски{x</shortDescr>
+  <shortDescr l="en">{Ywhisky{x</shortDescr>
+  <shortDescr l="ru">{Yв{yи{Yски{x</shortDescr>
+  <shortDescr l="ua">{Yвіскі</shortDescr>
   <sipSize>2</sipSize>
 </Liquid>

--- a/liquids/white wine.xml
+++ b/liquids/white wine.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Liquid type="DefaultLiquid">
-  <color>золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="en">gold</color>
+  <color l="ru">золот|ой|ого|ому|ой|ым|ом</color>
+  <color l="ua">золот|ий|ого|ому|ий|им|ому</color>
   <desires>
     <full>1</full>
     <thirst>8</thirst>
@@ -8,6 +10,8 @@
     <hunger>1</hunger>
   </desires>
   <flags>wine</flags>
-  <shortDescr>{Yбел|ое|ого|ому|ое|ым|ом {yвин|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="en">{Ywhite wine{x</shortDescr>
+  <shortDescr l="ru">{Yбел|ое|ого|ому|ое|ым|ом {yвин|о{x|а{x|у{x|о{x|ом{x|е{x</shortDescr>
+  <shortDescr l="ua">{Yбіл|е|ого|ому|е|им|ому вин|о|а|у|о|ом|і</shortDescr>
   <sipSize>5</sipSize>
 </Liquid>


### PR DESCRIPTION
Splits each liquid's bare `<color>`/`<shortDescr>` into explicit `l="en"/l="ru"/l="ua"` siblings so the per-language liquid getters (#614) have EN/UA content to render. EN = single invariant form; UA = declined pads (nom|gen|dat|acc|inst|prep) with colour codes preserved. RU preserved verbatim (no change for default viewers).

Pairs with dreamland_code #616 (per-language liquid message frames). Loads on next boot.