### PR TITLE
flagmessages: externalize exit_flags (ru/ua/en)

### DIFF
--- a/config/flagmessages.json
+++ b/config/flagmessages.json
@@ -572,5 +572,28 @@
         "smith":         { "ua": "креслення коваля", "en": "smith's blueprint" },
         "jeweler":       { "ua": "креслення ювеліра", "en": "jeweler's blueprint" },
         "mechanic":      { "ua": "креслення механіка", "en": "mechanic's blueprint" }
+    },
+    "exit_flags": {
+        "isdoor":        { "ru": "дверь", "ua": "двері", "en": "door" },
+        "closed":        { "ru": "закрыто", "ua": "зачинено", "en": "closed" },
+        "locked":        { "ru": "заперто", "ua": "замкнено", "en": "locked" },
+        "noflee":        { "ru": "нельзя сбежать", "ua": "не втекти", "en": "no flee" },
+        "noscan":        { "ru": "не просматривается", "ua": "не проглянути", "en": "no scan" },
+        "pickproof":     { "ru": "нельзя взломать", "ua": "неможливо зламати", "en": "pickproof" },
+        "nopass":        { "ru": "непроходимо", "ua": "непрохідно", "en": "no pass" },
+        "easy":          { "ru": "легко взломать", "ua": "легко зламати", "en": "easy to pick" },
+        "hard":          { "ru": "трудно взломать", "ua": "важко зламати", "en": "hard to pick" },
+        "infuriating":   { "ru": "почти невозможно взломать", "ua": "майже неможливо зламати", "en": "near-impossible to pick" },
+        "noclose":       { "ru": "нельзя закрыть", "ua": "не зачинити", "en": "cannot close" },
+        "nolock":        { "ru": "нельзя запереть", "ua": "не замкнути", "en": "cannot lock" },
+        "invisible":     { "ru": "невидимо", "ua": "невидиме", "en": "invisible" },
+        "hidden":        { "ru": "скрыто", "ua": "приховано", "en": "hidden" },
+        "improved":      { "ru": "укреплено", "ua": "укріплено", "en": "reinforced" },
+        "camouflage":    { "ru": "замаскировано", "ua": "замасковано", "en": "camouflaged" },
+        "fade":          { "ru": "тускнеет", "ua": "тьмяніє", "en": "fading" },
+        "nofly":         { "ru": "нельзя влететь", "ua": "не влетіти", "en": "no fly" },
+        "nowalk":        { "ru": "нельзя пройти пешком", "ua": "не пройти пішки", "en": "no walk" },
+        "swim_only":     { "ru": "только вплавь", "ua": "лише вплав", "en": "swim only" },
+        "bash_only":     { "ru": "только выломать", "ua": "лише виламати", "en": "bash only" }
     }
 }


### PR DESCRIPTION
exit_flags has empty in-binary messages, so identify's portal exit-properties line showed the raw snake_case bit names to everyone. Authors ru + ua + en for all 21 flags (door/pick/pass mechanics). Reboot-free (drone + plug reload most).