### PR TITLE
clans: Ukrainian nameUa pads for the 10 named clans

### DIFF
--- a/clans/battlerager.xml
+++ b/clans/battlerager.xml
@@ -34,6 +34,7 @@
   <monumentName>титульный лист властелин колец title page lord rings</monumentName>
   <orgs/>
   <nameRus>{RКлан||а|у||ом|е Ярости{x</nameRus>
+  <nameUa>{RКлан||у|у||ом|і Ярості{x</nameUa>
   <padName>{RКлан Ярости{x</padName>
   <recallVnum>548</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/chaos.xml
+++ b/clans/chaos.xml
@@ -33,6 +33,7 @@
   <monumentName>флюгер wind vane</monumentName>
   <orgs/>
   <nameRus>{MКруг||а|у||ом|е Хаоса{x</nameRus>  
+  <nameUa>{MКол|о|а|у|о|ом|і Хаосу{x</nameUa>
   <padName>{M       Хаос{x</padName>
   <recallVnum>553</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/flowers.xml
+++ b/clans/flowers.xml
@@ -19,6 +19,7 @@
   <monument></monument>
   <orgs/>
   <nameRus>{GКоммун|а|ы|е|у|ой|е Детей Цветов{x</nameRus>   
+  <nameUa>{GКомун|а|и|і|у|ою|і Дітей Квітів{x</nameUa>
   <padName>{GДети Цветов{x</padName>
   <recallVnum>4389</recallVnum>
   <recruiter>1</recruiter>

--- a/clans/ghost.xml
+++ b/clans/ghost.xml
@@ -22,6 +22,7 @@
   <monumentName>силуэт табличка silhouette sign plaque tablet</monumentName>
   <orgs/>
   <nameRus>{cКлан||а|у||ом|е Призраков{x</nameRus>   
+  <nameUa>{cКлан||у|у||ом|і Привидів{x</nameUa>
   <padName>{c   Призраки{x</padName>
   <recallVnum>708</recallVnum>
   <recruiter>1</recruiter>

--- a/clans/hunter.xml
+++ b/clans/hunter.xml
@@ -31,6 +31,7 @@
   <monumentName>разлагающиеся останки rotten remains</monumentName>
   <orgs/>
   <nameRus>{YАртел|ь|и|и|ь|ью|и Охотников{x</nameRus>    
+  <nameUa>{YАрті|ль|лі|лі|ль|ллю|лі Мисливців{x</nameUa>
   <padName>{Y   Охотники{x</padName>
   <recallVnum>573</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/invader.xml
+++ b/clans/invader.xml
@@ -43,6 +43,7 @@
     <name mg="f">групп|а|ы|е|у|ой|е</name>
   </orgs>
   <nameRus>{DКабал||а|у||ом|е Захватчиков{x</nameRus>    
+  <nameUa>{DКабал||у|у||ом|і Загарбників{x</nameUa>
   <padName>{D Захватчики{x</padName>
   <recallVnum>733</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/knight.xml
+++ b/clans/knight.xml
@@ -175,6 +175,7 @@
     <name>орден||а|у||ом|е</name>
   </orgs>
   <nameRus>{WОрден||а|у||ом|е Рыцарей{x</nameRus>    
+  <nameUa>{WОрден||у|у||ом|і Лицарів{x</nameUa>
   <padName>{W     Рыцари{x</padName>
   <recallVnum>524</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/lion.xml
+++ b/clans/lion.xml
@@ -44,6 +44,7 @@
   <monumentName>жутко воняющий толстый дуб smelly thick oak</monumentName>
   <orgs/>
   <nameRus>{gПрайд||а|у||ом|е Львов{x</nameRus>   
+  <nameUa>{gПрайд||у|у||ом|і Левів{x</nameUa>
   <padName>{g       Львы{x</padName>
   <recallVnum>504</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/ruler.xml
+++ b/clans/ruler.xml
@@ -32,6 +32,7 @@
   <monumentName>куча вонючего мусора останки дубинка pile stinky trash remains club</monumentName>
   <orgs/>
   <nameRus>{wОрден||а|у||ом|е Правителей{x</nameRus>   
+  <nameUa>{wОрден||у|у||ом|і Правителів{x</nameUa>
   <padName>{w  Правители{x</padName>
   <recallVnum>512</recallVnum>
   <recruiter>7</recruiter>

--- a/clans/shalafi.xml
+++ b/clans/shalafi.xml
@@ -43,6 +43,7 @@
   <monumentName>пугало огородное магический колпак scarecrow magic cap</monumentName>
   <orgs/>
   <nameRus>{BОрден||а|у||ом|е Шалафи{x</nameRus>   
+  <nameUa>{BОрден||у|у||ом|і Шалафі{x</nameUa>
   <padName>{B     Шалафи{x</padName>
   <orgs type="ClanOrgs">
     <node name="occultism" type="ShalafiFaculty">


### PR DESCRIPTION
Adds `<nameUa>` (color + 6-case Flexer pad) to the 10 named clan profiles, parallel to `<nameRus>`. Consumed by `ClanWrapper.nameUa` (dreamland_code #623); UA viewers see the clan name in Ukrainian in whois/score once the Fenia render lands. RU/EN output unchanged (empty-UA falls back to nameRus). `none` has no name and is skipped.