### PR TITLE
Mermaid race: drop legs from parts

### DIFF
--- a/races/mermaid.xml
+++ b/races/mermaid.xml
@@ -36,7 +36,7 @@ The main habitat is the waters around {hh1429Arcadia{x and other coastal places.
   <nameMlt>русалки</nameMlt>
   <nameNeuter>русалка</nameNeuter>
   <off>bash disarm dodge fast parry tail assist_race</off>
-  <parts>head arms legs heart brains guts hands fingers ear eye fins tail scales</parts>
+  <parts>head arms heart brains guts hands fingers ear eye fins tail scales</parts>
   <size>medium</size>
   <stats>
     <str>1</str>


### PR DESCRIPTION
Player report: a mermaid played the ambient line "переступает с ноги на ногу" despite having no legs. Root cause: the mermaid race `<parts>` list included `legs`, contradicting its own lore (fish tail) and wearloc (no leg slot). Removing `legs` filters leg-gated ambient/flavor for all 7 mermaid mobs. Reboot-gated (parts bake in at mob creation).