### PR TITLE
flagmessages: externalize container/drink/portal/recipe item-type flag tables

### DIFF
--- a/config/flagmessages.json
+++ b/config/flagmessages.json
@@ -537,5 +537,40 @@
         "spell":     { "ua": "чаклунськ|а|ої|ій|у|ою|ій", "en": "spellcasting" },
         "fading":    { "ua": "примарн|а|ої|ій|у|ою|ій" },
         "tattoo":    { "ua": "для татуювань", "en": "for tattoos" }
+    },
+    "container_flags": {
+        "closeable":     { "ua": "закривається" },
+        "pickproof":     { "ua": "неможливо зламати" },
+        "closed":        { "ua": "закрито" },
+        "locked":        { "ua": "замкнено" },
+        "put_on":        { "ua": "підставка", "en": "stand" },
+        "for_arrow":     { "ua": "для стріл", "en": "quiver" },
+        "put_on2":       { "ua": "підставка", "en": "stand" },
+        "pit":           { "ua": "яма", "en": "pit" },
+        "with_pockets":  { "ua": "з кишенями", "en": "with pockets" },
+        "nested":        { "ua": "вкладено", "en": "nested" }
+    },
+    "drink_flags": {
+        "poisoned":      { "ua": "отруєно", "en": "poisoned" },
+        "closed":        { "ua": "закрито", "en": "closed" },
+        "locked":        { "ua": "замкнено", "en": "locked" },
+        "close_cork":    { "ua": "закорковується", "en": "corked shut" },
+        "close_nail":    { "ua": "забивається цвяхами", "en": "nailed shut" },
+        "close_key":     { "ua": "замикається", "en": "key-locked" }
+    },
+    "portal_flags": {
+        "nocheck_exit":  { "ua": "без перевірок", "en": "no exit checks" },
+        "curse_allowed": { "ua": "можна проклятим", "en": "cursed may use" },
+        "gowith":        { "ua": "теж телепортується", "en": "teleports along" },
+        "buggy":         { "ua": "глючить", "en": "buggy" },
+        "random":        { "ua": "випадковий", "en": "random" },
+        "from_no_recall": { "ua": "можна з no_recall", "en": "usable from no-recall" }
+    },
+    "recipe_flags": {
+        "tattoo":        { "ua": "ескіз татуювання", "en": "tattoo design" },
+        "carpenter":     { "ua": "креслення тесляра", "en": "carpenter's blueprint" },
+        "smith":         { "ua": "креслення коваля", "en": "smith's blueprint" },
+        "jeweler":       { "ua": "креслення ювеліра", "en": "jeweler's blueprint" },
+        "mechanic":      { "ua": "креслення механіка", "en": "mechanic's blueprint" }
     }
 }


### PR DESCRIPTION
Adds UA pads (+ EN overrides for the snake_case bit names) for the four identify item-type flag tables (container_flags, drink_flags, portal_flags, recipe_flags), so identify/lore render their flag VALUES per viewer language. RU stays auto from the in-binary messages; 31 tables total. Reboot-free: goes live via drone sync + `plug reload most`. exit_flags deferred (empty in-binary RU + niche).