### PR TITLE
Fix null skill groups on the three Knight holy skills

### DIFF
--- a/clan-skills/holy attack.xml
+++ b/clan-skills/holy attack.xml
@@ -11,6 +11,7 @@
     </node>
   </clans>
   <dammsg mg="m"></dammsg>
+  <group registry="skillGroup">clan combat</group>
   <hard>4</hard>
   <help id="2151" level="102" type="SkillHelp">
   </help>

--- a/clan-skills/holy craft.xml
+++ b/clan-skills/holy craft.xml
@@ -11,6 +11,7 @@
     </node>
   </clans>
   <dammsg mg="m"></dammsg>
+  <group registry="skillGroup">clan enhancement</group>
   <hard>4</hard>
   <help id="2033" level="-1" type="SkillHelp">
     <keyword l="en">&apos;holy remedy&apos;</keyword>

--- a/clan-skills/holy remedy.xml
+++ b/clan-skills/holy remedy.xml
@@ -11,6 +11,7 @@
     </node>
   </clans>
   <dammsg mg="m"></dammsg>
+  <group registry="skillGroup">clan healing</group>
   <hard>4</hard>
   <help id="2152" level="102" type="SkillHelp">
   </help>


### PR DESCRIPTION
holy attack/remedy/craft (orden org skills) lacked a `<group registry="skillGroup">`, so `skill.groups` was empty -> NPC teachers refuse them and spam a 'has null groups' wiznet. Added clan-tagged role groups (clan combat / clan healing / clan enhancement). Reboot-free deploy via `plug reload most`.