### PR TITLE
desires: trilingual label + personal messages (en/ru/ua)

### DIFF
--- a/desires/bloodlust.xml
+++ b/desires/bloodlust.xml
@@ -5,13 +5,23 @@
   <drinkCoef>1</drinkCoef>
   <maxValue>96</maxValue>
   <minValue>-6</minValue>
-  <msgActive>Ты жаждешь крови.</msgActive>
+  <msgActive l="en">You crave blood.</msgActive>
+  <msgActive l="ru">Ты жаждешь крови.</msgActive>
+  <msgActive l="ua">Ти прагнеш крові.</msgActive>
   <msgDamageRoom>%1$^C1 страдает от жажды крови!</msgDamageRoom>
-  <msgDamageSelf>Ты страдаешь от жажды крови!</msgDamageSelf>
-  <msgReport>Ты жаждешь крови.</msgReport>
-  <msgStart>Ты жаждешь крови.</msgStart>
+  <msgDamageSelf l="en">You suffer from bloodlust!</msgDamageSelf>
+  <msgDamageSelf l="ru">Ты страдаешь от жажды крови!</msgDamageSelf>
+  <msgDamageSelf l="ua">Ти потерпаєш від жаги крові!</msgDamageSelf>
+  <msgReport l="en">You crave blood.</msgReport>
+  <msgReport l="ru">Ты жаждешь крови.</msgReport>
+  <msgReport l="ua">Ти прагнеш крові.</msgReport>
+  <msgStart l="en">You crave blood.</msgStart>
+  <msgStart l="ru">Ты жаждешь крови.</msgStart>
+  <msgStart l="ua">Ти прагнеш крові.</msgStart>
   <msgStop></msgStop>
   <resetAmount>40</resetAmount>
   <vomitAmount>-6</vomitAmount>
-  <what>Насыщение кровью</what>
+  <what l="en">Bloodlust</what>
+  <what l="ru">Насыщение кровью</what>
+  <what l="ua">Насичення кровʼю</what>
 </Desire>

--- a/desires/drunk.xml
+++ b/desires/drunk.xml
@@ -8,10 +8,18 @@
   <msgActive></msgActive>
   <msgDamageRoom></msgDamageRoom>
   <msgDamageSelf></msgDamageSelf>
-  <msgReport>Ты ПЬЯ%1$GНО|Н|НА!</msgReport>
-  <msgStart>Ты пьянеешь.</msgStart>
-  <msgStop>Ты трезвеешь.</msgStop>
+  <msgReport l="en">You are DRUNK!</msgReport>
+  <msgReport l="ru">Ты ПЬЯ%1$GНО|Н|НА!</msgReport>
+  <msgReport l="ua">Ти ПʼЯ%1$GНЕ|НИЙ|НА!</msgReport>
+  <msgStart l="en">You get drunk.</msgStart>
+  <msgStart l="ru">Ты пьянеешь.</msgStart>
+  <msgStart l="ua">Ти пʼянієш.</msgStart>
+  <msgStop l="en">You sober up.</msgStop>
+  <msgStop l="ru">Ты трезвеешь.</msgStop>
+  <msgStop l="ua">Ти тверезішаєш.</msgStop>
   <resetAmount>0</resetAmount>
   <vomitAmount>0</vomitAmount>
-  <what>Опьянение</what>
+  <what l="en">Drunkenness</what>
+  <what l="ru">Опьянение</what>
+  <what l="ua">Спʼяніння</what>
 </Desire>

--- a/desires/full.xml
+++ b/desires/full.xml
@@ -10,7 +10,9 @@
   <msgDamageSelf></msgDamageSelf>
   <msgReport></msgReport>
   <msgStart></msgStart>
-  <msgStop>Твой желудок полон.</msgStop>
+  <msgStop l="en">Your stomach is full.</msgStop>
+  <msgStop l="ru">Твой желудок полон.</msgStop>
+  <msgStop l="ua">Твій шлунок повний.</msgStop>
   <overflowLimit>80</overflowLimit>
   <resetAmount>40</resetAmount>
   <vomitAmount>0</vomitAmount>

--- a/desires/hunger.xml
+++ b/desires/hunger.xml
@@ -5,13 +5,25 @@
   <drinkCoef>1</drinkCoef>
   <maxValue>96</maxValue>
   <minValue>-6</minValue>
-  <msgActive>Ты хочешь есть.</msgActive>
+  <msgActive l="en">You are hungry.</msgActive>
+  <msgActive l="ru">Ты хочешь есть.</msgActive>
+  <msgActive l="ua">Ти хочеш їсти.</msgActive>
   <msgDamageRoom>%1$^C1 умирает от голода!</msgDamageRoom>
-  <msgDamageSelf>Ты умираешь от голода!</msgDamageSelf>
-  <msgReport>Ты хочешь есть.</msgReport>
-  <msgStart>Ты хочешь есть.</msgStart>
-  <msgStop>Ты больше не чувствуешь голода.</msgStop>
+  <msgDamageSelf l="en">You are starving!</msgDamageSelf>
+  <msgDamageSelf l="ru">Ты умираешь от голода!</msgDamageSelf>
+  <msgDamageSelf l="ua">Ти вмираєш з голоду!</msgDamageSelf>
+  <msgReport l="en">You are hungry.</msgReport>
+  <msgReport l="ru">Ты хочешь есть.</msgReport>
+  <msgReport l="ua">Ти хочеш їсти.</msgReport>
+  <msgStart l="en">You are hungry.</msgStart>
+  <msgStart l="ru">Ты хочешь есть.</msgStart>
+  <msgStart l="ua">Ти хочеш їсти.</msgStart>
+  <msgStop l="en">You are no longer hungry.</msgStop>
+  <msgStop l="ru">Ты больше не чувствуешь голода.</msgStop>
+  <msgStop l="ua">Ти більше не відчуваєш голоду.</msgStop>
   <resetAmount>40</resetAmount>
   <vomitAmount>-5</vomitAmount>
-  <what>Сытость</what>
+  <what l="en">Satiety</what>
+  <what l="ru">Сытость</what>
+  <what l="ua">Ситість</what>
 </Desire>

--- a/desires/thirst.xml
+++ b/desires/thirst.xml
@@ -5,13 +5,25 @@
   <drinkCoef>5</drinkCoef>
   <maxValue>96</maxValue>
   <minValue>-6</minValue>
-  <msgActive>Ты хочешь пить.</msgActive>
+  <msgActive l="en">You are thirsty.</msgActive>
+  <msgActive l="ru">Ты хочешь пить.</msgActive>
+  <msgActive l="ua">Ти хочеш пити.</msgActive>
   <msgDamageRoom>%1$^C1 умирает от жажды!</msgDamageRoom>
-  <msgDamageSelf>Ты умираешь от жажды!</msgDamageSelf>
-  <msgReport>Ты хочешь пить.</msgReport>
-  <msgStart>Ты хочешь пить.</msgStart>
-  <msgStop>Ты больше не чувствуешь жажды.</msgStop>
+  <msgDamageSelf l="en">You are dying of thirst!</msgDamageSelf>
+  <msgDamageSelf l="ru">Ты умираешь от жажды!</msgDamageSelf>
+  <msgDamageSelf l="ua">Ти вмираєш від спраги!</msgDamageSelf>
+  <msgReport l="en">You are thirsty.</msgReport>
+  <msgReport l="ru">Ты хочешь пить.</msgReport>
+  <msgReport l="ua">Ти хочеш пити.</msgReport>
+  <msgStart l="en">You are thirsty.</msgStart>
+  <msgStart l="ru">Ты хочешь пить.</msgStart>
+  <msgStart l="ua">Ти хочеш пити.</msgStart>
+  <msgStop l="en">You are no longer thirsty.</msgStop>
+  <msgStop l="ru">Ты больше не чувствуешь жажды.</msgStop>
+  <msgStop l="ua">Ти більше не відчуваєш спраги.</msgStop>
   <resetAmount>40</resetAmount>
   <vomitAmount>-5</vomitAmount>
-  <what>Утоление жажды</what>
+  <what l="en">Thirst</what>
+  <what l="ru">Утоление жажды</what>
+  <what l="ua">Тамування спраги</what>
 </Desire>


### PR DESCRIPTION
Adds `l="en"`/`l="ua"` to the converted desire fields (`what`, `msgReport`, `msgActive`, `msgStart`, `msgStop`, `msgDamageSelf`) for bloodlust/drunk/full/hunger/thirst, pinning legacy bare RU as `l="ru"`. Consumed by desire code #625. A UA viewer sees hunger/thirst/bloodlust/drunk status in Ukrainian; RU/EN unchanged. `drunk` `msgReport` preserves the `%1$G` gender alternation (neuter|masc|fem → ПʼЯНЕ|ПʼЯНИЙ|ПʼЯНА). `msgDamageRoom` stays RU (room broadcast, separate track).