### PR TITLE
wearlocations: trilingual purpose + display label (en/ru/ua)

### DIFF
--- a/craft-wearlocs/tat_arms.xml
+++ b/craft-wearlocs/tat_arms.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="CraftTattooWearloc">
   <displayAlways>false</displayAlways>
-  <msgDisplay>татуировка на плечах</msgDisplay>
+  <msgDisplay l="en">tattoo on the arms</msgDisplay>
+  <msgDisplay l="ru">татуировка на плечах</msgDisplay>
+  <msgDisplay l="ua">татуювання на плечах</msgDisplay>
   <msgSelfNoRib>Ты не можешь носить татуировку на плечах.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>9</orderDisplay>
   <orderWear>14</orderWear>
-  <purpose>Таттуируется на плечах</purpose>
+  <purpose l="en">Tattooed on the arms</purpose>
+  <purpose l="ru">Таттуируется на плечах</purpose>
+  <purpose l="ua">Татуюється на плечах</purpose>
   <ribName>плечи</ribName>
 </Wearlocation>

--- a/craft-wearlocs/tat_face.xml
+++ b/craft-wearlocs/tat_face.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="CraftTattooWearloc">
   <displayAlways>false</displayAlways>
-  <msgDisplay>татуировка на лице</msgDisplay>
+  <msgDisplay l="en">tattoo on the face</msgDisplay>
+  <msgDisplay l="ru">татуировка на лице</msgDisplay>
+  <msgDisplay l="ua">татуювання на обличчі</msgDisplay>
   <msgSelfNoRib>Ты не можешь носить татуировку на лице.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>3</orderDisplay>
   <orderWear>9</orderWear>
-  <purpose>Таттуируется на лице</purpose>
+  <purpose l="en">Tattooed on the face</purpose>
+  <purpose l="ru">Таттуируется на лице</purpose>
+  <purpose l="ua">Татуюється на обличчі</purpose>
   <ribName>лицо</ribName>
 </Wearlocation>

--- a/craft-wearlocs/tat_wrist_l.xml
+++ b/craft-wearlocs/tat_wrist_l.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="CraftTattooWearloc">
   <displayAlways>false</displayAlways>
-  <msgDisplay>татуировка на запястье</msgDisplay>
+  <msgDisplay l="en">tattoo on the wrist</msgDisplay>
+  <msgDisplay l="ru">татуировка на запястье</msgDisplay>
+  <msgDisplay l="ua">татуювання на запʼястку</msgDisplay>
   <msgSelfNoRib>Ты не можешь носить татуировку на левом запястье.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>11</orderDisplay>
   <orderWear>17</orderWear>
-  <purpose>Таттуируется на запястье</purpose>
+  <purpose l="en">Tattooed on the wrist</purpose>
+  <purpose l="ru">Таттуируется на запястье</purpose>
+  <purpose l="ua">Татуюється на запʼястку</purpose>
   <ribName>левое запястье</ribName>
 </Wearlocation>

--- a/craft-wearlocs/tat_wrist_r.xml
+++ b/craft-wearlocs/tat_wrist_r.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="CraftTattooWearloc">
   <displayAlways>false</displayAlways>
-  <msgDisplay>татуировка на запястье</msgDisplay>
+  <msgDisplay l="en">tattoo on the wrist</msgDisplay>
+  <msgDisplay l="ru">татуировка на запястье</msgDisplay>
+  <msgDisplay l="ua">татуювання на запʼястку</msgDisplay>
   <msgSelfNoRib>Ты не можешь носить татуировку на правом запястье.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>12</orderDisplay>
   <orderWear>18</orderWear>
-  <purpose>Таттуируется на запястье</purpose>
+  <purpose l="en">Tattooed on the wrist</purpose>
+  <purpose l="ru">Таттуируется на запястье</purpose>
+  <purpose l="ua">Татуюється на запʼястку</purpose>
   <ribName>правое запястье</ribName>
 </Wearlocation>

--- a/wearlocations/about.xml
+++ b/wearlocations/about.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_about</itemWear>
-  <msgDisplay>накинуто вокруг тела</msgDisplay>
+  <msgDisplay l="en">draped around the body</msgDisplay>
+  <msgDisplay l="ru">накинуто вокруг тела</msgDisplay>
+  <msgDisplay l="ua">накинуто на тіло</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются накинуть %2$O4 вокруг тела, но ничего не получается.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 накидыва%1$nет|ют %2$O4 вокруг тела.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь ничего накинуть вокруг себя.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>6</orderDisplay>
   <orderWear>15</orderWear>
-  <purpose>Накидывается вокруг тела</purpose>
+  <purpose l="en">Draped around the body</purpose>
+  <purpose l="ru">Накидывается вокруг тела</purpose>
+  <purpose l="ua">Накидається на тіло</purpose>
   <ribName>накидк|а|и|е|у|ой|е</ribName>
 </Wearlocation>

--- a/wearlocations/arms.xml
+++ b/wearlocations/arms.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_arms</itemWear>
-  <msgDisplay>надето на плечи</msgDisplay>
+  <msgDisplay l="en">worn on the arms</msgDisplay>
+  <msgDisplay l="ru">надето на плечи</msgDisplay>
+  <msgDisplay l="ua">вдягнено на плечі</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются надеть %2$O4 на плечи, которых нет.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надева%1$nет|ют %2$O4 на плечи.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь ничего надеть на плечи.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>9</orderDisplay>
   <orderWear>14</orderWear>
-  <purpose>Надевается на плечи</purpose>
+  <purpose l="en">Worn on the arms</purpose>
+  <purpose l="ru">Надевается на плечи</purpose>
+  <purpose l="ua">Вдягається на плечі</purpose>
   <ribName>плеч|и|ей|ам|и|ами|ах</ribName>
 </Wearlocation>

--- a/wearlocations/body.xml
+++ b/wearlocations/body.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_body</itemWear>
-  <msgDisplay>надето на тело</msgDisplay>
+  <msgDisplay l="en">worn on the body</msgDisplay>
+  <msgDisplay l="ru">надето на тело</msgDisplay>
+  <msgDisplay l="ua">вдягнено на тіло</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются надеть %2$O4 на тело, но ничего не получается.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надева%1$nет|ют %2$O4 на тело.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь ничего надеть на тело.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>7</orderDisplay>
   <orderWear>5</orderWear>
-  <purpose>Надевается на тело</purpose>
+  <purpose l="en">Worn on the body</purpose>
+  <purpose l="ru">Надевается на тело</purpose>
+  <purpose l="ua">Вдягається на тіло</purpose>
   <ribName>торс||а|у||ом|е</ribName>  
 </Wearlocation>

--- a/wearlocations/ears.xml
+++ b/wearlocations/ears.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_ears</itemWear>
-  <msgDisplay>вдето в уши</msgDisplay>
+  <msgDisplay l="en">worn in the ears</msgDisplay>
+  <msgDisplay l="ru">вдето в уши</msgDisplay>
+  <msgDisplay l="ua">вдіто у вуха</msgDisplay>
   <msgRoomNoRib>%1$^C1 тыч%1$nет|ут в уши %2$O4, но в мочке не хватает дырки для сережек.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 вдева%1$nет|ют в уши %2$O4.</msgRoomWear>
   <msgSelfNoRib>У тебя не проколоты уши -- обратись к квестору.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>2</orderDisplay>
   <orderWear>8</orderWear>
-  <purpose>Вдевается в уши</purpose>
+  <purpose l="en">Worn in the ears</purpose>
+  <purpose l="ru">Вдевается в уши</purpose>
+  <purpose l="ua">Вдягається у вуха</purpose>
   <ribName>уш|и|ей|ам|и|ами|ах</ribName>
 </Wearlocation>

--- a/wearlocations/face.xml
+++ b/wearlocations/face.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_face</itemWear>
-  <msgDisplay>прикрывает лицо</msgDisplay>
+  <msgDisplay l="en">covers the face</msgDisplay>
+  <msgDisplay l="ru">прикрывает лицо</msgDisplay>
+  <msgDisplay l="ua">прикриває обличчя</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются прикрыть %2$O5 несуществующее лицо.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 прикрывает лицо %2$O5.</msgRoomWear>
   <msgSelfNoRib>У тебя нет лица, какой ужас!</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>3</orderDisplay>
   <orderWear>9</orderWear>
-  <purpose>Надевается на лицо</purpose>
+  <purpose l="en">Worn on the face</purpose>
+  <purpose l="ru">Надевается на лицо</purpose>
+  <purpose l="ua">Вдягається на обличчя</purpose>
   <ribName>лиц|о|а|у|о|ом|е</ribName>
 </Wearlocation>

--- a/wearlocations/feet.xml
+++ b/wearlocations/feet.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_feet</itemWear>
-  <msgDisplay>обуто на ноги</msgDisplay>
+  <msgDisplay l="en">worn on the feet</msgDisplay>
+  <msgDisplay l="ru">обуто на ноги</msgDisplay>
+  <msgDisplay l="ua">взуто на ноги</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается обуть %2$O4 на несуществующие ступни.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 обувает %2$O4.</msgRoomWear>
   <msgSelfNoRib>У тебя нет ступней, на которые можно было бы это обуть.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>22</orderDisplay>
   <orderWear>11</orderWear>
-  <purpose>Обувается на ноги</purpose>
+  <purpose l="en">Worn on the feet</purpose>
+  <purpose l="ru">Обувается на ноги</purpose>
+  <purpose l="ua">Взувається на ноги</purpose>
   <ribName>ступн|и|ей|ям|и|ями|ях</ribName>
 </Wearlocation>

--- a/wearlocations/finger_l.xml
+++ b/wearlocations/finger_l.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_finger</itemWear>
-  <msgDisplay>надето на палец</msgDisplay>
+  <msgDisplay l="en">worn on a finger</msgDisplay>
+  <msgDisplay l="ru">надето на палец</msgDisplay>
+  <msgDisplay l="ua">вдягнено на палець</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующий палец.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на один из пальцев.</msgRoomWear>
   <msgSelfNoRib>У тебя нет пальцев на этой конечности.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <orderDisplay>13</orderDisplay>
   <orderWear>1</orderWear>
   <pair>finger_r</pair>
-  <purpose>Надевается на палец</purpose>
+  <purpose l="en">Worn on a finger</purpose>
+  <purpose l="ru">Надевается на палец</purpose>
+  <purpose l="ua">Вдягається на палець</purpose>
   <ribName>пал|ец|ьца|ьцу|ец|ьцем|ьце левой конечности</ribName>
 </Wearlocation>

--- a/wearlocations/finger_r.xml
+++ b/wearlocations/finger_r.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_finger</itemWear>
-  <msgDisplay>надето на палец</msgDisplay>
+  <msgDisplay l="en">worn on a finger</msgDisplay>
+  <msgDisplay l="ru">надето на палец</msgDisplay>
+  <msgDisplay l="ua">вдягнено на палець</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующий палец.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на один из пальцев.</msgRoomWear>
   <msgSelfNoRib>У тебя нет пальцев на этой конечности.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <orderDisplay>14</orderDisplay>
   <orderWear>2</orderWear>
   <pair>finger_l</pair>
-  <purpose>Надевается на палец</purpose>
+  <purpose l="en">Worn on a finger</purpose>
+  <purpose l="ru">Надевается на палец</purpose>
+  <purpose l="ua">Вдягається на палець</purpose>
   <ribName>пал|ец|ьца|ьцу|ец|ьцем|ьце правой конечности</ribName>
 </Wearlocation>

--- a/wearlocations/float.xml
+++ b/wearlocations/float.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_float</itemWear>
-  <msgDisplay>кружится поблизости</msgDisplay>
+  <msgDisplay l="en">floating nearby</msgDisplay>
+  <msgDisplay l="ru">кружится поблизости</msgDisplay>
+  <msgDisplay l="ua">кружляє поблизу</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается выпустить %2$O4 в полет вокруг себя, но промахивается.</msgRoomNoRib>
   <msgRoomRemove>%1$^C1 останавливает %2$O4, круживш%2$Gееся|ийся|уюся|ихся вокруг %1$P4.</msgRoomRemove>
   <msgRoomWear>%1$^C1 запускает %2$O4 кружиться вокруг %1$P4.</msgRoomWear>
@@ -14,6 +16,8 @@
   <needRib>true</needRib>
   <orderDisplay>25</orderDisplay>
   <orderWear>22</orderWear>
-  <purpose>Кружится поблизости</purpose>
+  <purpose l="en">Floating nearby</purpose>
+  <purpose l="ru">Кружится поблизости</purpose>
+  <purpose l="ua">Кружляє поблизу</purpose>
   <ribName>орбит|а|ы|е|у|ой|е для кружащейся вещи</ribName>  
 </Wearlocation>

--- a/wearlocations/hair.xml
+++ b/wearlocations/hair.xml
@@ -2,7 +2,9 @@
 <Wearlocation type="HairWearloc">
   <destroyChance>10</destroyChance>
   <displayAlways>false</displayAlways>
-  <msgDisplay>запуталось в волосах</msgDisplay>
+  <msgDisplay l="en">tangled in the hair</msgDisplay>
+  <msgDisplay l="ru">запуталось в волосах</msgDisplay>
+  <msgDisplay l="ua">заплуталось у волоссі</msgDisplay>
   <msgRoomRemove>%1$^C1 выпутывает из своих волос %2$O4.</msgRoomRemove>
   <msgRoomWear>%1$^C1 вплетает %2$O4 в волосы.</msgRoomWear>
   <msgSelfRemove>Ты выпутываешь из своих волос %2$O4.</msgSelfRemove>
@@ -10,6 +12,8 @@
   <needRib>false</needRib>
   <orderDisplay>2</orderDisplay>
   <orderWear>7</orderWear>
-  <purpose>Вплетается в волосы</purpose>
+  <purpose l="en">Woven into the hair</purpose>
+  <purpose l="ru">Вплетается в волосы</purpose>
+  <purpose l="ua">Вплітається у волосся</purpose>
   <ribName>волос|ы||ам|ы|ами|ах</ribName>  
 </Wearlocation>

--- a/wearlocations/hands.xml
+++ b/wearlocations/hands.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_hands</itemWear>
-  <msgDisplay>надето на ладони</msgDisplay>
+  <msgDisplay l="en">worn on the hands</msgDisplay>
+  <msgDisplay l="ru">надето на ладони</msgDisplay>
+  <msgDisplay l="ua">вдягнено на долоні</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на ладони, которых нет.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на ладони рук.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь надеть %2$O4 на ладони, у тебя их нет.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>10</orderDisplay>
   <orderWear>13</orderWear>
-  <purpose>Надевается на ладони рук</purpose>
+  <purpose l="en">Worn on the hands</purpose>
+  <purpose l="ru">Надевается на ладони рук</purpose>
+  <purpose l="ua">Вдягається на долоні</purpose>
   <ribName>кист|и|ей|ям|и|ями|ях</ribName>
 </Wearlocation>

--- a/wearlocations/head.xml
+++ b/wearlocations/head.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_head</itemWear>
-  <msgDisplay>надето на голову</msgDisplay>
+  <msgDisplay l="en">worn on the head</msgDisplay>
+  <msgDisplay l="ru">надето на голову</msgDisplay>
+  <msgDisplay l="ua">вдягнено на голову</msgDisplay>
   <msgRoomNoRib>%1$^C1 не может найти свою голову.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на голову.</msgRoomWear>
   <msgSelfNoRib>Твоя голова куда-то потерялась.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>1</orderDisplay>
   <orderWear>7</orderWear>
-  <purpose>Надевается на голову</purpose>
+  <purpose l="en">Worn on the head</purpose>
+  <purpose l="ru">Надевается на голову</purpose>
+  <purpose l="ua">Вдягається на голову</purpose>
   <ribName>голов|а|ы|е|у|ой|е</ribName>
 </Wearlocation>

--- a/wearlocations/hold.xml
+++ b/wearlocations/hold.xml
@@ -5,7 +5,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>hold</itemWear>
-  <msgDisplay>зажато в руках</msgDisplay>
+  <msgDisplay l="en">held in the hands</msgDisplay>
+  <msgDisplay l="ru">зажато в руках</msgDisplay>
+  <msgDisplay l="ua">затиснуто в руках</msgDisplay>
   <msgRoomWear>%1$^C1 берет в руки %2$O4.</msgRoomWear>
   <msgSelfConflict>Твои руки заняты оружием.</msgSelfConflict>
   <msgSelfNoRib>Ты не можешь ничего взять в руки.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <needRib>true</needRib>
   <orderDisplay>18</orderDisplay>
   <orderWear>21</orderWear>
-  <purpose>Берется в руки</purpose>
+  <purpose l="en">Held in the hands</purpose>
+  <purpose l="ru">Берется в руки</purpose>
+  <purpose l="ua">Береться в руки</purpose>
   <ribName>вещ|ь|и|и|ь|ью|и в левой руке</ribName>
 </Wearlocation>

--- a/wearlocations/hold_leg.xml
+++ b/wearlocations/hold_leg.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="DefaultWearlocation">
   <displayAlways>false</displayAlways>
-  <msgDisplay>зажимает ногу</msgDisplay>
+  <msgDisplay l="en">grips the leg</msgDisplay>
+  <msgDisplay l="ru">зажимает ногу</msgDisplay>
+  <msgDisplay l="ua">затискає ногу</msgDisplay>
   <msgRoomRemove>Изнемогая от невыносимой боли, %1$C1 высвобождает ногу из %2$O2.</msgRoomRemove>
   <msgSelfRemove>Изнемогая от невыносимой боли, ты высвобождаешь ногу из %2$O2.</msgSelfRemove>
   <needRib>false</needRib>

--- a/wearlocations/hooves.xml
+++ b/wearlocations/hooves.xml
@@ -4,7 +4,9 @@
   <destroyChance>50</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_hooves</itemWear>
-  <msgDisplay>на копытах</msgDisplay>
+  <msgDisplay l="en">on the hooves</msgDisplay>
+  <msgDisplay l="ru">на копытах</msgDisplay>
+  <msgDisplay l="ua">на копитах</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4, но для этого нужны копыта.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 подковывает себя %2$O5.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь носить %2$O4, у тебя нет копыт.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>23</orderDisplay>
   <orderWear>12</orderWear>
-  <purpose>Надевается на копыта</purpose>
+  <purpose l="en">Worn on the hooves</purpose>
+  <purpose l="ru">Надевается на копыта</purpose>
+  <purpose l="ua">Вдягається на копита</purpose>
   <ribName>копыт|а||ам|а|ами|ах</ribName>
 </Wearlocation>

--- a/wearlocations/horse.xml
+++ b/wearlocations/horse.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_horse</itemWear>
-  <msgDisplay>на лошадином крупе</msgDisplay>
+  <msgDisplay l="en">on the horse's croup</msgDisplay>
+  <msgDisplay l="ru">на лошадином крупе</msgDisplay>
+  <msgDisplay l="ua">на кінському крупі</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается найти в себе лошадь и надеть на нее %2$O4.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 накидывает %2$O4 поверх своего лошадиного крупа.</msgRoomWear>
   <msgSelfNoRib>У тебя нет лошадиного крупа.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>20</orderDisplay>
   <orderWear>6</orderWear>
-  <purpose>Надевается на круп</purpose>
+  <purpose l="en">Worn on the croup</purpose>
+  <purpose l="ru">Надевается на круп</purpose>
+  <purpose l="ua">Вдягається на круп</purpose>
   <ribName>круп||а|у||ом|е</ribName>  
 </Wearlocation>

--- a/wearlocations/legs.xml
+++ b/wearlocations/legs.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_legs</itemWear>
-  <msgDisplay>надето на ноги</msgDisplay>
+  <msgDisplay l="en">worn on the legs</msgDisplay>
+  <msgDisplay l="ru">надето на ноги</msgDisplay>
+  <msgDisplay l="ua">вдягнено на ноги</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующие ноги.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на ноги.</msgRoomWear>
   <msgSelfNoRib>У тебя нету ног.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>21</orderDisplay>
   <orderWear>10</orderWear>
-  <purpose>Надевается на ноги</purpose>
+  <purpose l="en">Worn on the legs</purpose>
+  <purpose l="ru">Надевается на ноги</purpose>
+  <purpose l="ua">Вдягається на ноги</purpose>
   <ribName>ног|и||ам|и|ами|ах</ribName>
 </Wearlocation>

--- a/wearlocations/light.xml
+++ b/wearlocations/light.xml
@@ -3,13 +3,17 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemType>light</itemType>
-  <msgDisplay>освещает путь</msgDisplay>
+  <msgDisplay l="en">lights the way</msgDisplay>
+  <msgDisplay l="ru">освещает путь</msgDisplay>
+  <msgDisplay l="ua">освітлює шлях</msgDisplay>
   <msgRoomRemove>%1$^C1 гасит свет, исходящий от %2$O2.</msgRoomRemove>
   <msgRoomWear>%1$^C1 зажигает %2$O4, освещая свой путь.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь ничего использовать в качестве освещения.</msgSelfNoRib>
   <msgSelfRemove>Ты гасишь свет, исходящий от %2$O2.</msgSelfRemove>
   <msgSelfWear>Ты зажигаешь %2$O4, освещая свой путь.</msgSelfWear>
   <needRib>true</needRib>
-  <purpose>Используется для освещения</purpose>
+  <purpose l="en">Used as a light source</purpose>
+  <purpose l="ru">Используется для освещения</purpose>
+  <purpose l="ua">Використовується для освітлення</purpose>
   <ribName>светильник||а|у||ом|е</ribName>  
 </Wearlocation>

--- a/wearlocations/neck_1.xml
+++ b/wearlocations/neck_1.xml
@@ -4,7 +4,9 @@
   <destroyChance>80</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_neck</itemWear>
-  <msgDisplay>надето на шею</msgDisplay>
+  <msgDisplay l="en">worn around the neck</msgDisplay>
+  <msgDisplay l="ru">надето на шею</msgDisplay>
+  <msgDisplay l="ua">вдягнено на шию</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующую шею.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг шеи.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующую шею.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <orderDisplay>4</orderDisplay>
   <orderWear>3</orderWear>
   <pair>neck_2</pair>
-  <purpose>Надевается на шею</purpose>
+  <purpose l="en">Worn around the neck</purpose>
+  <purpose l="ru">Надевается на шею</purpose>
+  <purpose l="ua">Вдягається на шию</purpose>
   <ribName>перв|ый|ого|ому|ый|ым|ом амулет||а|у||ом|е</ribName>   
 </Wearlocation>

--- a/wearlocations/neck_2.xml
+++ b/wearlocations/neck_2.xml
@@ -4,7 +4,9 @@
   <destroyChance>80</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_neck</itemWear>
-  <msgDisplay>надето на шею</msgDisplay>
+  <msgDisplay l="en">worn around the neck</msgDisplay>
+  <msgDisplay l="ru">надето на шею</msgDisplay>
+  <msgDisplay l="ua">вдягнено на шию</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующую шею.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг шеи.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующую шею.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <orderDisplay>5</orderDisplay>
   <orderWear>4</orderWear>
   <pair>neck_1</pair>
-  <purpose>Надевается на шею</purpose>
+  <purpose l="en">Worn around the neck</purpose>
+  <purpose l="ru">Надевается на шею</purpose>
+  <purpose l="ua">Вдягається на шию</purpose>
   <ribName>втор|ой|ого|ому|ой|ым|ом амулет||а|у||ом|е</ribName>    
 </Wearlocation>

--- a/wearlocations/second_wield.xml
+++ b/wearlocations/second_wield.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="SecondWieldWearloc">
   <displayAlways>false</displayAlways>
-  <msgDisplay>вторичное вооружение</msgDisplay>
+  <msgDisplay l="en">secondary weapon</msgDisplay>
+  <msgDisplay l="ru">вторичное вооружение</msgDisplay>
+  <msgDisplay l="ua">вторинне озброєння</msgDisplay>
   <msgRoomWear>%1$^C1 вооружается %2$O5 как вторичным оружием.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь носить второе оружие.</msgSelfNoRib>
   <msgSelfWear>Ты вооружаешься %2$O5 как вторичным оружием.</msgSelfWear>

--- a/wearlocations/sheath.xml
+++ b/wearlocations/sheath.xml
@@ -2,7 +2,9 @@
 <Wearlocation type="SheathWearloc">
   <config>
     <node name="scabbard">
-      <msgDisplay>в ножнах</msgDisplay>
+      <msgDisplay l="en">sheathed</msgDisplay>
+      <msgDisplay l="ru">в ножнах</msgDisplay>
+      <msgDisplay l="ua">у піхвах</msgDisplay>
       <msgRoomWear>%1$^C1 вкладыва%1$nет|ют %2$O4 в ножны.</msgRoomWear>
       <msgSelfWear>Ты вкладываешь %2$O4 в ножны.</msgSelfWear>
       <msgRoomRemove>%1$^C1 выхватыва%1$nет|ют %2$O4 из ножен!</msgRoomRemove>

--- a/wearlocations/shield.xml
+++ b/wearlocations/shield.xml
@@ -5,7 +5,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_shield</itemWear>
-  <msgDisplay>используется как щит</msgDisplay>
+  <msgDisplay l="en">used as a shield</msgDisplay>
+  <msgDisplay l="ru">используется как щит</msgDisplay>
+  <msgDisplay l="ua">використовується як щит</msgDisplay>
   <msgRoomWear>%1$^C1 надевает %2$O4 как щит.</msgRoomWear>
   <msgSelfConflict>Ты не можешь использовать щит, вооружившись вторичным оружием.</msgSelfConflict>
   <msgSelfNoRib>Ты не можешь носить щит.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <needRib>true</needRib>
   <orderDisplay>15</orderDisplay>
   <orderWear>19</orderWear>
-  <purpose>Используется как щит</purpose>
+  <purpose l="en">Used as a shield</purpose>
+  <purpose l="ru">Используется как щит</purpose>
+  <purpose l="ua">Використовується як щит</purpose>
   <ribName>щит||а|у||ом|е в левой руке</ribName>
 </Wearlocation>

--- a/wearlocations/stuck_in.xml
+++ b/wearlocations/stuck_in.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wearlocation type="StuckInWearloc">
   <displayAlways>false</displayAlways>
-  <msgDisplay>воткнуто</msgDisplay>
+  <msgDisplay l="en">stuck in</msgDisplay>
+  <msgDisplay l="ru">воткнуто</msgDisplay>
+  <msgDisplay l="ua">встромлено</msgDisplay>
   <msgRoomRemove>Изнемогая от невыносимой боли, %1$C1 извлекает %2$O4.</msgRoomRemove>
   <msgSelfRemove>Изнемогая от невыносимой боли, ты извлекаешь %2$O4.</msgSelfRemove>
   <needRib>false</needRib>

--- a/wearlocations/tail.xml
+++ b/wearlocations/tail.xml
@@ -2,7 +2,9 @@
 <Wearlocation type="TailWearloc">
   <destroyChance>10</destroyChance>
   <displayAlways>false</displayAlways>
-  <msgDisplay>надето на хвост</msgDisplay>
+  <msgDisplay l="en">worn on the tail</msgDisplay>
+  <msgDisplay l="ru">надето на хвост</msgDisplay>
+  <msgDisplay l="ua">вдягнено на хвіст</msgDisplay>
   <msgRoomRemove>%1$^C1 снимает с хвоста %2$O4.</msgRoomRemove>
   <msgRoomWear>%1$^C1 надевает %2$O4 себе на хвост.</msgRoomWear>
   <msgSelfRemove>Ты снимаешь с хвоста %2$O4.</msgSelfRemove>
@@ -11,6 +13,8 @@
   <needRib>true</needRib>
   <orderDisplay>22</orderDisplay>
   <orderWear>7</orderWear>
-  <purpose>Надевается на хвост</purpose>
+  <purpose l="en">Worn on the tail</purpose>
+  <purpose l="ru">Надевается на хвост</purpose>
+  <purpose l="ua">Вдягається на хвіст</purpose>
   <ribName>хвост||а|у||ом|е</ribName>    
 </Wearlocation>

--- a/wearlocations/tattoo.xml
+++ b/wearlocations/tattoo.xml
@@ -2,13 +2,17 @@
 <Wearlocation type="TattooWearloc">
   <displayAlways>true</displayAlways>
   <itemWear>wear_tattoo</itemWear>
-  <msgDisplay>на челе</msgDisplay>
+  <msgDisplay l="en">on the forehead</msgDisplay>
+  <msgDisplay l="ru">на челе</msgDisplay>
+  <msgDisplay l="ua">на чолі</msgDisplay>
   <msgRoomWear>%1$^C1 теперь использует %2$O4 как знак %1$Gего|его|её религии.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь носить знак религии.</msgSelfNoRib>
   <msgSelfWear>Ты теперь используешь %2$O4 как знак своей религии.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>1</orderDisplay>
   <orderWear>23</orderWear>
-  <purpose>Наносится на лоб</purpose>
+  <purpose l="en">Applied to the forehead</purpose>
+  <purpose l="ru">Наносится на лоб</purpose>
+  <purpose l="ua">Наноситься на чоло</purpose>
   <ribName>чел|о|а|у|о|ом|е</ribName>  
 </Wearlocation>

--- a/wearlocations/waist.xml
+++ b/wearlocations/waist.xml
@@ -4,7 +4,9 @@
   <destroyChance>80</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_waist</itemWear>
-  <msgDisplay>опоясывает тело</msgDisplay>
+  <msgDisplay l="en">worn around the waist</msgDisplay>
+  <msgDisplay l="ru">опоясывает тело</msgDisplay>
+  <msgDisplay l="ua">оперізує тіло</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается опоясаться %2$O5, но ничего не получается.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 опоясывается %2$O5.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь ничем опоясаться.</msgSelfNoRib>
@@ -12,6 +14,8 @@
   <needRib>true</needRib>
   <orderDisplay>19</orderDisplay>
   <orderWear>16</orderWear>
-  <purpose>Опоясывает тело</purpose>
+  <purpose l="en">Worn around the waist</purpose>
+  <purpose l="ru">Опоясывает тело</purpose>
+  <purpose l="ua">Оперізує тіло</purpose>
   <ribName>тали|я|и|е|ю|ей|и</ribName>  
 </Wearlocation>

--- a/wearlocations/wield.xml
+++ b/wearlocations/wield.xml
@@ -2,13 +2,17 @@
 <Wearlocation type="WieldWearloc">
   <displayAlways>true</displayAlways>
   <itemWear>wield</itemWear>
-  <msgDisplay>вооружение</msgDisplay>
+  <msgDisplay l="en">weapon</msgDisplay>
+  <msgDisplay l="ru">вооружение</msgDisplay>
+  <msgDisplay l="ua">озброєння</msgDisplay>
   <msgRoomWear>%1$^C1 вооружается %2$O5.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь носить оружие.</msgSelfNoRib>
   <msgSelfWear>Ты вооружаешься %2$O5.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>16</orderDisplay>
   <orderWear>20</orderWear>
-  <purpose>Используется для вооружения</purpose>
+  <purpose l="en">Used as a weapon</purpose>
+  <purpose l="ru">Используется для вооружения</purpose>
+  <purpose l="ua">Використовується для озброєння</purpose>
   <ribName>оружи|е|я|ю|е|ем|и</ribName>
 </Wearlocation>

--- a/wearlocations/wrist_l.xml
+++ b/wearlocations/wrist_l.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_wrist</itemWear>
-  <msgDisplay>надето на запястье</msgDisplay>
+  <msgDisplay l="en">worn on the wrist</msgDisplay>
+  <msgDisplay l="ru">надето на запястье</msgDisplay>
+  <msgDisplay l="ua">вдягнено на запʼясток</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующее запястье.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг левого запястья.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующее запястье.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <orderDisplay>11</orderDisplay>
   <orderWear>17</orderWear>
   <pair>wrist_r</pair>
-  <purpose>Надевается на запястье</purpose>
+  <purpose l="en">Worn on the wrist</purpose>
+  <purpose l="ru">Надевается на запястье</purpose>
+  <purpose l="ua">Вдягається на запʼясток</purpose>
   <ribName>лев|ое|ого|ому|ое|ым|ом запясть|е|я|ю|е|ем|и</ribName>
 </Wearlocation>

--- a/wearlocations/wrist_r.xml
+++ b/wearlocations/wrist_r.xml
@@ -4,7 +4,9 @@
   <destroyChance>100</destroyChance>
   <displayAlways>true</displayAlways>
   <itemWear>wear_wrist</itemWear>
-  <msgDisplay>надето на запястье</msgDisplay>
+  <msgDisplay l="en">worn on the wrist</msgDisplay>
+  <msgDisplay l="ru">надето на запястье</msgDisplay>
+  <msgDisplay l="ua">вдягнено на запʼясток</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующее запястье.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг правого запястья.</msgRoomWear>
   <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующее запястье.</msgSelfNoRib>
@@ -13,6 +15,8 @@
   <orderDisplay>12</orderDisplay>
   <orderWear>18</orderWear>
   <pair>wrist_l</pair>
-  <purpose>Надевается на запястье</purpose>
+  <purpose l="en">Worn on the wrist</purpose>
+  <purpose l="ru">Надевается на запястье</purpose>
+  <purpose l="ua">Вдягається на запʼясток</purpose>
   <ribName>прав|ое|ого|ому|ое|ым|ом запясть|е|я|ю|е|ем|и</ribName>
 </Wearlocation>


### PR DESCRIPTION
Adds `l="en"`/`l="ua"` siblings to `<purpose>` (shown in look/examine) and `<msgDisplay>` (the `equipment` slot label) across all 30 wear slots + 4 craft tattoo slots, and pins the legacy bare RU as explicit `l="ru"`. Consumed by wearloc code #624 — a UA viewer sees the slot purpose/label in Ukrainian, RU/EN unchanged (fallback to RU where a form is missing). `ribName` + wear/room messages stay RU (second wave).