### PR TITLE
bonuses: trilingual calendar-bonus messages (en/ru/ua)

### DIFF
--- a/bonuses/black friday.xml
+++ b/bonuses/black friday.xml
@@ -5,7 +5,9 @@
     
     </aliases>
     <shortDescr>расход||а|у||ом|е денег</shortDescr>
-    <msgTodayGlobal>Сегодня в магазинах очень большие скидки.</msgTodayGlobal>
+    <msgTodayGlobal l="en">Today the shops offer huge discounts.</msgTodayGlobal>
+    <msgTodayGlobal l="ru">Сегодня в магазинах очень большие скидки.</msgTodayGlobal>
+    <msgTodayGlobal l="ua">Сьогодні в крамницях дуже великі знижки.</msgTodayGlobal>
     <color>D</color>
     <legend>дешевые цены</legend>
     <globalDay>25</globalDay>

--- a/bonuses/experience.xml
+++ b/bonuses/experience.xml
@@ -5,8 +5,12 @@
     
     </aliases>
     <shortDescr>получени|е|я|ю|е|ем|и опыта за убийства</shortDescr>
-    <msgTodayReligion>Сегодня %1$N1 дарит тебе больше опыта за убийства.</msgTodayReligion>
-    <msgTodayGlobal>Сегодня можно получить больше опыта за убийства.</msgTodayGlobal>
+    <msgTodayReligion l="en">Today %1$N1 grants you more experience for kills.</msgTodayReligion>
+    <msgTodayReligion l="ru">Сегодня %1$N1 дарит тебе больше опыта за убийства.</msgTodayReligion>
+    <msgTodayReligion l="ua">Сьогодні %1$N1 дарує тобі більше досвіду за вбивства.</msgTodayReligion>
+    <msgTodayGlobal l="en">Today you can gain more experience for kills.</msgTodayGlobal>
+    <msgTodayGlobal l="ru">Сегодня можно получить больше опыта за убийства.</msgTodayGlobal>
+    <msgTodayGlobal l="ua">Сьогодні можна отримати більше досвіду за вбивства.</msgTodayGlobal>
     <color>c</color>
     <legend>больше опыта за убийства</legend>
     <globalDay>12</globalDay>

--- a/bonuses/learning.xml
+++ b/bonuses/learning.xml
@@ -4,8 +4,12 @@
     <aliases>
     </aliases>
     <shortDescr>обучени|е|я|ю|е|ем|и</shortDescr>
-    <msgTodayReligion>Сегодня %N1 помогает тебе быстрее учиться.</msgTodayReligion>
-    <msgTodayGlobal>Сегодня умения учатся быстрее чем обычно.</msgTodayGlobal>
+    <msgTodayReligion l="en">Today %N1 helps you learn faster.</msgTodayReligion>
+    <msgTodayReligion l="ru">Сегодня %N1 помогает тебе быстрее учиться.</msgTodayReligion>
+    <msgTodayReligion l="ua">Сьогодні %N1 допомагає тобі швидше вчитися.</msgTodayReligion>
+    <msgTodayGlobal l="en">Today skills are learned faster than usual.</msgTodayGlobal>
+    <msgTodayGlobal l="ru">Сегодня умения учатся быстрее чем обычно.</msgTodayGlobal>
+    <msgTodayGlobal l="ua">Сьогодні вміння вчаться швидше, ніж зазвичай.</msgTodayGlobal>
     <color>G</color>
     <legend>быстрее учатся умения</legend>
     <globalDay>6</globalDay>

--- a/bonuses/mana.xml
+++ b/bonuses/mana.xml
@@ -5,8 +5,12 @@
     
     </aliases>
     <shortDescr>расход||а|у||ом|е маны</shortDescr>
-    <msgTodayReligion>Сегодня благодаря %1$N3 заклинания и молитвы отнимают меньше маны.</msgTodayReligion>
-    <msgTodayGlobal>Сегодня заклинания и молитвы отнимают меньше маны.</msgTodayGlobal>
+    <msgTodayReligion l="en">Today thanks to %1$N3 spells and prayers cost less mana.</msgTodayReligion>
+    <msgTodayReligion l="ru">Сегодня благодаря %1$N3 заклинания и молитвы отнимают меньше маны.</msgTodayReligion>
+    <msgTodayReligion l="ua">Сьогодні завдяки %1$N3 заклинання та молитви забирають менше мани.</msgTodayReligion>
+    <msgTodayGlobal l="en">Today spells and prayers cost less mana.</msgTodayGlobal>
+    <msgTodayGlobal l="ru">Сегодня заклинания и молитвы отнимают меньше маны.</msgTodayGlobal>
+    <msgTodayGlobal l="ua">Сьогодні заклинання та молитви забирають менше мани.</msgTodayGlobal>
     <color>b</color>
     <legend>меньше расход маны</legend>
     <globalDay>32</globalDay>

--- a/bonuses/pet day.xml
+++ b/bonuses/pet day.xml
@@ -5,7 +5,9 @@
     
     </aliases>
     <shortDescr>улучшение параметров домашних животных</shortDescr>
-    <msgTodayGlobal>В День Защиты Животных все питомцы очень быстро улучшают свои параметры.</msgTodayGlobal>
+    <msgTodayGlobal l="en">On Animal Protection Day all pets improve their stats very quickly.</msgTodayGlobal>
+    <msgTodayGlobal l="ru">В День Защиты Животных все питомцы очень быстро улучшают свои параметры.</msgTodayGlobal>
+    <msgTodayGlobal l="ua">У День захисту тварин усі улюбленці дуже швидко покращують свої параметри.</msgTodayGlobal>
     <color>g</color>
     <legend>питомцы быстрее улучшают параметры</legend>
     <globalDay>0</globalDay>

--- a/bonuses/thief skills.xml
+++ b/bonuses/thief skills.xml
@@ -5,10 +5,18 @@
     
     </aliases>
     <shortDescr>воровск|ие|их|им|ие|ими|их умени|я|й|ям|я|ями|ях</shortDescr>
-    <msgTodayReligion>Благодаря %1$N3, все воровские умения работают сегодня гораздо лучше.</msgTodayReligion>
-    <msgTodayGlobal>Сегодня все воровские умения работают гораздо лучше.</msgTodayGlobal>
-    <msgActionReligion>Ты чувствуешь, будто %1$^N1 направляет твою руку.</msgActionReligion>
-    <msgActionGlobal>Удача улыбнулась тебе!</msgActionGlobal>
+    <msgTodayReligion l="en">Thanks to %1$N3, all thieving skills work much better today.</msgTodayReligion>
+    <msgTodayReligion l="ru">Благодаря %1$N3, все воровские умения работают сегодня гораздо лучше.</msgTodayReligion>
+    <msgTodayReligion l="ua">Завдяки %1$N3, усі злодійські вміння працюють сьогодні набагато краще.</msgTodayReligion>
+    <msgTodayGlobal l="en">Today all thieving skills work much better.</msgTodayGlobal>
+    <msgTodayGlobal l="ru">Сегодня все воровские умения работают гораздо лучше.</msgTodayGlobal>
+    <msgTodayGlobal l="ua">Сьогодні всі злодійські вміння працюють набагато краще.</msgTodayGlobal>
+    <msgActionReligion l="en">You feel as if %1$^N1 guides your hand.</msgActionReligion>
+    <msgActionReligion l="ru">Ты чувствуешь, будто %1$^N1 направляет твою руку.</msgActionReligion>
+    <msgActionReligion l="ua">Ти відчуваєш, ніби %1$^N1 скеровує твою руку.</msgActionReligion>
+    <msgActionGlobal l="en">Luck smiles upon you!</msgActionGlobal>
+    <msgActionGlobal l="ru">Удача улыбнулась тебе!</msgActionGlobal>
+    <msgActionGlobal l="ua">Удача усміхнулась тобі!</msgActionGlobal>
     <color>M</color>
     <legend>успех воровских умений</legend>
     <globalDay>24</globalDay>


### PR DESCRIPTION
Adds `l=en`/`l=ua` to the per-player bonus message fields (`msgTodayReligion/Global`, `msgActionReligion/Global`) for the 6 calendar bonuses; `%N` religion-name placeholders preserved. Consumed by bonus code #626. RU/EN unchanged; global day-change broadcast stays RU.