### PR TITLE
behaviors: fix wrong bottle/fire identify descriptions

### DIFF
--- a/behaviors/bottle.xml
+++ b/behaviors/bottle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
-  <description>{hh1023Используй{x {hh95бутылку{x, чтобы отпить из нее.</description>
+  <description>В бою {hh95бутылку{x можно разбить об голову врага, а в мирное время -- раскрутить на полу и сыграть в бутылочку.</description>
   <help id="95" level="-1" type="BehaviorHelp">
     <keyword l="en">bottle</keyword>
     <keyword l="ru">бутылочка</keyword>

--- a/behaviors/fire.xml
+++ b/behaviors/fire.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
-  <description>{hh1023Используй{x {hh249пламя{x, чтобы поджечь горючую вещь.</description>
+  <description>{hh1023Используй{x {hh249костер{x, чтобы погреть руки; у огня быстрее восстанавливаются силы и заживают раны.</description>
   <help id="249" level="-1" type="BehaviorHelp">
     <extra l="en">ignite kindle light burn</extra>
     <extra l="ru">поджечь разжечь развести сжечь зажечь</extra>


### PR DESCRIPTION
In-game report: bottle's identify description said 'drink from it', but the bottle behavior actually smashes over a foe's head in combat or plays spin-the-bottle in peacetime. Audited all 40 obj-behavior descriptions against their actual onUse code — only bottle and fire were wrong (fire said 'ignite a flammable thing' but its onUse just warms your hands by the campfire; ignition is torch/matches). Rewrote both to match the code. Deploys with the next reboot (behavior XML loads at boot).