### PR TITLE
Trilingual profession titles + wearloc self-messages (Ukrainization 2567)

### DIFF
--- a/craft-wearlocs/tat_arms.xml
+++ b/craft-wearlocs/tat_arms.xml
@@ -4,7 +4,9 @@
   <msgDisplay l="en">tattoo on the arms</msgDisplay>
   <msgDisplay l="ru">татуировка на плечах</msgDisplay>
   <msgDisplay l="ua">татуювання на плечах</msgDisplay>
-  <msgSelfNoRib>Ты не можешь носить татуировку на плечах.</msgSelfNoRib>
+  <msgSelfNoRib l="en">You cannot wear a tattoo on your shoulders.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить татуировку на плечах.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити татуювання на плечах.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>9</orderDisplay>
   <orderWear>14</orderWear>

--- a/craft-wearlocs/tat_face.xml
+++ b/craft-wearlocs/tat_face.xml
@@ -4,7 +4,9 @@
   <msgDisplay l="en">tattoo on the face</msgDisplay>
   <msgDisplay l="ru">татуировка на лице</msgDisplay>
   <msgDisplay l="ua">татуювання на обличчі</msgDisplay>
-  <msgSelfNoRib>Ты не можешь носить татуировку на лице.</msgSelfNoRib>
+  <msgSelfNoRib l="en">You cannot wear a tattoo on your face.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить татуировку на лице.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити татуювання на обличчі.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>3</orderDisplay>
   <orderWear>9</orderWear>

--- a/craft-wearlocs/tat_wrist_l.xml
+++ b/craft-wearlocs/tat_wrist_l.xml
@@ -4,7 +4,9 @@
   <msgDisplay l="en">tattoo on the wrist</msgDisplay>
   <msgDisplay l="ru">татуировка на запястье</msgDisplay>
   <msgDisplay l="ua">татуювання на запʼястку</msgDisplay>
-  <msgSelfNoRib>Ты не можешь носить татуировку на левом запястье.</msgSelfNoRib>
+  <msgSelfNoRib l="en">You cannot wear a tattoo on your left wrist.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить татуировку на левом запястье.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити татуювання на лівому запʼясті.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>11</orderDisplay>
   <orderWear>17</orderWear>

--- a/craft-wearlocs/tat_wrist_r.xml
+++ b/craft-wearlocs/tat_wrist_r.xml
@@ -4,7 +4,9 @@
   <msgDisplay l="en">tattoo on the wrist</msgDisplay>
   <msgDisplay l="ru">татуировка на запястье</msgDisplay>
   <msgDisplay l="ua">татуювання на запʼястку</msgDisplay>
-  <msgSelfNoRib>Ты не можешь носить татуировку на правом запястье.</msgSelfNoRib>
+  <msgSelfNoRib l="en">You cannot wear a tattoo on your right wrist.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить татуировку на правом запястье.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити татуювання на правому запʼясті.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>12</orderDisplay>
   <orderWear>18</orderWear>

--- a/professions/anti-paladin.xml
+++ b/professions/anti-paladin.xml
@@ -54,410 +54,818 @@
     <node>
       <female>Гадина</female>
       <male>Гаденыш</male>
+      <maleUa>Гаденя</maleUa>
+      <femaleUa>Гадюка</femaleUa>
+      <maleEn>Guttersnipe</maleEn>
+      <femaleEn>Viper</femaleEn>
     </node>
     <node>
       <female>Шваль</female>
       <male>Шваль</male>
+      <maleUa>Наволоч</maleUa>
+      <femaleUa>Наволоч</femaleUa>
+      <maleEn>Scum</maleEn>
+      <femaleEn>Scum</femaleEn>
     </node>
     <node>
       <female>Быкота</female>
       <male>Быкота</male>
+      <maleUa>Бугай</maleUa>
+      <femaleUa>Бугай</femaleUa>
+      <maleEn>Bully</maleEn>
+      <femaleEn>Bully</femaleEn>
     </node>
     <node>
       <female>Поганка</female>
       <male>Поганец</male>
+      <maleUa>Поганець</maleUa>
+      <femaleUa>Поганка</femaleUa>
+      <maleEn>Thug</maleEn>
+      <femaleEn>Moll</femaleEn>
     </node>
     <node>
       <female>Сучка</female>
       <male>Фраер</male>
+      <maleUa>Фраєр</maleUa>
+      <femaleUa>Сучка</femaleUa>
+      <maleEn>Brute</maleEn>
+      <femaleEn>Bitch</femaleEn>
     </node>
     <node>
       <female>Задира</female>
       <male>Задира</male>
+      <maleUa>Задира</maleUa>
+      <femaleUa>Задира</femaleUa>
+      <maleEn>Ruffian</maleEn>
+      <femaleEn>Butch</femaleEn>
     </node>
     <node>
       <female>Мародерша</female>
       <male>Мародер</male>
+      <maleUa>Мародер</maleUa>
+      <femaleUa>Мародерка</femaleUa>
+      <maleEn>Pillager</maleEn>
+      <femaleEn>Pillager</femaleEn>
     </node>
     <node>
       <female>Подлюка</female>
       <male>Подлюка</male>
+      <maleUa>Подлюка</maleUa>
+      <femaleUa>Подлюка</femaleUa>
+      <maleEn>Destroyer</maleEn>
+      <femaleEn>Destroyer</femaleEn>
     </node>
     <node>
       <female>Поджигательница</female>
       <male>Поджигатель</male>
+      <maleUa>Підпалювач</maleUa>
+      <femaleUa>Підпалювачка</femaleUa>
+      <maleEn>Burner</maleEn>
+      <femaleEn>Burner</femaleEn>
     </node>
     <node>
       <female>Бандюга</female>
       <male>Бандюга</male>
+      <maleUa>Бандюга</maleUa>
+      <femaleUa>Бандюга</femaleUa>
+      <maleEn>Hired Killer</maleEn>
+      <femaleEn>Hired Killer</femaleEn>
     </node>
     <node>
       <female>Изверг</female>
       <male>Изверг</male>
+      <maleUa>Ізверг</maleUa>
+      <femaleUa>Ізверг</femaleUa>
+      <maleEn>Brigand</maleEn>
+      <femaleEn>Brigand</femaleEn>
     </node>
     <node>
       <female>Продажная наемница</female>
       <male>Продажный наемник</male>
+      <maleUa>Продажний найманець</maleUa>
+      <femaleUa>Продажна найманка</femaleUa>
+      <maleEn>Mercenary</maleEn>
+      <femaleEn>Mercenary</femaleEn>
     </node>
     <node>
       <female>Продажная наемница</female>
       <male>Продажный наемник</male>
+      <maleUa>Продажний найманець</maleUa>
+      <femaleUa>Продажна найманка</femaleUa>
+      <maleEn>Mercenary</maleEn>
+      <femaleEn>Mercenary</femaleEn>
     </node>
     <node>
       <female>Черный клинок</female>
       <male>Черный клинок</male>
+      <maleUa>Чорний клинок</maleUa>
+      <femaleUa>Чорний клинок</femaleUa>
+      <maleEn>Black Sword</maleEn>
+      <femaleEn>Black Sword</femaleEn>
     </node>
     <node>
       <female>Черный клинок</female>
       <male>Черный клинок</male>
+      <maleUa>Чорний клинок</maleUa>
+      <femaleUa>Чорний клинок</femaleUa>
+      <maleEn>Black Sword</maleEn>
+      <femaleEn>Black Sword</femaleEn>
     </node>
     <node>
       <female>Алый клинок</female>
       <male>Алый клинок</male>
+      <maleUa>Багряний клинок</maleUa>
+      <femaleUa>Багряний клинок</femaleUa>
+      <maleEn>Crimson Sword</maleEn>
+      <femaleEn>Crimson Sword</femaleEn>
     </node>
     <node>
       <female>Алый клинок</female>
       <male>Алый клинок</male>
+      <maleUa>Багряний клинок</maleUa>
+      <femaleUa>Багряний клинок</femaleUa>
+      <maleEn>Crimson Sword</maleEn>
+      <femaleEn>Crimson Sword</femaleEn>
     </node>
     <node>
       <female>Проныра</female>
       <male>Проныра</male>
+      <maleUa>Пронира</maleUa>
+      <femaleUa>Пронира</femaleUa>
+      <maleEn>Sneaky</maleEn>
+      <femaleEn>Sneaky</femaleEn>
     </node>
     <node>
       <female>Проныра</female>
       <male>Проныра</male>
+      <maleUa>Пронира</maleUa>
+      <femaleUa>Пронира</femaleUa>
+      <maleEn>Sneaky</maleEn>
+      <femaleEn>Sneaky</femaleEn>
     </node>
     <node>
       <female>Мучительница</female>
       <male>Мучитель</male>
+      <maleUa>Мучитель</maleUa>
+      <femaleUa>Мучителька</femaleUa>
+      <maleEn>Cruel</maleEn>
+      <femaleEn>Cruel</femaleEn>
     </node>
     <node>
       <female>Мучительница</female>
       <male>Мучитель</male>
+      <maleUa>Мучитель</maleUa>
+      <femaleUa>Мучителька</femaleUa>
+      <maleEn>Cruel</maleEn>
+      <femaleEn>Cruel</femaleEn>
     </node>
     <node>
       <female>Каналья</female>
       <male>Каналья</male>
+      <maleUa>Каналія</maleUa>
+      <femaleUa>Каналія</femaleUa>
+      <maleEn>Stealer</maleEn>
+      <femaleEn>Stealer</femaleEn>
     </node>
     <node>
       <female>Каналья</female>
       <male>Каналья</male>
+      <maleUa>Каналія</maleUa>
+      <femaleUa>Каналія</femaleUa>
+      <maleEn>Stealer</maleEn>
+      <femaleEn>Stealer</femaleEn>
     </node>
     <node>
       <female>Печально известная</female>
       <male>Печально известный</male>
+      <maleUa>Сумнозвісний</maleUa>
+      <femaleUa>Сумнозвісна</femaleUa>
+      <maleEn>Infamous</maleEn>
+      <femaleEn>Infamous</femaleEn>
     </node>
     <node>
       <female>Печально известная</female>
       <male>Печально известный</male>
+      <maleUa>Сумнозвісний</maleUa>
+      <femaleUa>Сумнозвісна</femaleUa>
+      <maleEn>Infamous</maleEn>
+      <femaleEn>Infamous</femaleEn>
     </node>
     <node>
       <female>Ненавидимая всеми</female>
       <male>Ненавидимый всеми</male>
+      <maleUa>Ненависний усім</maleUa>
+      <femaleUa>Ненависна усім</femaleUa>
+      <maleEn>Hated</maleEn>
+      <femaleEn>Hated</femaleEn>
     </node>
     <node>
       <female>Ненавидимая всеми</female>
       <male>Ненавидимый всеми</male>
+      <maleUa>Ненависний усім</maleUa>
+      <femaleUa>Ненависна усім</femaleUa>
+      <maleEn>Hated</maleEn>
+      <femaleEn>Hated</femaleEn>
     </node>
     <node>
       <female>Полнейшая мразь</female>
       <male>Полнейший ублюдок</male>
+      <maleUa>Цілковитий вилупок</maleUa>
+      <femaleUa>Цілковита мерзота</femaleUa>
+      <maleEn>Complete Bastard</maleEn>
+      <femaleEn>Complete Bitch</femaleEn>
     </node>
     <node>
       <female>Полнейшая мразь</female>
       <male>Полнейший ублюдок</male>
+      <maleUa>Цілковитий вилупок</maleUa>
+      <femaleUa>Цілковита мерзота</femaleUa>
+      <maleEn>Complete Bastard</maleEn>
+      <femaleEn>Complete Bitch</femaleEn>
     </node>
     <node>
       <female>Изуверша</female>
       <male>Изувер</male>
+      <maleUa>Ізувер</maleUa>
+      <femaleUa>Ізуверка</femaleUa>
+      <maleEn>Anti-Paladin</maleEn>
+      <femaleEn>Anti-Paladin</femaleEn>
     </node>
     <node>
       <female>Изуверша</female>
       <male>Изувер</male>
+      <maleUa>Ізувер</maleUa>
+      <femaleUa>Ізуверка</femaleUa>
+      <maleEn>Anti-Paladin</maleEn>
+      <femaleEn>Anti-Paladin</femaleEn>
     </node>
     <node>
       <female>Прощелыга</female>
       <male>Прощелыга</male>
+      <maleUa>Пройдисвіт</maleUa>
+      <femaleUa>Пройдисвіт</femaleUa>
+      <maleEn>Evil Fighter</maleEn>
+      <femaleEn>Evil Fighter</femaleEn>
     </node>
     <node>
       <female>Прощелыга</female>
       <male>Прощелыга</male>
+      <maleUa>Пройдисвіт</maleUa>
+      <femaleUa>Пройдисвіт</femaleUa>
+      <maleEn>Evil Fighter</maleEn>
+      <femaleEn>Evil Fighter</femaleEn>
     </node>
     <node>
       <female>Паскудная мамзель</female>
       <male>Паскудный рыцарь</male>
+      <maleUa>Паскудний лицар</maleUa>
+      <femaleUa>Паскудна панянка</femaleUa>
+      <maleEn>Rogue Knight</maleEn>
+      <femaleEn>Rogue Lady</femaleEn>
     </node>
     <node>
       <female>Паскудная мамзель</female>
       <male>Паскудный рыцарь</male>
+      <maleUa>Паскудний лицар</maleUa>
+      <femaleUa>Паскудна панянка</femaleUa>
+      <maleEn>Rogue Knight</maleEn>
+      <femaleEn>Rogue Lady</femaleEn>
     </node>
     <node>
       <female>Чемпионка подлости</female>
       <male>Чемпион подлости</male>
+      <maleUa>Чемпіон підлості</maleUa>
+      <femaleUa>Чемпіонка підлості</femaleUa>
+      <maleEn>Evil Champion</maleEn>
+      <femaleEn>Evil Champion</femaleEn>
     </node>
     <node>
       <female>Чемпионка подлости</female>
       <male>Чемпион подлости</male>
+      <maleUa>Чемпіон підлості</maleUa>
+      <femaleUa>Чемпіонка підлості</femaleUa>
+      <maleEn>Evil Champion</maleEn>
+      <femaleEn>Evil Champion</femaleEn>
     </node>
     <node>
       <female>Зараза</female>
       <male>Зараза</male>
+      <maleUa>Зараза</maleUa>
+      <femaleUa>Зараза</femaleUa>
+      <maleEn>Dishonorable</maleEn>
+      <femaleEn>Dishonorable</femaleEn>
     </node>
     <node>
       <female>Зараза</female>
       <male>Зараза</male>
+      <maleUa>Зараза</maleUa>
+      <femaleUa>Зараза</femaleUa>
+      <maleEn>Dishonorable</maleEn>
+      <femaleEn>Dishonorable</femaleEn>
     </node>
     <node>
       <female>Черная дама</female>
       <male>Черный рыцарь</male>
+      <maleUa>Чорний лицар</maleUa>
+      <femaleUa>Чорна дама</femaleUa>
+      <maleEn>Black Knight</maleEn>
+      <femaleEn>Black Lady</femaleEn>
     </node>
     <node>
       <female>Черная дама</female>
       <male>Черный рыцарь</male>
+      <maleUa>Чорний лицар</maleUa>
+      <femaleUa>Чорна дама</femaleUa>
+      <maleEn>Black Knight</maleEn>
+      <femaleEn>Black Lady</femaleEn>
     </node>
     <node>
       <female>Алая дама</female>
       <male>Алый рыцарь</male>
+      <maleUa>Багряний лицар</maleUa>
+      <femaleUa>Багряна дама</femaleUa>
+      <maleEn>Crimson Knight</maleEn>
+      <femaleEn>Crimson Lady</femaleEn>
     </node>
     <node>
       <female>Алая дама</female>
       <male>Алый рыцарь</male>
+      <maleUa>Багряний лицар</maleUa>
+      <femaleUa>Багряна дама</femaleUa>
+      <maleEn>Crimson Knight</maleEn>
+      <femaleEn>Crimson Lady</femaleEn>
     </node>
     <node>
       <female>Адская дама</female>
       <male>Адский рыцарь</male>
+      <maleUa>Пекельний лицар</maleUa>
+      <femaleUa>Пекельна дама</femaleUa>
+      <maleEn>Knight of Brimstone</maleEn>
+      <femaleEn>Lady of Brimstone</femaleEn>
     </node>
     <node>
       <female>Адская дама</female>
       <male>Адский рыцарь</male>
+      <maleUa>Пекельний лицар</maleUa>
+      <femaleUa>Пекельна дама</femaleUa>
+      <maleEn>Knight of Brimstone</maleEn>
+      <femaleEn>Lady of Brimstone</femaleEn>
     </node>
     <node>
       <female>Дама Перевернутого Креста</female>
       <male>Кавалер Перевернутого Креста</male>
+      <maleUa>Кавалер Перевернутого Хреста</maleUa>
+      <femaleUa>Дама Перевернутого Хреста</femaleUa>
+      <maleEn>Knight of the Inverted Cross</maleEn>
+      <femaleEn>Lady of the Inverted Cross</femaleEn>
     </node>
     <node>
       <female>Дама Перевернутого Креста</female>
       <male>Кавалер Перевернутого Крестаs</male>
+      <maleUa>Кавалер Перевернутого Хреста</maleUa>
+      <femaleUa>Дама Перевернутого Хреста</femaleUa>
+      <maleEn>Knight of the Inverted Cross</maleEn>
+      <femaleEn>Lady of the Inverted Cross</femaleEn>
     </node>
     <node>
       <female>Дама Боли</female>
       <male>Кавалер Боли</male>
+      <maleUa>Кавалер Болю</maleUa>
+      <femaleUa>Дама Болю</femaleUa>
+      <maleEn>Knight of Pain</maleEn>
+      <femaleEn>Lady of Pain</femaleEn>
     </node>
     <node>
       <female>Дама Боли</female>
       <male>Кавалер Боли</male>
+      <maleUa>Кавалер Болю</maleUa>
+      <femaleUa>Дама Болю</femaleUa>
+      <maleEn>Knight of Pain</maleEn>
+      <femaleEn>Lady of Pain</femaleEn>
     </node>
     <node>
       <female>Дама Страданий</female>
       <male>Кавалер Страдания</male>
+      <maleUa>Кавалер Страждання</maleUa>
+      <femaleUa>Дама Страждань</femaleUa>
+      <maleEn>Knight of Legion</maleEn>
+      <femaleEn>Lady of Legion</femaleEn>
     </node>
     <node>
       <female>Дама Страданий</female>
       <male>Кавалер Страдания</male>
+      <maleUa>Кавалер Страждання</maleUa>
+      <femaleUa>Дама Страждань</femaleUa>
+      <maleEn>Knight of Legion</maleEn>
+      <femaleEn>Lady of Legion</femaleEn>
     </node>
     <node>
       <female>Дама Отчаяния</female>
       <male>Кавалер Отчаяния</male>
+      <maleUa>Кавалер Відчаю</maleUa>
+      <femaleUa>Дама Відчаю</femaleUa>
+      <maleEn>Footman of Legion</maleEn>
+      <femaleEn>Footwoman of Legion</femaleEn>
     </node>
     <node>
       <female>Дама Отчаяния</female>
       <male>Кавалер Отчаяния</male>
+      <maleUa>Кавалер Відчаю</maleUa>
+      <femaleUa>Дама Відчаю</femaleUa>
+      <maleEn>Footman of Legion</maleEn>
+      <femaleEn>Footwoman of Legion</femaleEn>
     </node>
     <node>
       <female>Дама Хаоса</female>
       <male>Кавалер Хаоса</male>
+      <maleUa>Кавалер Хаосу</maleUa>
+      <femaleUa>Дама Хаосу</femaleUa>
+      <maleEn>Cavalier of Legion</maleEn>
+      <femaleEn>Cavalier of Legion</femaleEn>
     </node>
     <node>
       <female>Дама Хаоса</female>
       <male>Кавалер Хаоса</male>
+      <maleUa>Кавалер Хаосу</maleUa>
+      <femaleUa>Дама Хаосу</femaleUa>
+      <maleEn>Cavalier of Legion</maleEn>
+      <femaleEn>Cavalier of Legion</femaleEn>
     </node>
     <node>
       <female>Капитанша Адского Легиона</female>
       <male>Капитан Адского Легиона</male>
+      <maleUa>Капітан Пекельного Легіону</maleUa>
+      <femaleUa>Капітанша Пекельного Легіону</femaleUa>
+      <maleEn>Captain of Legion</maleEn>
+      <femaleEn>Captain of Legion</femaleEn>
     </node>
     <node>
       <female>Капитан Адского Легиона</female>
       <male>Капитан Адского Легиона</male>
+      <maleUa>Капітан Пекельного Легіону</maleUa>
+      <femaleUa>Капітанша Пекельного Легіону</femaleUa>
+      <maleEn>Captain of Legion</maleEn>
+      <femaleEn>Captain of Legion</femaleEn>
     </node>
     <node>
       <female>Генерал Адского Легиона</female>
       <male>Генерал Адского Легиона</male>
+      <maleUa>Генерал Пекельного Легіону</maleUa>
+      <femaleUa>Генерал Пекельного Легіону</femaleUa>
+      <maleEn>General of Legion</maleEn>
+      <femaleEn>General of Legion</femaleEn>
     </node>
     <node>
       <female>Генерал Адского Легиона</female>
       <male>Генерал Адского Легиона</male>
+      <maleUa>Генерал Пекельного Легіону</maleUa>
+      <femaleUa>Генерал Пекельного Легіону</femaleUa>
+      <maleEn>General of Legion</maleEn>
+      <femaleEn>General of Legion</femaleEn>
     </node>
     <node>
       <female>Маршал Адского Легиона</female>
       <male>Маршал Адского Легиона</male>
+      <maleUa>Маршал Пекельного Легіону</maleUa>
+      <femaleUa>Маршал Пекельного Легіону</femaleUa>
+      <maleEn>Field Marshall of Legion</maleEn>
+      <femaleEn>Field Marshall of Legion</femaleEn>
     </node>
     <node>
       <female>Маршал Адского Легиона</female>
       <male>Маршал Адского Легиона</male>
+      <maleUa>Маршал Пекельного Легіону</maleUa>
+      <femaleUa>Маршал Пекельного Легіону</femaleUa>
+      <maleEn>Field Marshall of Legion</maleEn>
+      <femaleEn>Field Marshall of Legion</femaleEn>
     </node>
     <node>
       <female>Вестница Апокалипсиса</female>
       <male>Вестник Апокалипсиса</male>
+      <maleUa>Вісник Апокаліпсису</maleUa>
+      <femaleUa>Вісниця Апокаліпсису</femaleUa>
+      <maleEn>Knight of the Apocaplypse</maleEn>
+      <femaleEn>Lady of the Apocalypse</femaleEn>
     </node>
     <node>
       <female>Вестница Апокалипсиса</female>
       <male>Вестник Апокалипсиса</male>
+      <maleUa>Вісник Апокаліпсису</maleUa>
+      <femaleUa>Вісниця Апокаліпсису</femaleUa>
+      <maleEn>Knight of the Apocaplypse</maleEn>
+      <femaleEn>Lady of the Apocalypse</femaleEn>
     </node>
     <node>
       <female>Гасительница Света</female>
       <male>Гаситель Света</male>
+      <maleUa>Гаситель Світла</maleUa>
+      <femaleUa>Гасителька Світла</femaleUa>
+      <maleEn>LightSlayer</maleEn>
+      <femaleEn>LightSlayer</femaleEn>
     </node>
     <node>
       <female>Гасительница Света</female>
       <male>Гаситель Света</male>
+      <maleUa>Гаситель Світла</maleUa>
+      <femaleUa>Гасителька Світла</femaleUa>
+      <maleEn>LightSlayer</maleEn>
+      <femaleEn>LightSlayer</femaleEn>
     </node>
     <node>
       <female>Воплощение Страдания</female>
       <male>Воплощение Страдания</male>
+      <maleUa>Втілення Страждання</maleUa>
+      <femaleUa>Втілення Страждання</femaleUa>
+      <maleEn>Invoker of Suffering</maleEn>
+      <femaleEn>Invokeress of Suffering</femaleEn>
     </node>
     <node>
       <female>Воплощение Страдания</female>
       <male>Воплощение Страдания</male>
+      <maleUa>Втілення Страждання</maleUa>
+      <femaleUa>Втілення Страждання</femaleUa>
+      <maleEn>Invoker of Suffering</maleEn>
+      <femaleEn>Invokeress of Suffering</femaleEn>
     </node>
     <node>
       <female>Воплощение Смерти</female>
       <male>Воплощение Смерти</male>
+      <maleUa>Втілення Смерті</maleUa>
+      <femaleUa>Втілення Смерті</femaleUa>
+      <maleEn>Necromancer</maleEn>
+      <femaleEn>Necromancer</femaleEn>
     </node>
     <node>
       <female>Воплощение Смерти</female>
       <male>Воплощение Смерти</male>
+      <maleUa>Втілення Смерті</maleUa>
+      <femaleUa>Втілення Смерті</femaleUa>
+      <maleEn>Necromancer</maleEn>
+      <femaleEn>Necromancer</femaleEn>
     </node>
     <node>
       <female>Воплощение Отчаяния</female>
       <male>Воплощение Отчаяния</male>
+      <maleUa>Втілення Відчаю</maleUa>
+      <femaleUa>Втілення Відчаю</femaleUa>
+      <maleEn>Evil Knight</maleEn>
+      <femaleEn>Evil Lady</femaleEn>
     </node>
     <node>
       <female>Воплощение Отчаяния</female>
       <male>Воплощение Отчаяния</male>
+      <maleUa>Втілення Відчаю</maleUa>
+      <femaleUa>Втілення Відчаю</femaleUa>
+      <maleEn>Evil Knight</maleEn>
+      <femaleEn>Evil Lady</femaleEn>
     </node>
     <node>
       <female>Воплощение Хаоса</female>
       <male>Воплощение Хаоса</male>
+      <maleUa>Втілення Хаосу</maleUa>
+      <femaleUa>Втілення Хаосу</femaleUa>
+      <maleEn>Evil Lord</maleEn>
+      <femaleEn>Evil Baroness</femaleEn>
     </node>
     <node>
       <female>Воплощение Хаоса</female>
       <male>Воплощение Хаоса</male>
+      <maleUa>Втілення Хаосу</maleUa>
+      <femaleUa>Втілення Хаосу</femaleUa>
+      <maleEn>Evil Lord</maleEn>
+      <femaleEn>Evil Baroness</femaleEn>
     </node>
     <node>
       <female>Воплощение Зла</female>
       <male>Воплощение Зла</male>
+      <maleUa>Втілення Зла</maleUa>
+      <femaleUa>Втілення Зла</femaleUa>
+      <maleEn>Evil King</maleEn>
+      <femaleEn>Evil Queen</femaleEn>
     </node>
     <node>
       <female>Воплощение Зла</female>
       <male>Воплощение Зла</male>
+      <maleUa>Втілення Зла</maleUa>
+      <femaleUa>Втілення Зла</femaleUa>
+      <maleEn>Evil King</maleEn>
+      <femaleEn>Evil Queen</femaleEn>
     </node>
     <node>
       <female>Всадница на белом коне</female>
       <male>Всадник на белом коне</male>
+      <maleUa>Вершник на білому коні</maleUa>
+      <femaleUa>Вершниця на білому коні</femaleUa>
+      <maleEn>Herald of War</maleEn>
+      <femaleEn>Herald of War</femaleEn>
     </node>
     <node>
       <female>Всадница на белом коне</female>
       <male>Всадник на белом коне</male>
+      <maleUa>Вершник на білому коні</maleUa>
+      <femaleUa>Вершниця на білому коні</femaleUa>
+      <maleEn>Herald of War</maleEn>
+      <femaleEn>Herald of War</femaleEn>
     </node>
     <node>
       <female>Всадница на алом коне</female>
       <male>Всадник на алом коне</male>
+      <maleUa>Вершник на багряному коні</maleUa>
+      <femaleUa>Вершниця на багряному коні</femaleUa>
+      <maleEn>Spreader of Pestilence</maleEn>
+      <femaleEn>Spreader of Pestilence</femaleEn>
     </node>
     <node>
       <female>Всадница на алом коне</female>
       <male>Всадник на алом коне</male>
+      <maleUa>Вершник на багряному коні</maleUa>
+      <femaleUa>Вершниця на багряному коні</femaleUa>
+      <maleEn>Spreader of Pestilence</maleEn>
+      <femaleEn>Spreader of Pestilence</femaleEn>
     </node>
     <node>
       <female>Всадница на вороном коне</female>
       <male>Всадник на вороном коне</male>
+      <maleUa>Вершник на вороному коні</maleUa>
+      <femaleUa>Вершниця на вороному коні</femaleUa>
+      <maleEn>Bringer of Famine</maleEn>
+      <femaleEn>Bringer of Famine</femaleEn>
     </node>
     <node>
       <female>tВсадница на вороном коне</female>
       <male>Всадник на вороном коне</male>
+      <maleUa>Вершник на вороному коні</maleUa>
+      <femaleUa>Вершниця на вороному коні</femaleUa>
+      <maleEn>Bringer of Famine</maleEn>
+      <femaleEn>Bringer of Famine</femaleEn>
     </node>
     <node>
       <female>Всадница на бледном коне</female>
       <male>Всадник на бледном коне</male>
+      <maleUa>Вершник на блідому коні</maleUa>
+      <femaleUa>Вершниця на блідому коні</femaleUa>
+      <maleEn>Harbringer of Death</maleEn>
+      <femaleEn>Harbringer of Death</femaleEn>
     </node>
     <node>
       <female>Всадница на бледном коне</female>
       <male>Всадник на бледном коне</male>
+      <maleUa>Вершник на блідому коні</maleUa>
+      <femaleUa>Вершниця на блідому коні</femaleUa>
+      <maleEn>Harbringer of Death</maleEn>
+      <femaleEn>Harbringer of Death</femaleEn>
     </node>
     <node>
       <female>Слуга Дьявола</female>
       <male>Слуга Дьявола</male>
+      <maleUa>Слуга Диявола</maleUa>
+      <femaleUa>Слуга Диявола</femaleUa>
+      <maleEn>Unholy Bishop</maleEn>
+      <femaleEn>Unholy Priestess</femaleEn>
     </node>
     <node>
       <female>Слуга Дьявола</female>
       <male>Слуга Дьявола</male>
+      <maleUa>Слуга Диявола</maleUa>
+      <femaleUa>Слуга Диявола</femaleUa>
+      <maleEn>Unholy Bishop</maleEn>
+      <femaleEn>Unholy Priestess</femaleEn>
     </node>
     <node>
       <female>Жрица Дьявола</female>
       <male>Жрец Дьявола</male>
+      <maleUa>Жрець Диявола</maleUa>
+      <femaleUa>Жриця Диявола</femaleUa>
+      <maleEn>Slayer</maleEn>
+      <femaleEn>Slayer</femaleEn>
     </node>
     <node>
       <female>Жрица Дьявола</female>
       <male>Жрец Дьявола</male>
+      <maleUa>Жрець Диявола</maleUa>
+      <femaleUa>Жриця Диявола</femaleUa>
+      <maleEn>Slayer</maleEn>
+      <femaleEn>Slayer</femaleEn>
     </node>
     <node>
       <female>Епископ Дьявола</female>
       <male>Епископ Дьявола</male>
+      <maleUa>Єпископ Диявола</maleUa>
+      <femaleUa>Єпископ Диявола</femaleUa>
+      <maleEn>Evil Incarnate</maleEn>
+      <femaleEn>Evil Incarnate</femaleEn>
     </node>
     <node>
       <female>Епископ Дьявола</female>
       <male>Епископ Дьявола</male>
+      <maleUa>Єпископ Диявола</maleUa>
+      <femaleUa>Єпископ Диявола</femaleUa>
+      <maleEn>Evil Incarnate</maleEn>
+      <femaleEn>Evil Incarnate</femaleEn>
     </node>
     <node>
       <female>Архиепископ Дьявола</female>
       <male>Архиепископ Дьявола</male>
+      <maleUa>Архієпископ Диявола</maleUa>
+      <femaleUa>Архієпископ Диявола</femaleUa>
+      <maleEn>Unholy Knight</maleEn>
+      <femaleEn>Unholy Lady</femaleEn>
     </node>
     <node>
       <female>Архиепископ Дьявола</female>
       <male>Архиепископ Дьявола</male>
+      <maleUa>Архієпископ Диявола</maleUa>
+      <femaleUa>Архієпископ Диявола</femaleUa>
+      <maleEn>Unholy Knight</maleEn>
+      <femaleEn>Unholy Lady</femaleEn>
     </node>
     <node>
       <female>Кардинал Дьявола</female>
       <male>Кардинал Дьявола</male>
+      <maleUa>Кардинал Диявола</maleUa>
+      <femaleUa>Кардинал Диявола</femaleUa>
+      <maleEn>Anti-Hero</maleEn>
+      <femaleEn>Anti-Heroine</femaleEn>
     </node>
     <node>
       <female>Кардинал Дьявола</female>
       <male>Кардинал Дьявола</male>
+      <maleUa>Кардинал Диявола</maleUa>
+      <femaleUa>Кардинал Диявола</femaleUa>
+      <maleEn>Avatar of Evil</maleEn>
+      <femaleEn>Avatar of Evil</femaleEn>
     </node>
     <node>
       <female>Великий Кардинал Дьявола</female>
       <male>Великий Кардинал Дьявола</male>
+      <maleUa>Великий Кардинал Диявола</maleUa>
+      <femaleUa>Великий Кардинал Диявола</femaleUa>
+      <maleEn>Angel of Evil</maleEn>
+      <femaleEn>Angel of Evil</femaleEn>
     </node>
     <node>
       <female>Великий Кардинал Дьявола</female>
       <male>Великий Кардинал Дьявола</male>
+      <maleUa>Великий Кардинал Диявола</maleUa>
+      <femaleUa>Великий Кардинал Диявола</femaleUa>
+      <maleEn>Demigod of Evil</maleEn>
+      <femaleEn>Demigoddess of Evil</femaleEn>
     </node>
     <node>
       <female>Поработительница народов</female>
       <male>Поработитель народов</male>
+      <maleUa>Поневолювач народів</maleUa>
+      <femaleUa>Поневолювачка народів</femaleUa>
+      <maleEn>Immortal Anti-Knight</maleEn>
+      <femaleEn>Immortal Anti-Knight</femaleEn>
     </node>
     <node>
       <female>Поработительница народов</female>
       <male>Поработитель народов</male>
+      <maleUa>Поневолювач народів</maleUa>
+      <femaleUa>Поневолювачка народів</femaleUa>
+      <maleEn>God of Evil</maleEn>
+      <femaleEn>God of Evil</femaleEn>
     </node>
     <node>
       <female>Разрушительница цивилизаций</female>
       <male>Разрушитель цивилизаций</male>
+      <maleUa>Руйнівник цивілізацій</maleUa>
+      <femaleUa>Руйнівниця цивілізацій</femaleUa>
+      <maleEn>Deity of Evil</maleEn>
+      <femaleEn>Deity of Evil</femaleEn>
     </node>
     <node>
       <female>Разрушительница цивилизаций</female>
       <male>Разрушитель цивилизаций</male>
+      <maleUa>Руйнівник цивілізацій</maleUa>
+      <femaleUa>Руйнівниця цивілізацій</femaleUa>
+      <maleEn>Supreme Master of Evil</maleEn>
+      <femaleEn>Supreme Mistress of Evil</femaleEn>
     </node>
     <node>
       <female>Покорительница мира</female>
       <male>Покоритель мира</male>
+      <maleUa>Завойовник світу</maleUa>
+      <femaleUa>Завойовниця світу</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Покорительница мира</female>
       <male>Покоритель мира</male>
+      <maleUa>Завойовник світу</maleUa>
+      <femaleUa>Завойовниця світу</femaleUa>
+      <maleEn>Implementor</maleEn>
+      <femaleEn>Implementress</femaleEn>
     </node>
     <node>
       <female>Великая анти-героиня</female>
       <male>Великий анти-герой</male>
+      <maleUa>Великий антигерой</maleUa>
+      <femaleUa>Велика антигероїня</femaleUa>
+      <maleEn>Great Anti-Hero</maleEn>
+      <femaleEn>Great Anti-Heroine</femaleEn>
     </node>
     <node>
       <female>the Avatar of Evil</female>

--- a/professions/cleric.xml
+++ b/professions/cleric.xml
@@ -67,442 +67,882 @@ Note that clerics must choose a {hh1religion{x -- otherwise the {hh2036level{x o
     <node>
       <female>Верующая</female>
       <male>Верующий</male>
+      <maleUa>Вірянин</maleUa>
+      <femaleUa>Вірянка</femaleUa>
+      <maleEn>Believer</maleEn>
+      <femaleEn>Believer</femaleEn>
     </node>
     <node>
       <female>Служительница</female>
       <male>Служитель</male>
+      <maleUa>Служитель</maleUa>
+      <femaleUa>Служителька</femaleUa>
+      <maleEn>Attendant</maleEn>
+      <femaleEn>Attendant</femaleEn>
     </node>
     <node>
       <female>Аколит</female>
       <male>Аколит</male>
+      <maleUa>Аколіт</maleUa>
+      <femaleUa>Аколіт</femaleUa>
+      <maleEn>Acolyte</maleEn>
+      <femaleEn>Acolyte</femaleEn>
     </node>
     <node>
       <female>Послушница</female>
       <male>Послушник</male>
+      <maleUa>Послушник</maleUa>
+      <femaleUa>Послушниця</femaleUa>
+      <maleEn>Novice</maleEn>
+      <femaleEn>Novice</femaleEn>
     </node>
     <node>
       <female>Миссионер</female>
       <male>Миссионер</male>
+      <maleUa>Місіонер</maleUa>
+      <femaleUa>Місіонер</femaleUa>
+      <maleEn>Missionary</maleEn>
+      <femaleEn>Missionary</femaleEn>
     </node>
     <node>
       <female>Адепт</female>
       <male>Адепт</male>
+      <maleUa>Адепт</maleUa>
+      <femaleUa>Адепт</femaleUa>
+      <maleEn>Adept</maleEn>
+      <femaleEn>Adept</femaleEn>
     </node>
     <node>
       <female>Диаконесса</female>
       <male>Диакон</male>
+      <maleUa>Диякон</maleUa>
+      <femaleUa>Дияконеса</femaleUa>
+      <maleEn>Deacon</maleEn>
+      <femaleEn>Deaconess</femaleEn>
     </node>
     <node>
       <female>Викарий</female>
       <male>Викарий</male>
+      <maleUa>Вікарій</maleUa>
+      <femaleUa>Вікарій</femaleUa>
+      <maleEn>Vicar</maleEn>
+      <femaleEn>Vicaress</femaleEn>
     </node>
     <node>
       <female>Жрица</female>
       <male>Жрец</male>
+      <maleUa>Жрець</maleUa>
+      <femaleUa>Жриця</femaleUa>
+      <maleEn>Priest</maleEn>
+      <femaleEn>Priestess</femaleEn>
     </node>
     <node>
       <female>Священница</female>
       <male>Священник</male>
+      <maleUa>Священик</maleUa>
+      <femaleUa>Священиця</femaleUa>
+      <maleEn>Minister</maleEn>
+      <femaleEn>Lady Minister</femaleEn>
     </node>
     <node>
       <female>Каноник</female>
       <male>Каноник</male>
+      <maleUa>Канонік</maleUa>
+      <femaleUa>Канонік</femaleUa>
+      <maleEn>Canon</maleEn>
+      <femaleEn>Canon</femaleEn>
     </node>
     <node>
       <female>Каноник</female>
       <male>Каноник</male>
+      <maleUa>Канонік</maleUa>
+      <femaleUa>Канонік</femaleUa>
+      <maleEn>Canon</maleEn>
+      <femaleEn>Canon</femaleEn>
     </node>
     <node>
       <female>Левит</female>
       <male>Левит</male>
+      <maleUa>Левіт</maleUa>
+      <femaleUa>Левіт</femaleUa>
+      <maleEn>Levite</maleEn>
+      <femaleEn>Levitess</femaleEn>
     </node>
     <node>
       <female>Левит</female>
       <male>Левит</male>
+      <maleUa>Левіт</maleUa>
+      <femaleUa>Левіт</femaleUa>
+      <maleEn>Levite</maleEn>
+      <femaleEn>Levitess</femaleEn>
     </node>
     <node>
       <female>Куратор</female>
       <male>Куратор</male>
+      <maleUa>Куратор</maleUa>
+      <femaleUa>Куратор</femaleUa>
+      <maleEn>Curate</maleEn>
+      <femaleEn>Curess</femaleEn>
     </node>
     <node>
       <female>Куратор</female>
       <male>Куратор</male>
+      <maleUa>Куратор</maleUa>
+      <femaleUa>Куратор</femaleUa>
+      <maleEn>Curate</maleEn>
+      <femaleEn>Curess</femaleEn>
     </node>
     <node>
       <female>Монахиня</female>
       <male>Монах</male>
+      <maleUa>Монах</maleUa>
+      <femaleUa>Монахиня</femaleUa>
+      <maleEn>Monk</maleEn>
+      <femaleEn>Nun</femaleEn>
     </node>
     <node>
       <female>Монахиня</female>
       <male>Монах</male>
+      <maleUa>Монах</maleUa>
+      <femaleUa>Монахиня</femaleUa>
+      <maleEn>Monk</maleEn>
+      <femaleEn>Nun</femaleEn>
     </node>
     <node>
       <female>Лекарь</female>
       <male>Лекарь</male>
+      <maleUa>Цілитель</maleUa>
+      <femaleUa>Цілитель</femaleUa>
+      <maleEn>Healer</maleEn>
+      <femaleEn>Healess</femaleEn>
     </node>
     <node>
       <female>Лекарь</female>
       <male>Лекарь</male>
+      <maleUa>Цілитель</maleUa>
+      <femaleUa>Цілитель</femaleUa>
+      <maleEn>Healer</maleEn>
+      <femaleEn>Healess</femaleEn>
     </node>
     <node>
       <female>Капеллана</female>
       <male>Капеллан</male>
+      <maleUa>Капелан</maleUa>
+      <femaleUa>Капеланка</femaleUa>
+      <maleEn>Chaplain</maleEn>
+      <femaleEn>Chaplain</femaleEn>
     </node>
     <node>
       <female>Капеллана</female>
       <male>Капеллан</male>
+      <maleUa>Капелан</maleUa>
+      <femaleUa>Капеланка</femaleUa>
+      <maleEn>Chaplain</maleEn>
+      <femaleEn>Chaplain</femaleEn>
     </node>
     <node>
       <female>Толковательница Божественного Слова</female>
       <male>Толкователь Божественного Слова</male>
+      <maleUa>Тлумач Божественного Слова</maleUa>
+      <femaleUa>Тлумачка Божественного Слова</femaleUa>
+      <maleEn>Expositor</maleEn>
+      <femaleEn>Expositress</femaleEn>
     </node>
     <node>
       <female>Толковательница Божественного Слова</female>
       <male>Толкователь Божественного Слова</male>
+      <maleUa>Тлумач Божественного Слова</maleUa>
+      <femaleUa>Тлумачка Божественного Слова</femaleUa>
+      <maleEn>Expositor</maleEn>
+      <femaleEn>Expositress</femaleEn>
     </node>
     <node>
       <female>Леди Епископ</female>
       <male>Епископ</male>
+      <maleUa>Єпископ</maleUa>
+      <femaleUa>Леді Єпископ</femaleUa>
+      <maleEn>Bishop</maleEn>
+      <femaleEn>Bishop</femaleEn>
     </node>
     <node>
       <female>Леди Епископ</female>
       <male>Епископ</male>
+      <maleUa>Єпископ</maleUa>
+      <femaleUa>Леді Єпископ</femaleUa>
+      <maleEn>Bishop</maleEn>
+      <femaleEn>Bishop</femaleEn>
     </node>
     <node>
       <female>Леди Архиепископ</female>
       <male>Архиепископ</male>
+      <maleUa>Архієпископ</maleUa>
+      <femaleUa>Леді Архієпископ</femaleUa>
+      <maleEn>Arch Bishop</maleEn>
+      <femaleEn>Arch Lady of the Church</femaleEn>
     </node>
     <node>
       <female>Леди Архиепископ</female>
       <male>Архиепископ</male>
+      <maleUa>Архієпископ</maleUa>
+      <femaleUa>Леді Архієпископ</femaleUa>
+      <maleEn>Arch Bishop</maleEn>
+      <femaleEn>Arch Lady of the Church</femaleEn>
     </node>
     <node>
       <female>Матриарх</female>
       <male>Патриарх</male>
+      <maleUa>Патріарх</maleUa>
+      <femaleUa>Матріарх</femaleUa>
+      <maleEn>Patriarch</maleEn>
+      <femaleEn>Matriarch</femaleEn>
     </node>
     <node>
       <female>Матриарх</female>
       <male>Патриарх</male>
+      <maleUa>Патріарх</maleUa>
+      <femaleUa>Матріарх</femaleUa>
+      <maleEn>Patriarch</maleEn>
+      <femaleEn>Matriarch</femaleEn>
     </node>
     <node>
       <female>Старейшина Матриарх</female>
       <male>Старейшина Патриарх</male>
+      <maleUa>Старійшина Патріарх</maleUa>
+      <femaleUa>Старійшина Матріарх</femaleUa>
+      <maleEn>Elder Patriarch</maleEn>
+      <femaleEn>Elder Matriarch</femaleEn>
     </node>
     <node>
       <female>Старейшина Матриарх</female>
       <male>Старейшина Патриарх</male>
+      <maleUa>Старійшина Патріарх</maleUa>
+      <femaleUa>Старійшина Матріарх</femaleUa>
+      <maleEn>Elder Patriarch</maleEn>
+      <femaleEn>Elder Matriarch</femaleEn>
     </node>
     <node>
       <female>Великий Матриарх</female>
       <male>Великий Патриарх</male>
+      <maleUa>Великий Патріарх</maleUa>
+      <femaleUa>Великий Матріарх</femaleUa>
+      <maleEn>Grand Patriarch</maleEn>
+      <femaleEn>Grand Matriarch</femaleEn>
     </node>
     <node>
       <female>Великий Матриарх</female>
       <male>Великий Патриарх</male>
+      <maleUa>Великий Патріарх</maleUa>
+      <femaleUa>Великий Матріарх</femaleUa>
+      <maleEn>Grand Patriarch</maleEn>
+      <femaleEn>Grand Matriarch</femaleEn>
     </node>
     <node>
       <female>Великий Матриарх</female>
       <male>Великий Патриарх</male>
+      <maleUa>Великий Патріарх</maleUa>
+      <femaleUa>Великий Матріарх</femaleUa>
+      <maleEn>Great Patriarch</maleEn>
+      <femaleEn>Great Matriarch</femaleEn>
     </node>
     <node>
       <female>Великий Матриарх</female>
       <male>Великий Патриарх</male>
+      <maleUa>Великий Патріарх</maleUa>
+      <femaleUa>Великий Матріарх</femaleUa>
+      <maleEn>Great Patriarch</maleEn>
+      <femaleEn>Great Matriarch</femaleEn>
     </node>
     <node>
       <female>Убийца демонов</female>
       <male>Убийца демонов</male>
+      <maleUa>Вбивця демонів</maleUa>
+      <femaleUa>Вбивця демонів</femaleUa>
+      <maleEn>Demon Killer</maleEn>
+      <femaleEn>Demon Killer</femaleEn>
     </node>
     <node>
       <female>Убийца демонов</female>
       <male>Убийца демонов</male>
+      <maleUa>Вбивця демонів</maleUa>
+      <femaleUa>Вбивця демонів</femaleUa>
+      <maleEn>Demon Killer</maleEn>
+      <femaleEn>Demon Killer</femaleEn>
     </node>
     <node>
       <female>Великая Убийца Демонов</female>
       <male>Великий Убийца Демонов</male>
+      <maleUa>Великий Вбивця Демонів</maleUa>
+      <femaleUa>Велика Вбивця Демонів</femaleUa>
+      <maleEn>Greater Demon Killer</maleEn>
+      <femaleEn>Greater Demon Killer</femaleEn>
     </node>
     <node>
       <female>Великая Убийца Демонов</female>
       <male>Великий Убийца Демонов</male>
+      <maleUa>Великий Вбивця Демонів</maleUa>
+      <femaleUa>Велика Вбивця Демонів</femaleUa>
+      <maleEn>Greater Demon Killer</maleEn>
+      <femaleEn>Greater Demon Killer</femaleEn>
     </node>
     <node>
       <female>Кардинал Морей</female>
       <male>Кардинал Морей</male>
+      <maleUa>Кардинал Морів</maleUa>
+      <femaleUa>Кардинал Морів</femaleUa>
+      <maleEn>Cardinal of the Sea</maleEn>
+      <femaleEn>Cardinal of the Sea</femaleEn>
     </node>
     <node>
       <female>Кардинал Морей</female>
       <male>Кардинал Морей</male>
+      <maleUa>Кардинал Морів</maleUa>
+      <femaleUa>Кардинал Морів</femaleUa>
+      <maleEn>Cardinal of the Sea</maleEn>
+      <femaleEn>Cardinal of the Sea</femaleEn>
     </node>
     <node>
       <female>Кардинал Земли</female>
       <male>Кардинал Земли</male>
+      <maleUa>Кардинал Землі</maleUa>
+      <femaleUa>Кардинал Землі</femaleUa>
+      <maleEn>Cardinal of the Earth</maleEn>
+      <femaleEn>Cardinal of the Earth</femaleEn>
     </node>
     <node>
       <female>Кардинал Земли</female>
       <male>Кардинал Земли</male>
+      <maleUa>Кардинал Землі</maleUa>
+      <femaleUa>Кардинал Землі</femaleUa>
+      <maleEn>Cardinal of the Earth</maleEn>
+      <femaleEn>Cardinal of the Earth</femaleEn>
     </node>
     <node>
       <female>Кардинал Воздуха</female>
       <male>Кардинал Воздуха</male>
+      <maleUa>Кардинал Повітря</maleUa>
+      <femaleUa>Кардинал Повітря</femaleUa>
+      <maleEn>Cardinal of the Air</maleEn>
+      <femaleEn>Cardinal of the Air</femaleEn>
     </node>
     <node>
       <female>Кардинал Воздуха</female>
       <male>Кардинал Воздуха</male>
+      <maleUa>Кардинал Повітря</maleUa>
+      <femaleUa>Кардинал Повітря</femaleUa>
+      <maleEn>Cardinal of the Air</maleEn>
+      <femaleEn>Cardinal of the Air</femaleEn>
     </node>
     <node>
       <female>Кардинал Зефира</female>
       <male>Кардинал Зефира</male>
+      <maleUa>Кардинал Зефіра</maleUa>
+      <femaleUa>Кардинал Зефіра</femaleUa>
+      <maleEn>Cardinal of the Ether</maleEn>
+      <femaleEn>Cardinal of the Ether</femaleEn>
     </node>
     <node>
       <female>Кардинал Эфира</female>
       <male>Кардинал Эфира</male>
+      <maleUa>Кардинал Ефіру</maleUa>
+      <femaleUa>Кардинал Ефіру</femaleUa>
+      <maleEn>Cardinal of the Ether</maleEn>
+      <femaleEn>Cardinal of the Ether</femaleEn>
     </node>
     <node>
       <female>Кардинал Небес</female>
       <male>Кардинал Небес</male>
+      <maleUa>Кардинал Небес</maleUa>
+      <femaleUa>Кардинал Небес</femaleUa>
+      <maleEn>Cardinal of the Heavens</maleEn>
+      <femaleEn>Cardinal of the Heavens</femaleEn>
     </node>
     <node>
       <female>Кардинал Небес</female>
       <male>Кардинал Небес</male>
+      <maleUa>Кардинал Небес</maleUa>
+      <femaleUa>Кардинал Небес</femaleUa>
+      <maleEn>Cardinal of the Heavens</maleEn>
+      <femaleEn>Cardinal of the Heavens</femaleEn>
     </node>
     <node>
       <female>Просветленная</female>
       <male>Просветленный</male>
+      <maleUa>Просвітлений</maleUa>
+      <femaleUa>Просвітлена</femaleUa>
+      <maleEn>Enlightened</maleEn>
+      <femaleEn>Enlightened</femaleEn>
     </node>
     <node>
       <female>Просветленная</female>
       <male>Просветленный</male>
+      <maleUa>Просвітлений</maleUa>
+      <femaleUa>Просвітлена</femaleUa>
+      <maleEn>Enlightened</maleEn>
+      <femaleEn>Enlightened</femaleEn>
     </node>
     <node>
       <female>Священная</female>
       <male>Священный</male>
+      <maleUa>Священний</maleUa>
+      <femaleUa>Священна</femaleUa>
+      <maleEn>Sacred</maleEn>
+      <femaleEn>Sacred</femaleEn>
     </node>
     <node>
       <female>Священная</female>
       <male>Священный</male>
+      <maleUa>Священний</maleUa>
+      <femaleUa>Священна</femaleUa>
+      <maleEn>Sacred</maleEn>
+      <femaleEn>Sacred</femaleEn>
     </node>
     <node>
       <female>Святая</female>
       <male>Святой</male>
+      <maleUa>Святий</maleUa>
+      <femaleUa>Свята</femaleUa>
+      <maleEn>Saint</maleEn>
+      <femaleEn>Saint</femaleEn>
     </node>
     <node>
       <female>Святая</female>
       <male>Святой</male>
+      <maleUa>Святий</maleUa>
+      <femaleUa>Свята</femaleUa>
+      <maleEn>Saint</maleEn>
+      <femaleEn>Saint</femaleEn>
     </node>
     <node>
       <female>Богослов</female>
       <male>Богослов</male>
+      <maleUa>Богослов</maleUa>
+      <femaleUa>Богослов</femaleUa>
+      <maleEn>Divine</maleEn>
+      <femaleEn>Divine</femaleEn>
     </node>
     <node>
       <female>Богослов</female>
       <male>Богослов</male>
+      <maleUa>Богослов</maleUa>
+      <femaleUa>Богослов</femaleUa>
+      <maleEn>Divine</maleEn>
+      <femaleEn>Divine</femaleEn>
     </node>
     <node>
       <female>Кардинал Цветов</female>
       <male>Кардинал Цветов</male>
+      <maleUa>Кардинал Квітів</maleUa>
+      <femaleUa>Кардинал Квітів</femaleUa>
+      <maleEn>Cardinal of Flowers</maleEn>
+      <femaleEn>Cardinal of Flowers</femaleEn>
     </node>
     <node>
       <female>Кардинал Цветов</female>
       <male>Кардинал Цветов</male>
+      <maleUa>Кардинал Квітів</maleUa>
+      <femaleUa>Кардинал Квітів</femaleUa>
+      <maleEn>Cardinal of Flowers</maleEn>
+      <femaleEn>Cardinal of Flowers</femaleEn>
     </node>
     <node>
       <female>Кардинал Воды</female>
       <male>Кардинал Воды</male>
+      <maleUa>Кардинал Води</maleUa>
+      <femaleUa>Кардинал Води</femaleUa>
+      <maleEn>Cardinal of Water</maleEn>
+      <femaleEn>Cardinal of Water</femaleEn>
     </node>
     <node>
       <female>Кардинал Воды</female>
       <male>Кардинал Воды</male>
+      <maleUa>Кардинал Води</maleUa>
+      <femaleUa>Кардинал Води</femaleUa>
+      <maleEn>Cardinal of Water</maleEn>
+      <femaleEn>Cardinal of Water</femaleEn>
     </node>
     <node>
       <female>Кардинал Огня</female>
       <male>Кардинал Огня</male>
+      <maleUa>Кардинал Вогню</maleUa>
+      <femaleUa>Кардинал Вогню</femaleUa>
+      <maleEn>Cardinal of Fire</maleEn>
+      <femaleEn>Cardinal of Fire</femaleEn>
     </node>
     <node>
       <female>Кардинал Огня</female>
       <male>Кардинал Огня</male>
+      <maleUa>Кардинал Вогню</maleUa>
+      <femaleUa>Кардинал Вогню</femaleUa>
+      <maleEn>Cardinal of Fire</maleEn>
+      <femaleEn>Cardinal of Fire</femaleEn>
     </node>
     <node>
       <female>Кардинал Льда</female>
       <male>Кардинал Льда</male>
+      <maleUa>Кардинал Льоду</maleUa>
+      <femaleUa>Кардинал Льоду</femaleUa>
+      <maleEn>Cardinal of Ice</maleEn>
+      <femaleEn>Cardinal of Ice</femaleEn>
     </node>
     <node>
       <female>Кардинал Льда</female>
       <male>Кардинал Льда</male>
+      <maleUa>Кардинал Льоду</maleUa>
+      <femaleUa>Кардинал Льоду</femaleUa>
+      <maleEn>Cardinal of Ice</maleEn>
+      <femaleEn>Cardinal of Ice</femaleEn>
     </node>
     <node>
       <female>Кардинал Ветров</female>
       <male>Кардинал Ветров</male>
+      <maleUa>Кардинал Вітрів</maleUa>
+      <femaleUa>Кардинал Вітрів</femaleUa>
+      <maleEn>Cardinal of the Winds</maleEn>
+      <femaleEn>Cardinal of the Winds</femaleEn>
     </node>
     <node>
       <female>Кардинал Ветров</female>
       <male>Кардинал Ветров</male>
+      <maleUa>Кардинал Вітрів</maleUa>
+      <femaleUa>Кардинал Вітрів</femaleUa>
+      <maleEn>Cardinal of the Winds</maleEn>
+      <femaleEn>Cardinal of the Winds</femaleEn>
     </node>
     <node>
       <female>Кардинал Штормов</female>
       <male>Кардинал Штормов</male>
+      <maleUa>Кардинал Штормів</maleUa>
+      <femaleUa>Кардинал Штормів</femaleUa>
+      <maleEn>Cardinal of Storms</maleEn>
+      <femaleEn>Cardinal of Storms</femaleEn>
     </node>
     <node>
       <female>Кардинал Штормов</female>
       <male>Кардинал Штормов</male>
+      <maleUa>Кардинал Штормів</maleUa>
+      <femaleUa>Кардинал Штормів</femaleUa>
+      <maleEn>Cardinal of Storms</maleEn>
+      <femaleEn>Cardinal of Storms</femaleEn>
     </node>
     <node>
       <female>Мать Земли</female>
       <male>Отец Земли</male>
+      <maleUa>Батько Землі</maleUa>
+      <femaleUa>Мати Землі</femaleUa>
+      <maleEn>Father of Earth</maleEn>
+      <femaleEn>Mother of Earth</femaleEn>
     </node>
     <node>
       <female>Мать Земли</female>
       <male>Отец Земли</male>
+      <maleUa>Батько Землі</maleUa>
+      <femaleUa>Мати Землі</femaleUa>
+      <maleEn>Father of Earth</maleEn>
+      <femaleEn>Mother of Earth</femaleEn>
     </node>
     <node>
       <female>Мать Морей</female>
       <male>Отец Морей</male>
+      <maleUa>Батько Морів</maleUa>
+      <femaleUa>Мати Морів</femaleUa>
+      <maleEn>Father of the Sea</maleEn>
+      <femaleEn>Mother of the Sea</femaleEn>
     </node>
     <node>
       <female>Мать Драконов</female>
       <male>Отец Драконов</male>
+      <maleUa>Батько Драконів</maleUa>
+      <femaleUa>Мати Драконів</femaleUa>
+      <maleEn>Father of Dragons</maleEn>
+      <femaleEn>Mother of Dragons</femaleEn>
     </node>
     <node>
       <female>Мать Времени</female>
       <male>Отец Времени</male>
+      <maleUa>Батько Часу</maleUa>
+      <femaleUa>Мати Часу</femaleUa>
+      <maleEn>Father of Time</maleEn>
+      <femaleEn>Mother of Time</femaleEn>
     </node>
     <node>
       <female>Мать Времени</female>
       <male>Отец Времени</male>
+      <maleUa>Батько Часу</maleUa>
+      <femaleUa>Мати Часу</femaleUa>
+      <maleEn>Father of Time</maleEn>
+      <femaleEn>Mother of Time</femaleEn>
     </node>
     <node>
       <female>Священное сердце</female>
       <male>Священное сердце</male>
+      <maleUa>Священне Серце</maleUa>
+      <femaleUa>Священне Серце</femaleUa>
+      <maleEn>Sacred Heart</maleEn>
+      <femaleEn>Sacred Heart</femaleEn>
     </node>
     <node>
       <female>Священное сердце</female>
       <male>Священное сердце</male>
+      <maleUa>Священне Серце</maleUa>
+      <femaleUa>Священне Серце</femaleUa>
+      <maleEn>Sacred Heart</maleEn>
+      <femaleEn>Sacred Heart</femaleEn>
     </node>
     <node>
       <female>Святая Мать</female>
       <male>Святой Отец</male>
+      <maleUa>Святий Отець</maleUa>
+      <femaleUa>Свята Мати</femaleUa>
+      <maleEn>Holy Father</maleEn>
+      <femaleEn>Holy Mother</femaleEn>
     </node>
     <node>
       <female>Святая Мать</female>
       <male>Святой Отец</male>
+      <maleUa>Святий Отець</maleUa>
+      <femaleUa>Свята Мати</femaleUa>
+      <maleEn>Holy Father</maleEn>
+      <femaleEn>Holy Mother</femaleEn>
     </node>
     <node>
       <female>Аватар Бессмертного</female>
       <male>Аватар Бессмертного</male>
+      <maleUa>Аватар Безсмертного</maleUa>
+      <femaleUa>Аватар Безсмертного</femaleUa>
+      <maleEn>Avatar of an Immortal</maleEn>
+      <femaleEn>Avatar of an Immortal</femaleEn>
     </node>
     <node>
       <female>Аватар Бессмертного</female>
       <male>Аватар Бессмертного</male>
+      <maleUa>Аватар Безсмертного</maleUa>
+      <femaleUa>Аватар Безсмертного</femaleUa>
+      <maleEn>Avatar of an Immortal</maleEn>
+      <femaleEn>Avatar of an Immortal</femaleEn>
     </node>
     <node>
       <female>Аватар Божества</female>
       <male>Аватар Божества</male>
+      <maleUa>Аватар Божества</maleUa>
+      <femaleUa>Аватар Божества</femaleUa>
+      <maleEn>Avatar of a Deity</maleEn>
+      <femaleEn>Avatar of a Deity</femaleEn>
     </node>
     <node>
       <female>Аватар Божества</female>
       <male>Аватар Божества</male>
+      <maleUa>Аватар Божества</maleUa>
+      <femaleUa>Аватар Божества</femaleUa>
+      <maleEn>Avatar of a Deity</maleEn>
+      <femaleEn>Avatar of a Deity</femaleEn>
     </node>
     <node>
       <female>Аватар Верховного</female>
       <male>Аватар Верховного</male>
+      <maleUa>Аватар Верховного</maleUa>
+      <femaleUa>Аватар Верховного</femaleUa>
+      <maleEn>Avatar of a Supremity</maleEn>
+      <femaleEn>Avatar of a Supremity</femaleEn>
     </node>
     <node>
       <female>Аватар Верховного</female>
       <male>Аватар Верховного</male>
+      <maleUa>Аватар Верховного</maleUa>
+      <femaleUa>Аватар Верховного</femaleUa>
+      <maleEn>Avatar of a Supremity</maleEn>
+      <femaleEn>Avatar of a Supremity</femaleEn>
     </node>
     <node>
       <female>Аватар Имплементора</female>
       <male>Аватар Имплементора</male>
+      <maleUa>Аватар Імплементора</maleUa>
+      <femaleUa>Аватар Імплементора</femaleUa>
+      <maleEn>Avatar of an Implementor</maleEn>
+      <femaleEn>Avatar of an Implementor</femaleEn>
     </node>
     <node>
       <female>Аватар Имплементора</female>
       <male>Аватар Имплементора</male>
+      <maleUa>Аватар Імплементора</maleUa>
+      <femaleUa>Аватар Імплементора</femaleUa>
+      <maleEn>Avatar of an Implementor</maleEn>
+      <femaleEn>Avatar of an Implementor</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Госпожа Святых Небес</female>
       <male>Господин Святых Небес</male>
+      <maleUa>Господар Святих Небес</maleUa>
+      <femaleUa>Господиня Святих Небес</femaleUa>
+      <maleEn>Master of all Divinity</maleEn>
+      <femaleEn>Mistress of all Divinity</femaleEn>
     </node>
     <node>
       <female>Святая Героиня</female>
       <male>Святой Герой</male>
+      <maleUa>Святий Герой</maleUa>
+      <femaleUa>Свята Героїня</femaleUa>
+      <maleEn>Holy Hero</maleEn>
+      <femaleEn>Holy Heroine</femaleEn>
     </node>
     <node>
       <female>Святой Аватар</female>
       <male>Святой Аватар</male>
+      <maleUa>Святий Аватар</maleUa>
+      <femaleUa>Святий Аватар</femaleUa>
+      <maleEn>Holy Avatar</maleEn>
+      <femaleEn>Holy Avatar</femaleEn>
     </node>
     <node>
       <female>Ангел</female>
       <male>Ангел</male>
+      <maleUa>Ангел</maleUa>
+      <femaleUa>Ангел</femaleUa>
+      <maleEn>Angel</maleEn>
+      <femaleEn>Angel</femaleEn>
     </node>
     <node>
       <female>Полубогиня</female>
       <male>Полубог</male>
+      <maleUa>Напівбог</maleUa>
+      <femaleUa>Напівбогиня</femaleUa>
+      <maleEn>Demigod</maleEn>
+      <femaleEn>Demigoddess</femaleEn>
     </node>
     <node>
       <female>Бессмертная</female>
       <male>Бессмертный</male>
+      <maleUa>Безсмертний</maleUa>
+      <femaleUa>Безсмертна</femaleUa>
+      <maleEn>Immortal</maleEn>
+      <femaleEn>Immortal</femaleEn>
     </node>
     <node>
       <female>Богиня</female>
       <male>Бог</male>
+      <maleUa>Бог</maleUa>
+      <femaleUa>Богиня</femaleUa>
+      <maleEn>God</maleEn>
+      <femaleEn>Goddess</femaleEn>
     </node>
     <node>
       <female>Божественная</female>
       <male>Божественный</male>
+      <maleUa>Божественний</maleUa>
+      <femaleUa>Божественна</femaleUa>
+      <maleEn>Divine</maleEn>
+      <femaleEn>Divine</femaleEn>
     </node>
     <node>
       <female>Верховная Госпожа</female>
       <male>Верховный Господин</male>
+      <maleUa>Верховний Господар</maleUa>
+      <femaleUa>Верховна Господиня</femaleUa>
+      <maleEn>Supreme Master</maleEn>
+      <femaleEn>Supreme Mistress</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Имплементор</female>
       <male>Имплементор</male>
+      <maleUa>Імплементор</maleUa>
+      <femaleUa>Імплементор</femaleUa>
+      <maleEn>Implementor</maleEn>
+      <femaleEn>Implementor</femaleEn>
     </node>
   </titles>
   <weapon>40100</weapon>

--- a/professions/druid.xml
+++ b/professions/druid.xml
@@ -64,6 +64,8 @@ To use their powers, druids must choose a {hh1religion{x -- and only gods of the
   <thac32>2</thac32>
   <titles type="ProfessionTitlesByConstant">
     <title>Лесной Пастырь</title>
+    <titleUa>Лісовий Пастир</titleUa>
+    <titleEn>Forest Shepherd</titleEn>
   </titles>
   <weapon>40118</weapon>
   <wearModifiers>

--- a/professions/necromancer.xml
+++ b/professions/necromancer.xml
@@ -46,446 +46,890 @@
     <node>
       <female>Женщина</female>
       <male>Мужчина</male>
+      <maleUa>Чоловік</maleUa>
+      <femaleUa>Жінка</femaleUa>
+      <maleEn>Man</maleEn>
+      <femaleEn>Woman</femaleEn>
     </node>
     <node>
       <female>Ученица Магии</female>
       <male>Ученик Магии</male>
+      <maleUa>Учень Магії</maleUa>
+      <femaleUa>Учениця Магії</femaleUa>
+      <maleEn>Apprentice of Magic</maleEn>
+      <femaleEn>Apprentice of Magic</femaleEn>
     </node>
     <node>
       <female>Студентка Магии</female>
       <male>Студент Магии</male>
+      <maleUa>Студент Магії</maleUa>
+      <femaleUa>Студентка Магії</femaleUa>
+      <maleEn>Spell Student</maleEn>
+      <femaleEn>Spell Student</femaleEn>
     </node>
     <node>
       <female>Изучающая Магию</female>
       <male>Изучающий Магию</male>
+      <maleUa>Вивчаючий Магію</maleUa>
+      <femaleUa>Вивчаюча Магію</femaleUa>
+      <maleEn>Scholar of Magic</maleEn>
+      <femaleEn>Scholar of Magic</femaleEn>
     </node>
     <node>
       <female>Погружающаяся в Магию</female>
       <male>Погружающийся в Магию</male>
+      <maleUa>Занурений у Магію</maleUa>
+      <femaleUa>Занурена у Магію</femaleUa>
+      <maleEn>Delver in Spells</maleEn>
+      <femaleEn>Delveress in Spells</femaleEn>
     </node>
     <node>
       <female>Проводница Магии</female>
       <male>Проводник Магии</male>
+      <maleUa>Провідник Магії</maleUa>
+      <femaleUa>Провідниця Магії</femaleUa>
+      <maleEn>Medium of Magic</maleEn>
+      <femaleEn>Medium of Magic</femaleEn>
     </node>
     <node>
       <female>Пишущая Магию</female>
       <male>Пишущий Магию</male>
+      <maleUa>Пишучий Магію</maleUa>
+      <femaleUa>Пишуча Магію</femaleUa>
+      <maleEn>Scribe of Magic</maleEn>
+      <femaleEn>Scribess of Magic</femaleEn>
     </node>
     <node>
       <female>Видящая</female>
       <male>Видящий</male>
+      <maleUa>Провидець</maleUa>
+      <femaleUa>Провидиця</femaleUa>
+      <maleEn>Seer</maleEn>
+      <femaleEn>Seeress</femaleEn>
     </node>
     <node>
       <female>Мудрая</female>
       <male>Мудрец</male>
+      <maleUa>Мудрець</maleUa>
+      <femaleUa>Мудра</femaleUa>
+      <maleEn>Sage</maleEn>
+      <femaleEn>Sage</femaleEn>
     </node>
     <node>
       <female>Мастерица Иллюзий</female>
       <male>Мастер Иллюзий</male>
+      <maleUa>Майстер Ілюзій</maleUa>
+      <femaleUa>Майстриня Ілюзій</femaleUa>
+      <maleEn>Illusionist</maleEn>
+      <femaleEn>Illusionist</femaleEn>
     </node>
     <node>
       <female>Мастерица Аффектов</female>
       <male>Мастер Аффектов</male>
+      <maleUa>Майстер Афектів</maleUa>
+      <femaleUa>Майстриня Афектів</femaleUa>
+      <maleEn>Abjurer</maleEn>
+      <femaleEn>Abjuress</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Invoker</maleEn>
+      <femaleEn>Invoker</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Invoker</maleEn>
+      <femaleEn>Invoker</femaleEn>
     </node>
     <node>
       <female>Мастерица Проклятий</female>
       <male>Мастер Проклятий</male>
+      <maleUa>Майстер Прокльонів</maleUa>
+      <femaleUa>Майстриня Прокльонів</femaleUa>
+      <maleEn>Enchanter</maleEn>
+      <femaleEn>Enchantress</femaleEn>
     </node>
     <node>
       <female>Мастерица Проклятий</female>
       <male>Мастер Проклятий</male>
+      <maleUa>Майстер Прокльонів</maleUa>
+      <femaleUa>Майстриня Прокльонів</femaleUa>
+      <maleEn>Enchanter</maleEn>
+      <femaleEn>Enchantress</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Призову</maleUa>
+      <femaleUa>Майстриня Призову</femaleUa>
+      <maleEn>Conjurer</maleEn>
+      <femaleEn>Conjuress</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Призову</maleUa>
+      <femaleUa>Майстриня Призову</femaleUa>
+      <maleEn>Conjurer</maleEn>
+      <femaleEn>Conjuress</femaleEn>
     </node>
     <node>
       <female>Магичка</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Магиня</femaleUa>
+      <maleEn>Magician</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Магичка</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Магиня</femaleUa>
+      <maleEn>Magician</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Savant</maleEn>
+      <femaleEn>Savant</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Savant</maleEn>
+      <femaleEn>Savant</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чароплет</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Magus</maleEn>
+      <femaleEn>Craftess</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чароплет</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Magus</maleEn>
+      <femaleEn>Craftess</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Wizard</maleEn>
+      <femaleEn>Wizard</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Wizard</maleEn>
+      <femaleEn>Wizard</femaleEn>
     </node>
     <node>
       <female>Чернокнижница</female>
       <male>Чернокнижник</male>
+      <maleUa>Чорнокнижник</maleUa>
+      <femaleUa>Чорнокнижниця</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>War Witch</femaleEn>
     </node>
     <node>
       <female>Чернокнижница</female>
       <male>Чернокнижник</male>
+      <maleUa>Чорнокнижник</maleUa>
+      <femaleUa>Чорнокнижниця</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>War Witch</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Кудесник</maleUa>
+      <femaleUa>Кудесниця</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Кудесник</maleUa>
+      <femaleUa>Кудесниця</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Кудесник</maleUa>
+      <femaleUa>Старша Кудесниця</femaleUa>
+      <maleEn>Elder Sorcerer</maleEn>
+      <femaleEn>Elder Sorceress</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Кудесник</maleUa>
+      <femaleUa>Старша Кудесниця</femaleUa>
+      <maleEn>Elder Sorcerer</maleEn>
+      <femaleEn>Elder Sorceress</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Кудесник</maleUa>
+      <femaleUa>Велика Кудесниця</femaleUa>
+      <maleEn>Grand Sorcerer</maleEn>
+      <femaleEn>Grand Sorceress</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Кудесник</maleUa>
+      <femaleUa>Велика Кудесниця</femaleUa>
+      <maleEn>Grand Sorcerer</maleEn>
+      <femaleEn>Grand Sorceress</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Кудесник</maleUa>
+      <femaleUa>Найвеличніша Кудесниця</femaleUa>
+      <maleEn>Great Sorcerer</maleEn>
+      <femaleEn>Great Sorceress</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Кудесник</maleUa>
+      <femaleUa>Найвеличніша Кудесниця</femaleUa>
+      <maleEn>Great Sorcerer</maleEn>
+      <femaleEn>Great Sorceress</femaleEn>
     </node>
     <node>
       <female>Мастерица Тьмы</female>
       <male>Мастер Тьмы</male>
+      <maleUa>Майстер Темряви</maleUa>
+      <femaleUa>Майстриня Темряви</femaleUa>
+      <maleEn>Master of Darkness</maleEn>
+      <femaleEn>Mistress of Darkness</femaleEn>
     </node>
     <node>
       <female>Мастерица Тьмы</female>
       <male>Мастер Тьмы</male>
+      <maleUa>Майстер Темряви</maleUa>
+      <femaleUa>Майстриня Темряви</femaleUa>
+      <maleEn>Master of Darkness</maleEn>
+      <femaleEn>Mistress of Darkness</femaleEn>
     </node>
     <node>
       <female>Властительница Тьмы</female>
       <male>Властелин Тьмы</male>
+      <maleUa>Владар Темряви</maleUa>
+      <femaleUa>Владарка Темряви</femaleUa>
+      <maleEn>Sovereign of Darkness</maleEn>
+      <femaleEn>Sovereign of Darkness</femaleEn>
     </node>
     <node>
       <female>Властительница Тьмы</female>
       <male>Властелин Тьмы</male>
+      <maleUa>Владар Темряви</maleUa>
+      <femaleUa>Владарка Темряви</femaleUa>
+      <maleEn>Sovereign of Darkness</maleEn>
+      <femaleEn>Sovereign of Darkness</femaleEn>
     </node>
     <node>
       <female>Повелительница Тьмы</female>
       <male>Повелитель Тьмы</male>
+      <maleUa>Повелитель Темряви</maleUa>
+      <femaleUa>Повелителька Темряви</femaleUa>
+      <maleEn>Lord of Darkness</maleEn>
+      <femaleEn>Lady of Darkness</femaleEn>
     </node>
     <node>
       <female>Повелительница Тьмы</female>
       <male>Повелитель Тьмы</male>
+      <maleUa>Повелитель Темряви</maleUa>
+      <femaleUa>Повелителька Темряви</femaleUa>
+      <maleEn>Lord of Darkness</maleEn>
+      <femaleEn>Lady of Darkness</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Повелитель Алхімії</maleUa>
+      <femaleUa>Повелителька Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Повелитель Алхімії</maleUa>
+      <femaleUa>Повелителька Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Повелитель Артефактів</maleUa>
+      <femaleUa>Повелителька Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Повелитель Артефактів</maleUa>
+      <femaleUa>Повелителька Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Проникаючий в Інші Простори</maleUa>
+      <femaleUa>Проникаюча в Інші Простори</femaleUa>
+      <maleEn>Piercer of Other Realms</maleEn>
+      <femaleEn>Piercer of Other Realms</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Проникаючий в Інші Простори</maleUa>
+      <femaleUa>Проникаюча в Інші Простори</femaleUa>
+      <maleEn>Piercer of Other Realms</maleEn>
+      <femaleEn>Piercer of Other Realms</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Взиваючий до Демонів</maleUa>
+      <femaleUa>Взиваюча до Демонів</femaleUa>
+      <maleEn>Caller of Demons</maleEn>
+      <femaleEn>Caller of Demons</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Взиваючий до Демонів</maleUa>
+      <femaleUa>Взиваюча до Демонів</femaleUa>
+      <maleEn>Caller of Demons</maleEn>
+      <femaleEn>Caller of Demons</femaleEn>
     </node>
     <node>
       <female>Ездящая на Призраках</female>
       <male>Ездок на Призраках</male>
+      <maleUa>Вершник на Привидах</maleUa>
+      <femaleUa>Вершниця на Привидах</femaleUa>
+      <maleEn>Rider of Phantoms</maleEn>
+      <femaleEn>Rider of Phantoms</femaleEn>
     </node>
     <node>
       <female>Ездящая на Призраках</female>
       <male>Ездок на Призраках</male>
+      <maleUa>Вершник на Привидах</maleUa>
+      <femaleUa>Вершниця на Привидах</femaleUa>
+      <maleEn>Rider of Phantoms</maleEn>
+      <femaleEn>Rider of Phantoms</femaleEn>
     </node>
     <node>
       <female>Повелительница Призраков</female>
       <male>Повелитель Призраков</male>
+      <maleUa>Повелитель Привидів</maleUa>
+      <femaleUa>Повелителька Привидів</femaleUa>
+      <maleEn>Lord of Phantoms</maleEn>
+      <femaleEn>Lady of Phantoms</femaleEn>
     </node>
     <node>
       <female>Повелительница Призраков</female>
       <male>Повелитель Призраков</male>
+      <maleUa>Повелитель Привидів</maleUa>
+      <femaleUa>Повелителька Привидів</femaleUa>
+      <maleEn>Lord of Phantoms</maleEn>
+      <femaleEn>Lady of Phantoms</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Повелитель Чарів</maleUa>
+      <femaleUa>Повелителька Чарів</femaleUa>
+      <maleEn>Lord of Enchantments</maleEn>
+      <femaleEn>Lady of Enchantments</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Повелитель Чарів</maleUa>
+      <femaleUa>Повелителька Чарів</femaleUa>
+      <maleEn>Lord of Enchantments</maleEn>
+      <femaleEn>Lady of Enchantments</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Повелитель Чаклунства</maleUa>
+      <femaleUa>Повелителька Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Повелитель Чаклунства</maleUa>
+      <femaleUa>Повелителька Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Spellcaster</maleEn>
+      <femaleEn>Great Spellcaster</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Spellcaster</maleEn>
+      <femaleEn>Great Spellcaster</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoness</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoness</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Крізь Час</maleUa>
+      <femaleUa>Провидиця Крізь Час</femaleUa>
+      <maleEn>Seer Through Time</maleEn>
+      <femaleEn>Seeress Through Time</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Крізь Час</maleUa>
+      <femaleUa>Провидиця Крізь Час</femaleUa>
+      <maleEn>Seer Through Time</maleEn>
+      <femaleEn>Seeress Through Time</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Повелитель Потоку</maleUa>
+      <femaleUa>Повелителька Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Повелитель Потоку</maleUa>
+      <femaleUa>Повелителька Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Осягаючий Хаос</maleUa>
+      <femaleUa>Осягаюча Хаос</femaleUa>
+      <maleEn>Adept of Chaos</maleEn>
+      <femaleEn>Adept of Chaos</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Осягаючий Хаос</maleUa>
+      <femaleUa>Осягаюча Хаос</femaleUa>
+      <maleEn>Adept of Chaos</maleEn>
+      <femaleEn>Adept of Chaos</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкуючий Хаос</maleUa>
+      <femaleUa>Приборкуюча Хаос</femaleUa>
+      <maleEn>Tamer of Chaos</maleEn>
+      <femaleEn>Tamer of Chaos</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкуючий Хаос</maleUa>
+      <femaleUa>Приборкуюча Хаос</femaleUa>
+      <maleEn>Tamer of Chaos</maleEn>
+      <femaleEn>Tamer of Chaos</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Заклинаючий Хаос</maleUa>
+      <femaleUa>Заклинаюча Хаос</femaleUa>
+      <maleEn>Chaos Binder</maleEn>
+      <femaleEn>Chaos Binder</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Заклинаючий Хаос</maleUa>
+      <femaleUa>Заклинаюча Хаос</femaleUa>
+      <maleEn>Chaos Binder</maleEn>
+      <femaleEn>Chaos Binder</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Пануючий над Хаосом</maleUa>
+      <femaleUa>Пануюча над Хаосом</femaleUa>
+      <maleEn>Ruler of Chaos</maleEn>
+      <femaleEn>Ruler of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Пануючий над Хаосом</maleUa>
+      <femaleUa>Пануюча над Хаосом</femaleUa>
+      <maleEn>Ruler of Chaos</maleEn>
+      <femaleEn>Ruler of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Повелитель Магії</maleUa>
+      <femaleUa>Повелителька Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Повелитель Магії</maleUa>
+      <femaleUa>Повелителька Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Повелитель Минулого</maleUa>
+      <femaleUa>Повелителька Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Повелитель Минулого</maleUa>
+      <femaleUa>Повелителька Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Повелитель Сьогодення</maleUa>
+      <femaleUa>Повелителька Сьогодення</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Повелитель Сьогодення</maleUa>
+      <femaleUa>Повелителька Сьогодення</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Повелитель Майбутнього</maleUa>
+      <femaleUa>Повелителька Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Повелитель Майбутнього</maleUa>
+      <femaleUa>Повелителька Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Повелительница Умертвий</female>
       <male>Повелитель Умертвий</male>
+      <maleUa>Повелитель Умертвих</maleUa>
+      <femaleUa>Повелителька Умертвих</femaleUa>
+      <maleEn>Lord of the Undead</maleEn>
+      <femaleEn>Lady of the Undead</femaleEn>
     </node>
     <node>
       <female>Повелительница Умертвий</female>
       <male>Повелитель Умертвий</male>
+      <maleUa>Повелитель Умертвих</maleUa>
+      <femaleUa>Повелителька Умертвих</femaleUa>
+      <maleEn>Lord of the Undead</maleEn>
+      <femaleEn>Lady of the Undead</femaleEn>
     </node>
     <node>
       <female>Повелительница Умертвий</female>
       <male>Повелитель Умертвий</male>
+      <maleUa>Повелитель Умертвих</maleUa>
+      <femaleUa>Повелителька Умертвих</femaleUa>
+      <maleEn>Lord of the Undead</maleEn>
+      <femaleEn>Lady of the Undead</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Нічний Господар</maleUa>
+      <femaleUa>Нічна Господиня</femaleUa>
+      <maleEn>Night Master</maleEn>
+      <femaleEn>Night Mistress</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Нічний Господар</maleUa>
+      <femaleUa>Нічна Господиня</femaleUa>
+      <maleEn>Night Master</maleEn>
+      <femaleEn>Night Mistress</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Нічний Господар</maleUa>
+      <femaleUa>Нічна Господиня</femaleUa>
+      <maleEn>Night Master</maleEn>
+      <femaleEn>Night Mistress</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Нічний Господар</maleUa>
+      <femaleUa>Нічна Господиня</femaleUa>
+      <maleEn>Night Master</maleEn>
+      <femaleEn>Night Mistress</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Смерти</female>
       <male>Великий Повелитель Смерти</male>
+      <maleUa>Великий Повелитель Смерті</maleUa>
+      <femaleUa>Велика Повелителька Смерті</femaleUa>
+      <maleEn>Great Lord of Death</maleEn>
+      <femaleEn>Great Lady of Death</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Смерти</female>
       <male>Великий Повелитель Смерти</male>
+      <maleUa>Великий Повелитель Смерті</maleUa>
+      <femaleUa>Велика Повелителька Смерті</femaleUa>
+      <maleEn>Great Lord of Death</maleEn>
+      <femaleEn>Great Lady of Death</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Смерти</female>
       <male>Великий Повелитель Смерти</male>
+      <maleUa>Великий Повелитель Смерті</maleUa>
+      <femaleUa>Велика Повелителька Смерті</femaleUa>
+      <maleEn>Great Lord of Death</maleEn>
+      <femaleEn>Great Lady of Death</femaleEn>
     </node>
     <node>
       <female>Легендарная Некромантка</female>
       <male>Легендарный Некромант</male>
+      <maleUa>Легендарний Некромант</maleUa>
+      <femaleUa>Легендарна Некромантка</femaleUa>
+      <maleEn>Legendary Necromancer</maleEn>
+      <femaleEn>Legendary Necromancer</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
   </titles>
   <weapon>40101</weapon>

--- a/professions/ninja.xml
+++ b/professions/ninja.xml
@@ -56,406 +56,810 @@
     <node>
       <female>Укэ</female>
       <male>Укэ</male>
+      <maleUa>Уке</maleUa>
+      <femaleUa>Уке</femaleUa>
+      <maleEn>Uke</maleEn>
+      <femaleEn>Uke</femaleEn>
     </node>
     <node>
       <female>Тори</female>
       <male>Тори</male>
+      <maleUa>Торі</maleUa>
+      <femaleUa>Торі</femaleUa>
+      <maleEn>Tori</maleEn>
+      <femaleEn>Tori</femaleEn>
     </node>
     <node>
       <female>Белый Пояс</female>
       <male>Белый Пояс</male>
+      <maleUa>Білий Пояс</maleUa>
+      <femaleUa>Білий Пояс</femaleUa>
+      <maleEn>White Belt</maleEn>
+      <femaleEn>White Belt</femaleEn>
     </node>
     <node>
       <female>Жёлтый Пояс</female>
       <male>Жёлтый Пояс</male>
+      <maleUa>Жовтий Пояс</maleUa>
+      <femaleUa>Жовтий Пояс</femaleUa>
+      <maleEn>Yellow Belt</maleEn>
+      <femaleEn>Yellow Belt</femaleEn>
     </node>
     <node>
       <female>Зелёный Пояс</female>
       <male>Зелёный Пояс</male>
+      <maleUa>Зелений Пояс</maleUa>
+      <femaleUa>Зелений Пояс</femaleUa>
+      <maleEn>Green Belt</maleEn>
+      <femaleEn>Green Belt</femaleEn>
     </node>
     <node>
       <female>Коричневый Пояс Третий Кю</female>
       <male>Коричневый Пояс Третий Кю</male>
+      <maleUa>Коричневий Пояс Третій Кю</maleUa>
+      <femaleUa>Коричневий Пояс Третій Кю</femaleUa>
+      <maleEn>3rd Brown</maleEn>
+      <femaleEn>3rd Brown</femaleEn>
     </node>
     <node>
       <female>Коричневый Пояс Второй Кю</female>
       <male>Коричневый Пояс Второй Кю</male>
+      <maleUa>Коричневий Пояс Другий Кю</maleUa>
+      <femaleUa>Коричневий Пояс Другий Кю</femaleUa>
+      <maleEn>2nd Brown</maleEn>
+      <femaleEn>2nd Brown</femaleEn>
     </node>
     <node>
       <female>Коричневый Пояс Первый Кю</female>
       <male>Коричневый Пояс Первый Кю</male>
+      <maleUa>Коричневий Пояс Перший Кю</maleUa>
+      <femaleUa>Коричневий Пояс Перший Кю</femaleUa>
+      <maleEn>1st Brown</maleEn>
+      <femaleEn>1st Brown</femaleEn>
     </node>
     <node>
       <female>Чёрный Пояс Первый Дан</female>
       <male>Чёрный Пояс Первый Дан</male>
+      <maleUa>Чорний Пояс Перший Дан</maleUa>
+      <femaleUa>Чорний Пояс Перший Дан</femaleUa>
+      <maleEn>Black Belt First Dan</maleEn>
+      <femaleEn>Black Belt First Dan</femaleEn>
     </node>
     <node>
       <female>Чёрный Пояс Второй Дан</female>
       <male>Чёрный Пояс Второй Дан</male>
+      <maleUa>Чорний Пояс Другий Дан</maleUa>
+      <femaleUa>Чорний Пояс Другий Дан</femaleUa>
+      <maleEn>Black Belt Second Dan</maleEn>
+      <femaleEn>Black Belt Second Dan</femaleEn>
     </node>
     <node>
       <female>Окуири</female>
       <male>Окуири</male>
+      <maleUa>Окуірі</maleUa>
+      <femaleUa>Окуірі</femaleUa>
+      <maleEn>Okuiri</maleEn>
+      <femaleEn>Okuiri</femaleEn>
     </node>
     <node>
       <female>Окуири</female>
       <male>Окуири</male>
+      <maleUa>Окуірі</maleUa>
+      <femaleUa>Окуірі</femaleUa>
+      <maleEn>Okuiri</maleEn>
+      <femaleEn>Okuiri</femaleEn>
     </node>
     <node>
       <female>Шуто</female>
       <male>Шуто</male>
+      <maleUa>Шуто</maleUa>
+      <femaleUa>Шуто</femaleUa>
+      <maleEn>Shuto</maleEn>
+      <femaleEn>Shuto</femaleEn>
     </node>
     <node>
       <female>Шуто</female>
       <male>Шуто</male>
+      <maleUa>Шуто</maleUa>
+      <femaleUa>Шуто</femaleUa>
+      <maleEn>Shuto</maleEn>
+      <femaleEn>Shuto</femaleEn>
     </node>
     <node>
       <female>Уракэн</female>
       <male>Уракэн</male>
+      <maleUa>Уракен</maleUa>
+      <femaleUa>Уракен</femaleUa>
+      <maleEn>Uraken</maleEn>
+      <femaleEn>Uraken</femaleEn>
     </node>
     <node>
       <female>Уракэн</female>
       <male>Уракэн</male>
+      <maleUa>Уракен</maleUa>
+      <femaleUa>Уракен</femaleUa>
+      <maleEn>Uraken</maleEn>
+      <femaleEn>Uraken</femaleEn>
     </node>
     <node>
       <female>Шотей</female>
       <male>Шотей</male>
+      <maleUa>Шотей</maleUa>
+      <femaleUa>Шотей</femaleUa>
+      <maleEn>Shotei</maleEn>
+      <femaleEn>Shotei</femaleEn>
     </node>
     <node>
       <female>Шотей</female>
       <male>Шотей</male>
+      <maleUa>Шотей</maleUa>
+      <femaleUa>Шотей</femaleUa>
+      <maleEn>Shotei</maleEn>
+      <femaleEn>Shotei</femaleEn>
     </node>
     <node>
       <female>Татэкен</female>
       <male>Татэкен</male>
+      <maleUa>Татекен</maleUa>
+      <femaleUa>Татекен</femaleUa>
+      <maleEn>Tateken</maleEn>
+      <femaleEn>Tateken</femaleEn>
     </node>
     <node>
       <female>Татэкен</female>
       <male>Татэкен</male>
+      <maleUa>Татекен</maleUa>
+      <femaleUa>Татекен</femaleUa>
+      <maleEn>Tateken</maleEn>
+      <femaleEn>Tateken</femaleEn>
     </node>
     <node>
       <female>Сэйкэн</female>
       <male>Сэйкэн</male>
+      <maleUa>Сейкен</maleUa>
+      <femaleUa>Сейкен</femaleUa>
+      <maleEn>Seiken</maleEn>
+      <femaleEn>Seiken</femaleEn>
     </node>
     <node>
       <female>Сэйкэн</female>
       <male>Сэйкэн</male>
+      <maleUa>Сейкен</maleUa>
+      <femaleUa>Сейкен</femaleUa>
+      <maleEn>Seiken</maleEn>
+      <femaleEn>Seiken</femaleEn>
     </node>
     <node>
       <female>Уде</female>
       <male>Уде</male>
+      <maleUa>Уде</maleUa>
+      <femaleUa>Уде</femaleUa>
+      <maleEn>Ude</maleEn>
+      <femaleEn>Ude</femaleEn>
     </node>
     <node>
       <female>Уде</female>
       <male>Уде</male>
+      <maleUa>Уде</maleUa>
+      <femaleUa>Уде</femaleUa>
+      <maleEn>Ude</maleEn>
+      <femaleEn>Ude</femaleEn>
     </node>
     <node>
       <female>Энпи</female>
       <male>Энпи</male>
+      <maleUa>Енпі</maleUa>
+      <femaleUa>Енпі</femaleUa>
+      <maleEn>Empi</maleEn>
+      <femaleEn>Empi</femaleEn>
     </node>
     <node>
       <female>Энпи</female>
       <male>Энпи</male>
+      <maleUa>Енпі</maleUa>
+      <femaleUa>Енпі</femaleUa>
+      <maleEn>Empi</maleEn>
+      <femaleEn>Empi</femaleEn>
     </node>
     <node>
       <female>Джосокутэй</female>
       <male>Джосокутэй</male>
+      <maleUa>Джосокутей</maleUa>
+      <femaleUa>Джосокутей</femaleUa>
+      <maleEn>Josokutei</maleEn>
+      <femaleEn>Josokotei</femaleEn>
     </node>
     <node>
       <female>Джосокутэй</female>
       <male>Джосокутэй</male>
+      <maleUa>Джосокутей</maleUa>
+      <femaleUa>Джосокутей</femaleUa>
+      <maleEn>Josokutei</maleEn>
+      <femaleEn>Josokotei</femaleEn>
     </node>
     <node>
       <female>Касокутэй</female>
       <male>Касокутэй</male>
+      <maleUa>Касокутей</maleUa>
+      <femaleUa>Касокутей</femaleUa>
+      <maleEn>Kasokutei</maleEn>
+      <femaleEn>Kasokutei</femaleEn>
     </node>
     <node>
       <female>Касокутэй</female>
       <male>Касокутэй</male>
+      <maleUa>Касокутей</maleUa>
+      <femaleUa>Касокутей</femaleUa>
+      <maleEn>Kasokutei</maleEn>
+      <femaleEn>Kasokutei</femaleEn>
     </node>
     <node>
       <female>Мастер Атэми Вадза</female>
       <male>Мастер Атэми Вадза</male>
+      <maleUa>Майстер Атемі Вадза</maleUa>
+      <femaleUa>Майстер Атемі Вадза</femaleUa>
+      <maleEn>Master of Atemi Waza</maleEn>
+      <femaleEn>Mistress of Atemi Waza</femaleEn>
     </node>
     <node>
       <female>Мастер Атэми Вадза</female>
       <male>Мастер Атэми Вадза</male>
+      <maleUa>Майстер Атемі Вадза</maleUa>
+      <femaleUa>Майстер Атемі Вадза</femaleUa>
+      <maleEn>Master of Atemi Waza</maleEn>
+      <femaleEn>Mistress of Atemi Waza</femaleEn>
     </node>
     <node>
       <female>Мастер Коте Гаеши</female>
       <male>Мастер Коте Гаеши</male>
+      <maleUa>Майстер Коте Гаеші</maleUa>
+      <femaleUa>Майстер Коте Гаеші</femaleUa>
+      <maleEn>Master of Kotegaeshi</maleEn>
+      <femaleEn>Mistress of Kotegaeshi</femaleEn>
     </node>
     <node>
       <female>Мастер Коте Гаеши</female>
       <male>Мастер Коте Гаеши</male>
+      <maleUa>Майстер Коте Гаеші</maleUa>
+      <femaleUa>Майстер Коте Гаеші</femaleUa>
+      <maleEn>Master of Kotegaeshi</maleEn>
+      <femaleEn>Mistress of Kotegaeshi</femaleEn>
     </node>
     <node>
       <female>Мастер Кансэтсу Вадза</female>
       <male>Мастер Кансэтсу Вадза</male>
+      <maleUa>Майстер Кансетсу Вадза</maleUa>
+      <femaleUa>Майстер Кансетсу Вадза</femaleUa>
+      <maleEn>Master of Kansetsuwaza</maleEn>
+      <femaleEn>Mistress of Kansetsuwaza</femaleEn>
     </node>
     <node>
       <female>Мастер Кансэтсу Вадза</female>
       <male>Мастер Кансэтсу Вадза</male>
+      <maleUa>Майстер Кансетсу Вадза</maleUa>
+      <femaleUa>Майстер Кансетсу Вадза</femaleUa>
+      <maleEn>Master of Kansetsuwaza</maleEn>
+      <femaleEn>Mistress of Kansetsuwaza</femaleEn>
     </node>
     <node>
       <female>Мастер Тай Сабаки</female>
       <male>Мастер Тай Сабаки</male>
+      <maleUa>Майстер Тай Сабакі</maleUa>
+      <femaleUa>Майстер Тай Сабакі</femaleUa>
+      <maleEn>Master of Taisabaki</maleEn>
+      <femaleEn>Mistress of Taisabaki</femaleEn>
     </node>
     <node>
       <female>Мастер Тай Сабаки</female>
       <male>Мастер Тай Сабаки</male>
+      <maleUa>Майстер Тай Сабакі</maleUa>
+      <femaleUa>Майстер Тай Сабакі</femaleUa>
+      <maleEn>Master of Taisabaki</maleEn>
+      <femaleEn>Mistress of Taisabaki</femaleEn>
     </node>
     <node>
       <female>Мастер Кюшо</female>
       <male>Мастер Кюшо</male>
+      <maleUa>Майстер Кюшо</maleUa>
+      <femaleUa>Майстер Кюшо</femaleUa>
+      <maleEn>Master of Kyusho</maleEn>
+      <femaleEn>Mistress of Kyusho</femaleEn>
     </node>
     <node>
       <female>Мастер Кюшо</female>
       <male>Мастер Кюшо</male>
+      <maleUa>Майстер Кюшо</maleUa>
+      <femaleUa>Майстер Кюшо</femaleUa>
+      <maleEn>Master of Kyusho</maleEn>
+      <femaleEn>Mistress of Kyusho</femaleEn>
     </node>
     <node>
       <female>Ученик Камаэ</female>
       <male>Ученик Камаэ</male>
+      <maleUa>Учень Камае</maleUa>
+      <femaleUa>Учень Камае</femaleUa>
+      <maleEn>Student of Kamae</maleEn>
+      <femaleEn>Student of Kamae</femaleEn>
     </node>
     <node>
       <female>Ученик Камаэ</female>
       <male>Ученик Камаэ</male>
+      <maleUa>Учень Камае</maleUa>
+      <femaleUa>Учень Камае</femaleUa>
+      <maleEn>Student of Kamae</maleEn>
+      <femaleEn>Student of Kamae</femaleEn>
     </node>
     <node>
       <female>Мастер Камаэ</female>
       <male>Мастер Камаэ</male>
+      <maleUa>Майстер Камае</maleUa>
+      <femaleUa>Майстер Камае</femaleUa>
+      <maleEn>Master of Kamae</maleEn>
+      <femaleEn>Mistress of Kamae</femaleEn>
     </node>
     <node>
       <female>Мастер Камаэ</female>
       <male>Мастер Камаэ</male>
+      <maleUa>Майстер Камае</maleUa>
+      <femaleUa>Майстер Камае</femaleUa>
+      <maleEn>Master of Kamae</maleEn>
+      <femaleEn>Mistress of Kamae</femaleEn>
     </node>
     <node>
       <female>Мастер Укеми</female>
       <male>Мастер Укеми</male>
+      <maleUa>Майстер Укемі</maleUa>
+      <femaleUa>Майстер Укемі</femaleUa>
+      <maleEn>Master of Ukemi</maleEn>
+      <femaleEn>Master of Ukemi</femaleEn>
     </node>
     <node>
       <female>Мастер Укеми</female>
       <male>Мастер Укеми</male>
+      <maleUa>Майстер Укемі</maleUa>
+      <femaleUa>Майстер Укемі</femaleUa>
+      <maleEn>Master of Ukemi</maleEn>
+      <femaleEn>Master of Ukemi</femaleEn>
     </node>
     <node>
       <female>Мокуроку</female>
       <male>Мокуроку</male>
+      <maleUa>Мокуроку</maleUa>
+      <femaleUa>Мокуроку</femaleUa>
+      <maleEn>Mokuroku</maleEn>
+      <femaleEn>Mokuroku</femaleEn>
     </node>
     <node>
       <female>Мокуроку</female>
       <male>Мокуроку</male>
+      <maleUa>Мокуроку</maleUa>
+      <femaleUa>Мокуроку</femaleUa>
+      <maleEn>Mokuroku</maleEn>
+      <femaleEn>Mokuroku</femaleEn>
     </node>
     <node>
       <female>О Гоши</female>
       <male>О Гоши</male>
+      <maleUa>О Гоші</maleUa>
+      <femaleUa>О Гоші</femaleUa>
+      <maleEn>Ogoshi</maleEn>
+      <femaleEn>Ogoshi</femaleEn>
     </node>
     <node>
       <female>О Гоши</female>
       <male>О Гоши</male>
+      <maleUa>О Гоші</maleUa>
+      <femaleUa>О Гоші</femaleUa>
+      <maleEn>Ogoshi</maleEn>
+      <femaleEn>Ogoshi</femaleEn>
     </node>
     <node>
       <female>Иппон Сэойнагэ</female>
       <male>Иппон Сэойнагэ</male>
+      <maleUa>Іппон Сеойнаге</maleUa>
+      <femaleUa>Іппон Сеойнаге</femaleUa>
+      <maleEn>Ippon Seinage</maleEn>
+      <femaleEn>Ippon Seinage</femaleEn>
     </node>
     <node>
       <female>Иппон Сэойнагэ</female>
       <male>Иппон Сэойнагэ</male>
+      <maleUa>Іппон Сеойнаге</maleUa>
+      <femaleUa>Іппон Сеойнаге</femaleUa>
+      <maleEn>Ippon Seinage</maleEn>
+      <femaleEn>Ippon Seinage</femaleEn>
     </node>
     <node>
       <female>Коши Гурума</female>
       <male>Коши Гурума</male>
+      <maleUa>Коші Гурума</maleUa>
+      <femaleUa>Коші Гурума</femaleUa>
+      <maleEn>Koshi Garuma</maleEn>
+      <femaleEn>Koshi Garuma</femaleEn>
     </node>
     <node>
       <female>Коши Гурума</female>
       <male>Коши Гурума</male>
+      <maleUa>Коші Гурума</maleUa>
+      <femaleUa>Коші Гурума</femaleUa>
+      <maleEn>Koshi Garuma</maleEn>
+      <femaleEn>Koshi Garuma</femaleEn>
     </node>
     <node>
       <female>Сукуи Нагэ</female>
       <male>Сукуи Нагэ</male>
+      <maleUa>Сукуі Наге</maleUa>
+      <femaleUa>Сукуі Наге</femaleUa>
+      <maleEn>Sukuinage</maleEn>
+      <femaleEn>Sukuinage</femaleEn>
     </node>
     <node>
       <female>Сукуи Нагэ</female>
       <male>Сукуи Нагэ</male>
+      <maleUa>Сукуі Наге</maleUa>
+      <femaleUa>Сукуі Наге</femaleUa>
+      <maleEn>Sukuinage</maleEn>
+      <femaleEn>Sukuinage</femaleEn>
     </node>
     <node>
       <female>О Сото Гари</female>
       <male>О Сото Гари</male>
+      <maleUa>О Сото Гарі</maleUa>
+      <femaleUa>О Сото Гарі</femaleUa>
+      <maleEn>Osotogari</maleEn>
+      <femaleEn>Osotogari</femaleEn>
     </node>
     <node>
       <female>О Сото Гари</female>
       <male>О Сото Гари</male>
+      <maleUa>О Сото Гарі</maleUa>
+      <femaleUa>О Сото Гарі</femaleUa>
+      <maleEn>Osotogari</maleEn>
+      <femaleEn>Osotogari</femaleEn>
     </node>
     <node>
       <female>Уки Гоши</female>
       <male>Уки Гоши</male>
+      <maleUa>Укі Гоші</maleUa>
+      <femaleUa>Укі Гоші</femaleUa>
+      <maleEn>Uki Goshi</maleEn>
+      <femaleEn>Uki Goshi</femaleEn>
     </node>
     <node>
       <female>Уки Гоши</female>
       <male>Уки Гоши</male>
+      <maleUa>Укі Гоші</maleUa>
+      <femaleUa>Укі Гоші</femaleUa>
+      <maleEn>Uki Goshi</maleEn>
+      <femaleEn>Uki Goshi</femaleEn>
     </node>
     <node>
       <female>Тай Отоси</female>
       <male>Тай Отоси</male>
+      <maleUa>Тай Отосі</maleUa>
+      <femaleUa>Тай Отосі</femaleUa>
+      <maleEn>Taiotoshi</maleEn>
+      <femaleEn>Taiotoshi</femaleEn>
     </node>
     <node>
       <female>Тай Отоси</female>
       <male>Тай Отоси</male>
+      <maleUa>Тай Отосі</maleUa>
+      <femaleUa>Тай Отосі</femaleUa>
+      <maleEn>Taiotoshi</maleEn>
+      <femaleEn>Taiotoshi</femaleEn>
     </node>
     <node>
       <female>Харай Госи</female>
       <male>Харай Госи</male>
+      <maleUa>Харай Госі</maleUa>
+      <femaleUa>Харай Госі</femaleUa>
+      <maleEn>Harai Goshi</maleEn>
+      <femaleEn>Harai Goshi</femaleEn>
     </node>
     <node>
       <female>Харай Госи</female>
       <male>Харай Госи</male>
+      <maleUa>Харай Госі</maleUa>
+      <femaleUa>Харай Госі</femaleUa>
+      <maleEn>Harai Goshi</maleEn>
+      <femaleEn>Harai Goshi</femaleEn>
     </node>
     <node>
       <female>Яма Араси</female>
       <male>Яма Араси</male>
+      <maleUa>Яма Арасі</maleUa>
+      <femaleUa>Яма Арасі</femaleUa>
+      <maleEn>Yama Arashi</maleEn>
+      <femaleEn>Yama Arashi</femaleEn>
     </node>
     <node>
       <female>Яма Араси</female>
       <male>Яма Араси</male>
+      <maleUa>Яма Арасі</maleUa>
+      <femaleUa>Яма Арасі</femaleUa>
+      <maleEn>Yama Arashi</maleEn>
+      <femaleEn>Yama Arashi</femaleEn>
     </node>
     <node>
       <female>Мастер Нагэ Вадза</female>
       <male>Мастер Нагэ Вадза</male>
+      <maleUa>Майстер Наге Вадза</maleUa>
+      <femaleUa>Майстер Наге Вадза</femaleUa>
+      <maleEn>Master of Nage Waza</maleEn>
+      <femaleEn>Mistress of Nage Waza</femaleEn>
     </node>
     <node>
       <female>Мастер Нагэ Вадза</female>
       <male>Мастер Нагэ Вадза</male>
+      <maleUa>Майстер Наге Вадза</maleUa>
+      <femaleUa>Майстер Наге Вадза</femaleUa>
+      <maleEn>Master of Nage Waza</maleEn>
+      <femaleEn>Mistress of Nage Waza</femaleEn>
     </node>
     <node>
       <female>Вступающая в О Вадза</female>
       <male>Вступающий в О Вадза</male>
+      <maleUa>Вступаючий в О Вадза</maleUa>
+      <femaleUa>Вступаюча в О Вадза</femaleUa>
+      <maleEn>Entrance to Owaza</maleEn>
+      <femaleEn>Entrance to Owaza</femaleEn>
     </node>
     <node>
       <female>Вступающая в О Вадза</female>
       <male>Вступающий в О Вадза</male>
+      <maleUa>Вступаючий в О Вадза</maleUa>
+      <femaleUa>Вступаюча в О Вадза</femaleUa>
+      <maleEn>Entrance to Owaza</maleEn>
+      <femaleEn>Entrance to Owaza</femaleEn>
     </node>
     <node>
       <female>Новичок О Вадза</female>
       <male>Новичок О Вадза</male>
+      <maleUa>Новачок О Вадза</maleUa>
+      <femaleUa>Новачок О Вадза</femaleUa>
+      <maleEn>Novice of Owaza</maleEn>
+      <femaleEn>Novice of Owaza</femaleEn>
     </node>
     <node>
       <female>Новичок О Вадза</female>
       <male>Новичок О Вадза</male>
+      <maleUa>Новачок О Вадза</maleUa>
+      <femaleUa>Новачок О Вадза</femaleUa>
+      <maleEn>Novice of Owaza</maleEn>
+      <femaleEn>Novice of Owaza</femaleEn>
     </node>
     <node>
       <female>Ученица О Вадза</female>
       <male>Ученик О Вадза</male>
+      <maleUa>Учень О Вадза</maleUa>
+      <femaleUa>Учениця О Вадза</femaleUa>
+      <maleEn>Student of Owaza</maleEn>
+      <femaleEn>Student of Owaza</femaleEn>
     </node>
     <node>
       <female>Ученица О Вадза</female>
       <male>Ученик О Вадза</male>
+      <maleUa>Учень О Вадза</maleUa>
+      <femaleUa>Учениця О Вадза</femaleUa>
+      <maleEn>Student of Owaza</maleEn>
+      <femaleEn>Student of Owaza</femaleEn>
     </node>
     <node>
       <female>Познавшая О Вадза</female>
       <male>Познавший О Вадза</male>
+      <maleUa>Знавець О Вадза</maleUa>
+      <femaleUa>Знавчиня О Вадза</femaleUa>
+      <maleEn>Learned of Owaza</maleEn>
+      <femaleEn>Learned of Owaza</femaleEn>
     </node>
     <node>
       <female>Познавшая О Вадза</female>
       <male>Познавший О Вадза</male>
+      <maleUa>Знавець О Вадза</maleUa>
+      <femaleUa>Знавчиня О Вадза</femaleUa>
+      <maleEn>Learned of Owaza</maleEn>
+      <femaleEn>Learned of Owaza</femaleEn>
     </node>
     <node>
       <female>Мастер О Вадза</female>
       <male>Мастер О Вадза</male>
+      <maleUa>Майстер О Вадза</maleUa>
+      <femaleUa>Майстер О Вадза</femaleUa>
+      <maleEn>Master of Owaza</maleEn>
+      <femaleEn>Mistress of Owaza</femaleEn>
     </node>
     <node>
       <female>Мастер О Вадза</female>
       <male>Мастер О Вадза</male>
+      <maleUa>Майстер О Вадза</maleUa>
+      <femaleUa>Майстер О Вадза</femaleUa>
+      <maleEn>Master of Owaza</maleEn>
+      <femaleEn>Mistress of Owaza</femaleEn>
     </node>
     <node>
       <female>Мэнкё</female>
       <male>Мэнкё</male>
+      <maleUa>Менке</maleUa>
+      <femaleUa>Менке</femaleUa>
+      <maleEn>Menkyo</maleEn>
+      <femaleEn>Menkyo</femaleEn>
     </node>
     <node>
       <female>Мэнкё</female>
       <male>Мэнкё</male>
+      <maleUa>Менке</maleUa>
+      <femaleUa>Менке</femaleUa>
+      <maleEn>Menkyo</maleEn>
+      <femaleEn>Menkyo</femaleEn>
     </node>
     <node>
       <female>Сенсей</female>
       <male>Сенсей</male>
+      <maleUa>Сенсей</maleUa>
+      <femaleUa>Сенсей</femaleUa>
+      <maleEn>Sensei</maleEn>
+      <femaleEn>Sensei</femaleEn>
     </node>
     <node>
       <female>Сенсей</female>
       <male>Сенсей</male>
+      <maleUa>Сенсей</maleUa>
+      <femaleUa>Сенсей</femaleUa>
+      <maleEn>Sensei</maleEn>
+      <femaleEn>Sensei</femaleEn>
     </node>
     <node>
       <female>Сихан</female>
       <male>Сихан</male>
+      <maleUa>Сихан</maleUa>
+      <femaleUa>Сихан</femaleUa>
+      <maleEn>Shinan</maleEn>
+      <femaleEn>Shinan</femaleEn>
     </node>
     <node>
       <female>Сихан</female>
       <male>Сихан</male>
+      <maleUa>Сихан</maleUa>
+      <femaleUa>Сихан</femaleUa>
+      <maleEn>Shinan</maleEn>
+      <femaleEn>Shinan</femaleEn>
     </node>
     <node>
       <female>Сихан</female>
       <male>Сихан</male>
+      <maleUa>Сихан</maleUa>
+      <femaleUa>Сихан</femaleUa>
+      <maleEn>Shihan</maleEn>
+      <femaleEn>Shihan</femaleEn>
     </node>
     <node>
       <female>Сихан</female>
       <male>Сихан</male>
+      <maleUa>Сихан</maleUa>
+      <femaleUa>Сихан</femaleUa>
+      <maleEn>Shihan</maleEn>
+      <femaleEn>Shihan</femaleEn>
     </node>
     <node>
       <female>Мэнкё Кайдэн</female>
       <male>Мэнкё Кайдэн</male>
+      <maleUa>Менке Кайден</maleUa>
+      <femaleUa>Менке Кайден</femaleUa>
+      <maleEn>Kaiden</maleEn>
+      <femaleEn>Kaiden</femaleEn>
     </node>
     <node>
       <female>Мэнкё Кайдэн</female>
       <male>Мэнкё Кайдэн</male>
+      <maleUa>Менке Кайден</maleUa>
+      <femaleUa>Менке Кайден</femaleUa>
+      <maleEn>Kaiden</maleEn>
+      <femaleEn>Kaiden</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Мастер Мияма Рю</female>
       <male>Мастер Мияма Рю</male>
+      <maleUa>Майстер Міяма Рю</maleUa>
+      <femaleUa>Майстер Міяма Рю</femaleUa>
+      <maleEn>Master of the Miyama Ryu</maleEn>
+      <femaleEn>Mistress of the Miyama Ryu</femaleEn>
     </node>
     <node>
       <female>Ниндзя-Герой</female>
       <male>Ниндзя-Герой</male>
+      <maleUa>Ніндзя-Герой</maleUa>
+      <femaleUa>Ніндзя-Герой</femaleUa>
+      <maleEn>Ninja Hero</maleEn>
+      <femaleEn>Ninja Hero</femaleEn>
     </node>
     <node>
       <female>the Ninja Avatar</female>

--- a/professions/paladin.xml
+++ b/professions/paladin.xml
@@ -53,410 +53,818 @@ Of course, paladins must choose a {hh1religion{x -- otherwise the {hh2036level{x
     <node>
       <female>Женщина</female>
       <male>Мужчина</male>
+      <maleUa>Чоловік</maleUa>
+      <femaleUa>Жінка</femaleUa>
+      <maleEn>Man</maleEn>
+      <femaleEn>Woman</femaleEn>
     </node>
     <node>
       <female>Служка</female>
       <male>Служка</male>
+      <maleUa>Служка</maleUa>
+      <femaleUa>Служка</femaleUa>
+      <maleEn>Paladin Pupil</maleEn>
+      <femaleEn>Paladin Pupil</femaleEn>
     </node>
     <node>
       <female>Посудомойка</female>
       <male>Посудомойщик</male>
+      <maleUa>Посудомийник</maleUa>
+      <femaleUa>Посудомийниця</femaleUa>
+      <maleEn>Scullery Man</maleEn>
+      <femaleEn>Scullery Maid</femaleEn>
     </node>
     <node>
       <female>Кандидатка в Сквайры</female>
       <male>Кандидат в Сквайры</male>
+      <maleUa>Кандидат у Сквайри</maleUa>
+      <femaleUa>Кандидатка у Сквайри</femaleUa>
+      <maleEn>Squire Candidate</maleEn>
+      <femaleEn>Squire Candidate</femaleEn>
     </node>
     <node>
       <female>Носительница Щита</female>
       <male>Носитель Щита</male>
+      <maleUa>Носій Щита</maleUa>
+      <femaleUa>Носійка Щита</femaleUa>
+      <maleEn>Shield Bearer</maleEn>
+      <femaleEn>Shield Bearer</femaleEn>
     </node>
     <node>
       <female>Носительница Меча</female>
       <male>Носитель Меча</male>
+      <maleUa>Носій Меча</maleUa>
+      <femaleUa>Носійка Меча</femaleUa>
+      <maleEn>Sword Bearer</maleEn>
+      <femaleEn>Sword Bearer</femaleEn>
     </node>
     <node>
       <female>Носительница Лука</female>
       <male>Носитель Лука</male>
+      <maleUa>Носій Лука</maleUa>
+      <femaleUa>Носійка Лука</femaleUa>
+      <maleEn>Bow Bearer</maleEn>
+      <femaleEn>Bow Bearer</femaleEn>
     </node>
     <node>
       <female>Носительница Штандарта</female>
       <male>Носитель Штандарта</male>
+      <maleUa>Носій Штандарта</maleUa>
+      <femaleUa>Носійка Штандарта</femaleUa>
+      <maleEn>Standard Bearer</maleEn>
+      <femaleEn>Standard Bearer</femaleEn>
     </node>
     <node>
       <female>Всадница</female>
       <male>Всадник</male>
+      <maleUa>Вершник</maleUa>
+      <femaleUa>Вершниця</femaleUa>
+      <maleEn>Horseman</maleEn>
+      <femaleEn>Horsewoman</femaleEn>
     </node>
     <node>
       <female>Неопытная Сквайр</female>
       <male>Неопытный Сквайр</male>
+      <maleUa>Недосвідчений Сквайр</maleUa>
+      <femaleUa>Недосвідчена Сквайр</femaleUa>
+      <maleEn>Squire Initiate</maleEn>
+      <femaleEn>Squire Initiate</femaleEn>
     </node>
     <node>
       <female>Сквайр</female>
       <male>Сквайр</male>
+      <maleUa>Сквайр</maleUa>
+      <femaleUa>Сквайр</femaleUa>
+      <maleEn>Squire</maleEn>
+      <femaleEn>Squire</femaleEn>
     </node>
     <node>
       <female>Пехотинка</female>
       <male>Пехотинец</male>
+      <maleUa>Піхотинець</maleUa>
+      <femaleUa>Піхотинка</femaleUa>
+      <maleEn>Footman</maleEn>
+      <femaleEn>Footwoman</femaleEn>
     </node>
     <node>
       <female>Пехотинка</female>
       <male>Пехотинец</male>
+      <maleUa>Піхотинець</maleUa>
+      <femaleUa>Піхотинка</femaleUa>
+      <maleEn>Footman</maleEn>
+      <femaleEn>Footwoman</femaleEn>
     </node>
     <node>
       <female>Пикинерша</female>
       <male>Пикинер</male>
+      <maleUa>Пікінер</maleUa>
+      <femaleUa>Пікінерка</femaleUa>
+      <maleEn>Pikeman</maleEn>
+      <femaleEn>Pikewoman</femaleEn>
     </node>
     <node>
       <female>Пикинерша</female>
       <male>Пикинер</male>
+      <maleUa>Пікінер</maleUa>
+      <femaleUa>Пікінерка</femaleUa>
+      <maleEn>Pikeman</maleEn>
+      <femaleEn>Pikewoman</femaleEn>
     </node>
     <node>
       <female>Лучница</female>
       <male>Лучник</male>
+      <maleUa>Лучник</maleUa>
+      <femaleUa>Лучниця</femaleUa>
+      <maleEn>Bowman</maleEn>
+      <femaleEn>Bowwoman</femaleEn>
     </node>
     <node>
       <female>Лучница</female>
       <male>Лучник</male>
+      <maleUa>Лучник</maleUa>
+      <femaleUa>Лучниця</femaleUa>
+      <maleEn>Bowman</maleEn>
+      <femaleEn>Bowwoman</femaleEn>
     </node>
     <node>
       <female>Мечница</female>
       <male>Мечник</male>
+      <maleUa>Мечник</maleUa>
+      <femaleUa>Мечниця</femaleUa>
+      <maleEn>Swordsman</maleEn>
+      <femaleEn>Swordswoman</femaleEn>
     </node>
     <node>
       <female>Мечница</female>
       <male>Мечник</male>
+      <maleUa>Мечник</maleUa>
+      <femaleUa>Мечниця</femaleUa>
+      <maleEn>Swordsman</maleEn>
+      <femaleEn>Swordswoman</femaleEn>
     </node>
     <node>
       <female>Честная</female>
       <male>Честный</male>
+      <maleUa>Чесний</maleUa>
+      <femaleUa>Чесна</femaleUa>
+      <maleEn>Honorable</maleEn>
+      <femaleEn>Honorable</femaleEn>
     </node>
     <node>
       <female>Честная</female>
       <male>Честный</male>
+      <maleUa>Чесний</maleUa>
+      <femaleUa>Чесна</femaleUa>
+      <maleEn>Honorable</maleEn>
+      <femaleEn>Honorable</femaleEn>
     </node>
     <node>
       <female>Благородная</female>
       <male>Благородный</male>
+      <maleUa>Благородний</maleUa>
+      <femaleUa>Благородна</femaleUa>
+      <maleEn>Noble</maleEn>
+      <femaleEn>Noble</femaleEn>
     </node>
     <node>
       <female>Благородная</female>
       <male>Благородный</male>
+      <maleUa>Благородний</maleUa>
+      <femaleUa>Благородна</femaleUa>
+      <maleEn>Noble</maleEn>
+      <femaleEn>Noble</femaleEn>
     </node>
     <node>
       <female>Благонадежная</female>
       <male>Благонадежный</male>
+      <maleUa>Благонадійний</maleUa>
+      <femaleUa>Благонадійна</femaleUa>
+      <maleEn>Trustworthy</maleEn>
+      <femaleEn>Trustworthy</femaleEn>
     </node>
     <node>
       <female>Благонадежная</female>
       <male>Благонадежный</male>
+      <maleUa>Благонадійний</maleUa>
+      <femaleUa>Благонадійна</femaleUa>
+      <maleEn>Trustworthy</maleEn>
+      <femaleEn>Trustworthy</femaleEn>
     </node>
     <node>
       <female>Верная</female>
       <male>Верный</male>
+      <maleUa>Вірний</maleUa>
+      <femaleUa>Вірна</femaleUa>
+      <maleEn>Truthful</maleEn>
+      <femaleEn>Truthful</femaleEn>
     </node>
     <node>
       <female>Верная</female>
       <male>Верный</male>
+      <maleUa>Вірний</maleUa>
+      <femaleUa>Вірна</femaleUa>
+      <maleEn>Truthful</maleEn>
+      <femaleEn>Truthful</femaleEn>
     </node>
     <node>
       <female>Рыцарственная</female>
       <male>Рыцарственный</male>
+      <maleUa>Лицарственний</maleUa>
+      <femaleUa>Лицарственна</femaleUa>
+      <maleEn>Chivalrous</maleEn>
+      <femaleEn>Chivalrous</femaleEn>
     </node>
     <node>
       <female>Рыцарственная</female>
       <male>Рыцарственный</male>
+      <maleUa>Лицарственний</maleUa>
+      <femaleUa>Лицарственна</femaleUa>
+      <maleEn>Chivalrous</maleEn>
+      <femaleEn>Chivalrous</femaleEn>
     </node>
     <node>
       <female>Паладинка</female>
       <male>Паладин</male>
+      <maleUa>Паладин</maleUa>
+      <femaleUa>Паладинка</femaleUa>
+      <maleEn>Paladin</maleEn>
+      <femaleEn>Paladin</femaleEn>
     </node>
     <node>
       <female>Паладинка</female>
       <male>Паладин</male>
+      <maleUa>Паладин</maleUa>
+      <femaleUa>Паладинка</femaleUa>
+      <maleEn>Paladin</maleEn>
+      <femaleEn>Paladin</femaleEn>
     </node>
     <node>
       <female>Ищущая</female>
       <male>Ищущий</male>
+      <maleUa>Шукач</maleUa>
+      <femaleUa>Шукачка</femaleUa>
+      <maleEn>Questor</maleEn>
+      <femaleEn>Questor</femaleEn>
     </node>
     <node>
       <female>Ищущая</female>
       <male>Ищущий</male>
+      <maleUa>Шукач</maleUa>
+      <femaleUa>Шукачка</femaleUa>
+      <maleEn>Questor</maleEn>
+      <femaleEn>Questor</femaleEn>
     </node>
     <node>
       <female>Кавалерша</female>
       <male>Кавалер</male>
+      <maleUa>Кавалер</maleUa>
+      <femaleUa>Кавалерша</femaleUa>
+      <maleEn>Cavalier</maleEn>
+      <femaleEn>Cavalier</femaleEn>
     </node>
     <node>
       <female>Кавалерша</female>
       <male>Кавалер</male>
+      <maleUa>Кавалер</maleUa>
+      <femaleUa>Кавалерша</femaleUa>
+      <maleEn>Cavalier</maleEn>
+      <femaleEn>Cavalier</femaleEn>
     </node>
     <node>
       <female>Чемпионка</female>
       <male>Чемпион</male>
+      <maleUa>Чемпіон</maleUa>
+      <femaleUa>Чемпіонка</femaleUa>
+      <maleEn>Champion</maleEn>
+      <femaleEn>Champion</femaleEn>
     </node>
     <node>
       <female>Чемпионка</female>
       <male>Чемпион</male>
+      <maleUa>Чемпіон</maleUa>
+      <femaleUa>Чемпіонка</femaleUa>
+      <maleEn>Champion</maleEn>
+      <femaleEn>Champion</femaleEn>
     </node>
     <node>
       <female>Славная Рыцарша</female>
       <male>Славный Рыцарь</male>
+      <maleUa>Славний Лицар</maleUa>
+      <femaleUa>Славна Лицарка</femaleUa>
+      <maleEn>Knight of Renown</maleEn>
+      <femaleEn>Knight of Renown</femaleEn>
     </node>
     <node>
       <female>Славная Рыцарша</female>
       <male>Славный Рыцарь</male>
+      <maleUa>Славний Лицар</maleUa>
+      <femaleUa>Славна Лицарка</femaleUa>
+      <maleEn>Knight of Renown</maleEn>
+      <femaleEn>Knight of Renown</femaleEn>
     </node>
     <node>
       <female>Леди Паладин</female>
       <male>Лорд Паладин</male>
+      <maleUa>Лорд Паладин</maleUa>
+      <femaleUa>Леді Паладин</femaleUa>
+      <maleEn>Paladin Knight</maleEn>
+      <femaleEn>Paladin Lady</femaleEn>
     </node>
     <node>
       <female>Леди Паладин</female>
       <male>Лорд Паладин</male>
+      <maleUa>Лорд Паладин</maleUa>
+      <femaleUa>Леді Паладин</femaleUa>
+      <maleEn>Paladin Knight</maleEn>
+      <femaleEn>Paladin Lady</femaleEn>
     </node>
     <node>
       <female>Послушница Храмовников</female>
       <male>Послушник Храмовников</male>
+      <maleUa>Послушник Храмовників</maleUa>
+      <femaleUa>Послушниця Храмовників</femaleUa>
+      <maleEn>Templar Initiate</maleEn>
+      <femaleEn>Templar Initiate</femaleEn>
     </node>
     <node>
       <female>Послушница Храмовников</female>
       <male>Послушник Храмовников</male>
+      <maleUa>Послушник Храмовників</maleUa>
+      <femaleUa>Послушниця Храмовників</femaleUa>
+      <maleEn>Templar Initiate</maleEn>
+      <femaleEn>Templar Initiate</femaleEn>
     </node>
     <node>
       <female>Священница-Рыцарь</female>
       <male>Священник-Рыцарь</male>
+      <maleUa>Священик-Лицар</maleUa>
+      <femaleUa>Священиця-Лицар</femaleUa>
+      <maleEn>Priest-Knight</maleEn>
+      <femaleEn>Priestess-Knight</femaleEn>
     </node>
     <node>
       <female>Священница-Рыцарь</female>
       <male>Священник-Рыцарь</male>
+      <maleUa>Священик-Лицар</maleUa>
+      <femaleUa>Священиця-Лицар</femaleUa>
+      <maleEn>Priest-Knight</maleEn>
+      <femaleEn>Priestess-Knight</femaleEn>
     </node>
     <node>
       <female>Леди Света</female>
       <male>Лорд Света</male>
+      <maleUa>Лорд Світла</maleUa>
+      <femaleUa>Леді Світла</femaleUa>
+      <maleEn>Lord of Light</maleEn>
+      <femaleEn>Lady of Light</femaleEn>
     </node>
     <node>
       <female>Леди Света</female>
       <male>Лорд Света</male>
+      <maleUa>Лорд Світла</maleUa>
+      <femaleUa>Леді Світла</femaleUa>
+      <maleEn>Lord of Light</maleEn>
+      <femaleEn>Lady of Light</femaleEn>
     </node>
     <node>
       <female>Чемпионка Света</female>
       <male>Чемпион Света</male>
+      <maleUa>Чемпіон Світла</maleUa>
+      <femaleUa>Чемпіонка Світла</femaleUa>
+      <maleEn>Champion of Light</maleEn>
+      <femaleEn>Champion of Light</femaleEn>
     </node>
     <node>
       <female>Чемпионка Света</female>
       <male>Чемпион Света</male>
+      <maleUa>Чемпіон Світла</maleUa>
+      <femaleUa>Чемпіонка Світла</femaleUa>
+      <maleEn>Champion of Light</maleEn>
+      <femaleEn>Champion of Light</femaleEn>
     </node>
     <node>
       <female>Чемпионка Света</female>
       <male>Чемпион Света</male>
+      <maleUa>Чемпіон Світла</maleUa>
+      <femaleUa>Чемпіонка Світла</femaleUa>
+      <maleEn>Champion of Light</maleEn>
+      <femaleEn>Champion of Light</femaleEn>
     </node>
     <node>
       <female>Леди Храмовница</female>
       <male>Лорд Храмовник</male>
+      <maleUa>Лорд Храмовник</maleUa>
+      <femaleUa>Леді Храмовниця</femaleUa>
+      <maleEn>Knight Templar</maleEn>
+      <femaleEn>Lady Templar</femaleEn>
     </node>
     <node>
       <female>Леди Храмовница</female>
       <male>Лорд Храмовник</male>
+      <maleUa>Лорд Храмовник</maleUa>
+      <femaleUa>Леді Храмовниця</femaleUa>
+      <maleEn>Knight Templar</maleEn>
+      <femaleEn>Lady Templar</femaleEn>
     </node>
     <node>
       <female>Леди Храмовница</female>
       <male>Лорд Храмовник</male>
+      <maleUa>Лорд Храмовник</maleUa>
+      <femaleUa>Леді Храмовниця</femaleUa>
+      <maleEn>Knight Templar</maleEn>
+      <femaleEn>Lady Templar</femaleEn>
     </node>
     <node>
       <female>Рядовая Тамплиеров</female>
       <male>Рядовой Тамплиеров</male>
+      <maleUa>Рядовий Тамплієрів</maleUa>
+      <femaleUa>Рядова Тамплієрів</femaleUa>
+      <maleEn>Templar Footman</maleEn>
+      <femaleEn>Templar Footwoman</femaleEn>
     </node>
     <node>
       <female>Рядовая Тамплиеров</female>
       <male>Рядовой Тамплиеров</male>
+      <maleUa>Рядовий Тамплієрів</maleUa>
+      <femaleUa>Рядова Тамплієрів</femaleUa>
+      <maleEn>Templar Footman</maleEn>
+      <femaleEn>Templar Footwoman</femaleEn>
     </node>
     <node>
       <female>Лейтенантша Тамплиеров</female>
       <male>Лейтенант Тамплиеров</male>
+      <maleUa>Лейтенант Тамплієрів</maleUa>
+      <femaleUa>Лейтенантка Тамплієрів</femaleUa>
+      <maleEn>Templar Lieutenant</maleEn>
+      <femaleEn>Templar Lieutenant</femaleEn>
     </node>
     <node>
       <female>Лейтенантша Тамплиеров</female>
       <male>Лейтенант Тамплиеров</male>
+      <maleUa>Лейтенант Тамплієрів</maleUa>
+      <femaleUa>Лейтенантка Тамплієрів</femaleUa>
+      <maleEn>Templar Lieutenant</maleEn>
+      <femaleEn>Templar Lieutenant</femaleEn>
     </node>
     <node>
       <female>Капитанша Тамплиеров</female>
       <male>Капитан Тамплиеров</male>
+      <maleUa>Капітан Тамплієрів</maleUa>
+      <femaleUa>Капітанка Тамплієрів</femaleUa>
+      <maleEn>Templar Captain</maleEn>
+      <femaleEn>Templar Captain</femaleEn>
     </node>
     <node>
       <female>Капитанша Тамплиеров</female>
       <male>Капитан Тамплиеров</male>
+      <maleUa>Капітан Тамплієрів</maleUa>
+      <femaleUa>Капітанка Тамплієрів</femaleUa>
+      <maleEn>Templar Captain</maleEn>
+      <femaleEn>Templar Captain</femaleEn>
     </node>
     <node>
       <female>Полковница Тамплиеров</female>
       <male>Полковник Тамплиеров</male>
+      <maleUa>Полковник Тамплієрів</maleUa>
+      <femaleUa>Полковниця Тамплієрів</femaleUa>
+      <maleEn>Templar Colonel</maleEn>
+      <femaleEn>Templar Colonel</femaleEn>
     </node>
     <node>
       <female>Полковница Тамплиеров</female>
       <male>Полковник Тамплиеров</male>
+      <maleUa>Полковник Тамплієрів</maleUa>
+      <femaleUa>Полковниця Тамплієрів</femaleUa>
+      <maleEn>Templar Colonel</maleEn>
+      <femaleEn>Templar Colonel</femaleEn>
     </node>
     <node>
       <female>Генеральша Тамплиеров</female>
       <male>Генерал Тамплиеров</male>
+      <maleUa>Генерал Тамплієрів</maleUa>
+      <femaleUa>Генералка Тамплієрів</femaleUa>
+      <maleEn>Templar General</maleEn>
+      <femaleEn>Templar General</femaleEn>
     </node>
     <node>
       <female>Генеральша Тамплиеров</female>
       <male>Генерал Тамплиеров</male>
+      <maleUa>Генерал Тамплієрів</maleUa>
+      <femaleUa>Генералка Тамплієрів</femaleUa>
+      <maleEn>Templar General</maleEn>
+      <femaleEn>Templar General</femaleEn>
     </node>
     <node>
       <female>Маршальша Тамплиеров</female>
       <male>Маршал Тамплиеров</male>
+      <maleUa>Маршал Тамплієрів</maleUa>
+      <femaleUa>Маршалка Тамплієрів</femaleUa>
+      <maleEn>Templar Field Marshall</maleEn>
+      <femaleEn>Templar Field Marshall</femaleEn>
     </node>
     <node>
       <female>Маршальша Тамплиеров</female>
       <male>Маршал Тамплиеров</male>
+      <maleUa>Маршал Тамплієрів</maleUa>
+      <femaleUa>Маршалка Тамплієрів</femaleUa>
+      <maleEn>Templar Field Marshall</maleEn>
+      <femaleEn>Templar Field Marshall</femaleEn>
     </node>
     <node>
       <female>Леди Целительница</female>
       <male>Лорд Целитель</male>
+      <maleUa>Лорд Цілитель</maleUa>
+      <femaleUa>Леді Цілителька</femaleUa>
+      <maleEn>Healer-Knight</maleEn>
+      <femaleEn>Healer-Lady</femaleEn>
     </node>
     <node>
       <female>Леди Целительница</female>
       <male>Лорд Целитель</male>
+      <maleUa>Лорд Цілитель</maleUa>
+      <femaleUa>Леді Цілителька</femaleUa>
+      <maleEn>Healer-Knight</maleEn>
+      <femaleEn>Healer-Lady</femaleEn>
     </node>
     <node>
       <female>Мстительница</female>
       <male>Мститель</male>
+      <maleUa>Месник</maleUa>
+      <femaleUa>Месниця</femaleUa>
+      <maleEn>Avenger</maleEn>
+      <femaleEn>Avenger</femaleEn>
     </node>
     <node>
       <female>Мстительница</female>
       <male>Мститель</male>
+      <maleUa>Месник</maleUa>
+      <femaleUa>Месниця</femaleUa>
+      <maleEn>Avenger</maleEn>
+      <femaleEn>Avenger</femaleEn>
     </node>
     <node>
       <female>Крестоносица</female>
       <male>Крестоносец</male>
+      <maleUa>Хрестоносець</maleUa>
+      <femaleUa>Хрестоносиця</femaleUa>
+      <maleEn>Crusader</maleEn>
+      <femaleEn>Crusader</femaleEn>
     </node>
     <node>
       <female>Крестоносица</female>
       <male>Крестоносец</male>
+      <maleUa>Хрестоносець</maleUa>
+      <femaleUa>Хрестоносиця</femaleUa>
+      <maleEn>Crusader</maleEn>
+      <femaleEn>Crusader</femaleEn>
     </node>
     <node>
       <female>Сжигающая Неверных</female>
       <male>Сжигающий Неверных</male>
+      <maleUa>Спалювач Невірних</maleUa>
+      <femaleUa>Спалювачка Невірних</femaleUa>
+      <maleEn>Burner of Infidels</maleEn>
+      <femaleEn>Burner of Infidels</femaleEn>
     </node>
     <node>
       <female>Сжигающая Неверных</female>
       <male>Сжигающий Неверных</male>
+      <maleUa>Спалювач Невірних</maleUa>
+      <femaleUa>Спалювачка Невірних</femaleUa>
+      <maleEn>Burner of Infidels</maleEn>
+      <femaleEn>Burner of Infidels</femaleEn>
     </node>
     <node>
       <female>Испепеляющая Ересь</female>
       <male>Испепеляющий Ересь</male>
+      <maleUa>Спопелювач Єресі</maleUa>
+      <femaleUa>Спопелювачка Єресі</femaleUa>
+      <maleEn>Incinerator of Heresy</maleEn>
+      <femaleEn>Incinerator of Heresy</femaleEn>
     </node>
     <node>
       <female>Испепеляющая Ересь</female>
       <male>Испепеляющий Ересь</male>
+      <maleUa>Спопелювач Єресі</maleUa>
+      <femaleUa>Спопелювачка Єресі</femaleUa>
+      <maleEn>Incinerator of Heresy</maleEn>
+      <femaleEn>Incinerator of Heresy</femaleEn>
     </node>
     <node>
       <female>Чемпионка Тамплиеров</female>
       <male>Чемпион Тамплиеров</male>
+      <maleUa>Чемпіон Тамплієрів</maleUa>
+      <femaleUa>Чемпіонка Тамплієрів</femaleUa>
+      <maleEn>Champion of the Templars</maleEn>
+      <femaleEn>Champion of the Templars</femaleEn>
     </node>
     <node>
       <female>Чемпионка Тамплиеров</female>
       <male>Чемпион Тамплиеров</male>
+      <maleUa>Чемпіон Тамплієрів</maleUa>
+      <femaleUa>Чемпіонка Тамплієрів</femaleUa>
+      <maleEn>Champion of the Templars</maleEn>
+      <femaleEn>Champion of the Templars</femaleEn>
     </node>
     <node>
       <female>Священница Тамплиеров</female>
       <male>Священник Тамплиеров</male>
+      <maleUa>Священик Тамплієрів</maleUa>
+      <femaleUa>Священиця Тамплієрів</femaleUa>
+      <maleEn>Priest of the Templars</maleEn>
+      <femaleEn>Priestess of the Templars</femaleEn>
     </node>
     <node>
       <female>Священница Тамплиеров</female>
       <male>Священник Тамплиеров</male>
+      <maleUa>Священик Тамплієрів</maleUa>
+      <femaleUa>Священиця Тамплієрів</femaleUa>
+      <maleEn>Priest of the Templars</maleEn>
+      <femaleEn>Priestess of the Templars</femaleEn>
     </node>
     <node>
       <female>Высшая Священница Тамплиеров</female>
       <male>Высший Священник Тамплиеров</male>
+      <maleUa>Вищий Священик Тамплієрів</maleUa>
+      <femaleUa>Вища Священиця Тамплієрів</femaleUa>
+      <maleEn>High Priest of the Templars</maleEn>
+      <femaleEn>High Priestess of the Templars</femaleEn>
     </node>
     <node>
       <female>Высшая Священница Тамплиеров</female>
       <male>Высший Священник Тамплиеров</male>
+      <maleUa>Вищий Священик Тамплієрів</maleUa>
+      <femaleUa>Вища Священиця Тамплієрів</femaleUa>
+      <maleEn>High Priest of the Templars</maleEn>
+      <femaleEn>High Priestess of the Templars</femaleEn>
     </node>
     <node>
       <female>Леди Тамплиеров</female>
       <male>Лорд Тамплиеров</male>
+      <maleUa>Лорд Тамплієрів</maleUa>
+      <femaleUa>Леді Тамплієрів</femaleUa>
+      <maleEn>Lord of the Templars</maleEn>
+      <femaleEn>Lady of the Templars</femaleEn>
     </node>
     <node>
       <female>Леди Тамплиеров</female>
       <male>Лорд Тамплиеров</male>
+      <maleUa>Лорд Тамплієрів</maleUa>
+      <femaleUa>Леді Тамплієрів</femaleUa>
+      <maleEn>Lord of the Templars</maleEn>
+      <femaleEn>Lady of the Templars</femaleEn>
     </node>
     <node>
       <female>Молот Еретиков</female>
       <male>Молот Еретиков</male>
+      <maleUa>Молот Єретиків</maleUa>
+      <femaleUa>Молот Єретиків</femaleUa>
+      <maleEn>Hammer of Heretics</maleEn>
+      <femaleEn>Hammer of Heretics</femaleEn>
     </node>
     <node>
       <female>Молот Еретиков</female>
       <male>Молот Еретиков</male>
+      <maleUa>Молот Єретиків</maleUa>
+      <femaleUa>Молот Єретиків</femaleUa>
+      <maleEn>Hammer of Heretics</maleEn>
+      <femaleEn>Hammer of Heretics</femaleEn>
     </node>
     <node>
       <female>Поработительница Нечистых</female>
       <male>Поработитель Нечистых</male>
+      <maleUa>Поневолювач Нечистих</maleUa>
+      <femaleUa>Поневолювачка Нечистих</femaleUa>
+      <maleEn>Enslaver of the Unclean</maleEn>
+      <femaleEn>Enslaver of the Unclean</femaleEn>
     </node>
     <node>
       <female>Поработительница Нечистых</female>
       <male>Поработитель Нечистых</male>
+      <maleUa>Поневолювач Нечистих</maleUa>
+      <femaleUa>Поневолювачка Нечистих</femaleUa>
+      <maleEn>Enslaver of the Unclean</maleEn>
+      <femaleEn>Enslaver of the Unclean</femaleEn>
     </node>
     <node>
       <female>Богоравная</female>
       <male>Богоравный</male>
+      <maleUa>Богорівний</maleUa>
+      <femaleUa>Богорівна</femaleUa>
+      <maleEn>Godlike</maleEn>
+      <femaleEn>Godlike</femaleEn>
     </node>
     <node>
       <female>Богоравная</female>
       <male>Богоравный</male>
+      <maleUa>Богорівний</maleUa>
+      <femaleUa>Богорівна</femaleUa>
+      <maleEn>Godlike</maleEn>
+      <femaleEn>Godlike</femaleEn>
     </node>
     <node>
       <female>Богоравная</female>
       <male>Богоравный</male>
+      <maleUa>Богорівний</maleUa>
+      <femaleUa>Богорівна</femaleUa>
+      <maleEn>Godlike</maleEn>
+      <femaleEn>Godlike</femaleEn>
     </node>
     <node>
       <female>Богоравная</female>
       <male>Богоравный</male>
+      <maleUa>Богорівний</maleUa>
+      <femaleUa>Богорівна</femaleUa>
+      <maleEn>Godlike</maleEn>
+      <femaleEn>Godlike</femaleEn>
     </node>
     <node>
       <female>Святая Леди</female>
       <male>Святой Рыцарь</male>
+      <maleUa>Святий Лицар</maleUa>
+      <femaleUa>Свята Леді</femaleUa>
+      <maleEn>Holy Knight</maleEn>
+      <femaleEn>Holy Lady</femaleEn>
     </node>
     <node>
       <female>Святая Леди</female>
       <male>Святой Рыцарь</male>
+      <maleUa>Святий Лицар</maleUa>
+      <femaleUa>Свята Леді</femaleUa>
+      <maleEn>Holy Knight</maleEn>
+      <femaleEn>Holy Lady</femaleEn>
     </node>
     <node>
       <female>Святая Леди</female>
       <male>Святой Рыцарь</male>
+      <maleUa>Святий Лицар</maleUa>
+      <femaleUa>Свята Леді</femaleUa>
+      <maleEn>Holy Knight</maleEn>
+      <femaleEn>Holy Lady</femaleEn>
     </node>
     <node>
       <female>Святая Леди</female>
       <male>Святой Рыцарь</male>
+      <maleUa>Святий Лицар</maleUa>
+      <femaleUa>Свята Леді</femaleUa>
+      <maleEn>Holy Knight</maleEn>
+      <femaleEn>Holy Lady</femaleEn>
     </node>
     <node>
       <female>Длань Варды</female>
       <male>Меч Разера</male>
+      <maleUa>Меч Разера</maleUa>
+      <femaleUa>Длань Варди</femaleUa>
+      <maleEn>Sword of Razer</maleEn>
+      <femaleEn>Hand of Varda</femaleEn>
     </node>
     <node>
       <female>Длань Варды</female>
       <male>Меч Разера</male>
+      <maleUa>Меч Разера</maleUa>
+      <femaleUa>Длань Варди</femaleUa>
+      <maleEn>Sword of Razer</maleEn>
+      <femaleEn>Hand of Varda</femaleEn>
     </node>
     <node>
       <female>Длань Варды</female>
       <male>Меч Разера</male>
+      <maleUa>Меч Разера</maleUa>
+      <femaleUa>Длань Варди</femaleUa>
+      <maleEn>Sword of Razer</maleEn>
+      <femaleEn>Hand of Varda</femaleEn>
     </node>
     <node>
       <female>Длань Варды</female>
       <male>Меч Разера</male>
+      <maleUa>Меч Разера</maleUa>
+      <femaleUa>Длань Варди</femaleUa>
+      <maleEn>Sword of Razer</maleEn>
+      <femaleEn>Hand of Varda</femaleEn>
     </node>
     <node>
       <female>Длань Варды</female>
       <male>Меч Разера</male>
+      <maleUa>Меч Разера</maleUa>
+      <femaleUa>Длань Варди</femaleUa>
+      <maleEn>Sword of Razer</maleEn>
+      <femaleEn>Hand of Varda</femaleEn>
     </node>
     <node>
       <female>Длань Варды</female>
       <male>Меч Разера</male>
+      <maleUa>Меч Разера</maleUa>
+      <femaleUa>Длань Варди</femaleUa>
+      <maleEn>Sword of Razer</maleEn>
+      <femaleEn>Hand of Varda</femaleEn>
     </node>
     <node>
       <female>Легендарная Паладинка</female>
       <male>Легендарный Паладин</male>
+      <maleUa>Легендарний Паладин</maleUa>
+      <femaleUa>Легендарна Паладинка</femaleUa>
+      <maleEn>Legendary Paladin</maleEn>
+      <femaleEn>Legendary Paladin</femaleEn>
     </node>
     <node>
       <female>the Avatar of Honor</female>

--- a/professions/ranger.xml
+++ b/professions/ranger.xml
@@ -57,442 +57,882 @@
     <node>
       <female>Ученица леса</female>
       <male>Ученик леса</male>
+      <maleUa>Учень лісу</maleUa>
+      <femaleUa>Учениця лісу</femaleUa>
+      <maleEn>Forest Pupil</maleEn>
+      <femaleEn>Forest Pupil</femaleEn>
     </node>
     <node>
       <female>Новобранец леса</female>
       <male>Новобранец леса</male>
+      <maleUa>Новобранець лісу</maleUa>
+      <femaleUa>Новобранець лісу</femaleUa>
+      <maleEn>Forest Recruit</maleEn>
+      <femaleEn>Forest Recruit</femaleEn>
     </node>
     <node>
       <female>Обитательница Лесов</female>
       <male>Обитатель Лесов</male>
+      <maleUa>Мешканець лісів</maleUa>
+      <femaleUa>Мешканка лісів</femaleUa>
+      <maleEn>Forester</maleEn>
+      <femaleEn>Forester</femaleEn>
     </node>
     <node>
       <female>Изготовительница стрел</female>
       <male>Изготовитель стрел</male>
+      <maleUa>Виготовлювач стріл</maleUa>
+      <femaleUa>Виготовлювачка стріл</femaleUa>
+      <maleEn>Fletcher</maleEn>
+      <femaleEn>Fletcher</femaleEn>
     </node>
     <node>
       <female>Изготовительница луков</female>
       <male>Изготовитель луков</male>
+      <maleUa>Виготовлювач луків</maleUa>
+      <femaleUa>Виготовлювачка луків</femaleUa>
+      <maleEn>Bowyer</maleEn>
+      <femaleEn>Bowyer</femaleEn>
     </node>
     <node>
       <female>Капканщица</female>
       <male>Капканщик</male>
+      <maleUa>Капканник</maleUa>
+      <femaleUa>Капканниця</femaleUa>
+      <maleEn>Trapper</maleEn>
+      <femaleEn>Trapper</femaleEn>
     </node>
     <node>
       <female>Охотница</female>
       <male>Охотник</male>
+      <maleUa>Мисливець</maleUa>
+      <femaleUa>Мисливиця</femaleUa>
+      <maleEn>Hunter</maleEn>
+      <femaleEn>Huntress</femaleEn>
     </node>
     <node>
       <female>Следопыт</female>
       <male>Следопыт</male>
+      <maleUa>Слідопит</maleUa>
+      <femaleUa>Слідопит</femaleUa>
+      <maleEn>Tracker</maleEn>
+      <femaleEn>Tracker</femaleEn>
     </node>
     <node>
       <female>Искательница</female>
       <male>Искатель</male>
+      <maleUa>Шукач</maleUa>
+      <femaleUa>Шукачка</femaleUa>
+      <maleEn>Seeker</maleEn>
+      <femaleEn>Seeker</femaleEn>
     </node>
     <node>
       <female>Разведчица</female>
       <male>Разведчик</male>
+      <maleUa>Розвідник</maleUa>
+      <femaleUa>Розвідниця</femaleUa>
+      <maleEn>Scout</maleEn>
+      <femaleEn>Scout</femaleEn>
     </node>
     <node>
       <female>Мастер Разведки</female>
       <male>Мастер Разведки</male>
+      <maleUa>Майстер Розвідки</maleUa>
+      <femaleUa>Майстриня Розвідки</femaleUa>
+      <maleEn>Master Scout</maleEn>
+      <femaleEn>Mistress Scout</femaleEn>
     </node>
     <node>
       <female>Мастер Разведки</female>
       <male>Мастер Разведки</male>
+      <maleUa>Майстер Розвідки</maleUa>
+      <femaleUa>Майстриня Розвідки</femaleUa>
+      <maleEn>Master Scout</maleEn>
+      <femaleEn>Mistress Scout</femaleEn>
     </node>
     <node>
       <female>Женщина Леса</female>
       <male>Мужчина Леса</male>
+      <maleUa>Чоловік Лісу</maleUa>
+      <femaleUa>Жінка Лісу</femaleUa>
+      <maleEn>Green Man</maleEn>
+      <femaleEn>Green Woman</femaleEn>
     </node>
     <node>
       <female>Женщина Леса</female>
       <male>Мужчина Леса</male>
+      <maleUa>Чоловік Лісу</maleUa>
+      <femaleUa>Жінка Лісу</femaleUa>
+      <maleEn>Green Man</maleEn>
+      <femaleEn>Green Woman</femaleEn>
     </node>
     <node>
       <female>Лучница</female>
       <male>Лучник</male>
+      <maleUa>Лучник</maleUa>
+      <femaleUa>Лучниця</femaleUa>
+      <maleEn>Archer</maleEn>
+      <femaleEn>Archer</femaleEn>
     </node>
     <node>
       <female>Лучница</female>
       <male>Лучник</male>
+      <maleUa>Лучник</maleUa>
+      <femaleUa>Лучниця</femaleUa>
+      <maleEn>Archer</maleEn>
+      <femaleEn>Archer</femaleEn>
     </node>
     <node>
       <female>Ученица Стрелка</female>
       <male>Ученик Стрелка</male>
+      <maleUa>Учень Рейнджера</maleUa>
+      <femaleUa>Учениця Рейнджера</femaleUa>
+      <maleEn>Apprentice Ranger</maleEn>
+      <femaleEn>Apprentice Ranger</femaleEn>
     </node>
     <node>
       <female>Ученица Стрелка</female>
       <male>Ученик Стрелка</male>
+      <maleUa>Учень Рейнджера</maleUa>
+      <femaleUa>Учениця Рейнджера</femaleUa>
+      <maleEn>Apprentice Ranger</maleEn>
+      <femaleEn>Apprentice Ranger</femaleEn>
     </node>
     <node>
       <female>Жительница Леса</female>
       <male>Житель Леса</male>
+      <maleUa>Житель Лісу</maleUa>
+      <femaleUa>Жителька Лісу</femaleUa>
+      <maleEn>Woodsman</maleEn>
+      <femaleEn>Woodswoman</femaleEn>
     </node>
     <node>
       <female>Жительница Леса</female>
       <male>Житель Леса</male>
+      <maleUa>Житель Лісу</maleUa>
+      <femaleUa>Жителька Лісу</femaleUa>
+      <maleEn>Woodsman</maleEn>
+      <femaleEn>Woodswoman</femaleEn>
     </node>
     <node>
       <female>Мастер Выживания</female>
       <male>Мастер Выживания</male>
+      <maleUa>Майстер Виживання</maleUa>
+      <femaleUa>Майстриня Виживання</femaleUa>
+      <maleEn>Master of Survival</maleEn>
+      <femaleEn>Mistress of Survival</femaleEn>
     </node>
     <node>
       <female>Мастер Выживания</female>
       <male>Мастер Выживания</male>
+      <maleUa>Майстер Виживання</maleUa>
+      <femaleUa>Майстриня Виживання</femaleUa>
+      <maleEn>Master of Survival</maleEn>
+      <femaleEn>Mistress of Survival</femaleEn>
     </node>
     <node>
       <female>Стрелок-Ученица</female>
       <male>Стрелок-Ученик</male>
+      <maleUa>Рейнджер-Учень</maleUa>
+      <femaleUa>Рейнджер-Учениця</femaleUa>
+      <maleEn>Ranger Initiate</maleEn>
+      <femaleEn>Ranger Initiate</femaleEn>
     </node>
     <node>
       <female>Стрелок-Ученица</female>
       <male>Стрелок-Ученик</male>
+      <maleUa>Рейнджер-Учень</maleUa>
+      <femaleUa>Рейнджер-Учениця</femaleUa>
+      <maleEn>Ranger Initiate</maleEn>
+      <femaleEn>Ranger Initiate</femaleEn>
     </node>
     <node>
       <female>Стрелок-Кандидат</female>
       <male>Стрелок-Кандидат</male>
+      <maleUa>Рейнджер-Кандидат</maleUa>
+      <femaleUa>Рейнджер-Кандидат</femaleUa>
+      <maleEn>Ranger Candidate</maleEn>
+      <femaleEn>Ranger Candidate</femaleEn>
     </node>
     <node>
       <female>Стрелок-Кандидат</female>
       <male>Стрелок-Кандидат</male>
+      <maleUa>Рейнджер-Кандидат</maleUa>
+      <femaleUa>Рейнджер-Кандидат</femaleUa>
+      <maleEn>Ranger Candidate</maleEn>
+      <femaleEn>Ranger Candidate</femaleEn>
     </node>
     <node>
       <female>Стрелок-сквайр</female>
       <male>Стрелок-сквайр</male>
+      <maleUa>Рейнджер-сквайр</maleUa>
+      <femaleUa>Рейнджер-сквайр</femaleUa>
+      <maleEn>Ranger Squire</maleEn>
+      <femaleEn>Ranger Squire</femaleEn>
     </node>
     <node>
       <female>Стрелок-сквайр</female>
       <male>Стрелок-сквайр</male>
+      <maleUa>Рейнджер-сквайр</maleUa>
+      <femaleUa>Рейнджер-сквайр</femaleUa>
+      <maleEn>Ranger Squire</maleEn>
+      <femaleEn>Ranger Squire</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок</female>
       <male>Стрелок</male>
+      <maleUa>Рейнджер</maleUa>
+      <femaleUa>Рейнджер</femaleUa>
+      <maleEn>Ranger</maleEn>
+      <femaleEn>Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок-Командир</female>
       <male>Стрелок-Командир</male>
+      <maleUa>Рейнджер-Командир</maleUa>
+      <femaleUa>Рейнджер-Командир</femaleUa>
+      <maleEn>Ranger Captain</maleEn>
+      <femaleEn>Ranger Captain</femaleEn>
     </node>
     <node>
       <female>Стрелок-Командир</female>
       <male>Стрелок-Командир</male>
+      <maleUa>Рейнджер-Командир</maleUa>
+      <femaleUa>Рейнджер-Командир</femaleUa>
+      <maleEn>Ranger Captain</maleEn>
+      <femaleEn>Ranger Captain</femaleEn>
     </node>
     <node>
       <female>Стражница</female>
       <male>Стражник</male>
+      <maleUa>Вартовий</maleUa>
+      <femaleUa>Вартова</femaleUa>
+      <maleEn>Warder</maleEn>
+      <femaleEn>Warder</femaleEn>
     </node>
     <node>
       <female>Стражница</female>
       <male>Стражник</male>
+      <maleUa>Вартовий</maleUa>
+      <femaleUa>Вартова</femaleUa>
+      <maleEn>Warder</maleEn>
+      <femaleEn>Warder</femaleEn>
     </node>
     <node>
       <female>Стражница-Командир</female>
       <male>Стражник-Командир</male>
+      <maleUa>Вартовий-Командир</maleUa>
+      <femaleUa>Вартова-Командир</femaleUa>
+      <maleEn>Warder Captain</maleEn>
+      <femaleEn>Warder Captain</femaleEn>
     </node>
     <node>
       <female>Стражница-Командир</female>
       <male>Стражник-Командир</male>
+      <maleUa>Вартовий-Командир</maleUa>
+      <femaleUa>Вартова-Командир</femaleUa>
+      <maleEn>Warder Captain</maleEn>
+      <femaleEn>Warder Captain</femaleEn>
     </node>
     <node>
       <female>Стражница-Полководец</female>
       <male>Стражник-Полководец</male>
+      <maleUa>Вартовий-Полководець</maleUa>
+      <femaleUa>Вартова-Полководець</femaleUa>
+      <maleEn>Warder General</maleEn>
+      <femaleEn>Warder General</femaleEn>
     </node>
     <node>
       <female>Стражница-Полководец</female>
       <male>Стражник-Полководец</male>
+      <maleUa>Вартовий-Полководець</maleUa>
+      <femaleUa>Вартова-Полководець</femaleUa>
+      <maleEn>Warder General</maleEn>
+      <femaleEn>Warder General</femaleEn>
     </node>
     <node>
       <female>Повелительница Стражей</female>
       <male>Повелитель Стражей</male>
+      <maleUa>Повелитель Вартових</maleUa>
+      <femaleUa>Повелителька Вартових</femaleUa>
+      <maleEn>Master of Warders</maleEn>
+      <femaleEn>Mistress of Warders</femaleEn>
     </node>
     <node>
       <female>Повелительница Стражей</female>
       <male>Повелитель Стражей</male>
+      <maleUa>Повелитель Вартових</maleUa>
+      <femaleUa>Повелителька Вартових</femaleUa>
+      <maleEn>Master of Warders</maleEn>
+      <femaleEn>Mistress of Warders</femaleEn>
     </node>
     <node>
       <female>Лесная Леди</female>
       <male>Лесной Рыцарь</male>
+      <maleUa>Лісовий Лицар</maleUa>
+      <femaleUa>Лісова Леді</femaleUa>
+      <maleEn>Knight of the Forest</maleEn>
+      <femaleEn>Lady of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесная Леди</female>
       <male>Лесной Рыцарь</male>
+      <maleUa>Лісовий Лицар</maleUa>
+      <femaleUa>Лісова Леді</femaleUa>
+      <maleEn>Knight of the Forest</maleEn>
+      <femaleEn>Lady of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесной Меч</female>
       <male>Лесной Меч</male>
+      <maleUa>Лісовий Меч</maleUa>
+      <femaleUa>Лісовий Меч</femaleUa>
+      <maleEn>Sword of the Forest</maleEn>
+      <femaleEn>Sword of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесной Меч</female>
       <male>Лесной Меч</male>
+      <maleUa>Лісовий Меч</maleUa>
+      <femaleUa>Лісовий Меч</femaleUa>
+      <maleEn>Sword of the Forest</maleEn>
+      <femaleEn>Sword of the Forest</femaleEn>
     </node>
     <node>
       <female>Защитница Леса</female>
       <male>Защитник Леса</male>
+      <maleUa>Захисник Лісу</maleUa>
+      <femaleUa>Захисниця Лісу</femaleUa>
+      <maleEn>Guardian of the Forest</maleEn>
+      <femaleEn>Guardian of the Forest</femaleEn>
     </node>
     <node>
       <female>Защитница Леса</female>
       <male>Защитник Леса</male>
+      <maleUa>Захисник Лісу</maleUa>
+      <femaleUa>Захисниця Лісу</femaleUa>
+      <maleEn>Guardian of the Forest</maleEn>
+      <femaleEn>Guardian of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесная Баронесса</female>
       <male>Лесной Барон</male>
+      <maleUa>Лісовий Барон</maleUa>
+      <femaleUa>Лісова Баронеса</femaleUa>
+      <maleEn>Baron of the Forest</maleEn>
+      <femaleEn>Baroness of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесная Баронесса</female>
       <male>Лесной Барон</male>
+      <maleUa>Лісовий Барон</maleUa>
+      <femaleUa>Лісова Баронеса</femaleUa>
+      <maleEn>Baron of the Forest</maleEn>
+      <femaleEn>Baroness of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесная Королева</female>
       <male>Лесной Король</male>
+      <maleUa>Лісовий Король</maleUa>
+      <femaleUa>Лісова Королева</femaleUa>
+      <maleEn>King of the Forest</maleEn>
+      <femaleEn>Queen of the Forest</femaleEn>
     </node>
     <node>
       <female>Лесная Королева</female>
       <male>Лесной Король</male>
+      <maleUa>Лісовий Король</maleUa>
+      <femaleUa>Лісова Королева</femaleUa>
+      <maleEn>King of the Forest</maleEn>
+      <femaleEn>Queen of the Forest</femaleEn>
     </node>
     <node>
       <female>Повелительница Леса</female>
       <male>Повелитель Леса</male>
+      <maleUa>Повелитель Лісу</maleUa>
+      <femaleUa>Повелителька Лісу</femaleUa>
+      <maleEn>Master of the Forest</maleEn>
+      <femaleEn>Mistress of the Forest</femaleEn>
     </node>
     <node>
       <female>Повелительница Леса</female>
       <male>Повелитель Леса</male>
+      <maleUa>Повелитель Лісу</maleUa>
+      <femaleUa>Повелителька Лісу</femaleUa>
+      <maleEn>Master of the Forest</maleEn>
+      <femaleEn>Mistress of the Forest</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Охотница</female>
       <male>Охотник</male>
+      <maleUa>Мисливець</maleUa>
+      <femaleUa>Мисливиця</femaleUa>
+      <maleEn>Huntsman</maleEn>
+      <femaleEn>Huntswoman</femaleEn>
     </node>
     <node>
       <female>Охотница</female>
       <male>Охотник</male>
+      <maleUa>Мисливець</maleUa>
+      <femaleUa>Мисливиця</femaleUa>
+      <maleEn>Huntsman</maleEn>
+      <femaleEn>Huntswoman</femaleEn>
     </node>
     <node>
       <female>Призывающая Стаю</female>
       <male>Призывающий Стаю</male>
+      <maleUa>Прикликач Зграї</maleUa>
+      <femaleUa>Прикликачка Зграї</femaleUa>
+      <maleEn>Caller of the Pack</maleEn>
+      <femaleEn>Caller of the Pack</femaleEn>
     </node>
     <node>
       <female>Призывающая Стаю</female>
       <male>Призывающий Стаю</male>
+      <maleUa>Прикликач Зграї</maleUa>
+      <femaleUa>Прикликачка Зграї</femaleUa>
+      <maleEn>Caller of the Pack</maleEn>
+      <femaleEn>Caller of the Pack</femaleEn>
     </node>
     <node>
       <female>Владычица Стаи</female>
       <male>Владыка Стаи</male>
+      <maleUa>Володар Зграї</maleUa>
+      <femaleUa>Володарка Зграї</femaleUa>
+      <maleEn>Master of the Pack</maleEn>
+      <femaleEn>Mistress of the Pack</femaleEn>
     </node>
     <node>
       <female>Владычица Стаи</female>
       <male>Владыка Стаи</male>
+      <maleUa>Володар Зграї</maleUa>
+      <femaleUa>Володарка Зграї</femaleUa>
+      <maleEn>Master of the Pack</maleEn>
+      <femaleEn>Mistress of the Pack</femaleEn>
     </node>
     <node>
       <female>Начинающая Леди-Стрелок</female>
       <male>Начинающий Рыцарь-Стрелок</male>
+      <maleUa>Рейнджер-Лицар-Новачок</maleUa>
+      <femaleUa>Рейнджер-Леді-Новачка</femaleUa>
+      <maleEn>Ranger Knight Initiate</maleEn>
+      <femaleEn>Ranger Lady Initiate</femaleEn>
     </node>
     <node>
       <female>Начинающая Леди-Стрелок</female>
       <male>Начинающий Рыцарь-Стрелок</male>
+      <maleUa>Рейнджер-Лицар-Новачок</maleUa>
+      <femaleUa>Рейнджер-Леді-Новачка</femaleUa>
+      <maleEn>Ranger Knight Initiate</maleEn>
+      <femaleEn>Ranger Lady Initiate</femaleEn>
     </node>
     <node>
       <female>Леди-Стрелок</female>
       <male>Рыцарь-Стрелок</male>
+      <maleUa>Рейнджер-Лицар</maleUa>
+      <femaleUa>Рейнджер-Леді</femaleUa>
+      <maleEn>Ranger Knight</maleEn>
+      <femaleEn>Ranger Lady</femaleEn>
     </node>
     <node>
       <female>Леди-Стрелок</female>
       <male>Рыцарь-Стрелок</male>
+      <maleUa>Рейнджер-Лицар</maleUa>
+      <femaleUa>Рейнджер-Леді</femaleUa>
+      <maleEn>Ranger Knight</maleEn>
+      <femaleEn>Ranger Lady</femaleEn>
     </node>
     <node>
       <female>Баронесса-Стрелок</female>
       <male>Барон-Стрелок</male>
+      <maleUa>Рейнджер-Барон</maleUa>
+      <femaleUa>Рейнджер-Баронеса</femaleUa>
+      <maleEn>Ranger Baron</maleEn>
+      <femaleEn>Ranger Baroness</femaleEn>
     </node>
     <node>
       <female>Баронесса-Стрелок</female>
       <male>Барон-Стрелок</male>
+      <maleUa>Рейнджер-Барон</maleUa>
+      <femaleUa>Рейнджер-Баронеса</femaleUa>
+      <maleEn>Ranger Baron</maleEn>
+      <femaleEn>Ranger Baroness</femaleEn>
     </node>
     <node>
       <female>Принцесса-Стрелок</female>
       <male>Принц-Стрелок</male>
+      <maleUa>Рейнджер-Принц</maleUa>
+      <femaleUa>Рейнджер-Принцеса</femaleUa>
+      <maleEn>Ranger Prince</maleEn>
+      <femaleEn>Ranger Princess</femaleEn>
     </node>
     <node>
       <female>Принцесса-Стрелок</female>
       <male>Принц-Стрелок</male>
+      <maleUa>Рейнджер-Принц</maleUa>
+      <femaleUa>Рейнджер-Принцеса</femaleUa>
+      <maleEn>Ranger Prince</maleEn>
+      <femaleEn>Ranger Princess</femaleEn>
     </node>
     <node>
       <female>Стрелок-Королева</female>
       <male>Стрелок-Король</male>
+      <maleUa>Рейнджер-Король</maleUa>
+      <femaleUa>Рейнджер-Королева</femaleUa>
+      <maleEn>Ranger King</maleEn>
+      <femaleEn>Ranger Queen</femaleEn>
     </node>
     <node>
       <female>Стрелок-Королева</female>
       <male>Стрелок-Король</male>
+      <maleUa>Рейнджер-Король</maleUa>
+      <femaleUa>Рейнджер-Королева</femaleUa>
+      <maleEn>Ranger King</maleEn>
+      <femaleEn>Ranger Queen</femaleEn>
     </node>
     <node>
       <female>Царица-Стрелок</female>
       <male>Царь-Стрелок</male>
+      <maleUa>Рейнджер-Цар</maleUa>
+      <femaleUa>Рейнджер-Цариця</femaleUa>
+      <maleEn>Ranger Tsar</maleEn>
+      <femaleEn>Ranger Tsarina</femaleEn>
     </node>
     <node>
       <female>Царица-Стрелок</female>
       <male>Царь-Стрелок</male>
+      <maleUa>Рейнджер-Цар</maleUa>
+      <femaleUa>Рейнджер-Цариця</femaleUa>
+      <maleEn>Ranger Tsar</maleEn>
+      <femaleEn>Ranger Tsarina</femaleEn>
     </node>
     <node>
       <female>Смотрительница Лесной Поляны</female>
       <male>Смотритель Лесной Поляны</male>
+      <maleUa>Доглядач Лісової Галявини</maleUa>
+      <femaleUa>Доглядачка Лісової Галявини</femaleUa>
+      <maleEn>Warder of the Glade</maleEn>
+      <femaleEn>Warder of the Glade</femaleEn>
     </node>
     <node>
       <female>Смотрительница Лесной Поляны</female>
       <male>Смотритель Лесной Поляны</male>
+      <maleUa>Доглядач Лісової Галявини</maleUa>
+      <femaleUa>Доглядачка Лісової Галявини</femaleUa>
+      <maleEn>Warder of the Glade</maleEn>
+      <femaleEn>Warder of the Glade</femaleEn>
     </node>
     <node>
       <female>Хранительница Лесной Поляны</female>
       <male>Хранитель Лесной Поляны</male>
+      <maleUa>Хранитель Лісової Галявини</maleUa>
+      <femaleUa>Хранителька Лісової Галявини</femaleUa>
+      <maleEn>Keeper of the Glade</maleEn>
+      <femaleEn>Keeper of the Glade</femaleEn>
     </node>
     <node>
       <female>Хранительница Лесной Поляны</female>
       <male>Хранитель Лесной Поляны</male>
+      <maleUa>Хранитель Лісової Галявини</maleUa>
+      <femaleUa>Хранителька Лісової Галявини</femaleUa>
+      <maleEn>Keeper of the Glade</maleEn>
+      <femaleEn>Keeper of the Glade</femaleEn>
     </node>
     <node>
       <female>Леди Лесной Поляны</female>
       <male>Рыцарь Лесной Поляны</male>
+      <maleUa>Лицар Лісової Галявини</maleUa>
+      <femaleUa>Леді Лісової Галявини</femaleUa>
+      <maleEn>Knight of the Glade</maleEn>
+      <femaleEn>Lady of the Glade</femaleEn>
     </node>
     <node>
       <female>Леди Лесной Поляны</female>
       <male>Рыцарь Лесной Поляны</male>
+      <maleUa>Лицар Лісової Галявини</maleUa>
+      <femaleUa>Леді Лісової Галявини</femaleUa>
+      <maleEn>Knight of the Glade</maleEn>
+      <femaleEn>Lady of the Glade</femaleEn>
     </node>
     <node>
       <female>Хозяйка Лесной Поляны</female>
       <male>Хозяин Лесной Поляны</male>
+      <maleUa>Господар Лісової Галявини</maleUa>
+      <femaleUa>Господиня Лісової Галявини</femaleUa>
+      <maleEn>Master of the Glade</maleEn>
+      <femaleEn>Mistress of the Glade</femaleEn>
     </node>
     <node>
       <female>Хозяйка Лесной Поляны</female>
       <male>Хозяин Лесной Поляны</male>
+      <maleUa>Господар Лісової Галявини</maleUa>
+      <femaleUa>Господиня Лісової Галявини</femaleUa>
+      <maleEn>Master of the Glade</maleEn>
+      <femaleEn>Mistress of the Glade</femaleEn>
     </node>
     <node>
       <female>Королева Лесной Поляны</female>
       <male>Король Лесной Поляны</male>
+      <maleUa>Король Лісової Галявини</maleUa>
+      <femaleUa>Королева Лісової Галявини</femaleUa>
+      <maleEn>King of the Glade</maleEn>
+      <femaleEn>Queen of the Glade</femaleEn>
     </node>
     <node>
       <female>Королева Лесной Поляны</female>
       <male>Король Лесной Поляны</male>
+      <maleUa>Король Лісової Галявини</maleUa>
+      <femaleUa>Королева Лісової Галявини</femaleUa>
+      <maleEn>King of the Glade</maleEn>
+      <femaleEn>Queen of the Glade</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Спостерігач</maleUa>
+      <femaleUa>Спостерігачка</femaleUa>
+      <maleEn>Watcher</maleEn>
+      <femaleEn>Watcher</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Спостерігач</maleUa>
+      <femaleUa>Спостерігачка</femaleUa>
+      <maleEn>Watcher</maleEn>
+      <femaleEn>Watcher</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>Хранитель</male>
+      <maleUa>Хранитель</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>Keeper</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Хранительница</female>
       <male>the Watcher</male>
+      <maleUa>Вартовий</maleUa>
+      <femaleUa>Хранителька</femaleUa>
+      <maleEn>the Watcher</maleEn>
+      <femaleEn>Keeper</femaleEn>
     </node>
     <node>
       <female>Стрелок Героиня</female>
       <male>Стрелок Герой</male>
+      <maleUa>Рейнджер-Герой</maleUa>
+      <femaleUa>Рейнджер-Героїня</femaleUa>
+      <maleEn>Ranger Hero</maleEn>
+      <femaleEn>Ranger Heroine</femaleEn>
     </node>
     <node>
       <female>Воплощение Стрелка</female>
       <male>Воплощение Стрелка</male>
+      <maleUa>Втілення Рейнджера</maleUa>
+      <femaleUa>Втілення Рейнджера</femaleUa>
+      <maleEn>Embodiment of the Ranger</maleEn>
+      <femaleEn>Embodiment of the Ranger</femaleEn>
     </node>
     <node>
       <female>Ангел Стрелок</female>
       <male>Ангел Стрелок</male>
+      <maleUa>Ангел-Рейнджер</maleUa>
+      <femaleUa>Ангел-Рейнджер</femaleUa>
+      <maleEn>Angel Ranger</maleEn>
+      <femaleEn>Angel Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок Полубогиня</female>
       <male>Стрелок Полубог</male>
+      <maleUa>Рейнджер-Напівбог</maleUa>
+      <femaleUa>Рейнджер-Напівбогиня</femaleUa>
+      <maleEn>Ranger Demigod</maleEn>
+      <femaleEn>Ranger Demigoddess</femaleEn>
     </node>
     <node>
       <female>Бессмертный Стрелок</female>
       <male>Бессмертный Стрелок</male>
+      <maleUa>Безсмертний Рейнджер</maleUa>
+      <femaleUa>Безсмертний Рейнджер</femaleUa>
+      <maleEn>Immortal Ranger</maleEn>
+      <femaleEn>Immortal Ranger</femaleEn>
     </node>
     <node>
       <female>Стрелок-Богиня</female>
       <male>Стрелок-Бог</male>
+      <maleUa>Рейнджер-Бог</maleUa>
+      <femaleUa>Рейнджер-Богиня</femaleUa>
+      <maleEn>Ranger God</maleEn>
+      <femaleEn>Ranger Goddess</femaleEn>
     </node>
     <node>
       <female>Божественный Стрелок</female>
       <male>Божественный Стрелок</male>
+      <maleUa>Божественний Рейнджер</maleUa>
+      <femaleUa>Божественний Рейнджер</femaleUa>
+      <maleEn>Divine Ranger</maleEn>
+      <femaleEn>Divine Ranger</femaleEn>
     </node>
     <node>
       <female>Высший Стрелок</female>
       <male>Высший Стрелок</male>
+      <maleUa>Найвищий Рейнджер</maleUa>
+      <femaleUa>Найвищий Рейнджер</femaleUa>
+      <maleEn>Supreme Ranger</maleEn>
+      <femaleEn>Supreme Ranger</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Имплементор</female>
       <male>Имплементор</male>
+      <maleUa>Імплементор</maleUa>
+      <femaleUa>Імплементор</femaleUa>
+      <maleEn>Implementor</maleEn>
+      <femaleEn>Implementor</femaleEn>
     </node>
   </titles>
   <weapon>40102</weapon>

--- a/professions/samurai.xml
+++ b/professions/samurai.xml
@@ -56,406 +56,810 @@
     <node>
       <female>Кохай</female>
       <male>Кохай</male>
+      <maleUa>Кохай</maleUa>
+      <femaleUa>Кохай</femaleUa>
+      <maleEn>Kohai</maleEn>
+      <femaleEn>Kohai</femaleEn>
     </node>
     <node>
       <female>Сэмпай</female>
       <male>Сэмпай</male>
+      <maleUa>Семпай</maleUa>
+      <femaleUa>Семпай</femaleUa>
+      <maleEn>Sempai</maleEn>
+      <femaleEn>Sempai</femaleEn>
     </node>
     <node>
       <female>Кэнкаку</female>
       <male>Кэнкаку</male>
+      <maleUa>Кенкаку</maleUa>
+      <femaleUa>Кенкаку</femaleUa>
+      <maleEn>Kenkaku</maleEn>
+      <femaleEn>Kenkaku</femaleEn>
     </node>
     <node>
       <female>Кенси</female>
       <male>Кенси</male>
+      <maleUa>Кенси</maleUa>
+      <femaleUa>Кенси</femaleUa>
+      <maleEn>Kenshi</maleEn>
+      <femaleEn>Kenshi</femaleEn>
     </node>
     <node>
       <female>Буси</female>
       <male>Буси</male>
+      <maleUa>Буси</maleUa>
+      <femaleUa>Буси</femaleUa>
+      <maleEn>Bushi</maleEn>
+      <femaleEn>Bushi</femaleEn>
     </node>
     <node>
       <female>Цувамоно</female>
       <male>Цувамоно</male>
+      <maleUa>Цувамоно</maleUa>
+      <femaleUa>Цувамоно</femaleUa>
+      <maleEn>Tsuwamono</maleEn>
+      <femaleEn>Tsuwamono</femaleEn>
     </node>
     <node>
       <female>Хейси</female>
       <male>Хейси</male>
+      <maleUa>Хейси</maleUa>
+      <femaleUa>Хейси</femaleUa>
+      <maleEn>Heishi</maleEn>
+      <femaleEn>Heishi</femaleEn>
     </node>
     <node>
       <female>Сенси</female>
       <male>Сенси</male>
+      <maleUa>Сенси</maleUa>
+      <femaleUa>Сенси</femaleUa>
+      <maleEn>Senshi</maleEn>
+      <femaleEn>Senshi</femaleEn>
     </node>
     <node>
       <female>Асигару</female>
       <male>Асигару</male>
+      <maleUa>Асигару</maleUa>
+      <femaleUa>Асигару</femaleUa>
+      <maleEn>Ashigaru</maleEn>
+      <femaleEn>Ashigaru</femaleEn>
     </node>
     <node>
       <female>Буке</female>
       <male>Буке</male>
+      <maleUa>Буке</maleUa>
+      <femaleUa>Буке</femaleUa>
+      <maleEn>Buke</maleEn>
+      <femaleEn>Buke</femaleEn>
     </node>
     <node>
       <female>Камикадзе</female>
       <male>Камикадзе</male>
+      <maleUa>Камикадзе</maleUa>
+      <femaleUa>Камикадзе</femaleUa>
+      <maleEn>Kamikaze</maleEn>
+      <femaleEn>Kamikaze</femaleEn>
     </node>
     <node>
       <female>Кэрай</female>
       <male>Кэрай</male>
+      <maleUa>Керай</maleUa>
+      <femaleUa>Керай</femaleUa>
+      <maleEn>Kerai</maleEn>
+      <femaleEn>Kerai</femaleEn>
     </node>
     <node>
       <female>Самурай</female>
       <male>Самурай</male>
+      <maleUa>Самурай</maleUa>
+      <femaleUa>Самурай</femaleUa>
+      <maleEn>Samurai</maleEn>
+      <femaleEn>Samurai</femaleEn>
     </node>
     <node>
       <female>Ронин</female>
       <male>Ронин</male>
+      <maleUa>Ронин</maleUa>
+      <femaleUa>Ронин</femaleUa>
+      <maleEn>Ronin</maleEn>
+      <femaleEn>Ronin</femaleEn>
     </node>
     <node>
       <female>Масурао</female>
       <male>Масурао</male>
+      <maleUa>Масурао</maleUa>
+      <femaleUa>Масурао</femaleUa>
+      <maleEn>Masurao</maleEn>
+      <femaleEn>Masurao</femaleEn>
     </node>
     <node>
       <female>Тсукаи</female>
       <male>Тсукаи</male>
+      <maleUa>Тсукаи</maleUa>
+      <femaleUa>Тсукаи</femaleUa>
+      <maleEn>Tsukai</maleEn>
+      <femaleEn>Tsukai</femaleEn>
     </node>
     <node>
       <female>О-Бан</female>
       <male>О-Бан</male>
+      <maleUa>О-Бан</maleUa>
+      <femaleUa>О-Бан</femaleUa>
+      <maleEn>O-Ban</maleEn>
+      <femaleEn>O-Ban</femaleEn>
     </node>
     <node>
       <female>Эдзи</female>
       <male>Эдзи</male>
+      <maleUa>Едзи</maleUa>
+      <femaleUa>Едзи</femaleUa>
+      <maleEn>Eji</maleEn>
+      <femaleEn>Eji</femaleEn>
     </node>
     <node>
       <female>Хьо</female>
       <male>Хьо</male>
+      <maleUa>Хе</maleUa>
+      <femaleUa>Хе</femaleUa>
+      <maleEn>Hyo</maleEn>
+      <femaleEn>Hyo</femaleEn>
     </node>
     <node>
       <female>Коноэ</female>
       <male>Коноэ</male>
+      <maleUa>Коное</maleUa>
+      <femaleUa>Коное</femaleUa>
+      <maleEn>Konoe</maleEn>
+      <femaleEn>Konoe</femaleEn>
     </node>
     <node>
       <female>Хатамото</female>
       <male>Хатамото</male>
+      <maleUa>Хатамото</maleUa>
+      <femaleUa>Хатамото</femaleUa>
+      <maleEn>Hatamoto</maleEn>
+      <femaleEn>Hatamoto</femaleEn>
     </node>
     <node>
       <female>О-Мономи</female>
       <male>О-Мономи</male>
+      <maleUa>О-Мономи</maleUa>
+      <femaleUa>О-Мономи</femaleUa>
+      <maleEn>O-Monomi</maleEn>
+      <femaleEn>O-Monomi</femaleEn>
     </node>
     <node>
       <female>Нака-Мономи</female>
       <male>Нака-Мономи</male>
+      <maleUa>Нака-Мономи</maleUa>
+      <femaleUa>Нака-Мономи</femaleUa>
+      <maleEn>Naka-Monomi</maleEn>
+      <femaleEn>Naka-Monomi</femaleEn>
     </node>
     <node>
       <female>Се-Мономи</female>
       <male>Се-Мономи</male>
+      <maleUa>Се-Мономи</maleUa>
+      <femaleUa>Се-Мономи</femaleUa>
+      <maleEn>Se-Monomi</maleEn>
+      <femaleEn>Se-Monomi</femaleEn>
     </node>
     <node>
       <female>Бугэй</female>
       <male>Бугэй</male>
+      <maleUa>Бугей</maleUa>
+      <femaleUa>Бугей</femaleUa>
+      <maleEn>Bugei</maleEn>
+      <femaleEn>Bugei</femaleEn>
     </node>
     <node>
       <female>Когасира</female>
       <male>Когасира</male>
+      <maleUa>Когасира</maleUa>
+      <femaleUa>Когасира</femaleUa>
+      <maleEn>Kogashira</maleEn>
+      <femaleEn>Kogashira</femaleEn>
     </node>
     <node>
       <female>О-Бан Кумигасира</female>
       <male>О-Бан Кумигасира</male>
+      <maleUa>О-Бан Кумигасира</maleUa>
+      <femaleUa>О-Бан Кумигасира</femaleUa>
+      <maleEn>O-Ban Kumigashira</maleEn>
+      <femaleEn>O-Ban Kumigashira</femaleEn>
     </node>
     <node>
       <female>Эмон-но Сиоси</female>
       <male>Эмон-но Сиоси</male>
+      <maleUa>Емон-но Сиоси</maleUa>
+      <femaleUa>Емон-но Сиоси</femaleUa>
+      <maleEn>Emon-no Shioshi</maleEn>
+      <femaleEn>Emon-no Shioshi</femaleEn>
     </node>
     <node>
       <female>Саемон-но Сиоси</female>
       <male>Саемон-но Сиоси</male>
+      <maleUa>Саемон-но Сиоси</maleUa>
+      <femaleUa>Саемон-но Сиоси</femaleUa>
+      <maleEn>Saemon-no Shioshi</maleEn>
+      <femaleEn>Saemon-no Shioshi</femaleEn>
     </node>
     <node>
       <female>Уё-но Сиоси</female>
       <male>Уё-но Сиоси</male>
+      <maleUa>Уе-но Сиоси</maleUa>
+      <femaleUa>Уе-но Сиоси</femaleUa>
+      <maleEn>Uyo-no Shioshi</maleEn>
+      <femaleEn>Uyo-no Shioshi</femaleEn>
     </node>
     <node>
       <female>Сайё-но Сиоси</female>
       <male>Сайё-но Сиоси</male>
+      <maleUa>Сайе-но Сиоси</maleUa>
+      <femaleUa>Сайе-но Сиоси</femaleUa>
+      <maleEn>Saiyo-no Shioshi</maleEn>
+      <femaleEn>Saiyo-no Shioshi</femaleEn>
     </node>
     <node>
       <female>Эмон-но Таиси</female>
       <male>Эмон-но Таиси</male>
+      <maleUa>Емон-но Таиси</maleUa>
+      <femaleUa>Емон-но Таиси</femaleUa>
+      <maleEn>Emon-no Taishi</maleEn>
+      <femaleEn>Emon-no Taishi</femaleEn>
     </node>
     <node>
       <female>Саемон-но Таиси</female>
       <male>Саемон-но Таиси</male>
+      <maleUa>Саемон-но Таиси</maleUa>
+      <femaleUa>Саемон-но Таиси</femaleUa>
+      <maleEn>Saemon-no Taishi</maleEn>
+      <femaleEn>Saemon-no Taishi</femaleEn>
     </node>
     <node>
       <female>Уё-но Таиси</female>
       <male>Уё-но Таиси</male>
+      <maleUa>Уе-но Таиси</maleUa>
+      <femaleUa>Уе-но Таиси</femaleUa>
+      <maleEn>Uyo-no Taishi</maleEn>
+      <femaleEn>Uyo-no Taishi</femaleEn>
     </node>
     <node>
       <female>Сайё-но Таиси</female>
       <male>Сайё-но Таиси</male>
+      <maleUa>Сайе-но Таиси</maleUa>
+      <femaleUa>Сайе-но Таиси</femaleUa>
+      <maleEn>Saiyo-no Taishi</maleEn>
+      <femaleEn>Saiyo-no Taishi</femaleEn>
     </node>
     <node>
       <female>Укон-но Сюсо</female>
       <male>Укон-но Сюсо</male>
+      <maleUa>Укон-но Сюсо</maleUa>
+      <femaleUa>Укон-но Сюсо</femaleUa>
+      <maleEn>Ukon-no Shuso</maleEn>
+      <femaleEn>Ukon-no Shuso</femaleEn>
     </node>
     <node>
       <female>Сакон-но Сюсо</female>
       <male>Сакон-но Сюсо</male>
+      <maleUa>Сакон-но Сюсо</maleUa>
+      <femaleUa>Сакон-но Сюсо</femaleUa>
+      <maleEn>Sakon-no Shuso</maleEn>
+      <femaleEn>Sakon-no Shuso</femaleEn>
     </node>
     <node>
       <female>Моногасира</female>
       <male>Моногасира</male>
+      <maleUa>Моногасира</maleUa>
+      <femaleUa>Моногасира</femaleUa>
+      <maleEn>Monogashira</maleEn>
+      <femaleEn>Monogashira</femaleEn>
     </node>
     <node>
       <female>О-Бан Касира</female>
       <male>О-Бан Касира</male>
+      <maleUa>О-Бан Касира</maleUa>
+      <femaleUa>О-Бан Касира</femaleUa>
+      <maleEn>O-Ban Kashira</maleEn>
+      <femaleEn>O-Ban Kashira</femaleEn>
     </node>
     <node>
       <female>Эмон-но Сёй</female>
       <male>Эмон-но Сёй</male>
+      <maleUa>Емон-но Сеи</maleUa>
+      <femaleUa>Емон-но Сеи</femaleUa>
+      <maleEn>Emon-no Shoi</maleEn>
+      <femaleEn>Emon-no Shoi</femaleEn>
     </node>
     <node>
       <female>Саемон-но Сёй</female>
       <male>Саемон-но Сёй</male>
+      <maleUa>Саемон-но Сеи</maleUa>
+      <femaleUa>Саемон-но Сеи</femaleUa>
+      <maleEn>Saemon-no Shoi</maleEn>
+      <femaleEn>Saemon-no Shoi</femaleEn>
     </node>
     <node>
       <female>Уё-но Сёй</female>
       <male>Уё-но Сёй</male>
+      <maleUa>Уе-но Сеи</maleUa>
+      <femaleUa>Уе-но Сеи</femaleUa>
+      <maleEn>Uyo-no Shoi</maleEn>
+      <femaleEn>Uyo-no Shoi</femaleEn>
     </node>
     <node>
       <female>Сайё-но Сёй</female>
       <male>Сайё-но Сёй</male>
+      <maleUa>Сайе-но Сеи</maleUa>
+      <femaleUa>Сайе-но Сеи</femaleUa>
+      <maleEn>Saiyo-no Shoi</maleEn>
+      <femaleEn>Saiyo-no Shoi</femaleEn>
     </node>
     <node>
       <female>Эмон-но Тайи</female>
       <male>Эмон-но Тайи</male>
+      <maleUa>Емон-но Тайи</maleUa>
+      <femaleUa>Емон-но Тайи</femaleUa>
+      <maleEn>Emon-no Taii</maleEn>
+      <femaleEn>Emon-no Taii</femaleEn>
     </node>
     <node>
       <female>Саемон-но Тайи</female>
       <male>Саемон-но Тайи</male>
+      <maleUa>Саемон-но Тайи</maleUa>
+      <femaleUa>Саемон-но Тайи</femaleUa>
+      <maleEn>Saemon-no Taii</maleEn>
+      <femaleEn>Saemon-no Taii</femaleEn>
     </node>
     <node>
       <female>Уё-но Тайи</female>
       <male>Уё-но Тайи</male>
+      <maleUa>Уе-но Тайи</maleUa>
+      <femaleUa>Уе-но Тайи</femaleUa>
+      <maleEn>Uyo-no Taii</maleEn>
+      <femaleEn>Uyo-no Taii</femaleEn>
     </node>
     <node>
       <female>Сайё-но Тайи</female>
       <male>Сайё-но Тайи</male>
+      <maleUa>Сайе-но Тайи</maleUa>
+      <femaleUa>Сайе-но Тайи</femaleUa>
+      <maleEn>Saiyo-no Taii</maleEn>
+      <femaleEn>Saiyo-no Taii</femaleEn>
     </node>
     <node>
       <female>Укон-но Сёгэн</female>
       <male>Укон-но Сёгэн</male>
+      <maleUa>Укон-но Сеген</maleUa>
+      <femaleUa>Укон-но Сеген</femaleUa>
+      <maleEn>Ukon-no Shogen</maleEn>
+      <femaleEn>Ukon-no Shogen</femaleEn>
     </node>
     <node>
       <female>Сакон-но Сёгэн</female>
       <male>Сакон-но Сёгэн</male>
+      <maleUa>Сакон-но Сеген</maleUa>
+      <femaleUa>Сакон-но Сеген</femaleUa>
+      <maleEn>Sakon-no Shogen</maleEn>
+      <femaleEn>Sakon-no Shogen</femaleEn>
     </node>
     <node>
       <female>Эмон-но Сюкэ</female>
       <male>Эмон-но Сюкэ</male>
+      <maleUa>Емон-но Сюке</maleUa>
+      <femaleUa>Емон-но Сюке</femaleUa>
+      <maleEn>Emon-no Shuke</maleEn>
+      <femaleEn>Emon-no Shuke</femaleEn>
     </node>
     <node>
       <female>Саемон-но Сюкэ</female>
       <male>Саемон-но Сюкэ</male>
+      <maleUa>Саемон-но Сюке</maleUa>
+      <femaleUa>Саемон-но Сюке</femaleUa>
+      <maleEn>Saemon-no Shuke</maleEn>
+      <femaleEn>Saemon-no Shuke</femaleEn>
     </node>
     <node>
       <female>Уё-но Сюкэ</female>
       <male>Уё-но Сюкэ</male>
+      <maleUa>Уе-но Сюке</maleUa>
+      <femaleUa>Уе-но Сюке</femaleUa>
+      <maleEn>Uyo-no Shuke</maleEn>
+      <femaleEn>Uyo-no Shuke</femaleEn>
     </node>
     <node>
       <female>Сайё-но Сюкэ</female>
       <male>Сайё-но Сюкэ</male>
+      <maleUa>Сайе-но Сюке</maleUa>
+      <femaleUa>Сайе-но Сюке</femaleUa>
+      <maleEn>Saiyo-no Shuke</maleEn>
+      <femaleEn>Saiyo-no Shuke</femaleEn>
     </node>
     <node>
       <female>Укон-но Сёусёу</female>
       <male>Укон-но Сёусёу</male>
+      <maleUa>Укон-но Сеусеу</maleUa>
+      <femaleUa>Укон-но Сеусеу</femaleUa>
+      <maleEn>Ukon-no Shosho</maleEn>
+      <femaleEn>Ukon-no Shosho</femaleEn>
     </node>
     <node>
       <female>Сакон-но Сёусёу</female>
       <male>Сакон-но Сёусёу</male>
+      <maleUa>Сакон-но Сеусеу</maleUa>
+      <femaleUa>Сакон-но Сеусеу</femaleUa>
+      <maleEn>Sakon-no Shosho</maleEn>
+      <femaleEn>Sakon-no Shosho</femaleEn>
     </node>
     <node>
       <female>Укон-но Тюдзё</female>
       <male>Укон-но Тюдзё</male>
+      <maleUa>Укон-но Тюдзе</maleUa>
+      <femaleUa>Укон-но Тюдзе</femaleUa>
+      <maleEn>Ukon-no Chujo</maleEn>
+      <femaleEn>Ukon-no Chujo</femaleEn>
     </node>
     <node>
       <female>Сакон-но Тюдзё</female>
       <male>Сакон-но Тюдзё</male>
+      <maleUa>Сакон-но Тюдзе</maleUa>
+      <femaleUa>Сакон-но Тюдзе</femaleUa>
+      <maleEn>Sakon-no Chujo</maleEn>
+      <femaleEn>Sakon-no Chujo</femaleEn>
     </node>
     <node>
       <female>Эмон-но Ками</female>
       <male>Эмон-но Ками</male>
+      <maleUa>Емон-но Ками</maleUa>
+      <femaleUa>Емон-но Ками</femaleUa>
+      <maleEn>Emon-no Kami</maleEn>
+      <femaleEn>Emon-no Kami</femaleEn>
     </node>
     <node>
       <female>Саемон-но Ками</female>
       <male>Саемон-но Ками</male>
+      <maleUa>Саемон-но Ками</maleUa>
+      <femaleUa>Саемон-но Ками</femaleUa>
+      <maleEn>Saemon-no Kami</maleEn>
+      <femaleEn>Saemon-no Kami</femaleEn>
     </node>
     <node>
       <female>Уё-но Ками</female>
       <male>Уё-но Ками</male>
+      <maleUa>Уе-но Ками</maleUa>
+      <femaleUa>Уе-но Ками</femaleUa>
+      <maleEn>Uyo-no Kami</maleEn>
+      <femaleEn>Uyo-no Kami</femaleEn>
     </node>
     <node>
       <female>Сайё-но Ками</female>
       <male>Сайё-но Ками</male>
+      <maleUa>Сайе-но Ками</maleUa>
+      <femaleUa>Сайе-но Ками</femaleUa>
+      <maleEn>Saiyo-no Kami</maleEn>
+      <femaleEn>Saiyo-no Kami</femaleEn>
     </node>
     <node>
       <female>Яридайсё</female>
       <male>Яридайсё</male>
+      <maleUa>Яридайсе</maleUa>
+      <femaleUa>Яридайсе</femaleUa>
+      <maleEn>Yaridaisho</maleEn>
+      <femaleEn>Yaridaisho</femaleEn>
     </node>
     <node>
       <female>Юмидайсё</female>
       <male>Юмидайсё</male>
+      <maleUa>Юмидайсе</maleUa>
+      <femaleUa>Юмидайсе</femaleUa>
+      <maleEn>Yumidaisho</maleEn>
+      <femaleEn>Yumidaisho</femaleEn>
     </node>
     <node>
       <female>Укон-но Дайсё</female>
       <male>Укон-но Дайсё</male>
+      <maleUa>Укон-но Дайсе</maleUa>
+      <femaleUa>Укон-но Дайсе</femaleUa>
+      <maleEn>Ukon-no Daisho</maleEn>
+      <femaleEn>Ukon-no Daisho</femaleEn>
     </node>
     <node>
       <female>Сакон-но Дайсё</female>
       <male>Сакон-но Дайсё</male>
+      <maleUa>Сакон-но Дайсе</maleUa>
+      <femaleUa>Сакон-но Дайсе</femaleUa>
+      <maleEn>Sakon-no Daisho</maleEn>
+      <femaleEn>Sakon-no Daisho</femaleEn>
     </node>
     <node>
       <female>Гономоно</female>
       <male>Гономоно</male>
+      <maleUa>Гономоно</maleUa>
+      <femaleUa>Гономоно</femaleUa>
+      <maleEn>Gonomono</maleEn>
+      <femaleEn>Gonomono</femaleEn>
     </node>
     <node>
       <female>Кохей</female>
       <male>Кохей</male>
+      <maleUa>Кохей</maleUa>
+      <femaleUa>Кохей</femaleUa>
+      <maleEn>Kohei</maleEn>
+      <femaleEn>Kohei</femaleEn>
     </node>
     <node>
       <female>Гиоси</female>
       <male>Гиоси</male>
+      <maleUa>Гиоси</maleUa>
+      <femaleUa>Гиоси</femaleUa>
+      <maleEn>Gioshi</maleEn>
+      <femaleEn>Gioshi</femaleEn>
     </node>
     <node>
       <female>Сиомё</female>
       <male>Сиомё</male>
+      <maleUa>Сиоме</maleUa>
+      <femaleUa>Сиоме</femaleUa>
+      <maleEn>Shiomyo</maleEn>
+      <femaleEn>Shiomyo</femaleEn>
     </node>
     <node>
       <female>Рёсю</female>
       <male>Рёсю</male>
+      <maleUa>Ресю</maleUa>
+      <femaleUa>Ресю</femaleUa>
+      <maleEn>Ryoshu</maleEn>
+      <femaleEn>Ryoshu</femaleEn>
     </node>
     <node>
       <female>Дзёсю</female>
       <male>Дзёсю</male>
+      <maleUa>Дзесю</maleUa>
+      <femaleUa>Дзесю</femaleUa>
+      <maleEn>Joshu</maleEn>
+      <femaleEn>Joshu</femaleEn>
     </node>
     <node>
       <female>Сиромоти</female>
       <male>Сиромоти</male>
+      <maleUa>Сиромоти</maleUa>
+      <femaleUa>Сиромоти</femaleUa>
+      <maleEn>Shiromochi</maleEn>
+      <femaleEn>Shiromochi</femaleEn>
     </node>
     <node>
       <female>Кокусю</female>
       <male>Кокусю</male>
+      <maleUa>Кокусю</maleUa>
+      <femaleUa>Кокусю</femaleUa>
+      <maleEn>Kokushu</maleEn>
+      <femaleEn>Kokushu</femaleEn>
     </node>
     <node>
       <female>Кунимоти</female>
       <male>Кунимоти</male>
+      <maleUa>Кунимоти</maleUa>
+      <femaleUa>Кунимоти</femaleUa>
+      <maleEn>Kunimochi</maleEn>
+      <femaleEn>Kunimochi</femaleEn>
     </node>
     <node>
       <female>Кенин</female>
       <male>Кенин</male>
+      <maleUa>Кенин</maleUa>
+      <femaleUa>Кенин</femaleUa>
+      <maleEn>Kenin</maleEn>
+      <femaleEn>Kenin</femaleEn>
     </node>
     <node>
       <female>Кунигаро</female>
       <male>Кунигаро</male>
+      <maleUa>Кунигаро</maleUa>
+      <femaleUa>Кунигаро</femaleUa>
+      <maleEn>Kunigaro</maleEn>
+      <femaleEn>Kunigaro</femaleEn>
     </node>
     <node>
       <female>Русуй</female>
       <male>Русуй</male>
+      <maleUa>Русуй</maleUa>
+      <femaleUa>Русуй</femaleUa>
+      <maleEn>Rusui</maleEn>
+      <femaleEn>Rusui</femaleEn>
     </node>
     <node>
       <female>Ёнин</female>
       <male>Ёнин</male>
+      <maleUa>Енин</maleUa>
+      <femaleUa>Енин</femaleUa>
+      <maleEn>Yonin</maleEn>
+      <femaleEn>Yonin</femaleEn>
     </node>
     <node>
       <female>Каро</female>
       <male>Каро</male>
+      <maleUa>Каро</maleUa>
+      <femaleUa>Каро</femaleUa>
+      <maleEn>Karo</maleEn>
+      <femaleEn>Karo</femaleEn>
     </node>
     <node>
       <female>Мецукэ</female>
       <male>Мецукэ</male>
+      <maleUa>Мецуке</maleUa>
+      <femaleUa>Мецуке</femaleUa>
+      <maleEn>Metsuke</maleEn>
+      <femaleEn>Metsuke</femaleEn>
     </node>
     <node>
       <female>Даймё</female>
       <male>Даймё</male>
+      <maleUa>Дайме</maleUa>
+      <femaleUa>Дайме</femaleUa>
+      <maleEn>Daimyo</maleEn>
+      <femaleEn>Daimyo</femaleEn>
     </node>
     <node>
       <female>Кугэ</female>
       <male>Кугэ</male>
+      <maleUa>Куге</maleUa>
+      <femaleUa>Куге</femaleUa>
+      <maleEn>Kuge</maleEn>
+      <femaleEn>Kuge</femaleEn>
     </node>
     <node>
       <female>Хигокэнин</female>
       <male>Хигокэнин</male>
+      <maleUa>Хигокенин</maleUa>
+      <femaleUa>Хигокенин</femaleUa>
+      <maleEn>Higokenin</maleEn>
+      <femaleEn>Higokenin</femaleEn>
     </node>
     <node>
       <female>Гокэнин</female>
       <male>Гокэнин</male>
+      <maleUa>Гокенин</maleUa>
+      <femaleUa>Гокенин</femaleUa>
+      <maleEn>Gokenin</maleEn>
+      <femaleEn>Gokenin</femaleEn>
     </node>
     <node>
       <female>Дзикисан</female>
       <male>Дзикисан</male>
+      <maleUa>Дзикисан</maleUa>
+      <femaleUa>Дзикисан</femaleUa>
+      <maleEn>Jikisan</maleEn>
+      <femaleEn>Jikisan</femaleEn>
     </node>
     <node>
       <female>Родзю</female>
       <male>Родзю</male>
+      <maleUa>Родзю</maleUa>
+      <femaleUa>Родзю</femaleUa>
+      <maleEn>Roju</maleEn>
+      <femaleEn>Roju</femaleEn>
     </node>
     <node>
       <female>Сёгун</female>
       <male>Сёгун</male>
+      <maleUa>Сегун</maleUa>
+      <femaleUa>Сегун</femaleUa>
+      <maleEn>Shogun</maleEn>
+      <femaleEn>Shogun</femaleEn>
     </node>
     <node>
       <female>Тай-Сёгун</female>
       <male>Тай-Сёгун</male>
+      <maleUa>Тай-Сегун</maleUa>
+      <femaleUa>Тай-Сегун</femaleUa>
+      <maleEn>Tai-Shogun</maleEn>
+      <femaleEn>Tai-Shogun</femaleEn>
     </node>
     <node>
       <female>Сихон Микото</female>
       <male>Сихон Микото</male>
+      <maleUa>Сихон Микото</maleUa>
+      <femaleUa>Сихон Микото</femaleUa>
+      <maleEn>Shihon Mikoto</maleEn>
+      <femaleEn>Shihon Mikoto</femaleEn>
     </node>
     <node>
       <female>Самбон Микото</female>
       <male>Самбон Микото</male>
+      <maleUa>Самбон Микото</maleUa>
+      <femaleUa>Самбон Микото</femaleUa>
+      <maleEn>Sambon Mikoto</maleEn>
+      <femaleEn>Sambon Mikoto</femaleEn>
     </node>
     <node>
       <female>Нихон Микото</female>
       <male>Нихон Микото</male>
+      <maleUa>Нихон Микото</maleUa>
+      <femaleUa>Нихон Микото</femaleUa>
+      <maleEn>Nihon Mikoto</maleEn>
+      <femaleEn>Nihon Mikoto</femaleEn>
     </node>
     <node>
       <female>Ипон Микото</female>
       <male>Ипон Микото</male>
+      <maleUa>Ипон Микото</maleUa>
+      <femaleUa>Ипон Микото</femaleUa>
+      <maleEn>Ipon Mikoto</maleEn>
+      <femaleEn>Ipon Mikoto</femaleEn>
     </node>
     <node>
       <female>Ханси</female>
       <male>Ханси</male>
+      <maleUa>Ханси</maleUa>
+      <femaleUa>Ханси</femaleUa>
+      <maleEn>Hanshi</maleEn>
+      <femaleEn>Hanshi</femaleEn>
     </node>
     <node>
       <female>Нитэн</female>
       <male>Нитэн</male>
+      <maleUa>Нитен</maleUa>
+      <femaleUa>Нитен</femaleUa>
+      <maleEn>Niten</maleEn>
+      <femaleEn>Niten</femaleEn>
     </node>
     <node>
       <female>Кэнсэй</female>
       <male>Кэнсэй</male>
+      <maleUa>Кенсей</maleUa>
+      <femaleUa>Кенсей</femaleUa>
+      <maleEn>Kensei</maleEn>
+      <femaleEn>Kensei</femaleEn>
     </node>
     <node>
       <female>Ки-Кен-Тай-Иччи</female>
       <male>Ки-Кен-Тай-Иччи</male>
+      <maleUa>Ки-Кен-Тай-Иччи</maleUa>
+      <femaleUa>Ки-Кен-Тай-Иччи</femaleUa>
+      <maleEn>Ki-Ken-Tai-Icchi</maleEn>
+      <femaleEn>Ki-Ken-Tai-Icchi</femaleEn>
     </node>
     <node>
       <female>Ками</female>
       <male>Ками</male>
+      <maleUa>Ками</maleUa>
+      <femaleUa>Ками</femaleUa>
+      <maleEn>Kami</maleEn>
+      <femaleEn>Kami</femaleEn>
     </node>
     <node>
       <female>Тэнно</female>
       <male>Тэнно</male>
+      <maleUa>Тенно</maleUa>
+      <femaleUa>Тенно</femaleUa>
+      <maleEn>Tenno</maleEn>
+      <femaleEn>Tenno</femaleEn>
     </node>
     <node>
       <female>Микадо</female>
       <male>Микадо</male>
+      <maleUa>Микадо</maleUa>
+      <femaleUa>Микадо</femaleUa>
+      <maleEn>Mikado</maleEn>
+      <femaleEn>Mikado</femaleEn>
     </node>
     <node>
       <female>Сункецу Буси</female>
       <male>Сункецу Буси</male>
+      <maleUa>Сункецу Буси</maleUa>
+      <femaleUa>Сункецу Буси</femaleUa>
+      <maleEn>Sunketsu Bushi</maleEn>
+      <femaleEn>Sunketsu Bushi</femaleEn>
     </node>
     <node>
       <female>Денкитэки Буси</female>
       <male>Денкитэки Буси</male>
+      <maleUa>Денкитеки Буси</maleUa>
+      <femaleUa>Денкитеки Буси</femaleUa>
+      <maleEn>Denkiteki Bushi</maleEn>
+      <femaleEn>Denkiteki Bushi</femaleEn>
     </node>
     <node>
       <female>Kesshi Busi</female>

--- a/professions/thief.xml
+++ b/professions/thief.xml
@@ -49,442 +49,882 @@
     <node>
       <female>Воришка</female>
       <male>Воришка</male>
+      <maleUa>Хапуга</maleUa>
+      <femaleUa>Хапуга</femaleUa>
+      <maleEn>Pilferer</maleEn>
+      <femaleEn>Pilferess</femaleEn>
     </node>
     <node>
       <female>Разбойница</female>
       <male>Разбойник</male>
+      <maleUa>Розбійник</maleUa>
+      <femaleUa>Розбійниця</femaleUa>
+      <maleEn>Footpad</maleEn>
+      <femaleEn>Footpad</femaleEn>
     </node>
     <node>
       <female>Мелкая воришка</female>
       <male>Мелкий воришка</male>
+      <maleUa>Дрібний Хапуга</maleUa>
+      <femaleUa>Дрібна Хапуга</femaleUa>
+      <maleEn>Filcher</maleEn>
+      <femaleEn>Filcheress</femaleEn>
     </node>
     <node>
       <female>Карманница</female>
       <male>Карманник</male>
+      <maleUa>Кишеньковий Крадій</maleUa>
+      <femaleUa>Кишенькова Крадійка</femaleUa>
+      <maleEn>Pick-Pocket</maleEn>
+      <femaleEn>Pick-Pocket</femaleEn>
     </node>
     <node>
       <female>Крадущаяся</female>
       <male>Крадущийся</male>
+      <maleUa>Скрадач</maleUa>
+      <femaleUa>Скрадачка</femaleUa>
+      <maleEn>Sneak</maleEn>
+      <femaleEn>Sneak</femaleEn>
     </node>
     <node>
       <female>Щипач</female>
       <male>Щипач</male>
+      <maleUa>Щипач</maleUa>
+      <femaleUa>Щипач</femaleUa>
+      <maleEn>Pincher</maleEn>
+      <femaleEn>Pincheress</femaleEn>
     </node>
     <node>
       <female>Подрезающая Кошельки</female>
       <male>Подрезающий Кошельки</male>
+      <maleUa>Обрізувач Гаманців</maleUa>
+      <femaleUa>Обрізувачка Гаманців</femaleUa>
+      <maleEn>Cut-Purse</maleEn>
+      <femaleEn>Cut-Purse</femaleEn>
     </node>
     <node>
       <female>Похитительница</female>
       <male>Похититель</male>
+      <maleUa>Викрадач</maleUa>
+      <femaleUa>Викрадачка</femaleUa>
+      <maleEn>Snatcher</maleEn>
+      <femaleEn>Snatcheress</femaleEn>
     </node>
     <node>
       <female>Шулер</female>
       <male>Шулер</male>
+      <maleUa>Шулер</maleUa>
+      <femaleUa>Шулер</femaleUa>
+      <maleEn>Sharper</maleEn>
+      <femaleEn>Sharpress</femaleEn>
     </node>
     <node>
       <female>Мошенница</female>
       <male>Мошенник</male>
+      <maleUa>Шахрай</maleUa>
+      <femaleUa>Шахрайка</femaleUa>
+      <maleEn>Rogue</maleEn>
+      <femaleEn>Rogue</femaleEn>
     </node>
     <node>
       <female>Грабительница</female>
       <male>Грабитель</male>
+      <maleUa>Грабіжник</maleUa>
+      <femaleUa>Грабіжниця</femaleUa>
+      <maleEn>Robber</maleEn>
+      <femaleEn>Robber</femaleEn>
     </node>
     <node>
       <female>Грабительница</female>
       <male>Грабитель</male>
+      <maleUa>Грабіжник</maleUa>
+      <femaleUa>Грабіжниця</femaleUa>
+      <maleEn>Robber</maleEn>
+      <femaleEn>Robber</femaleEn>
     </node>
     <node>
       <female>Разводила</female>
       <male>Разводила</male>
+      <maleUa>Кидала</maleUa>
+      <femaleUa>Кидала</femaleUa>
+      <maleEn>Magsman</maleEn>
+      <femaleEn>Magswoman</femaleEn>
     </node>
     <node>
       <female>Разводила</female>
       <male>Разводила</male>
+      <maleUa>Кидала</maleUa>
+      <femaleUa>Кидала</femaleUa>
+      <maleEn>Magsman</maleEn>
+      <femaleEn>Magswoman</femaleEn>
     </node>
     <node>
       <female>Разбойница с Большой Дороги</female>
       <male>Разбойник с Большой Дороги</male>
+      <maleUa>Розбійник з Великого Шляху</maleUa>
+      <femaleUa>Розбійниця з Великого Шляху</femaleUa>
+      <maleEn>Highwayman</maleEn>
+      <femaleEn>Highwaywoman</femaleEn>
     </node>
     <node>
       <female>Разбойница с Большой Дороги</female>
       <male>Разбойник с Большой Дороги</male>
+      <maleUa>Розбійник з Великого Шляху</maleUa>
+      <femaleUa>Розбійниця з Великого Шляху</femaleUa>
+      <maleEn>Highwayman</maleEn>
+      <femaleEn>Highwaywoman</femaleEn>
     </node>
     <node>
       <female>Взломщица</female>
       <male>Взломщик</male>
+      <maleUa>Зломник</maleUa>
+      <femaleUa>Зломниця</femaleUa>
+      <maleEn>Burglar</maleEn>
+      <femaleEn>Burglaress</femaleEn>
     </node>
     <node>
       <female>Взломщица</female>
       <male>Взломщик</male>
+      <maleUa>Зломник</maleUa>
+      <femaleUa>Зломниця</femaleUa>
+      <maleEn>Burglar</maleEn>
+      <femaleEn>Burglaress</femaleEn>
     </node>
     <node>
       <female>Воровка</female>
       <male>Вор</male>
+      <maleUa>Крадій</maleUa>
+      <femaleUa>Крадійка</femaleUa>
+      <maleEn>Thief</maleEn>
+      <femaleEn>Thief</femaleEn>
     </node>
     <node>
       <female>Воровка</female>
       <male>Вор</male>
+      <maleUa>Крадій</maleUa>
+      <femaleUa>Крадійка</femaleUa>
+      <maleEn>Thief</maleEn>
+      <femaleEn>Thief</femaleEn>
     </node>
     <node>
       <female>Поножовщица</female>
       <male>Поножовщик</male>
+      <maleUa>Штрикач</maleUa>
+      <femaleUa>Штрикачка</femaleUa>
+      <maleEn>Knifer</maleEn>
+      <femaleEn>Knifer</femaleEn>
     </node>
     <node>
       <female>Поножовщица</female>
       <male>Поножовщик</male>
+      <maleUa>Штрикач</maleUa>
+      <femaleUa>Штрикачка</femaleUa>
+      <maleEn>Knifer</maleEn>
+      <femaleEn>Knifer</femaleEn>
     </node>
     <node>
       <female>Быстрый Клинок</female>
       <male>Быстрый Клинок</male>
+      <maleUa>Швидкий Клинок</maleUa>
+      <femaleUa>Швидкий Клинок</femaleUa>
+      <maleEn>Quick-Blade</maleEn>
+      <femaleEn>Quick-Blade</femaleEn>
     </node>
     <node>
       <female>Быстрый Клинок</female>
       <male>Быстрый Клинок</male>
+      <maleUa>Швидкий Клинок</maleUa>
+      <femaleUa>Швидкий Клинок</femaleUa>
+      <maleEn>Quick-Blade</maleEn>
+      <femaleEn>Quick-Blade</femaleEn>
     </node>
     <node>
       <female>Душегубка</female>
       <male>Душегуб</male>
+      <maleUa>Душогуб</maleUa>
+      <femaleUa>Душогубка</femaleUa>
+      <maleEn>Killer</maleEn>
+      <femaleEn>Murderess</femaleEn>
     </node>
     <node>
       <female>Душегубка</female>
       <male>Душегуб</male>
+      <maleUa>Душогуб</maleUa>
+      <femaleUa>Душогубка</femaleUa>
+      <maleEn>Killer</maleEn>
+      <femaleEn>Murderess</femaleEn>
     </node>
     <node>
       <female>Бандитка</female>
       <male>Бандит</male>
+      <maleUa>Бандит</maleUa>
+      <femaleUa>Бандитка</femaleUa>
+      <maleEn>Brigand</maleEn>
+      <femaleEn>Brigand</femaleEn>
     </node>
     <node>
       <female>Бандитка</female>
       <male>Бандит</male>
+      <maleUa>Бандит</maleUa>
+      <femaleUa>Бандитка</femaleUa>
+      <maleEn>Brigand</maleEn>
+      <femaleEn>Brigand</femaleEn>
     </node>
     <node>
       <female>Перерезающая Горло</female>
       <male>Перерезающий Горло</male>
+      <maleUa>Горлоріз</maleUa>
+      <femaleUa>Горлорізка</femaleUa>
+      <maleEn>Cut-Throat</maleEn>
+      <femaleEn>Cut-Throat</femaleEn>
     </node>
     <node>
       <female>Перерезающая Горло</female>
       <male>Перерезающий Горло</male>
+      <maleUa>Горлоріз</maleUa>
+      <femaleUa>Горлорізка</femaleUa>
+      <maleEn>Cut-Throat</maleEn>
+      <femaleEn>Cut-Throat</femaleEn>
     </node>
     <node>
       <female>Шпионка</female>
       <male>Шпион</male>
+      <maleUa>Шпигун</maleUa>
+      <femaleUa>Шпигунка</femaleUa>
+      <maleEn>Spy</maleEn>
+      <femaleEn>Spy</femaleEn>
     </node>
     <node>
       <female>Шпионка</female>
       <male>Шпион</male>
+      <maleUa>Шпигун</maleUa>
+      <femaleUa>Шпигунка</femaleUa>
+      <maleEn>Spy</maleEn>
+      <femaleEn>Spy</femaleEn>
     </node>
     <node>
       <female>Великая Шпионка</female>
       <male>Великий Шпион</male>
+      <maleUa>Великий Шпигун</maleUa>
+      <femaleUa>Велика Шпигунка</femaleUa>
+      <maleEn>Grand Spy</maleEn>
+      <femaleEn>Grand Spy</femaleEn>
     </node>
     <node>
       <female>Великая Шпионка</female>
       <male>Великий Шпион</male>
+      <maleUa>Великий Шпигун</maleUa>
+      <femaleUa>Велика Шпигунка</femaleUa>
+      <maleEn>Grand Spy</maleEn>
+      <femaleEn>Grand Spy</femaleEn>
     </node>
     <node>
       <female>Главная Шпионка</female>
       <male>Главный Шпион</male>
+      <maleUa>Головний Шпигун</maleUa>
+      <femaleUa>Головна Шпигунка</femaleUa>
+      <maleEn>Master Spy</maleEn>
+      <femaleEn>Master Spy</femaleEn>
     </node>
     <node>
       <female>Главная Шпионка</female>
       <male>Главный Шпион</male>
+      <maleUa>Головний Шпигун</maleUa>
+      <femaleUa>Головна Шпигунка</femaleUa>
+      <maleEn>Master Spy</maleEn>
+      <femaleEn>Master Spy</femaleEn>
     </node>
     <node>
       <female>Убийца</female>
       <male>Убийца</male>
+      <maleUa>Вбивця</maleUa>
+      <femaleUa>Вбивця</femaleUa>
+      <maleEn>Assassin</maleEn>
+      <femaleEn>Assassin</femaleEn>
     </node>
     <node>
       <female>Убийца</female>
       <male>Убийца</male>
+      <maleUa>Вбивця</maleUa>
+      <femaleUa>Вбивця</femaleUa>
+      <maleEn>Assassin</maleEn>
+      <femaleEn>Assassin</femaleEn>
     </node>
     <node>
       <female>Великая Убийца</female>
       <male>Великий Убийца</male>
+      <maleUa>Великий Вбивця</maleUa>
+      <femaleUa>Велика Вбивця</femaleUa>
+      <maleEn>Greater Assassin</maleEn>
+      <femaleEn>Greater Assassin</femaleEn>
     </node>
     <node>
       <female>Великая Убийца</female>
       <male>Великий Убийца</male>
+      <maleUa>Великий Вбивця</maleUa>
+      <femaleUa>Велика Вбивця</femaleUa>
+      <maleEn>Greater Assassin</maleEn>
+      <femaleEn>Greater Assassin</femaleEn>
     </node>
     <node>
       <female>Повелительница Зрения</female>
       <male>Повелитель Зрения</male>
+      <maleUa>Володар Зору</maleUa>
+      <femaleUa>Володарка Зору</femaleUa>
+      <maleEn>Master of Vision</maleEn>
+      <femaleEn>Mistress of Vision</femaleEn>
     </node>
     <node>
       <female>Повелительница Зрения</female>
       <male>Повелитель Зрения</male>
+      <maleUa>Володар Зору</maleUa>
+      <femaleUa>Володарка Зору</femaleUa>
+      <maleEn>Master of Vision</maleEn>
+      <femaleEn>Mistress of Vision</femaleEn>
     </node>
     <node>
       <female>Повелительница Слуха</female>
       <male>Повелитель Слуха</male>
+      <maleUa>Володар Слуху</maleUa>
+      <femaleUa>Володарка Слуху</femaleUa>
+      <maleEn>Master of Hearing</maleEn>
+      <femaleEn>Mistress of Hearing</femaleEn>
     </node>
     <node>
       <female>Повелительница Слуха</female>
       <male>Повелитель Слуха</male>
+      <maleUa>Володар Слуху</maleUa>
+      <femaleUa>Володарка Слуху</femaleUa>
+      <maleEn>Master of Hearing</maleEn>
+      <femaleEn>Mistress of Hearing</femaleEn>
     </node>
     <node>
       <female>Повелительница Обоняния</female>
       <male>Повелитель Обоняния</male>
+      <maleUa>Володар Нюху</maleUa>
+      <femaleUa>Володарка Нюху</femaleUa>
+      <maleEn>Master of Smell</maleEn>
+      <femaleEn>Mistress of Smell</femaleEn>
     </node>
     <node>
       <female>Повелительница Обоняния</female>
       <male>Повелитель Обоняния</male>
+      <maleUa>Володар Нюху</maleUa>
+      <femaleUa>Володарка Нюху</femaleUa>
+      <maleEn>Master of Smell</maleEn>
+      <femaleEn>Mistress of Smell</femaleEn>
     </node>
     <node>
       <female>Повелительница Вкуса</female>
       <male>Повелитель Вкуса</male>
+      <maleUa>Володар Смаку</maleUa>
+      <femaleUa>Володарка Смаку</femaleUa>
+      <maleEn>Master of Taste</maleEn>
+      <femaleEn>Mistress of Taste</femaleEn>
     </node>
     <node>
       <female>Повелительница Вкуса</female>
       <male>Повелитель Вкуса</male>
+      <maleUa>Володар Смаку</maleUa>
+      <femaleUa>Володарка Смаку</femaleUa>
+      <maleEn>Master of Taste</maleEn>
+      <femaleEn>Mistress of Taste</femaleEn>
     </node>
     <node>
       <female>Повелительница Осязания</female>
       <male>Повелитель Осязания</male>
+      <maleUa>Володар Дотику</maleUa>
+      <femaleUa>Володарка Дотику</femaleUa>
+      <maleEn>Master of Touch</maleEn>
+      <femaleEn>Mistress of Touch</femaleEn>
     </node>
     <node>
       <female>Повелительница Осязания</female>
       <male>Повелитель Осязания</male>
+      <maleUa>Володар Дотику</maleUa>
+      <femaleUa>Володарка Дотику</femaleUa>
+      <maleEn>Master of Touch</maleEn>
+      <femaleEn>Mistress of Touch</femaleEn>
     </node>
     <node>
       <female>Лидер Преступности</female>
       <male>Лидер Преступности</male>
+      <maleUa>Лідер Злочинного Світу</maleUa>
+      <femaleUa>Лідер Злочинного Світу</femaleUa>
+      <maleEn>Crime Lord</maleEn>
+      <femaleEn>Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Лидер Преступности</female>
       <male>Лидер Преступности</male>
+      <maleUa>Лідер Злочинного Світу</maleUa>
+      <femaleUa>Лідер Злочинного Світу</femaleUa>
+      <maleEn>Crime Lord</maleEn>
+      <femaleEn>Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Бесчестный Лидер Преступности</female>
       <male>Бесчестный Лидер Преступности</male>
+      <maleUa>Безчесний Лідер Злочинного Світу</maleUa>
+      <femaleUa>Безчесний Лідер Злочинного Світу</femaleUa>
+      <maleEn>Infamous Crime Lord</maleEn>
+      <femaleEn>Infamous Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Бесчестный Лидер Преступности</female>
       <male>Бесчестный Лидер Преступности</male>
+      <maleUa>Безчесний Лідер Злочинного Світу</maleUa>
+      <femaleUa>Безчесний Лідер Злочинного Світу</femaleUa>
+      <maleEn>Infamous Crime Lord</maleEn>
+      <femaleEn>Infamous Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Большой Лидер Преступности</female>
       <male>Большой Лидер Преступности</male>
+      <maleUa>Великий Лідер Злочинного Світу</maleUa>
+      <femaleUa>Великий Лідер Злочинного Світу</femaleUa>
+      <maleEn>Greater Crime Lord</maleEn>
+      <femaleEn>Greater Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Большой Лидер Преступности</female>
       <male>Большой Лидер Преступности</male>
+      <maleUa>Великий Лідер Злочинного Світу</maleUa>
+      <femaleUa>Великий Лідер Злочинного Світу</femaleUa>
+      <maleEn>Greater Crime Lord</maleEn>
+      <femaleEn>Greater Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Повелительница Лидеров Преступности</female>
       <male>Повелитель Лидеров Преступности</male>
+      <maleUa>Володар Лідерів Злочинного Світу</maleUa>
+      <femaleUa>Володарка Лідерів Злочинного Світу</femaleUa>
+      <maleEn>Master Crime Lord</maleEn>
+      <femaleEn>Master Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Повелительница Лидеров Преступности</female>
       <male>Повелитель Лидеров Преступности</male>
+      <maleUa>Володар Лідерів Злочинного Світу</maleUa>
+      <femaleUa>Володарка Лідерів Злочинного Світу</femaleUa>
+      <maleEn>Master Crime Lord</maleEn>
+      <femaleEn>Master Crime Mistress</femaleEn>
     </node>
     <node>
       <female>Крестная Мать</female>
       <male>Крестный Отец</male>
+      <maleUa>Хрещений Батько</maleUa>
+      <femaleUa>Хрещена Мати</femaleUa>
+      <maleEn>Godfather</maleEn>
+      <femaleEn>Godmother</femaleEn>
     </node>
     <node>
       <female>Крестная Мать</female>
       <male>Крестный Отец</male>
+      <maleUa>Хрещений Батько</maleUa>
+      <femaleUa>Хрещена Мати</femaleUa>
+      <maleEn>Godfather</maleEn>
+      <femaleEn>Godmother</femaleEn>
     </node>
     <node>
       <female>Преступный Босс</female>
       <male>Преступный Босс</male>
+      <maleUa>Кримінальний Бос</maleUa>
+      <femaleUa>Кримінальний Бос</femaleUa>
+      <maleEn>Crime Boss</maleEn>
+      <femaleEn>Crime Boss</femaleEn>
     </node>
     <node>
       <female>Преступный Босс</female>
       <male>Преступный Босс</male>
+      <maleUa>Кримінальний Бос</maleUa>
+      <femaleUa>Кримінальний Бос</femaleUa>
+      <maleEn>Crime Boss</maleEn>
+      <femaleEn>Crime Boss</femaleEn>
     </node>
     <node>
       <female>Вор в законе</female>
       <male>Вор в законе</male>
+      <maleUa>Крадій в законі</maleUa>
+      <femaleUa>Крадій в законі</femaleUa>
+      <maleEn>Kingpin</maleEn>
+      <femaleEn>Kingpin</femaleEn>
     </node>
     <node>
       <female>Вор в законе</female>
       <male>Вор в законе</male>
+      <maleUa>Крадій в законі</maleUa>
+      <femaleUa>Крадій в законі</femaleUa>
+      <maleEn>Kingpin</maleEn>
+      <femaleEn>Kingpin</femaleEn>
     </node>
     <node>
       <female>Владычица Подземелий</female>
       <male>Владыка Подземелий</male>
+      <maleUa>Володар Підземель</maleUa>
+      <femaleUa>Володарка Підземель</femaleUa>
+      <maleEn>Lord of the Underworld</maleEn>
+      <femaleEn>Lady of the Underworld</femaleEn>
     </node>
     <node>
       <female>Владычица Подземелий</female>
       <male>Владыка Подземелий</male>
+      <maleUa>Володар Підземель</maleUa>
+      <femaleUa>Володарка Підземель</femaleUa>
+      <maleEn>Lord of the Underworld</maleEn>
+      <femaleEn>Lady of the Underworld</femaleEn>
     </node>
     <node>
       <female>Тень</female>
       <male>Тень</male>
+      <maleUa>Тінь</maleUa>
+      <femaleUa>Тінь</femaleUa>
+      <maleEn>Shadow</maleEn>
+      <femaleEn>Shadow</femaleEn>
     </node>
     <node>
       <female>Тень</female>
       <male>Тень</male>
+      <maleUa>Тінь</maleUa>
+      <femaleUa>Тінь</femaleUa>
+      <maleEn>Shadow</maleEn>
+      <femaleEn>Shadow</femaleEn>
     </node>
     <node>
       <female>Госпожа Ночи</female>
       <male>Господин Ночи</male>
+      <maleUa>Господар Ночі</maleUa>
+      <femaleUa>Господиня Ночі</femaleUa>
+      <maleEn>Master of the Night</maleEn>
+      <femaleEn>Mistress of the Night</femaleEn>
     </node>
     <node>
       <female>Госпожа Ночи</female>
       <male>Господин Ночи</male>
+      <maleUa>Господар Ночі</maleUa>
+      <femaleUa>Господиня Ночі</femaleUa>
+      <maleEn>Master of the Night</maleEn>
+      <femaleEn>Mistress of the Night</femaleEn>
     </node>
     <node>
       <female>Безмолвная Госпожа</female>
       <male>Безмолвный Господин</male>
+      <maleUa>Безмовний Господар</maleUa>
+      <femaleUa>Безмовна Господиня</femaleUa>
+      <maleEn>Master of Silence</maleEn>
+      <femaleEn>Mistress of Silence</femaleEn>
     </node>
     <node>
       <female>Безмолвная Госпожа</female>
       <male>Безмолвный Господин</male>
+      <maleUa>Безмовний Господар</maleUa>
+      <femaleUa>Безмовна Господиня</femaleUa>
+      <maleEn>Master of Silence</maleEn>
+      <femaleEn>Mistress of Silence</femaleEn>
     </node>
     <node>
       <female>Вероломная Госпожа</female>
       <male>Вероломный Господин</male>
+      <maleUa>Віроломний Господар</maleUa>
+      <femaleUa>Віроломна Господиня</femaleUa>
+      <maleEn>Master of Guile</maleEn>
+      <femaleEn>Mistress of Guile</femaleEn>
     </node>
     <node>
       <female>Вероломная Госпожа</female>
       <male>Вероломный Господин</male>
+      <maleUa>Віроломний Господар</maleUa>
+      <femaleUa>Віроломна Господиня</femaleUa>
+      <maleEn>Master of Guile</maleEn>
+      <femaleEn>Mistress of Guile</femaleEn>
     </node>
     <node>
       <female>Повелительница Клинков</female>
       <male>Повелитель Клинков</male>
+      <maleUa>Володар Клинків</maleUa>
+      <femaleUa>Володарка Клинків</femaleUa>
+      <maleEn>Master of the Blade</maleEn>
+      <femaleEn>Mistress of the Blade</femaleEn>
     </node>
     <node>
       <female>Повелительница Клинков</female>
       <male>Повелитель Клинков</male>
+      <maleUa>Володар Клинків</maleUa>
+      <femaleUa>Володарка Клинків</femaleUa>
+      <maleEn>Master of the Blade</maleEn>
+      <femaleEn>Mistress of the Blade</femaleEn>
     </node>
     <node>
       <female>Повелительница Ядов</female>
       <male>Повелитель Ядов</male>
+      <maleUa>Володар Отрут</maleUa>
+      <femaleUa>Володарка Отрут</femaleUa>
+      <maleEn>Master of Poison</maleEn>
+      <femaleEn>Mistress of Poison</femaleEn>
     </node>
     <node>
       <female>Повелительница Ядов</female>
       <male>Повелитель Ядов</male>
+      <maleUa>Володар Отрут</maleUa>
+      <femaleUa>Володарка Отрут</femaleUa>
+      <maleEn>Master of Poison</maleEn>
+      <femaleEn>Mistress of Poison</femaleEn>
     </node>
     <node>
       <female>Повелительница Хитрости</female>
       <male>Повелитель Хитрости</male>
+      <maleUa>Володар Хитрості</maleUa>
+      <femaleUa>Володарка Хитрості</femaleUa>
+      <maleEn>Master of Stealth</maleEn>
+      <femaleEn>Mistress of Stealth</femaleEn>
     </node>
     <node>
       <female>Повелительница Хитрости</female>
       <male>Повелитель Хитрости</male>
+      <maleUa>Володар Хитрості</maleUa>
+      <femaleUa>Володарка Хитрості</femaleUa>
+      <maleEn>Master of Stealth</maleEn>
+      <femaleEn>Mistress of Stealth</femaleEn>
     </node>
     <node>
       <female>Главная Воровка</female>
       <male>Главный Вор</male>
+      <maleUa>Головний Крадій</maleUa>
+      <femaleUa>Головна Крадійка</femaleUa>
+      <maleEn>Master Thief</maleEn>
+      <femaleEn>Master Thief</femaleEn>
     </node>
     <node>
       <female>Главная Воровка</female>
       <male>Главный Вор</male>
+      <maleUa>Головний Крадій</maleUa>
+      <femaleUa>Головна Крадійка</femaleUa>
+      <maleEn>Master Thief</maleEn>
+      <femaleEn>Master Thief</femaleEn>
     </node>
     <node>
       <female>Главная Убийца</female>
       <male>Главный Убийца</male>
+      <maleUa>Головний Вбивця</maleUa>
+      <femaleUa>Головна Вбивця</femaleUa>
+      <maleEn>Master Assassin</maleEn>
+      <femaleEn>Master Assassin</femaleEn>
     </node>
     <node>
       <female>Главная Убийца</female>
       <male>Главный Убийца</male>
+      <maleUa>Головний Вбивця</maleUa>
+      <femaleUa>Головна Вбивця</femaleUa>
+      <maleEn>Master Assassin</maleEn>
+      <femaleEn>Master Assassin</femaleEn>
     </node>
     <node>
       <female>Невидимая</female>
       <male>Невидимый</male>
+      <maleUa>Невидимий</maleUa>
+      <femaleUa>Невидима</femaleUa>
+      <maleEn>Unseen</maleEn>
+      <femaleEn>Unseen</femaleEn>
     </node>
     <node>
       <female>Невидимая</female>
       <male>Невидимый</male>
+      <maleUa>Невидимий</maleUa>
+      <femaleUa>Невидима</femaleUa>
+      <maleEn>Unseen</maleEn>
+      <femaleEn>Unseen</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Воров</female>
       <male>Великий Повелитель Воров</male>
+      <maleUa>Великий Володар Крадіїв</maleUa>
+      <femaleUa>Велика Володарка Крадіїв</femaleUa>
+      <maleEn>Grand Master of Thieves</maleEn>
+      <femaleEn>Grand Mistress of Thieves</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Воров</female>
       <male>Великий Повелитель Воров</male>
+      <maleUa>Великий Володар Крадіїв</maleUa>
+      <femaleUa>Велика Володарка Крадіїв</femaleUa>
+      <maleEn>Grand Master of Thieves</maleEn>
+      <femaleEn>Grand Mistress of Thieves</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Убийц</female>
       <male>Великий Повелитель Убийц</male>
+      <maleUa>Великий Володар Вбивць</maleUa>
+      <femaleUa>Велика Володарка Вбивць</femaleUa>
+      <maleEn>Grand Master of Assassins</maleEn>
+      <femaleEn>Grand Mistress of Assassins</femaleEn>
     </node>
     <node>
       <female>Героическая Убийца</female>
       <male>Героический Убийца</male>
+      <maleUa>Героїчний Вбивця</maleUa>
+      <femaleUa>Героїчна Вбивця</femaleUa>
+      <maleEn>Heroic Assassin</maleEn>
+      <femaleEn>Heroic Assassin</femaleEn>
     </node>
     <node>
       <female>Воплощение смерти</female>
       <male>Воплощение смерти</male>
+      <maleUa>Втілення Смерті</maleUa>
+      <femaleUa>Втілення Смерті</femaleUa>
+      <maleEn>Embodiment of Death</maleEn>
+      <femaleEn>Embodiment of Death</femaleEn>
     </node>
     <node>
       <female>Ангел смерти</female>
       <male>Ангел смерти</male>
+      <maleUa>Ангел Смерті</maleUa>
+      <femaleUa>Ангел Смерті</femaleUa>
+      <maleEn>Angel of Death</maleEn>
+      <femaleEn>Angel of Death</femaleEn>
     </node>
     <node>
       <female>Полубогиня Убийц</female>
       <male>Полубог Убийц</male>
+      <maleUa>Напівбог Вбивць</maleUa>
+      <femaleUa>Напівбогиня Вбивць</femaleUa>
+      <maleEn>Demigod of Assassins</maleEn>
+      <femaleEn>Demigoddess of Assassins</femaleEn>
     </node>
     <node>
       <female>Бессмертная Убийца</female>
       <male>Бессмертный Убийца</male>
+      <maleUa>Безсмертний Вбивця</maleUa>
+      <femaleUa>Безсмертна Вбивця</femaleUa>
+      <maleEn>Immortal Assassin</maleEn>
+      <femaleEn>Immortal Assassin</femaleEn>
     </node>
     <node>
       <female>Богиня Убийц</female>
       <male>Бог Убийц</male>
+      <maleUa>Бог Вбивць</maleUa>
+      <femaleUa>Богиня Вбивць</femaleUa>
+      <maleEn>God of Assassins</maleEn>
+      <femaleEn>Goddess of Assassins</femaleEn>
     </node>
     <node>
       <female>Божество Убийц</female>
       <male>Божество Убийц</male>
+      <maleUa>Божество Вбивць</maleUa>
+      <femaleUa>Божество Вбивць</femaleUa>
+      <maleEn>Deity of Assassins</maleEn>
+      <femaleEn>Deity of Assassins</femaleEn>
     </node>
     <node>
       <female>Высшая Госпожа</female>
       <male>Высший Господин</male>
+      <maleUa>Найвищий Господар</maleUa>
+      <femaleUa>Найвища Господиня</femaleUa>
+      <maleEn>Supreme Lord</maleEn>
+      <femaleEn>Supreme Lady</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creatress</femaleEn>
     </node>
     <node>
       <female>Имплементор</female>
       <male>Имплементор</male>
+      <maleUa>Імплементор</maleUa>
+      <femaleUa>Імплементор</femaleUa>
+      <maleEn>Implementor</maleEn>
+      <femaleEn>Implementor</femaleEn>
     </node>
   </titles>
   <weapon>40101</weapon>

--- a/professions/vampire.xml
+++ b/professions/vampire.xml
@@ -55,446 +55,890 @@ Every young vampire must undergo a one-time initiation ritual with the Master of
     <node>
       <female>Женщина</female>
       <male>Мужчина</male>
+      <maleUa>Чоловік</maleUa>
+      <femaleUa>Жінка</femaleUa>
+      <maleEn>Man</maleEn>
+      <femaleEn>Woman</femaleEn>
     </node>
     <node>
       <female>Ученица Крови</female>
       <male>Ученик Крови</male>
+      <maleUa>Учень Крові</maleUa>
+      <femaleUa>Учениця Крові</femaleUa>
+      <maleEn>Apprentice of Blood</maleEn>
+      <femaleEn>Apprentice of Blood</femaleEn>
     </node>
     <node>
       <female>Студентка Крови</female>
       <male>Студент Крови</male>
+      <maleUa>Студент Крові</maleUa>
+      <femaleUa>Студентка Крові</femaleUa>
+      <maleEn>Student of Blood</maleEn>
+      <femaleEn>Student of Blood</femaleEn>
     </node>
     <node>
       <female>Изучающая Кровь</female>
       <male>Изучающий Кровь</male>
+      <maleUa>Дослідник Крові</maleUa>
+      <femaleUa>Дослідниця Крові</femaleUa>
+      <maleEn>Scholar of Blood</maleEn>
+      <femaleEn>Scholar of Blood</femaleEn>
     </node>
     <node>
       <female>Погружающаяся в Кровь</female>
       <male>Погружающийся в Кровь</male>
+      <maleUa>Занурений у Кров</maleUa>
+      <femaleUa>Занурена у Кров</femaleUa>
+      <maleEn>Delver in Blood</maleEn>
+      <femaleEn>Delveress in Blood</femaleEn>
     </node>
     <node>
       <female>Проводница Крови</female>
       <male>Проводник Крови</male>
+      <maleUa>Провідник Крові</maleUa>
+      <femaleUa>Провідниця Крові</femaleUa>
+      <maleEn>Medium of Blood</maleEn>
+      <femaleEn>Medium of Blood</femaleEn>
     </node>
     <node>
       <female>Пишущая Кровью</female>
       <male>Пишущий Кровью</male>
+      <maleUa>Писар Кровʼю</maleUa>
+      <femaleUa>Писарка Кровʼю</femaleUa>
+      <maleEn>Scribe of Blood</maleEn>
+      <femaleEn>Scribess of Blood</femaleEn>
     </node>
     <node>
       <female>Видящая</female>
       <male>Видящий</male>
+      <maleUa>Провидець</maleUa>
+      <femaleUa>Провидиця</femaleUa>
+      <maleEn>Seer</maleEn>
+      <femaleEn>Seeress</femaleEn>
     </node>
     <node>
       <female>Мудрая</female>
       <male>Мудрец</male>
+      <maleUa>Мудрець</maleUa>
+      <femaleUa>Мудра</femaleUa>
+      <maleEn>Sage</maleEn>
+      <femaleEn>Sage</femaleEn>
     </node>
     <node>
       <female>Мастерица Иллюзий</female>
       <male>Мастер Иллюзий</male>
+      <maleUa>Майстер Ілюзій</maleUa>
+      <femaleUa>Майстриня Ілюзій</femaleUa>
+      <maleEn>Illusionist</maleEn>
+      <femaleEn>Illusionist</femaleEn>
     </node>
     <node>
       <female>Мастерица Аффектов</female>
       <male>Мастер Аффектов</male>
+      <maleUa>Майстер Афектів</maleUa>
+      <femaleUa>Майстриня Афектів</femaleUa>
+      <maleEn>Master of Affects</maleEn>
+      <femaleEn>Mistress of Affects</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Master of Rituals</maleEn>
+      <femaleEn>Mistress of Rituals</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Master of Rituals</maleEn>
+      <femaleEn>Mistress of Rituals</femaleEn>
     </node>
     <node>
       <female>Мастерица Проклятий</female>
       <male>Мастер Проклятий</male>
+      <maleUa>Майстер Прокляттів</maleUa>
+      <femaleUa>Майстриня Прокляттів</femaleUa>
+      <maleEn>Master of Curses</maleEn>
+      <femaleEn>Mistress of Curses</femaleEn>
     </node>
     <node>
       <female>Мастерица Проклятий</female>
       <male>Мастер Проклятий</male>
+      <maleUa>Майстер Прокляттів</maleUa>
+      <femaleUa>Майстриня Прокляттів</femaleUa>
+      <maleEn>Master of Curses</maleEn>
+      <femaleEn>Mistress of Curses</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Призову</maleUa>
+      <femaleUa>Майстриня Призову</femaleUa>
+      <maleEn>Conjurer</maleEn>
+      <femaleEn>Conjuress</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Призову</maleUa>
+      <femaleUa>Майстриня Призову</femaleUa>
+      <maleEn>Conjurer</maleEn>
+      <femaleEn>Conjuress</femaleEn>
     </node>
     <node>
       <female>Магичка</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Магиня</femaleUa>
+      <maleEn>Magician</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Магичка</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Магиня</femaleUa>
+      <maleEn>Magician</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Savant</maleEn>
+      <femaleEn>Savant</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Savant</maleEn>
+      <femaleEn>Savant</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чароплет</maleUa>
+      <femaleUa>Чаровниця</femaleUa>
+      <maleEn>Magus</maleEn>
+      <femaleEn>Craftess</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чароплет</maleUa>
+      <femaleUa>Чаровниця</femaleUa>
+      <maleEn>Magus</maleEn>
+      <femaleEn>Craftess</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Wizard</maleEn>
+      <femaleEn>Wizard</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Wizard</maleEn>
+      <femaleEn>Wizard</femaleEn>
     </node>
     <node>
       <female>Чернокнижница</female>
       <male>Чернокнижник</male>
+      <maleUa>Чорнокнижник</maleUa>
+      <femaleUa>Чорнокнижниця</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>War Witch</femaleEn>
     </node>
     <node>
       <female>Чернокнижница</female>
       <male>Чернокнижник</male>
+      <maleUa>Чорнокнижник</maleUa>
+      <femaleUa>Чорнокнижниця</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>War Witch</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Чарівник</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Чарівник</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Чарівник</maleUa>
+      <femaleUa>Старша Чарівниця</femaleUa>
+      <maleEn>Elder Sorcerer</maleEn>
+      <femaleEn>Elder Sorceress</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Чарівник</maleUa>
+      <femaleUa>Старша Чарівниця</femaleUa>
+      <maleEn>Elder Sorcerer</maleEn>
+      <femaleEn>Elder Sorceress</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Чарівник</maleUa>
+      <femaleUa>Велика Чарівниця</femaleUa>
+      <maleEn>Grand Sorcerer</maleEn>
+      <femaleEn>Grand Sorceress</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Чарівник</maleUa>
+      <femaleUa>Велика Чарівниця</femaleUa>
+      <maleEn>Grand Sorcerer</maleEn>
+      <femaleEn>Grand Sorceress</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Чарівник</maleUa>
+      <femaleUa>Найвеличніша Чарівниця</femaleUa>
+      <maleEn>Great Sorcerer</maleEn>
+      <femaleEn>Great Sorceress</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Чарівник</maleUa>
+      <femaleUa>Найвеличніша Чарівниця</femaleUa>
+      <maleEn>Great Sorcerer</maleEn>
+      <femaleEn>Great Sorceress</femaleEn>
     </node>
     <node>
       <female>Мастерица Крови</female>
       <male>Мастер Крови</male>
+      <maleUa>Майстер Крові</maleUa>
+      <femaleUa>Майстриня Крові</femaleUa>
+      <maleEn>Master of Blood</maleEn>
+      <femaleEn>Mistress of Blood</femaleEn>
     </node>
     <node>
       <female>Мастерица Крови</female>
       <male>Мастер Крови</male>
+      <maleUa>Майстер Крові</maleUa>
+      <femaleUa>Майстриня Крові</femaleUa>
+      <maleEn>Master of Blood</maleEn>
+      <femaleEn>Mistress of Blood</femaleEn>
     </node>
     <node>
       <female>Властительница Крови</female>
       <male>Властелин Крови</male>
+      <maleUa>Владика Крові</maleUa>
+      <femaleUa>Владичиця Крові</femaleUa>
+      <maleEn>Overlord of Blood</maleEn>
+      <femaleEn>Overlady of Blood</femaleEn>
     </node>
     <node>
       <female>Властительница Крови</female>
       <male>Властелин Крови</male>
+      <maleUa>Владика Крові</maleUa>
+      <femaleUa>Владичиця Крові</femaleUa>
+      <maleEn>Overlord of Blood</maleEn>
+      <femaleEn>Overlady of Blood</femaleEn>
     </node>
     <node>
       <female>Повелительница Крови</female>
       <male>Повелитель Крови</male>
+      <maleUa>Повелитель Крові</maleUa>
+      <femaleUa>Повелителька Крові</femaleUa>
+      <maleEn>Lord of Blood</maleEn>
+      <femaleEn>Lady of Blood</femaleEn>
     </node>
     <node>
       <female>Повелительница Крови</female>
       <male>Повелитель Крови</male>
+      <maleUa>Повелитель Крові</maleUa>
+      <femaleUa>Повелителька Крові</femaleUa>
+      <maleEn>Lord of Blood</maleEn>
+      <femaleEn>Lady of Blood</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Повелитель Алхімії</maleUa>
+      <femaleUa>Повелителька Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Повелитель Алхімії</maleUa>
+      <femaleUa>Повелителька Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Повелитель Артефактів</maleUa>
+      <femaleUa>Повелителька Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Повелитель Артефактів</maleUa>
+      <femaleUa>Повелителька Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Мандрівник Іншими Світами</maleUa>
+      <femaleUa>Мандрівниця Іншими Світами</femaleUa>
+      <maleEn>Wanderer of Other Worlds</maleEn>
+      <femaleEn>Wanderer of Other Worlds</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Мандрівник Іншими Світами</maleUa>
+      <femaleUa>Мандрівниця Іншими Світами</femaleUa>
+      <maleEn>Wanderer of Other Worlds</maleEn>
+      <femaleEn>Wanderer of Other Worlds</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Заклинач Демонів</maleUa>
+      <femaleUa>Заклиначка Демонів</femaleUa>
+      <maleEn>Demon Caller</maleEn>
+      <femaleEn>Demon Caller</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Заклинач Демонів</maleUa>
+      <femaleUa>Заклиначка Демонів</femaleUa>
+      <maleEn>Demon Caller</maleEn>
+      <femaleEn>Demon Caller</femaleEn>
     </node>
     <node>
       <female>Ездящая на Призраках</female>
       <male>Ездок на Призраках</male>
+      <maleUa>Вершник на Привидах</maleUa>
+      <femaleUa>Вершниця на Привидах</femaleUa>
+      <maleEn>Ghost Rider</maleEn>
+      <femaleEn>Ghost Rider</femaleEn>
     </node>
     <node>
       <female>Ездящая на Призраках</female>
       <male>Ездок на Призраках</male>
+      <maleUa>Вершник на Привидах</maleUa>
+      <femaleUa>Вершниця на Привидах</femaleUa>
+      <maleEn>Ghost Rider</maleEn>
+      <femaleEn>Ghost Rider</femaleEn>
     </node>
     <node>
       <female>Повелительница Призраков</female>
       <male>Повелитель Призраков</male>
+      <maleUa>Повелитель Привидів</maleUa>
+      <femaleUa>Повелителька Привидів</femaleUa>
+      <maleEn>Lord of Ghosts</maleEn>
+      <femaleEn>Lady of Ghosts</femaleEn>
     </node>
     <node>
       <female>Повелительница Призраков</female>
       <male>Повелитель Призраков</male>
+      <maleUa>Повелитель Привидів</maleUa>
+      <femaleUa>Повелителька Привидів</femaleUa>
+      <maleEn>Lord of Ghosts</maleEn>
+      <femaleEn>Lady of Ghosts</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Повелитель Чарів</maleUa>
+      <femaleUa>Повелителька Чарів</femaleUa>
+      <maleEn>Lord of Enchantments</maleEn>
+      <femaleEn>Lady of Enchantments</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Повелитель Чарів</maleUa>
+      <femaleUa>Повелителька Чарів</femaleUa>
+      <maleEn>Lord of Enchantments</maleEn>
+      <femaleEn>Lady of Enchantments</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Повелитель Чаклунства</maleUa>
+      <femaleUa>Повелителька Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Повелитель Чаклунства</maleUa>
+      <femaleUa>Повелителька Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Enchanter</maleEn>
+      <femaleEn>Great Enchantress</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Enchanter</maleEn>
+      <femaleEn>Great Enchantress</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoness</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoness</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Крізь Час</maleUa>
+      <femaleUa>Провидиця Крізь Час</femaleUa>
+      <maleEn>Time Seer</maleEn>
+      <femaleEn>Time Seeress</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Крізь Час</maleUa>
+      <femaleUa>Провидиця Крізь Час</femaleUa>
+      <maleEn>Time Seer</maleEn>
+      <femaleEn>Time Seeress</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Повелитель Потоку</maleUa>
+      <femaleUa>Повелителька Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Повелитель Потоку</maleUa>
+      <femaleUa>Повелителька Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Осягач Хаосу</maleUa>
+      <femaleUa>Осягачка Хаосу</femaleUa>
+      <maleEn>Chaos Adept</maleEn>
+      <femaleEn>Chaos Adept</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Осягач Хаосу</maleUa>
+      <femaleUa>Осягачка Хаосу</femaleUa>
+      <maleEn>Chaos Adept</maleEn>
+      <femaleEn>Chaos Adept</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкувач Хаосу</maleUa>
+      <femaleUa>Приборкувачка Хаосу</femaleUa>
+      <maleEn>Tamer of Chaos</maleEn>
+      <femaleEn>Tamer of Chaos</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкувач Хаосу</maleUa>
+      <femaleUa>Приборкувачка Хаосу</femaleUa>
+      <maleEn>Tamer of Chaos</maleEn>
+      <femaleEn>Tamer of Chaos</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Заклинач Хаосу</maleUa>
+      <femaleUa>Заклиначка Хаосу</femaleUa>
+      <maleEn>Binder of Chaos</maleEn>
+      <femaleEn>Binder of Chaos</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Заклинач Хаосу</maleUa>
+      <femaleUa>Заклиначка Хаосу</femaleUa>
+      <maleEn>Binder of Chaos</maleEn>
+      <femaleEn>Binder of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Повелитель Хаосу</maleUa>
+      <femaleUa>Повелителька Хаосу</femaleUa>
+      <maleEn>Ruler of Chaos</maleEn>
+      <femaleEn>Ruler of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Повелитель Хаосу</maleUa>
+      <femaleUa>Повелителька Хаосу</femaleUa>
+      <maleEn>Ruler of Chaos</maleEn>
+      <femaleEn>Ruler of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Повелитель Магії</maleUa>
+      <femaleUa>Повелителька Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Повелитель Магії</maleUa>
+      <femaleUa>Повелителька Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Повелитель Минулого</maleUa>
+      <femaleUa>Повелителька Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Повелитель Минулого</maleUa>
+      <femaleUa>Повелителька Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Повелитель Теперішнього</maleUa>
+      <femaleUa>Повелителька Теперішнього</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Повелитель Теперішнього</maleUa>
+      <femaleUa>Повелителька Теперішнього</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Повелитель Майбутнього</maleUa>
+      <femaleUa>Повелителька Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Повелитель Майбутнього</maleUa>
+      <femaleUa>Повелителька Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Повелительница Умертвий</female>
       <male>Повелитель Умертвий</male>
+      <maleUa>Повелитель Мерців</maleUa>
+      <femaleUa>Повелителька Мерців</femaleUa>
+      <maleEn>Lord of the Undead</maleEn>
+      <femaleEn>Lady of the Undead</femaleEn>
     </node>
     <node>
       <female>Повелительница Умертвий</female>
       <male>Повелитель Умертвий</male>
+      <maleUa>Повелитель Мерців</maleUa>
+      <femaleUa>Повелителька Мерців</femaleUa>
+      <maleEn>Lord of the Undead</maleEn>
+      <femaleEn>Lady of the Undead</femaleEn>
     </node>
     <node>
       <female>Повелительница Умертвий</female>
       <male>Повелитель Умертвий</male>
+      <maleUa>Повелитель Мерців</maleUa>
+      <femaleUa>Повелителька Мерців</femaleUa>
+      <maleEn>Lord of the Undead</maleEn>
+      <femaleEn>Lady of the Undead</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Володар Ночі</maleUa>
+      <femaleUa>Володарка Ночі</femaleUa>
+      <maleEn>Master of the Night</maleEn>
+      <femaleEn>Mistress of the Night</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Володар Ночі</maleUa>
+      <femaleUa>Володарка Ночі</femaleUa>
+      <maleEn>Master of the Night</maleEn>
+      <femaleEn>Mistress of the Night</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Володар Ночі</maleUa>
+      <femaleUa>Володарка Ночі</femaleUa>
+      <maleEn>Master of the Night</maleEn>
+      <femaleEn>Mistress of the Night</femaleEn>
     </node>
     <node>
       <female>Ночная Хозяйка</female>
       <male>Ночной Хозяин</male>
+      <maleUa>Володар Ночі</maleUa>
+      <femaleUa>Володарка Ночі</femaleUa>
+      <maleEn>Master of the Night</maleEn>
+      <femaleEn>Mistress of the Night</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Повелительница Смерти</female>
       <male>Повелитель Смерти</male>
+      <maleUa>Повелитель Смерті</maleUa>
+      <femaleUa>Повелителька Смерті</femaleUa>
+      <maleEn>Lord of Death</maleEn>
+      <femaleEn>Lady of Death</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Смерти</female>
       <male>Великий Повелитель Смерти</male>
+      <maleUa>Великий Повелитель Смерті</maleUa>
+      <femaleUa>Велика Повелителька Смерті</femaleUa>
+      <maleEn>Great Lord of Death</maleEn>
+      <femaleEn>Great Lady of Death</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Смерти</female>
       <male>Великий Повелитель Смерти</male>
+      <maleUa>Великий Повелитель Смерті</maleUa>
+      <femaleUa>Велика Повелителька Смерті</femaleUa>
+      <maleEn>Great Lord of Death</maleEn>
+      <femaleEn>Great Lady of Death</femaleEn>
     </node>
     <node>
       <female>Великая Повелительница Смерти</female>
       <male>Великий Повелитель Смерти</male>
+      <maleUa>Великий Повелитель Смерті</maleUa>
+      <femaleUa>Велика Повелителька Смерті</femaleUa>
+      <maleEn>Great Lord of Death</maleEn>
+      <femaleEn>Great Lady of Death</femaleEn>
     </node>
     <node>
       <female>Легендарная Вампирша</female>
       <male>Легендарный Вампир</male>
+      <maleUa>Легендарний Вампір</maleUa>
+      <femaleUa>Легендарна Вампірка</femaleUa>
+      <maleEn>Legendary Vampire</maleEn>
+      <femaleEn>Legendary Vampiress</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
   </titles>
   <weapon>40101</weapon>

--- a/professions/warlock.xml
+++ b/professions/warlock.xml
@@ -57,446 +57,890 @@ Only men can become warlocks. Female spellcasters become {hh139witches{x.
     <node>
       <female>Женщина</female>
       <male>Мужчина</male>
+      <maleUa>Чоловік</maleUa>
+      <femaleUa>Жінка</femaleUa>
+      <maleEn>Man</maleEn>
+      <femaleEn>Woman</femaleEn>
     </node>
     <node>
       <female>Ученица Магии</female>
       <male>Ученик Магии</male>
+      <maleUa>Учень Магії</maleUa>
+      <femaleUa>Учениця Магії</femaleUa>
+      <maleEn>Apprentice of Magic</maleEn>
+      <femaleEn>Apprentice of Magic</femaleEn>
     </node>
     <node>
       <female>Студентка Магии</female>
       <male>Студент Магии</male>
+      <maleUa>Студент Магії</maleUa>
+      <femaleUa>Студентка Магії</femaleUa>
+      <maleEn>Spell Student</maleEn>
+      <femaleEn>Spell Student</femaleEn>
     </node>
     <node>
       <female>Изучающая Магию</female>
       <male>Изучающий Магию</male>
+      <maleUa>Дослідник Магії</maleUa>
+      <femaleUa>Дослідниця Магії</femaleUa>
+      <maleEn>Scholar of Magic</maleEn>
+      <femaleEn>Scholar of Magic</femaleEn>
     </node>
     <node>
       <female>Погружающаяся в Магию</female>
       <male>Погружающийся в Магию</male>
+      <maleUa>Заглиблений у Магію</maleUa>
+      <femaleUa>Заглиблена у Магію</femaleUa>
+      <maleEn>Delver in Spells</maleEn>
+      <femaleEn>Delveress in Spells</femaleEn>
     </node>
     <node>
       <female>Проводница Магии</female>
       <male>Проводник Магии</male>
+      <maleUa>Провідник Магії</maleUa>
+      <femaleUa>Провідниця Магії</femaleUa>
+      <maleEn>Medium of Magic</maleEn>
+      <femaleEn>Medium of Magic</femaleEn>
     </node>
     <node>
       <female>Пишущая Магию</female>
       <male>Пишущий Магию</male>
+      <maleUa>Писар Магії</maleUa>
+      <femaleUa>Писарка Магії</femaleUa>
+      <maleEn>Scribe of Magic</maleEn>
+      <femaleEn>Scribess of Magic</femaleEn>
     </node>
     <node>
       <female>Видящая</female>
       <male>Видящий</male>
+      <maleUa>Провидець</maleUa>
+      <femaleUa>Провидиця</femaleUa>
+      <maleEn>Seer</maleEn>
+      <femaleEn>Seeress</femaleEn>
     </node>
     <node>
       <female>Мудрая</female>
       <male>Мудрец</male>
+      <maleUa>Мудрець</maleUa>
+      <femaleUa>Мудра</femaleUa>
+      <maleEn>Sage</maleEn>
+      <femaleEn>Sage</femaleEn>
     </node>
     <node>
       <female>Мастерица Иллюзий</female>
       <male>Мастер Иллюзий</male>
+      <maleUa>Майстер Ілюзій</maleUa>
+      <femaleUa>Майстриня Ілюзій</femaleUa>
+      <maleEn>Illusionist</maleEn>
+      <femaleEn>Illusionist</femaleEn>
     </node>
     <node>
       <female>Мастерица Аффектов</female>
       <male>Мастер Аффектов</male>
+      <maleUa>Майстер Афектів</maleUa>
+      <femaleUa>Майстриня Афектів</femaleUa>
+      <maleEn>Abjurer</maleEn>
+      <femaleEn>Abjuress</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Invoker</maleEn>
+      <femaleEn>Invoker</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Invoker</maleEn>
+      <femaleEn>Invoker</femaleEn>
     </node>
     <node>
       <female>Мастерица Зачарования</female>
       <male>Мастер Зачарования</male>
+      <maleUa>Майстер Зачарування</maleUa>
+      <femaleUa>Майстриня Зачарування</femaleUa>
+      <maleEn>Enchanter</maleEn>
+      <femaleEn>Enchantress</femaleEn>
     </node>
     <node>
       <female>Мастерица Зачарования</female>
       <male>Мастер Зачарования</male>
+      <maleUa>Майстер Зачарування</maleUa>
+      <femaleUa>Майстриня Зачарування</femaleUa>
+      <maleEn>Enchanter</maleEn>
+      <femaleEn>Enchantress</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Закликання</maleUa>
+      <femaleUa>Майстриня Закликання</femaleUa>
+      <maleEn>Conjurer</maleEn>
+      <femaleEn>Conjuress</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Закликання</maleUa>
+      <femaleUa>Майстриня Закликання</femaleUa>
+      <maleEn>Conjurer</maleEn>
+      <femaleEn>Conjuress</femaleEn>
     </node>
     <node>
       <female>Магичка</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Магиня</femaleUa>
+      <maleEn>Magician</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Магичка</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Магиня</femaleUa>
+      <maleEn>Magician</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creator</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Savant</maleEn>
+      <femaleEn>Savant</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Savant</maleEn>
+      <femaleEn>Savant</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чаротворець</maleUa>
+      <femaleUa>Чаротворка</femaleUa>
+      <maleEn>Magus</maleEn>
+      <femaleEn>Craftess</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чаротворець</maleUa>
+      <femaleUa>Чаротворка</femaleUa>
+      <maleEn>Magus</maleEn>
+      <femaleEn>Craftess</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чарівник</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Wizard</maleEn>
+      <femaleEn>Wizard</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чарівник</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Wizard</maleEn>
+      <femaleEn>Wizard</femaleEn>
     </node>
     <node>
       <female>Чернокнижница</female>
       <male>Чернокнижник</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>War Witch</femaleEn>
     </node>
     <node>
       <female>Чернокнижница</female>
       <male>Чернокнижник</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>War Witch</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Волхв</maleUa>
+      <femaleUa>Волхвиня</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Волхв</maleUa>
+      <femaleUa>Волхвиня</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Волхв</maleUa>
+      <femaleUa>Старша Волхвиня</femaleUa>
+      <maleEn>Elder Sorcerer</maleEn>
+      <femaleEn>Elder Sorceress</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Волхв</maleUa>
+      <femaleUa>Старша Волхвиня</femaleUa>
+      <maleEn>Elder Sorcerer</maleEn>
+      <femaleEn>Elder Sorceress</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Волхв</maleUa>
+      <femaleUa>Велика Волхвиня</femaleUa>
+      <maleEn>Grand Sorcerer</maleEn>
+      <femaleEn>Grand Sorceress</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Волхв</maleUa>
+      <femaleUa>Велика Волхвиня</femaleUa>
+      <maleEn>Grand Sorcerer</maleEn>
+      <femaleEn>Grand Sorceress</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Волхв</maleUa>
+      <femaleUa>Найвеличніша Волхвиня</femaleUa>
+      <maleEn>Great Sorcerer</maleEn>
+      <femaleEn>Great Sorceress</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Волхв</maleUa>
+      <femaleUa>Найвеличніша Волхвиня</femaleUa>
+      <maleEn>Great Sorcerer</maleEn>
+      <femaleEn>Great Sorceress</femaleEn>
     </node>
     <node>
       <female>Мастерица Энергии</female>
       <male>Мастер Энергии</male>
+      <maleUa>Майстер Енергії</maleUa>
+      <femaleUa>Майстриня Енергії</femaleUa>
+      <maleEn>Master of Energy</maleEn>
+      <femaleEn>Mistress of Energy</femaleEn>
     </node>
     <node>
       <female>Мастерица Энергии</female>
       <male>Мастер Энергии</male>
+      <maleUa>Майстер Енергії</maleUa>
+      <femaleUa>Майстриня Енергії</femaleUa>
+      <maleEn>Master of Energy</maleEn>
+      <femaleEn>Mistress of Energy</femaleEn>
     </node>
     <node>
       <female>Властительница Энергии</female>
       <male>Властелин Энергии</male>
+      <maleUa>Зверхник Енергії</maleUa>
+      <femaleUa>Зверхниця Енергії</femaleUa>
+      <maleEn>Sovereign of Energy</maleEn>
+      <femaleEn>Sovereign of Energy</femaleEn>
     </node>
     <node>
       <female>Властительница Энергии</female>
       <male>Властелин Энергии</male>
+      <maleUa>Зверхник Енергії</maleUa>
+      <femaleUa>Зверхниця Енергії</femaleUa>
+      <maleEn>Sovereign of Energy</maleEn>
+      <femaleEn>Sovereign of Energy</femaleEn>
     </node>
     <node>
       <female>Повелительница Энергии</female>
       <male>Повелитель Энергии</male>
+      <maleUa>Володар Енергії</maleUa>
+      <femaleUa>Володарка Енергії</femaleUa>
+      <maleEn>Lord of Energy</maleEn>
+      <femaleEn>Lady of Energy</femaleEn>
     </node>
     <node>
       <female>Повелительница Энергии</female>
       <male>Повелитель Энергии</male>
+      <maleUa>Володар Енергії</maleUa>
+      <femaleUa>Володарка Енергії</femaleUa>
+      <maleEn>Lord of Energy</maleEn>
+      <femaleEn>Lady of Energy</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Володар Алхімії</maleUa>
+      <femaleUa>Володарка Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Володар Алхімії</maleUa>
+      <femaleUa>Володарка Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Володар Артефактів</maleUa>
+      <femaleUa>Володарка Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Володар Артефактів</maleUa>
+      <femaleUa>Володарка Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Мандрівник Інших Просторів</maleUa>
+      <femaleUa>Мандрівниця Інших Просторів</femaleUa>
+      <maleEn>Voyager of Other Realms</maleEn>
+      <femaleEn>Voyager of Other Realms</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Мандрівник Інших Просторів</maleUa>
+      <femaleUa>Мандрівниця Інших Просторів</femaleUa>
+      <maleEn>Voyager of Other Realms</maleEn>
+      <femaleEn>Voyager of Other Realms</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Закликач Демонів</maleUa>
+      <femaleUa>Закликачка Демонів</femaleUa>
+      <maleEn>Caller of Demons</maleEn>
+      <femaleEn>Caller of Demons</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Закликач Демонів</maleUa>
+      <femaleUa>Закликачка Демонів</femaleUa>
+      <maleEn>Caller of Demons</maleEn>
+      <femaleEn>Caller of Demons</femaleEn>
     </node>
     <node>
       <female>Ездящая на Драконах</female>
       <male>Ездок на Драконах</male>
+      <maleUa>Вершник Драконів</maleUa>
+      <femaleUa>Вершниця Драконів</femaleUa>
+      <maleEn>Dragon Rider</maleEn>
+      <femaleEn>Dragon Rider</femaleEn>
     </node>
     <node>
       <female>Ездящая на Драконах</female>
       <male>Ездок на Драконах</male>
+      <maleUa>Вершник Драконів</maleUa>
+      <femaleUa>Вершниця Драконів</femaleUa>
+      <maleEn>Dragon Rider</maleEn>
+      <femaleEn>Dragon Rider</femaleEn>
     </node>
     <node>
       <female>Повелительница Драконов</female>
       <male>Повелитель Драконов</male>
+      <maleUa>Володар Драконів</maleUa>
+      <femaleUa>Володарка Драконів</femaleUa>
+      <maleEn>Lord of Dragons</maleEn>
+      <femaleEn>Lady of Dragons</femaleEn>
     </node>
     <node>
       <female>Повелительница Драконов</female>
       <male>Повелитель Драконов</male>
+      <maleUa>Володар Драконів</maleUa>
+      <femaleUa>Володарка Драконів</femaleUa>
+      <maleEn>Lord of Dragons</maleEn>
+      <femaleEn>Lady of Dragons</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Володар Чар</maleUa>
+      <femaleUa>Володарка Чар</femaleUa>
+      <maleEn>Lord of Charms</maleEn>
+      <femaleEn>Lady of Charms</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Володар Чар</maleUa>
+      <femaleUa>Володарка Чар</femaleUa>
+      <maleEn>Lord of Charms</maleEn>
+      <femaleEn>Lady of Charms</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Володар Чаклунства</maleUa>
+      <femaleUa>Володарка Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Володар Чаклунства</maleUa>
+      <femaleUa>Володарка Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Spellcaster</maleEn>
+      <femaleEn>Great Spellcaster</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Spellcaster</maleEn>
+      <femaleEn>Great Spellcaster</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoner</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoner</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Часу</maleUa>
+      <femaleUa>Провидиця Часу</femaleUa>
+      <maleEn>Seer Through Time</maleEn>
+      <femaleEn>Seer Through Time</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Часу</maleUa>
+      <femaleUa>Провидиця Часу</femaleUa>
+      <maleEn>Seer Through Time</maleEn>
+      <femaleEn>Seer Through Time</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Володар Потоку</maleUa>
+      <femaleUa>Володарка Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Володар Потоку</maleUa>
+      <femaleUa>Володарка Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Адепт Хаосу</maleUa>
+      <femaleUa>Адептка Хаосу</femaleUa>
+      <maleEn>Chaos Adept</maleEn>
+      <femaleEn>Chaos Adept</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Адепт Хаосу</maleUa>
+      <femaleUa>Адептка Хаосу</femaleUa>
+      <maleEn>Chaos Adept</maleEn>
+      <femaleEn>Chaos Adept</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкувач Хаосу</maleUa>
+      <femaleUa>Приборкувачка Хаосу</femaleUa>
+      <maleEn>Tamer of Chaos</maleEn>
+      <femaleEn>Tamer of Chaos</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкувач Хаосу</maleUa>
+      <femaleUa>Приборкувачка Хаосу</femaleUa>
+      <maleEn>Tamer of Chaos</maleEn>
+      <femaleEn>Tamer of Chaos</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Зачаклувач Хаосу</maleUa>
+      <femaleUa>Зачаклувачка Хаосу</femaleUa>
+      <maleEn>Binder of Chaos</maleEn>
+      <femaleEn>Binder of Chaos</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Зачаклувач Хаосу</maleUa>
+      <femaleUa>Зачаклувачка Хаосу</femaleUa>
+      <maleEn>Binder of Chaos</maleEn>
+      <femaleEn>Binder of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Володар Хаосу</maleUa>
+      <femaleUa>Володарка Хаосу</femaleUa>
+      <maleEn>Lord of Chaos</maleEn>
+      <femaleEn>Lady of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Володар Хаосу</maleUa>
+      <femaleUa>Володарка Хаосу</femaleUa>
+      <maleEn>Lord of Chaos</maleEn>
+      <femaleEn>Lady of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Володар Магії</maleUa>
+      <femaleUa>Володарка Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Володар Магії</maleUa>
+      <femaleUa>Володарка Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Володар Минулого</maleUa>
+      <femaleUa>Володарка Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Володар Минулого</maleUa>
+      <femaleUa>Володарка Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Володар Теперішнього</maleUa>
+      <femaleUa>Володарка Теперішнього</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Володар Теперішнього</maleUa>
+      <femaleUa>Володарка Теперішнього</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Володар Майбутнього</maleUa>
+      <femaleUa>Володарка Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Володар Майбутнього</maleUa>
+      <femaleUa>Володарка Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Архимагичка</female>
       <male>Архимаг</male>
+      <maleUa>Архімаг</maleUa>
+      <femaleUa>Архімагиня</femaleUa>
+      <maleEn>Archmage</maleEn>
+      <femaleEn>Archmage</femaleEn>
     </node>
     <node>
       <female>Архимагичка</female>
       <male>Архимаг</male>
+      <maleUa>Архімаг</maleUa>
+      <femaleUa>Архімагиня</femaleUa>
+      <maleEn>Archmage</maleEn>
+      <femaleEn>Archmage</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Героиня Магии</female>
       <male>the Mage Hero</male>
+      <maleUa>Герой Магії</maleUa>
+      <femaleUa>Героїня Магії</femaleUa>
+      <maleEn>the Mage Hero</maleEn>
+      <femaleEn>Heroine of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
   </titles>
   <weapon>40101</weapon>

--- a/professions/warrior.xml
+++ b/professions/warrior.xml
@@ -52,190 +52,378 @@ Warriors get the most out of defensive {hh2021combat{x and {hh1127weapon{x skill
     <node>
       <female>Женщина</female>
       <male>Мужчина</male>
+      <maleUa>Чоловік</maleUa>
+      <femaleUa>Жінка</femaleUa>
+      <maleEn>Man</maleEn>
+      <femaleEn>Woman</femaleEn>
     </node>
     <node>
       <female>Недотепа</female>
       <male>Недотепа</male>
+      <maleUa>Недотепа</maleUa>
+      <femaleUa>Недотепа</femaleUa>
+      <maleEn>Swordpupil</maleEn>
+      <femaleEn>Swordpupil</femaleEn>
     </node>
     <node>
       <female>Новобранка</female>
       <male>Новобранец</male>
+      <maleUa>Новобранець</maleUa>
+      <femaleUa>Новобранка</femaleUa>
+      <maleEn>Recruit</maleEn>
+      <femaleEn>Recruit</femaleEn>
     </node>
     <node>
       <female>Городовая</female>
       <male>Городовой</male>
+      <maleUa>Городовий</maleUa>
+      <femaleUa>Городова</femaleUa>
+      <maleEn>Sentry</maleEn>
+      <femaleEn>Sentress</femaleEn>
     </node>
     <node>
       <female>Боец</female>
       <male>Боец</male>
+      <maleUa>Боєць</maleUa>
+      <femaleUa>Боєць</femaleUa>
+      <maleEn>Fighter</maleEn>
+      <femaleEn>Fighter</femaleEn>
     </node>
     <node>
       <female>Солдатка</female>
       <male>Солдат</male>
+      <maleUa>Солдат</maleUa>
+      <femaleUa>Солдатка</femaleUa>
+      <maleEn>Soldier</maleEn>
+      <femaleEn>Soldier</femaleEn>
     </node>
     <node>
       <female>Воительница</female>
       <male>Воитель</male>
+      <maleUa>Воїтель</maleUa>
+      <femaleUa>Воїтелька</femaleUa>
+      <maleEn>Warrior</maleEn>
+      <femaleEn>Warrior</femaleEn>
     </node>
     <node>
       <female>Ветеранка</female>
       <male>Ветеран</male>
+      <maleUa>Ветеран</maleUa>
+      <femaleUa>Ветеранка</femaleUa>
+      <maleEn>Veteran</maleEn>
+      <femaleEn>Veteran</femaleEn>
     </node>
     <node>
       <female>Мечница</female>
       <male>Мечник</male>
+      <maleUa>Мечник</maleUa>
+      <femaleUa>Мечниця</femaleUa>
+      <maleEn>Swordsman</maleEn>
+      <femaleEn>Swordswoman</femaleEn>
     </node>
     <node>
       <female>Фехтовальщица</female>
       <male>Фехтовальщик</male>
+      <maleUa>Фехтувальник</maleUa>
+      <femaleUa>Фехтувальниця</femaleUa>
+      <maleEn>Fencer</maleEn>
+      <femaleEn>Fenceress</femaleEn>
     </node>
     <node>
       <female>Драчунья</female>
       <male>Драчун</male>
+      <maleUa>Забіяка</maleUa>
+      <femaleUa>Забіячка</femaleUa>
+      <maleEn>Combatant</maleEn>
+      <femaleEn>Combatess</femaleEn>
     </node>
     <node>
       <female>Комбатантка</female>
       <male>Комбатант</male>
+      <maleUa>Комбатант</maleUa>
+      <femaleUa>Комбатантка</femaleUa>
+      <maleEn>Combatant</maleEn>
+      <femaleEn>Lady Combatant</femaleEn>
     </node>
     <node>
       <female>Защитница</female>
       <male>Защитник</male>
+      <maleUa>Захисник</maleUa>
+      <femaleUa>Захисниця</femaleUa>
+      <maleEn>Protector</maleEn>
+      <femaleEn>Protectress</femaleEn>
     </node>
     <node>
       <female>Мирмидон</female>
       <male>Мирмидон</male>
+      <maleUa>Мірмідон</maleUa>
+      <femaleUa>Мірмідон</femaleUa>
+      <maleEn>Myrmidon</maleEn>
+      <femaleEn>Myrmidon</femaleEn>
     </node>
     <node>
       <female>Мирмидон</female>
       <male>Мирмидон</male>
+      <maleUa>Мірмідон</maleUa>
+      <femaleUa>Мірмідон</femaleUa>
+      <maleEn>Myrmidon</maleEn>
+      <femaleEn>Myrmidon</femaleEn>
     </node>
     <node>
       <female>Рубака</female>
       <male>Рубака</male>
+      <maleUa>Рубака</maleUa>
+      <femaleUa>Рубака</femaleUa>
+      <maleEn>Swashbuckler</maleEn>
+      <femaleEn>Swashbuckleress</femaleEn>
     </node>
     <node>
       <female>Рубака</female>
       <male>Рубака</male>
+      <maleUa>Рубака</maleUa>
+      <femaleUa>Рубака</femaleUa>
+      <maleEn>Swashbuckler</maleEn>
+      <femaleEn>Swashbuckleress</femaleEn>
     </node>
     <node>
       <female>Наемница</female>
       <male>Наемник</male>
+      <maleUa>Найманець</maleUa>
+      <femaleUa>Найманка</femaleUa>
+      <maleEn>Mercenary</maleEn>
+      <femaleEn>Mercenaress</femaleEn>
     </node>
     <node>
       <female>Наемница</female>
       <male>Наемник</male>
+      <maleUa>Найманець</maleUa>
+      <femaleUa>Найманка</femaleUa>
+      <maleEn>Mercenary</maleEn>
+      <femaleEn>Mercenaress</femaleEn>
     </node>
     <node>
       <female>Мастерица Меча</female>
       <male>Мастер Меча</male>
+      <maleUa>Майстер Меча</maleUa>
+      <femaleUa>Майстриня Меча</femaleUa>
+      <maleEn>Swordmaster</maleEn>
+      <femaleEn>Swordmistress</femaleEn>
     </node>
     <node>
       <female>Мастерица Меча</female>
       <male>Мастер Меча</male>
+      <maleUa>Майстер Меча</maleUa>
+      <femaleUa>Майстриня Меча</femaleUa>
+      <maleEn>Swordmaster</maleEn>
+      <femaleEn>Swordmistress</femaleEn>
     </node>
     <node>
       <female>Лейтенантша</female>
       <male>Лейтенант</male>
+      <maleUa>Лейтенант</maleUa>
+      <femaleUa>Лейтенантка</femaleUa>
+      <maleEn>Lieutenant</maleEn>
+      <femaleEn>Lieutenant</femaleEn>
     </node>
     <node>
       <female>Лейтенантша</female>
       <male>Лейтенант</male>
+      <maleUa>Лейтенант</maleUa>
+      <femaleUa>Лейтенантка</femaleUa>
+      <maleEn>Lieutenant</maleEn>
+      <femaleEn>Lieutenant</femaleEn>
     </node>
     <node>
       <female>Чемпионка</female>
       <male>Чемпион</male>
+      <maleUa>Чемпіон</maleUa>
+      <femaleUa>Чемпіонка</femaleUa>
+      <maleEn>Champion</maleEn>
+      <femaleEn>Lady Champion</femaleEn>
     </node>
     <node>
       <female>Чемпионка</female>
       <male>Чемпион</male>
+      <maleUa>Чемпіон</maleUa>
+      <femaleUa>Чемпіонка</femaleUa>
+      <maleEn>Champion</maleEn>
+      <femaleEn>Lady Champion</femaleEn>
     </node>
     <node>
       <female>Драгунша</female>
       <male>Драгун</male>
+      <maleUa>Драгун</maleUa>
+      <femaleUa>Драгунка</femaleUa>
+      <maleEn>Dragoon</maleEn>
+      <femaleEn>Lady Dragoon</femaleEn>
     </node>
     <node>
       <female>Драгунша</female>
       <male>Драгун</male>
+      <maleUa>Драгун</maleUa>
+      <femaleUa>Драгунка</femaleUa>
+      <maleEn>Dragoon</maleEn>
+      <femaleEn>Lady Dragoon</femaleEn>
     </node>
     <node>
       <female>Шевалье</female>
       <male>Шевалье</male>
+      <maleUa>Шевальє</maleUa>
+      <femaleUa>Шевальє</femaleUa>
+      <maleEn>Cavalier</maleEn>
+      <femaleEn>Lady Cavalier</femaleEn>
     </node>
     <node>
       <female>Шевалье</female>
       <male>Шевалье</male>
+      <maleUa>Шевальє</maleUa>
+      <femaleUa>Шевальє</femaleUa>
+      <maleEn>Cavalier</maleEn>
+      <femaleEn>Lady Cavalier</femaleEn>
     </node>
     <node>
       <female>Рыцарша</female>
       <male>Рыцарь</male>
+      <maleUa>Лицар</maleUa>
+      <femaleUa>Лицарка</femaleUa>
+      <maleEn>Knight</maleEn>
+      <femaleEn>Lady Knight</femaleEn>
     </node>
     <node>
       <female>Рыцарша</female>
       <male>Рыцарь</male>
+      <maleUa>Лицар</maleUa>
+      <femaleUa>Лицарка</femaleUa>
+      <maleEn>Knight</maleEn>
+      <femaleEn>Lady Knight</femaleEn>
     </node>
     <node>
       <female>Великая Рыцарша</female>
       <male>Великий Рыцарь</male>
+      <maleUa>Великий Лицар</maleUa>
+      <femaleUa>Велика Лицарка</femaleUa>
+      <maleEn>Grand Knight</maleEn>
+      <femaleEn>Grand Knight</femaleEn>
     </node>
     <node>
       <female>Великая Рыцарша</female>
       <male>Великий Рыцарь</male>
+      <maleUa>Великий Лицар</maleUa>
+      <femaleUa>Велика Лицарка</femaleUa>
+      <maleEn>Grand Knight</maleEn>
+      <femaleEn>Grand Knight</femaleEn>
     </node>
     <node>
       <female>Знаменитая Рыцарша</female>
       <male>Знаменитый Рыцарь</male>
+      <maleUa>Знаменитий Лицар</maleUa>
+      <femaleUa>Знаменита Лицарка</femaleUa>
+      <maleEn>Master Knight</maleEn>
+      <femaleEn>Master Knight</femaleEn>
     </node>
     <node>
       <female>Знаменитая Рыцарша</female>
       <male>Знаменитый Рыцарь</male>
+      <maleUa>Знаменитий Лицар</maleUa>
+      <femaleUa>Знаменита Лицарка</femaleUa>
+      <maleEn>Master Knight</maleEn>
+      <femaleEn>Master Knight</femaleEn>
     </node>
     <node>
       <female>Гладиаторша</female>
       <male>Гладиатор</male>
+      <maleUa>Гладіатор</maleUa>
+      <femaleUa>Гладіаторка</femaleUa>
+      <maleEn>Gladiator</maleEn>
+      <femaleEn>Gladiator</femaleEn>
     </node>
     <node>
       <female>Гладиаторша</female>
       <male>Гладиатор</male>
+      <maleUa>Гладіатор</maleUa>
+      <femaleUa>Гладіаторка</femaleUa>
+      <maleEn>Gladiator</maleEn>
+      <femaleEn>Gladiator</femaleEn>
     </node>
     <node>
       <female>Великая Гладиаторша</female>
       <male>Великий Гладиатор</male>
+      <maleUa>Великий Гладіатор</maleUa>
+      <femaleUa>Велика Гладіаторка</femaleUa>
+      <maleEn>Master Gladiator</maleEn>
+      <femaleEn>Master Gladiator</femaleEn>
     </node>
     <node>
       <female>Великая Гладиаторша</female>
       <male>Великий Гладиатор</male>
+      <maleUa>Великий Гладіатор</maleUa>
+      <femaleUa>Велика Гладіаторка</femaleUa>
+      <maleEn>Master Gladiator</maleEn>
+      <femaleEn>Master Gladiator</femaleEn>
     </node>
     <node>
       <female>Убийца Демонов</female>
       <male>Убийца Демонов</male>
+      <maleUa>Вбивця Демонів</maleUa>
+      <femaleUa>Вбивця Демонів</femaleUa>
+      <maleEn>Demon Slayer</maleEn>
+      <femaleEn>Demon Slayer</femaleEn>
     </node>
     <node>
       <female>Убийца Демонов</female>
       <male>Убийца Демонов</male>
+      <maleUa>Вбивця Демонів</maleUa>
+      <femaleUa>Вбивця Демонів</femaleUa>
+      <maleEn>Demon Slayer</maleEn>
+      <femaleEn>Demon Slayer</femaleEn>
     </node>
     <node>
       <female>Великая Убийца Демонов</female>
       <male>Великий Убийца Демонов</male>
+      <maleUa>Великий Вбивця Демонів</maleUa>
+      <femaleUa>Велика Вбивця Демонів</femaleUa>
+      <maleEn>Greater Demon Slayer</maleEn>
+      <femaleEn>Greater Demon Slayer</femaleEn>
     </node>
     <node>
       <female>Великая Убийца Демонов</female>
       <male>Великий Убийца Демонов</male>
+      <maleUa>Великий Вбивця Демонів</maleUa>
+      <femaleUa>Велика Вбивця Демонів</femaleUa>
+      <maleEn>Greater Demon Slayer</maleEn>
+      <femaleEn>Greater Demon Slayer</femaleEn>
     </node>
     <node>
       <female>Убийца Драконов</female>
       <male>Убийца Драконов</male>
+      <maleUa>Вбивця Драконів</maleUa>
+      <femaleUa>Вбивця Драконів</femaleUa>
+      <maleEn>Dragon Slayer</maleEn>
+      <femaleEn>Dragon Slayer</femaleEn>
     </node>
     <node>
       <female>Убийца Драконов</female>
       <male>Убийца Драконов</male>
+      <maleUa>Вбивця Драконів</maleUa>
+      <femaleUa>Вбивця Драконів</femaleUa>
+      <maleEn>Dragon Slayer</maleEn>
+      <femaleEn>Dragon Slayer</femaleEn>
     </node>
     <node>
       <female>Великая Убийца Драконов</female>
       <male>Великий Убийца Драконов</male>
+      <maleUa>Великий Вбивця Драконів</maleUa>
+      <femaleUa>Велика Вбивця Драконів</femaleUa>
+      <maleEn>Greater Dragon Slayer</maleEn>
+      <femaleEn>Greater Dragon Slayer</femaleEn>
     </node>
     <node>
       <female>Великая Убийца Драконов</female>
       <male>Великий Убийца Драконов</male>
+      <maleUa>Великий Вбивця Драконів</maleUa>
+      <femaleUa>Велика Вбивця Драконів</femaleUa>
+      <maleEn>Greater Dragon Slayer</maleEn>
+      <femaleEn>Greater Dragon Slayer</femaleEn>
     </node>
     <node>
       <female>the Underlord</female>
@@ -244,218 +432,434 @@ Warriors get the most out of defensive {hh2021combat{x and {hh1127weapon{x skill
     <node>
       <female>Помощница Варледи</female>
       <male>Помощник Варлорда</male>
+      <maleUa>Помічник Варлорда</maleUa>
+      <femaleUa>Помічниця Варледі</femaleUa>
+      <maleEn>Underlord</maleEn>
+      <femaleEn>Underlord</femaleEn>
     </node>
     <node>
       <female>Варледи</female>
       <male>Варлорд</male>
+      <maleUa>Варлорд</maleUa>
+      <femaleUa>Варледі</femaleUa>
+      <maleEn>Overlord</maleEn>
+      <femaleEn>Overlord</femaleEn>
     </node>
     <node>
       <female>Варледи</female>
       <male>Варлорд</male>
+      <maleUa>Варлорд</maleUa>
+      <femaleUa>Варледі</femaleUa>
+      <maleEn>Overlord</maleEn>
+      <femaleEn>Overlord</femaleEn>
     </node>
     <node>
       <female>Баронесса Грома</female>
       <male>Барон Грома</male>
+      <maleUa>Барон Грому</maleUa>
+      <femaleUa>Баронеса Грому</femaleUa>
+      <maleEn>Baron of Thunder</maleEn>
+      <femaleEn>Baroness of Thunder</femaleEn>
     </node>
     <node>
       <female>Баронесса Грома</female>
       <male>Барон Грома</male>
+      <maleUa>Барон Грому</maleUa>
+      <femaleUa>Баронеса Грому</femaleUa>
+      <maleEn>Baron of Thunder</maleEn>
+      <femaleEn>Baroness of Thunder</femaleEn>
     </node>
     <node>
       <female>Баронесса Шторма</female>
       <male>Барон Шторма</male>
+      <maleUa>Барон Шторму</maleUa>
+      <femaleUa>Баронеса Шторму</femaleUa>
+      <maleEn>Baron of Storms</maleEn>
+      <femaleEn>Baroness of Storms</femaleEn>
     </node>
     <node>
       <female>Баронесса Шторма</female>
       <male>Барон Шторма</male>
+      <maleUa>Барон Шторму</maleUa>
+      <femaleUa>Баронеса Шторму</femaleUa>
+      <maleEn>Baron of Storms</maleEn>
+      <femaleEn>Baroness of Storms</femaleEn>
     </node>
     <node>
       <female>Баронесса Торнадо</female>
       <male>Барон Торнадо</male>
+      <maleUa>Барон Торнадо</maleUa>
+      <femaleUa>Баронеса Торнадо</femaleUa>
+      <maleEn>Baron of Tornadoes</maleEn>
+      <femaleEn>Baroness of Tornadoes</femaleEn>
     </node>
     <node>
       <female>Баронесса Торнадо</female>
       <male>Барон Торнадо</male>
+      <maleUa>Барон Торнадо</maleUa>
+      <femaleUa>Баронеса Торнадо</femaleUa>
+      <maleEn>Baron of Tornadoes</maleEn>
+      <femaleEn>Baroness of Tornadoes</femaleEn>
     </node>
     <node>
       <female>Баронесса Ураганов</female>
       <male>Барон Ураганов</male>
+      <maleUa>Барон Ураганів</maleUa>
+      <femaleUa>Баронеса Ураганів</femaleUa>
+      <maleEn>Baron of Hurricanes</maleEn>
+      <femaleEn>Baroness of Hurricanes</femaleEn>
     </node>
     <node>
       <female>Баронесса Ураганов</female>
       <male>Барон Ураганов</male>
+      <maleUa>Барон Ураганів</maleUa>
+      <femaleUa>Баронеса Ураганів</femaleUa>
+      <maleEn>Baron of Hurricanes</maleEn>
+      <femaleEn>Baroness of Hurricanes</femaleEn>
     </node>
     <node>
       <female>Баронесса Метеоров</female>
       <male>Барон Метеоров</male>
+      <maleUa>Барон Метеорів</maleUa>
+      <femaleUa>Баронеса Метеорів</femaleUa>
+      <maleEn>Baron of Meteors</maleEn>
+      <femaleEn>Baroness of Meteors</femaleEn>
     </node>
     <node>
       <female>Баронесса Метеоров</female>
       <male>Барон Метеоров</male>
+      <maleUa>Барон Метеорів</maleUa>
+      <femaleUa>Баронеса Метеорів</femaleUa>
+      <maleEn>Baron of Meteors</maleEn>
+      <femaleEn>Baroness of Meteors</femaleEn>
     </node>
     <node>
       <female>Баронесса Пламени</female>
       <male>Барон Пламени</male>
+      <maleUa>Барон Вогню</maleUa>
+      <femaleUa>Баронеса Вогню</femaleUa>
+      <maleEn>Baron of Fire</maleEn>
+      <femaleEn>Baroness of Fire</femaleEn>
     </node>
     <node>
       <female>Баронесса Пламени</female>
       <male>Барон Пламени</male>
+      <maleUa>Барон Вогню</maleUa>
+      <femaleUa>Баронеса Вогню</femaleUa>
+      <maleEn>Baron of Fire</maleEn>
+      <femaleEn>Baroness of Fire</femaleEn>
     </node>
     <node>
       <female>Баронесса Стужи</female>
       <male>Барон Стужи</male>
+      <maleUa>Барон Стужі</maleUa>
+      <femaleUa>Баронеса Стужі</femaleUa>
+      <maleEn>Baron of Ice</maleEn>
+      <femaleEn>Baroness of Ice</femaleEn>
     </node>
     <node>
       <female>Баронесса Стужи</female>
       <male>Барон Стужи</male>
+      <maleUa>Барон Стужі</maleUa>
+      <femaleUa>Баронеса Стужі</femaleUa>
+      <maleEn>Baron of Ice</maleEn>
+      <femaleEn>Baroness of Ice</femaleEn>
     </node>
     <node>
       <female>Баронесса Молний</female>
       <male>Барон Молний</male>
+      <maleUa>Барон Блискавок</maleUa>
+      <femaleUa>Баронеса Блискавок</femaleUa>
+      <maleEn>Baron of Lightning</maleEn>
+      <femaleEn>Baroness of Lightning</femaleEn>
     </node>
     <node>
       <female>Баронесса Молний</female>
       <male>Барон Молний</male>
+      <maleUa>Барон Блискавок</maleUa>
+      <femaleUa>Баронеса Блискавок</femaleUa>
+      <maleEn>Baron of Lightning</maleEn>
+      <femaleEn>Baroness of Lightning</femaleEn>
     </node>
     <node>
       <female>Начинающая Ковательница</female>
       <male>Начинающий Кователь</male>
+      <maleUa>Молодий Кувальник</maleUa>
+      <femaleUa>Молода Кувальниця</femaleUa>
+      <maleEn>Novice Forger</maleEn>
+      <femaleEn>Novice Forger</femaleEn>
     </node>
     <node>
       <female>Начинающая Ковательница</female>
       <male>Начинающий Кователь</male>
+      <maleUa>Молодий Кувальник</maleUa>
+      <femaleUa>Молода Кувальниця</femaleUa>
+      <maleEn>Novice Forger</maleEn>
+      <femaleEn>Novice Forger</femaleEn>
     </node>
     <node>
       <female>Ковательница Меди</female>
       <male>Кователь Меди</male>
+      <maleUa>Кувальник Міді</maleUa>
+      <femaleUa>Кувальниця Міді</femaleUa>
+      <maleEn>Master of Copper</maleEn>
+      <femaleEn>Mistress of Copper</femaleEn>
     </node>
     <node>
       <female>Ковательница Меди</female>
       <male>Кователь Меди</male>
+      <maleUa>Кувальник Міді</maleUa>
+      <femaleUa>Кувальниця Міді</femaleUa>
+      <maleEn>Master of Copper</maleEn>
+      <femaleEn>Mistress of Copper</femaleEn>
     </node>
     <node>
       <female>Ковательница Бронзы</female>
       <male>Кователь Бронзы</male>
+      <maleUa>Кувальник Бронзи</maleUa>
+      <femaleUa>Кувальниця Бронзи</femaleUa>
+      <maleEn>Master of Bronze</maleEn>
+      <femaleEn>Mistress of Bronze</femaleEn>
     </node>
     <node>
       <female>Ковательница Бронзы</female>
       <male>Кователь Бронзы</male>
+      <maleUa>Кувальник Бронзи</maleUa>
+      <femaleUa>Кувальниця Бронзи</femaleUa>
+      <maleEn>Master of Bronze</maleEn>
+      <femaleEn>Mistress of Bronze</femaleEn>
     </node>
     <node>
       <female>Ковательница Латуни</female>
       <male>Кователь Латуни</male>
+      <maleUa>Кувальник Латуні</maleUa>
+      <femaleUa>Кувальниця Латуні</femaleUa>
+      <maleEn>Master of Brass</maleEn>
+      <femaleEn>Mistress of Brass</femaleEn>
     </node>
     <node>
       <female>Ковательница Латуни</female>
       <male>Кователь Латуни</male>
+      <maleUa>Кувальник Латуні</maleUa>
+      <femaleUa>Кувальниця Латуні</femaleUa>
+      <maleEn>Master of Brass</maleEn>
+      <femaleEn>Mistress of Brass</femaleEn>
     </node>
     <node>
       <female>Ковательница Железа</female>
       <male>Кователь Железа</male>
+      <maleUa>Кувальник Заліза</maleUa>
+      <femaleUa>Кувальниця Заліза</femaleUa>
+      <maleEn>Master of Iron</maleEn>
+      <femaleEn>Mistress of Iron</femaleEn>
     </node>
     <node>
       <female>Ковательница Железа</female>
       <male>Кователь Железа</male>
+      <maleUa>Кувальник Заліза</maleUa>
+      <femaleUa>Кувальниця Заліза</femaleUa>
+      <maleEn>Master of Iron</maleEn>
+      <femaleEn>Mistress of Iron</femaleEn>
     </node>
     <node>
       <female>Ковательница Стали</female>
       <male>Кователь Стали</male>
+      <maleUa>Кувальник Сталі</maleUa>
+      <femaleUa>Кувальниця Сталі</femaleUa>
+      <maleEn>Master of Steel</maleEn>
+      <femaleEn>Mistress of Steel</femaleEn>
     </node>
     <node>
       <female>Ковательница Стали</female>
       <male>Кователь Стали</male>
+      <maleUa>Кувальник Сталі</maleUa>
+      <femaleUa>Кувальниця Сталі</femaleUa>
+      <maleEn>Master of Steel</maleEn>
+      <femaleEn>Mistress of Steel</femaleEn>
     </node>
     <node>
       <female>Ковательница Мифрила</female>
       <male>Кователь Мифрила</male>
+      <maleUa>Кувальник Мітрилу</maleUa>
+      <femaleUa>Кувальниця Мітрилу</femaleUa>
+      <maleEn>Master of Mithril</maleEn>
+      <femaleEn>Mistress of Mithril</femaleEn>
     </node>
     <node>
       <female>Ковательница Мифрила</female>
       <male>Кователь Мифрила</male>
+      <maleUa>Кувальник Мітрилу</maleUa>
+      <femaleUa>Кувальниця Мітрилу</femaleUa>
+      <maleEn>Master of Mithril</maleEn>
+      <femaleEn>Mistress of Mithril</femaleEn>
     </node>
     <node>
       <female>Ковательница Адамантита</female>
       <male>Кователь Адамантита</male>
+      <maleUa>Кувальник Адамантиту</maleUa>
+      <femaleUa>Кувальниця Адамантиту</femaleUa>
+      <maleEn>Master of Adamantite</maleEn>
+      <femaleEn>Mistress of Adamantite</femaleEn>
     </node>
     <node>
       <female>Ковательница Адамантита</female>
       <male>Кователь Адамантита</male>
+      <maleUa>Кувальник Адамантиту</maleUa>
+      <femaleUa>Кувальниця Адамантиту</femaleUa>
+      <maleEn>Master of Adamantite</maleEn>
+      <femaleEn>Mistress of Adamantite</femaleEn>
     </node>
     <node>
       <female>Капитанша</female>
       <male>Капитан</male>
+      <maleUa>Капітан</maleUa>
+      <femaleUa>Капітанка</femaleUa>
+      <maleEn>Captain</maleEn>
+      <femaleEn>Captain</femaleEn>
     </node>
     <node>
       <female>Капитанша</female>
       <male>Капитан</male>
+      <maleUa>Капітан</maleUa>
+      <femaleUa>Капітанка</femaleUa>
+      <maleEn>Captain</maleEn>
+      <femaleEn>Captain</femaleEn>
     </node>
     <node>
       <female>Генеральша</female>
       <male>Генерал</male>
+      <maleUa>Генерал</maleUa>
+      <femaleUa>Генералка</femaleUa>
+      <maleEn>General</maleEn>
+      <femaleEn>General</femaleEn>
     </node>
     <node>
       <female>Генеральша</female>
       <male>Генерал</male>
+      <maleUa>Генерал</maleUa>
+      <femaleUa>Генералка</femaleUa>
+      <maleEn>General</maleEn>
+      <femaleEn>General</femaleEn>
     </node>
     <node>
       <female>Маршальша</female>
       <male>Маршал</male>
+      <maleUa>Маршал</maleUa>
+      <femaleUa>Маршалка</femaleUa>
+      <maleEn>Field Marshall</maleEn>
+      <femaleEn>Field Marshall</femaleEn>
     </node>
     <node>
       <female>Маршальша</female>
       <male>Маршал</male>
+      <maleUa>Маршал</maleUa>
+      <femaleUa>Маршалка</femaleUa>
+      <maleEn>Field Marshall</maleEn>
+      <femaleEn>Field Marshall</femaleEn>
     </node>
     <node>
       <female>Хозяйка Войны</female>
       <male>Хозяин Войны</male>
+      <maleUa>Володар Війни</maleUa>
+      <femaleUa>Володарка Війни</femaleUa>
+      <maleEn>Master of War</maleEn>
+      <femaleEn>Mistress of War</femaleEn>
     </node>
     <node>
       <female>Хозяйка Войны</female>
       <male>Хозяин Войны</male>
+      <maleUa>Володар Війни</maleUa>
+      <femaleUa>Володарка Війни</femaleUa>
+      <maleEn>Master of War</maleEn>
+      <femaleEn>Mistress of War</femaleEn>
     </node>
     <node>
       <female>Хозяйка Войны</female>
       <male>Хозяин Войны</male>
+      <maleUa>Володар Війни</maleUa>
+      <femaleUa>Володарка Війни</femaleUa>
+      <maleEn>Master of War</maleEn>
+      <femaleEn>Mistress of War</femaleEn>
     </node>
     <node>
       <female>Хозяйка Войны</female>
       <male>Хозяин Войны</male>
+      <maleUa>Володар Війни</maleUa>
+      <femaleUa>Володарка Війни</femaleUa>
+      <maleEn>Master of War</maleEn>
+      <femaleEn>Mistress of War</femaleEn>
     </node>
     <node>
       <female>Хозяйка Войны</female>
       <male>Хозяин Войны</male>
+      <maleUa>Володар Війни</maleUa>
+      <femaleUa>Володарка Війни</femaleUa>
+      <maleEn>Master of War</maleEn>
+      <femaleEn>Mistress of War</femaleEn>
     </node>
     <node>
       <female>Олицетворение Войны</female>
       <male>Олицетворение Войны</male>
+      <maleUa>Уособлення Війни</maleUa>
+      <femaleUa>Уособлення Війни</femaleUa>
+      <maleEn>Incarnation of War</maleEn>
+      <femaleEn>Incarnation of War</femaleEn>
     </node>
     <node>
       <female>Олицетворение Войны</female>
       <male>Олицетворение Войны</male>
+      <maleUa>Уособлення Війни</maleUa>
+      <femaleUa>Уособлення Війни</femaleUa>
+      <maleEn>Incarnation of War</maleEn>
+      <femaleEn>Incarnation of War</femaleEn>
     </node>
     <node>
       <female>Олицетворение Войны</female>
       <male>Олицетворение Войны</male>
+      <maleUa>Уособлення Війни</maleUa>
+      <femaleUa>Уособлення Війни</femaleUa>
+      <maleEn>Incarnation of War</maleEn>
+      <femaleEn>Incarnation of War</femaleEn>
     </node>
     <node>
       <female>Сестра Ареса</female>
       <male>Брат Ареса</male>
+      <maleUa>Брат Ареса</maleUa>
+      <femaleUa>Сестра Ареса</femaleUa>
+      <maleEn>Brother of Ares</maleEn>
+      <femaleEn>Sister of Ares</femaleEn>
     </node>
     <node>
       <female>Сестра Ареса</female>
       <male>Брат Ареса</male>
+      <maleUa>Брат Ареса</maleUa>
+      <femaleUa>Сестра Ареса</femaleUa>
+      <maleEn>Brother of Ares</maleEn>
+      <femaleEn>Sister of Ares</femaleEn>
     </node>
     <node>
       <female>Сестра Ареса</female>
       <male>Брат Ареса</male>
+      <maleUa>Брат Ареса</maleUa>
+      <femaleUa>Сестра Ареса</femaleUa>
+      <maleEn>Brother of Ares</maleEn>
+      <femaleEn>Sister of Ares</femaleEn>
     </node>
     <node>
       <female>Сестра Ареса</female>
       <male>Брат Ареса</male>
+      <maleUa>Брат Ареса</maleUa>
+      <femaleUa>Сестра Ареса</femaleUa>
+      <maleEn>Brother of Ares</maleEn>
+      <femaleEn>Sister of Ares</femaleEn>
     </node>
     <node>
       <female>Легендарная Воительница</female>
       <male>Легендарный Воитель</male>
+      <maleUa>Легендарний Воїтель</maleUa>
+      <femaleUa>Легендарна Воїтелька</femaleUa>
+      <maleEn>Legendary Warrior</maleEn>
+      <femaleEn>Legendary Warrior</femaleEn>
     </node>
     <node>
       <female>the Avatar of War</female>

--- a/professions/witch.xml
+++ b/professions/witch.xml
@@ -48,446 +48,890 @@
     <node>
       <female>Женщина</female>
       <male>Мужчина</male>
+      <maleUa>Чоловік</maleUa>
+      <femaleUa>Жінка</femaleUa>
+      <maleEn>Man</maleEn>
+      <femaleEn>Woman</femaleEn>
     </node>
     <node>
       <female>Ученица Магии</female>
       <male>Ученик Магии</male>
+      <maleUa>Учень Магії</maleUa>
+      <femaleUa>Учениця Магії</femaleUa>
+      <maleEn>Apprentice of Magic</maleEn>
+      <femaleEn>Apprentice of Magic</femaleEn>
     </node>
     <node>
       <female>Студентка Магии</female>
       <male>Студент Магии</male>
+      <maleUa>Студент Магії</maleUa>
+      <femaleUa>Студентка Магії</femaleUa>
+      <maleEn>Student of Magic</maleEn>
+      <femaleEn>Student of Magic</femaleEn>
     </node>
     <node>
       <female>Изучающая Магию</female>
       <male>Изучающий Магию</male>
+      <maleUa>Вивчаючий Магію</maleUa>
+      <femaleUa>Вивчаюча Магію</femaleUa>
+      <maleEn>Delver in Magic</maleEn>
+      <femaleEn>Delver in Magic</femaleEn>
     </node>
     <node>
       <female>Погружающаяся в Магию</female>
       <male>Погружающийся в Магию</male>
+      <maleUa>Заглиблений у Магію</maleUa>
+      <femaleUa>Заглиблена у Магію</femaleUa>
+      <maleEn>Immersed in Magic</maleEn>
+      <femaleEn>Immersed in Magic</femaleEn>
     </node>
     <node>
       <female>Проводница Магии</female>
       <male>Проводник Магии</male>
+      <maleUa>Провідник Магії</maleUa>
+      <femaleUa>Провідниця Магії</femaleUa>
+      <maleEn>Conduit of Magic</maleEn>
+      <femaleEn>Conduit of Magic</femaleEn>
     </node>
     <node>
       <female>Пишущая Магию</female>
       <male>Пишущий Магию</male>
+      <maleUa>Пишучий Магію</maleUa>
+      <femaleUa>Пишуча Магію</femaleUa>
+      <maleEn>Scribe of Magic</maleEn>
+      <femaleEn>Scribe of Magic</femaleEn>
     </node>
     <node>
       <female>Видящая</female>
       <male>Видящий</male>
+      <maleUa>Провидець</maleUa>
+      <femaleUa>Провидиця</femaleUa>
+      <maleEn>Seer</maleEn>
+      <femaleEn>Seeress</femaleEn>
     </node>
     <node>
       <female>Мудрая</female>
       <male>Мудрец</male>
+      <maleUa>Мудрець</maleUa>
+      <femaleUa>Мудра</femaleUa>
+      <maleEn>Sage</maleEn>
+      <femaleEn>Wise Woman</femaleEn>
     </node>
     <node>
       <female>Мастерица Иллюзий</female>
       <male>Мастер Иллюзий</male>
+      <maleUa>Майстер Ілюзій</maleUa>
+      <femaleUa>Майстриня Ілюзій</femaleUa>
+      <maleEn>Master of Illusions</maleEn>
+      <femaleEn>Mistress of Illusions</femaleEn>
     </node>
     <node>
       <female>Мастерица Аффектов</female>
       <male>Мастер Аффектов</male>
+      <maleUa>Майстер Ефектів</maleUa>
+      <femaleUa>Майстриня Ефектів</femaleUa>
+      <maleEn>Master of Effects</maleEn>
+      <femaleEn>Mistress of Effects</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Master of Rituals</maleEn>
+      <femaleEn>Mistress of Rituals</femaleEn>
     </node>
     <node>
       <female>Мастерица Ритуалов</female>
       <male>Мастер Ритуалов</male>
+      <maleUa>Майстер Ритуалів</maleUa>
+      <femaleUa>Майстриня Ритуалів</femaleUa>
+      <maleEn>Master of Rituals</maleEn>
+      <femaleEn>Mistress of Rituals</femaleEn>
     </node>
     <node>
       <female>Мастерица Зачарования</female>
       <male>Мастер Зачарования</male>
+      <maleUa>Майстер Зачарування</maleUa>
+      <femaleUa>Майстриня Зачарування</femaleUa>
+      <maleEn>Master of Enchantment</maleEn>
+      <femaleEn>Mistress of Enchantment</femaleEn>
     </node>
     <node>
       <female>Мастерица Зачарования</female>
       <male>Мастер Зачарования</male>
+      <maleUa>Майстер Зачарування</maleUa>
+      <femaleUa>Майстриня Зачарування</femaleUa>
+      <maleEn>Master of Enchantment</maleEn>
+      <femaleEn>Mistress of Enchantment</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Призову</maleUa>
+      <femaleUa>Майстриня Призову</femaleUa>
+      <maleEn>Master of Summoning</maleEn>
+      <femaleEn>Mistress of Summoning</femaleEn>
     </node>
     <node>
       <female>Мастерица Призыва</female>
       <male>Мастер Призыва</male>
+      <maleUa>Майстер Призову</maleUa>
+      <femaleUa>Майстриня Призову</femaleUa>
+      <maleEn>Master of Summoning</maleEn>
+      <femaleEn>Mistress of Summoning</femaleEn>
     </node>
     <node>
       <female>Ведьма</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Відьма</femaleUa>
+      <maleEn>Mage</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Ведьма</female>
       <male>Маг</male>
+      <maleUa>Маг</maleUa>
+      <femaleUa>Відьма</femaleUa>
+      <maleEn>Mage</maleEn>
+      <femaleEn>Witch</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creatress</femaleEn>
     </node>
     <node>
       <female>Создательница</female>
       <male>Создатель</male>
+      <maleUa>Творець</maleUa>
+      <femaleUa>Творчиня</femaleUa>
+      <maleEn>Creator</maleEn>
+      <femaleEn>Creatress</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Gifted One</maleEn>
+      <femaleEn>Gifted One</femaleEn>
     </node>
     <node>
       <female>Одаренная</female>
       <male>Одаренный</male>
+      <maleUa>Обдарований</maleUa>
+      <femaleUa>Обдарована</femaleUa>
+      <maleEn>Gifted One</maleEn>
+      <femaleEn>Gifted One</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чароплет</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Charm-Weaver</maleEn>
+      <femaleEn>Enchantress</femaleEn>
     </node>
     <node>
       <female>Чаровница</female>
       <male>Чароплет</male>
+      <maleUa>Чароплет</maleUa>
+      <femaleUa>Чарівниця</femaleUa>
+      <maleEn>Charm-Weaver</maleEn>
+      <femaleEn>Enchantress</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Колдунья</female>
       <male>Колдун</male>
+      <maleUa>Чаклун</maleUa>
+      <femaleUa>Чаклунка</femaleUa>
+      <maleEn>Sorcerer</maleEn>
+      <femaleEn>Sorceress</femaleEn>
     </node>
     <node>
       <female>Боевая Ведьма</female>
       <male>Чернокнижник</male>
+      <maleUa>Чорнокнижник</maleUa>
+      <femaleUa>Бойова Відьма</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>Battle Witch</femaleEn>
     </node>
     <node>
       <female>Боевая Ведьма</female>
       <male>Чернокнижник</male>
+      <maleUa>Чорнокнижник</maleUa>
+      <femaleUa>Бойова Відьма</femaleUa>
+      <maleEn>Warlock</maleEn>
+      <femaleEn>Battle Witch</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Кудесник</maleUa>
+      <femaleUa>Кудесниця</femaleUa>
+      <maleEn>Wonder-Worker</maleEn>
+      <femaleEn>Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Кудесница</female>
       <male>Кудесник</male>
+      <maleUa>Кудесник</maleUa>
+      <femaleUa>Кудесниця</femaleUa>
+      <maleEn>Wonder-Worker</maleEn>
+      <femaleEn>Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Кудесник</maleUa>
+      <femaleUa>Старша Кудесниця</femaleUa>
+      <maleEn>Elder Wonder-Worker</maleEn>
+      <femaleEn>Elder Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Старшая Кудесница</female>
       <male>Старший Кудесник</male>
+      <maleUa>Старший Кудесник</maleUa>
+      <femaleUa>Старша Кудесниця</femaleUa>
+      <maleEn>Elder Wonder-Worker</maleEn>
+      <femaleEn>Elder Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Кудесник</maleUa>
+      <femaleUa>Велика Кудесниця</femaleUa>
+      <maleEn>Great Wonder-Worker</maleEn>
+      <femaleEn>Great Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Великая Кудесница</female>
       <male>Великий Кудесник</male>
+      <maleUa>Великий Кудесник</maleUa>
+      <femaleUa>Велика Кудесниця</femaleUa>
+      <maleEn>Great Wonder-Worker</maleEn>
+      <femaleEn>Great Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Кудесник</maleUa>
+      <femaleUa>Найвеличніша Кудесниця</femaleUa>
+      <maleEn>Greatest Wonder-Worker</maleEn>
+      <femaleEn>Greatest Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Величайшая Кудесница</female>
       <male>Величайший Кудесник</male>
+      <maleUa>Найвеличніший Кудесник</maleUa>
+      <femaleUa>Найвеличніша Кудесниця</femaleUa>
+      <maleEn>Greatest Wonder-Worker</maleEn>
+      <femaleEn>Greatest Wonder-Worker</femaleEn>
     </node>
     <node>
       <female>Мастерица Оберегов</female>
       <male>Мастер Оберегов</male>
+      <maleUa>Майстер Оберегів</maleUa>
+      <femaleUa>Майстриня Оберегів</femaleUa>
+      <maleEn>Master of Wards</maleEn>
+      <femaleEn>Mistress of Wards</femaleEn>
     </node>
     <node>
       <female>Мастерица Оберегов</female>
       <male>Мастер Оберегов</male>
+      <maleUa>Майстер Оберегів</maleUa>
+      <femaleUa>Майстриня Оберегів</femaleUa>
+      <maleEn>Master of Wards</maleEn>
+      <femaleEn>Mistress of Wards</femaleEn>
     </node>
     <node>
       <female>Властительница Оберегов</female>
       <male>Властелин Оберегов</male>
+      <maleUa>Владар Оберегів</maleUa>
+      <femaleUa>Владарка Оберегів</femaleUa>
+      <maleEn>Lord of Wards</maleEn>
+      <femaleEn>Lady of Wards</femaleEn>
     </node>
     <node>
       <female>Властительница Оберегов</female>
       <male>Властелин Оберегов</male>
+      <maleUa>Владар Оберегів</maleUa>
+      <femaleUa>Владарка Оберегів</femaleUa>
+      <maleEn>Lord of Wards</maleEn>
+      <femaleEn>Lady of Wards</femaleEn>
     </node>
     <node>
       <female>Повелительница Метел</female>
       <male>Повелитель Метел</male>
+      <maleUa>Повелитель Метелиць</maleUa>
+      <femaleUa>Повелителька Метелиць</femaleUa>
+      <maleEn>Lord of Blizzards</maleEn>
+      <femaleEn>Lady of Blizzards</femaleEn>
     </node>
     <node>
       <female>Повелительница Метел</female>
       <male>Повелитель Метел</male>
+      <maleUa>Повелитель Метелиць</maleUa>
+      <femaleUa>Повелителька Метелиць</femaleUa>
+      <maleEn>Lord of Blizzards</maleEn>
+      <femaleEn>Lady of Blizzards</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Алхимии</female>
       <male>Мастер Алхимии</male>
+      <maleUa>Майстер Алхімії</maleUa>
+      <femaleUa>Майстриня Алхімії</femaleUa>
+      <maleEn>Master of Alchemy</maleEn>
+      <femaleEn>Mistress of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Повелитель Алхімії</maleUa>
+      <femaleUa>Повелителька Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Повелительница Алхимии</female>
       <male>Повелитель Алхимии</male>
+      <maleUa>Повелитель Алхімії</maleUa>
+      <femaleUa>Повелителька Алхімії</femaleUa>
+      <maleEn>Lord of Alchemy</maleEn>
+      <femaleEn>Lady of Alchemy</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Мастерица Артефактов</female>
       <male>Мастер Артефактов</male>
+      <maleUa>Майстер Артефактів</maleUa>
+      <femaleUa>Майстриня Артефактів</femaleUa>
+      <maleEn>Master of Artifacts</maleEn>
+      <femaleEn>Mistress of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Повелитель Артефактів</maleUa>
+      <femaleUa>Повелителька Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Повелительница Артефактов</female>
       <male>Повелитель Артефактов</male>
+      <maleUa>Повелитель Артефактів</maleUa>
+      <femaleUa>Повелителька Артефактів</femaleUa>
+      <maleEn>Lord of Artifacts</maleEn>
+      <femaleEn>Lady of Artifacts</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Проникаючий в Інші Простори</maleUa>
+      <femaleUa>Проникаюча в Інші Простори</femaleUa>
+      <maleEn>Delver into Other Realms</maleEn>
+      <femaleEn>Delver into Other Realms</femaleEn>
     </node>
     <node>
       <female>Проникающая в Иные Пространства</female>
       <male>Проникающий в Иные Пространства</male>
+      <maleUa>Проникаючий в Інші Простори</maleUa>
+      <femaleUa>Проникаюча в Інші Простори</femaleUa>
+      <maleEn>Delver into Other Realms</maleEn>
+      <femaleEn>Delver into Other Realms</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Взиваючий до Демонів</maleUa>
+      <femaleUa>Взиваюча до Демонів</femaleUa>
+      <maleEn>Invoker of Demons</maleEn>
+      <femaleEn>Invoker of Demons</femaleEn>
     </node>
     <node>
       <female>Взывающая к Демонам</female>
       <male>Взывающий к Демонам</male>
+      <maleUa>Взиваючий до Демонів</maleUa>
+      <femaleUa>Взиваюча до Демонів</femaleUa>
+      <maleEn>Invoker of Demons</maleEn>
+      <femaleEn>Invoker of Demons</femaleEn>
     </node>
     <node>
       <female>Ездящая на Драконах</female>
       <male>Ездок на Драконах</male>
+      <maleUa>Вершник на Драконах</maleUa>
+      <femaleUa>Вершниця на Драконах</femaleUa>
+      <maleEn>Dragon Rider</maleEn>
+      <femaleEn>Dragon Rider</femaleEn>
     </node>
     <node>
       <female>Ездящая на Драконах</female>
       <male>Ездок на Драконах</male>
+      <maleUa>Вершник на Драконах</maleUa>
+      <femaleUa>Вершниця на Драконах</femaleUa>
+      <maleEn>Dragon Rider</maleEn>
+      <femaleEn>Dragon Rider</femaleEn>
     </node>
     <node>
       <female>Повелительница Драконов</female>
       <male>Повелитель Драконов</male>
+      <maleUa>Повелитель Драконів</maleUa>
+      <femaleUa>Повелителька Драконів</femaleUa>
+      <maleEn>Lord of Dragons</maleEn>
+      <femaleEn>Lady of Dragons</femaleEn>
     </node>
     <node>
       <female>Повелительница Драконов</female>
       <male>Повелитель Драконов</male>
+      <maleUa>Повелитель Драконів</maleUa>
+      <femaleUa>Повелителька Драконів</femaleUa>
+      <maleEn>Lord of Dragons</maleEn>
+      <femaleEn>Lady of Dragons</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Повелитель Чар</maleUa>
+      <femaleUa>Повелителька Чар</femaleUa>
+      <maleEn>Lord of Charms</maleEn>
+      <femaleEn>Lady of Charms</femaleEn>
     </node>
     <node>
       <female>Повелительница Чар</female>
       <male>Повелитель Чар</male>
+      <maleUa>Повелитель Чар</maleUa>
+      <femaleUa>Повелителька Чар</femaleUa>
+      <maleEn>Lord of Charms</maleEn>
+      <femaleEn>Lady of Charms</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Повелитель Чаклунства</maleUa>
+      <femaleUa>Повелителька Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Повелительница Колдовства</female>
       <male>Повелитель Колдовства</male>
+      <maleUa>Повелитель Чаклунства</maleUa>
+      <femaleUa>Повелителька Чаклунства</femaleUa>
+      <maleEn>Lord of Sorcery</maleEn>
+      <femaleEn>Lady of Sorcery</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Spellcaster</maleEn>
+      <femaleEn>Great Spellcaster</femaleEn>
     </node>
     <node>
       <female>Великая Заклинательница</female>
       <male>Великий Заклинатель</male>
+      <maleUa>Великий Заклинач</maleUa>
+      <femaleUa>Велика Заклиначка</femaleUa>
+      <maleEn>Great Spellcaster</maleEn>
+      <femaleEn>Great Spellcaster</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoner</femaleEn>
     </node>
     <node>
       <female>Великая Призывательница</female>
       <male>Великий Призыватель</male>
+      <maleUa>Великий Призивач</maleUa>
+      <femaleUa>Велика Призивачка</femaleUa>
+      <maleEn>Great Summoner</maleEn>
+      <femaleEn>Great Summoner</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Крізь Час</maleUa>
+      <femaleUa>Провидиця Крізь Час</femaleUa>
+      <maleEn>Seer Through Time</maleEn>
+      <femaleEn>Seeress Through Time</femaleEn>
     </node>
     <node>
       <female>Видящая Сквозь Время</female>
       <male>Видящий Сквозь Время</male>
+      <maleUa>Провидець Крізь Час</maleUa>
+      <femaleUa>Провидиця Крізь Час</femaleUa>
+      <maleEn>Seer Through Time</maleEn>
+      <femaleEn>Seeress Through Time</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Повелитель Потоку</maleUa>
+      <femaleUa>Повелителька Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Повелительница Потока</female>
       <male>Повелитель Потока</male>
+      <maleUa>Повелитель Потоку</maleUa>
+      <femaleUa>Повелителька Потоку</femaleUa>
+      <maleEn>Lord of the Flow</maleEn>
+      <femaleEn>Lady of the Flow</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Осягаючий Хаос</maleUa>
+      <femaleUa>Осягаюча Хаос</femaleUa>
+      <maleEn>Adept of Chaos</maleEn>
+      <femaleEn>Adept of Chaos</femaleEn>
     </node>
     <node>
       <female>Постигающая Хаос</female>
       <male>Постигающий Хаос</male>
+      <maleUa>Осягаючий Хаос</maleUa>
+      <femaleUa>Осягаюча Хаос</femaleUa>
+      <maleEn>Adept of Chaos</maleEn>
+      <femaleEn>Adept of Chaos</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкуючий Хаос</maleUa>
+      <femaleUa>Приборкуюча Хаос</femaleUa>
+      <maleEn>Chaos Tamer</maleEn>
+      <femaleEn>Chaos Tamer</femaleEn>
     </node>
     <node>
       <female>Обуздывающая Хаос</female>
       <male>Обуздывающий Хаос</male>
+      <maleUa>Приборкуючий Хаос</maleUa>
+      <femaleUa>Приборкуюча Хаос</femaleUa>
+      <maleEn>Chaos Tamer</maleEn>
+      <femaleEn>Chaos Tamer</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Заклинаючий Хаос</maleUa>
+      <femaleUa>Заклинаюча Хаос</femaleUa>
+      <maleEn>Chaos Binder</maleEn>
+      <femaleEn>Chaos Binder</femaleEn>
     </node>
     <node>
       <female>Заклинающая Хаос</female>
       <male>Заклинающий Хаос</male>
+      <maleUa>Заклинаючий Хаос</maleUa>
+      <femaleUa>Заклинаюча Хаос</femaleUa>
+      <maleEn>Chaos Binder</maleEn>
+      <femaleEn>Chaos Binder</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Повелеваючий Хаосом</maleUa>
+      <femaleUa>Повелеваюча Хаосом</femaleUa>
+      <maleEn>Master of Chaos</maleEn>
+      <femaleEn>Mistress of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелевающая Хаосом</female>
       <male>Повелевающий Хаосом</male>
+      <maleUa>Повелеваючий Хаосом</maleUa>
+      <femaleUa>Повелеваюча Хаосом</femaleUa>
+      <maleEn>Master of Chaos</maleEn>
+      <femaleEn>Mistress of Chaos</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Повелитель Магії</maleUa>
+      <femaleUa>Повелителька Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Магии</female>
       <male>Повелитель Магии</male>
+      <maleUa>Повелитель Магії</maleUa>
+      <femaleUa>Повелителька Магії</femaleUa>
+      <maleEn>Lord of Magic</maleEn>
+      <femaleEn>Lady of Magic</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Повелитель Минулого</maleUa>
+      <femaleUa>Повелителька Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Прошлого</female>
       <male>Повелитель Прошлого</male>
+      <maleUa>Повелитель Минулого</maleUa>
+      <femaleUa>Повелителька Минулого</femaleUa>
+      <maleEn>Lord of the Past</maleEn>
+      <femaleEn>Lady of the Past</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Повелитель Теперішнього</maleUa>
+      <femaleUa>Повелителька Теперішнього</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Настоящего</female>
       <male>Повелитель Настоящего</male>
+      <maleUa>Повелитель Теперішнього</maleUa>
+      <femaleUa>Повелителька Теперішнього</femaleUa>
+      <maleEn>Lord of the Present</maleEn>
+      <femaleEn>Lady of the Present</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Повелитель Майбутнього</maleUa>
+      <femaleUa>Повелителька Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Повелительница Будущего</female>
       <male>Повелитель Будущего</male>
+      <maleUa>Повелитель Майбутнього</maleUa>
+      <femaleUa>Повелителька Майбутнього</femaleUa>
+      <maleEn>Lord of the Future</maleEn>
+      <femaleEn>Lady of the Future</femaleEn>
     </node>
     <node>
       <female>Архимагичка</female>
       <male>Архимаг</male>
+      <maleUa>Архімаг</maleUa>
+      <femaleUa>Архімагиня</femaleUa>
+      <maleEn>Archmage</maleEn>
+      <femaleEn>Archmage</femaleEn>
     </node>
     <node>
       <female>Архимагичка</female>
       <male>Архимаг</male>
+      <maleUa>Архімаг</maleUa>
+      <femaleUa>Архімагиня</femaleUa>
+      <maleEn>Archmage</maleEn>
+      <femaleEn>Archmage</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Мистик</female>
       <male>Мистик</male>
+      <maleUa>Містик</maleUa>
+      <femaleUa>Містик</femaleUa>
+      <maleEn>Mystic</maleEn>
+      <femaleEn>Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Великий Мистик</female>
       <male>Великий Мистик</male>
+      <maleUa>Великий Містик</maleUa>
+      <femaleUa>Великий Містик</femaleUa>
+      <maleEn>Great Mystic</maleEn>
+      <femaleEn>Great Mystic</femaleEn>
     </node>
     <node>
       <female>Героиня Магии</female>
       <male>the Mage Hero</male>
+      <maleUa>Герой Магії</maleUa>
+      <femaleUa>Героїня Магії</femaleUa>
+      <maleEn>The Mage Hero</maleEn>
+      <femaleEn>The Mage Heroine</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
     <node>
       <female>Божество Магии</female>
       <male>Божество Магии</male>
+      <maleUa>Божество Магії</maleUa>
+      <femaleUa>Божество Магії</femaleUa>
+      <maleEn>Deity of Magic</maleEn>
+      <femaleEn>Deity of Magic</femaleEn>
     </node>
   </titles>
   <weapon>40101</weapon>

--- a/wearlocations/about.xml
+++ b/wearlocations/about.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">накинуто на тіло</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются накинуть %2$O4 вокруг тела, но ничего не получается.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 накидыва%1$nет|ют %2$O4 вокруг тела.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь ничего накинуть вокруг себя.</msgSelfNoRib>
-  <msgSelfWear>Ты накидываешь %2$O4 вокруг тела.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot throw anything around yourself.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь ничего накинуть вокруг себя.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш нічого накинути навколо себе.</msgSelfNoRib>
+  <msgSelfWear l="en">You throw %2$O4 around your body.</msgSelfWear>
+  <msgSelfWear l="ru">Ты накидываешь %2$O4 вокруг тела.</msgSelfWear>
+  <msgSelfWear l="ua">Ти накидаєш %2$O4 навколо тіла.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>6</orderDisplay>
   <orderWear>15</orderWear>

--- a/wearlocations/arms.xml
+++ b/wearlocations/arms.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на плечі</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются надеть %2$O4 на плечи, которых нет.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надева%1$nет|ют %2$O4 на плечи.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь ничего надеть на плечи.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на плечи.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear anything on your shoulders.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь ничего надеть на плечи.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш нічого вдягти на плечі.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on your shoulders.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на плечи.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на плечі.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>9</orderDisplay>
   <orderWear>14</orderWear>

--- a/wearlocations/body.xml
+++ b/wearlocations/body.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на тіло</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются надеть %2$O4 на тело, но ничего не получается.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надева%1$nет|ют %2$O4 на тело.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь ничего надеть на тело.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на тело.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear anything on your body.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь ничего надеть на тело.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш нічого вдягти на тіло.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on your body.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на тело.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на тіло.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>7</orderDisplay>
   <orderWear>5</orderWear>

--- a/wearlocations/ears.xml
+++ b/wearlocations/ears.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдіто у вуха</msgDisplay>
   <msgRoomNoRib>%1$^C1 тыч%1$nет|ут в уши %2$O4, но в мочке не хватает дырки для сережек.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 вдева%1$nет|ют в уши %2$O4.</msgRoomWear>
-  <msgSelfNoRib>У тебя не проколоты уши -- обратись к квестору.</msgSelfNoRib>
-  <msgSelfWear>Ты вдеваешь в уши %2$O4.</msgSelfWear>
+  <msgSelfNoRib l="en">Your ears are not pierced -- see a quaestor.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя не проколоты уши -- обратись к квестору.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе не проколоті вуха -- звернися до квестора.</msgSelfNoRib>
+  <msgSelfWear l="en">You put %2$O4 in your ears.</msgSelfWear>
+  <msgSelfWear l="ru">Ты вдеваешь в уши %2$O4.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш у вуха %2$O4.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>2</orderDisplay>
   <orderWear>8</orderWear>

--- a/wearlocations/face.xml
+++ b/wearlocations/face.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">прикриває обличчя</msgDisplay>
   <msgRoomNoRib>%1$^C1 пыта%1$nется|ются прикрыть %2$O5 несуществующее лицо.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 прикрывает лицо %2$O5.</msgRoomWear>
-  <msgSelfNoRib>У тебя нет лица, какой ужас!</msgSelfNoRib>
-  <msgSelfWear>Ты прикрываешь лицо %2$O5.</msgSelfWear>
+  <msgSelfNoRib l="en">You have no face, how horrifying!</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя нет лица, какой ужас!</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе немає обличчя, який жах!</msgSelfNoRib>
+  <msgSelfWear l="en">You cover your face with %2$O5.</msgSelfWear>
+  <msgSelfWear l="ru">Ты прикрываешь лицо %2$O5.</msgSelfWear>
+  <msgSelfWear l="ua">Ти прикриваєш обличчя %2$O5.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>3</orderDisplay>
   <orderWear>9</orderWear>

--- a/wearlocations/feet.xml
+++ b/wearlocations/feet.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">взуто на ноги</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается обуть %2$O4 на несуществующие ступни.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 обувает %2$O4.</msgRoomWear>
-  <msgSelfNoRib>У тебя нет ступней, на которые можно было бы это обуть.</msgSelfNoRib>
-  <msgSelfWear>Ты обуваешь %2$O4.</msgSelfWear>
+  <msgSelfNoRib l="en">You have no feet to put that on.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя нет ступней, на которые можно было бы это обуть.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе немає стіп, на які можна було б це взути.</msgSelfNoRib>
+  <msgSelfWear l="en">You put on %2$O4.</msgSelfWear>
+  <msgSelfWear l="ru">Ты обуваешь %2$O4.</msgSelfWear>
+  <msgSelfWear l="ua">Ти взуваєш %2$O4.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>22</orderDisplay>
   <orderWear>11</orderWear>

--- a/wearlocations/finger_l.xml
+++ b/wearlocations/finger_l.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на палець</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующий палец.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на один из пальцев.</msgRoomWear>
-  <msgSelfNoRib>У тебя нет пальцев на этой конечности.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на один из пальцев.</msgSelfWear>
+  <msgSelfNoRib l="en">You have no fingers on that limb.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя нет пальцев на этой конечности.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе немає пальців на цій кінцівці.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on one of your fingers.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на один из пальцев.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на один із пальців.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>13</orderDisplay>
   <orderWear>1</orderWear>

--- a/wearlocations/finger_r.xml
+++ b/wearlocations/finger_r.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на палець</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующий палец.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на один из пальцев.</msgRoomWear>
-  <msgSelfNoRib>У тебя нет пальцев на этой конечности.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на один из пальцев.</msgSelfWear>
+  <msgSelfNoRib l="en">You have no fingers on that limb.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя нет пальцев на этой конечности.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе немає пальців на цій кінцівці.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on one of your fingers.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на один из пальцев.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на один із пальців.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>14</orderDisplay>
   <orderWear>2</orderWear>

--- a/wearlocations/float.xml
+++ b/wearlocations/float.xml
@@ -10,9 +10,13 @@
   <msgRoomNoRib>%1$^C1 пытается выпустить %2$O4 в полет вокруг себя, но промахивается.</msgRoomNoRib>
   <msgRoomRemove>%1$^C1 останавливает %2$O4, круживш%2$Gееся|ийся|уюся|ихся вокруг %1$P4.</msgRoomRemove>
   <msgRoomWear>%1$^C1 запускает %2$O4 кружиться вокруг %1$P4.</msgRoomWear>
-  <msgSelfNoRib>Вокруг тебя не может кружиться ничего, кроме мух.</msgSelfNoRib>
+  <msgSelfNoRib l="en">Nothing can circle around you except flies.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Вокруг тебя не может кружиться ничего, кроме мух.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Навколо тебе не може кружляти ніщо, крім мух.</msgSelfNoRib>
   <msgSelfRemove>Ты останавливаешь %2$O4, круживш%2$Gееся|ийся|уюся|ихся вокруг тебя.</msgSelfRemove>
-  <msgSelfWear>Ты запускаешь %2$O4 кружиться вокруг тебя.</msgSelfWear>
+  <msgSelfWear l="en">You set %2$O4 spinning around you.</msgSelfWear>
+  <msgSelfWear l="ru">Ты запускаешь %2$O4 кружиться вокруг тебя.</msgSelfWear>
+  <msgSelfWear l="ua">Ти запускаєш %2$O4 кружляти навколо тебе.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>25</orderDisplay>
   <orderWear>22</orderWear>

--- a/wearlocations/hair.xml
+++ b/wearlocations/hair.xml
@@ -8,7 +8,9 @@
   <msgRoomRemove>%1$^C1 выпутывает из своих волос %2$O4.</msgRoomRemove>
   <msgRoomWear>%1$^C1 вплетает %2$O4 в волосы.</msgRoomWear>
   <msgSelfRemove>Ты выпутываешь из своих волос %2$O4.</msgSelfRemove>
-  <msgSelfWear>Ты вплетаешь %2$O4 в волосы.</msgSelfWear>
+  <msgSelfWear l="en">You weave %2$O4 into your hair.</msgSelfWear>
+  <msgSelfWear l="ru">Ты вплетаешь %2$O4 в волосы.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вплітаєш %2$O4 у волосся.</msgSelfWear>
   <needRib>false</needRib>
   <orderDisplay>2</orderDisplay>
   <orderWear>7</orderWear>

--- a/wearlocations/hands.xml
+++ b/wearlocations/hands.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на долоні</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на ладони, которых нет.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на ладони рук.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь надеть %2$O4 на ладони, у тебя их нет.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на ладони рук.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear %2$O4 on your palms -- you don't have any.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь надеть %2$O4 на ладони, у тебя их нет.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш вдягти %2$O4 на долоні, у тебе їх немає.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on the palms of your hands.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на ладони рук.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на долоні рук.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>10</orderDisplay>
   <orderWear>13</orderWear>

--- a/wearlocations/head.xml
+++ b/wearlocations/head.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на голову</msgDisplay>
   <msgRoomNoRib>%1$^C1 не может найти свою голову.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на голову.</msgRoomWear>
-  <msgSelfNoRib>Твоя голова куда-то потерялась.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на голову.</msgSelfWear>
+  <msgSelfNoRib l="en">Your head is missing somewhere.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Твоя голова куда-то потерялась.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Твоя голова кудись загубилася.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on your head.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на голову.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на голову.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>1</orderDisplay>
   <orderWear>7</orderWear>

--- a/wearlocations/hold.xml
+++ b/wearlocations/hold.xml
@@ -10,8 +10,12 @@
   <msgDisplay l="ua">затиснуто в руках</msgDisplay>
   <msgRoomWear>%1$^C1 берет в руки %2$O4.</msgRoomWear>
   <msgSelfConflict>Твои руки заняты оружием.</msgSelfConflict>
-  <msgSelfNoRib>Ты не можешь ничего взять в руки.</msgSelfNoRib>
-  <msgSelfWear>Ты берешь в руки %2$O4.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot take anything in your hands.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь ничего взять в руки.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш нічого взяти в руки.</msgSelfNoRib>
+  <msgSelfWear l="en">You take %2$O4 in your hands.</msgSelfWear>
+  <msgSelfWear l="ru">Ты берешь в руки %2$O4.</msgSelfWear>
+  <msgSelfWear l="ua">Ти береш у руки %2$O4.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>18</orderDisplay>
   <orderWear>21</orderWear>

--- a/wearlocations/hooves.xml
+++ b/wearlocations/hooves.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">на копитах</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4, но для этого нужны копыта.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 подковывает себя %2$O5.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь носить %2$O4, у тебя нет копыт.</msgSelfNoRib>
-  <msgSelfWear>Ты подковываешь себя %2$O5.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear %2$O4 -- you have no hooves.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить %2$O4, у тебя нет копыт.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити %2$O4, у тебе немає копит.</msgSelfNoRib>
+  <msgSelfWear l="en">You shoe yourself with %2$O5.</msgSelfWear>
+  <msgSelfWear l="ru">Ты подковываешь себя %2$O5.</msgSelfWear>
+  <msgSelfWear l="ua">Ти підковуєш себе %2$O5.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>23</orderDisplay>
   <orderWear>12</orderWear>

--- a/wearlocations/horse.xml
+++ b/wearlocations/horse.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">на кінському крупі</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается найти в себе лошадь и надеть на нее %2$O4.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 накидывает %2$O4 поверх своего лошадиного крупа.</msgRoomWear>
-  <msgSelfNoRib>У тебя нет лошадиного крупа.</msgSelfNoRib>
-  <msgSelfWear>Ты накидываешь %2$O4 поверх своего лошадиного крупа.</msgSelfWear>
+  <msgSelfNoRib l="en">You have no horse's rump.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя нет лошадиного крупа.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе немає кінського крупа.</msgSelfNoRib>
+  <msgSelfWear l="en">You throw %2$O4 over your horse's rump.</msgSelfWear>
+  <msgSelfWear l="ru">Ты накидываешь %2$O4 поверх своего лошадиного крупа.</msgSelfWear>
+  <msgSelfWear l="ua">Ти накидаєш %2$O4 поверх свого кінського крупа.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>20</orderDisplay>
   <orderWear>6</orderWear>

--- a/wearlocations/legs.xml
+++ b/wearlocations/legs.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на ноги</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующие ноги.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 на ноги.</msgRoomWear>
-  <msgSelfNoRib>У тебя нету ног.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 на ноги.</msgSelfWear>
+  <msgSelfNoRib l="en">You have no legs.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">У тебя нету ног.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">У тебе немає ніг.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on your legs.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на ноги.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на ноги.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>21</orderDisplay>
   <orderWear>10</orderWear>

--- a/wearlocations/light.xml
+++ b/wearlocations/light.xml
@@ -8,9 +8,13 @@
   <msgDisplay l="ua">освітлює шлях</msgDisplay>
   <msgRoomRemove>%1$^C1 гасит свет, исходящий от %2$O2.</msgRoomRemove>
   <msgRoomWear>%1$^C1 зажигает %2$O4, освещая свой путь.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь ничего использовать в качестве освещения.</msgSelfNoRib>
+  <msgSelfNoRib l="en">You cannot use anything as a light source.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь ничего использовать в качестве освещения.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш нічого використати як освітлення.</msgSelfNoRib>
   <msgSelfRemove>Ты гасишь свет, исходящий от %2$O2.</msgSelfRemove>
-  <msgSelfWear>Ты зажигаешь %2$O4, освещая свой путь.</msgSelfWear>
+  <msgSelfWear l="en">You light %2$O4, lighting your way.</msgSelfWear>
+  <msgSelfWear l="ru">Ты зажигаешь %2$O4, освещая свой путь.</msgSelfWear>
+  <msgSelfWear l="ua">Ти запалюєш %2$O4, освітлюючи свій шлях.</msgSelfWear>
   <needRib>true</needRib>
   <purpose l="en">Used as a light source</purpose>
   <purpose l="ru">Используется для освещения</purpose>

--- a/wearlocations/neck_1.xml
+++ b/wearlocations/neck_1.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на шию</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующую шею.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг шеи.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующую шею.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 вокруг шеи.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear %2$O4 on a nonexistent neck.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь надеть %2$O4 на несуществующую шею.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш вдягти %2$O4 на неіснуючу шию.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 around your neck.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 вокруг шеи.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 навколо шиї.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>4</orderDisplay>
   <orderWear>3</orderWear>

--- a/wearlocations/neck_2.xml
+++ b/wearlocations/neck_2.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на шию</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующую шею.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг шеи.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующую шею.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 вокруг шеи.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear %2$O4 on a nonexistent neck.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь надеть %2$O4 на несуществующую шею.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш вдягти %2$O4 на неіснуючу шию.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 around your neck.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 вокруг шеи.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 навколо шиї.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>5</orderDisplay>
   <orderWear>4</orderWear>

--- a/wearlocations/second_wield.xml
+++ b/wearlocations/second_wield.xml
@@ -5,8 +5,12 @@
   <msgDisplay l="ru">вторичное вооружение</msgDisplay>
   <msgDisplay l="ua">вторинне озброєння</msgDisplay>
   <msgRoomWear>%1$^C1 вооружается %2$O5 как вторичным оружием.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь носить второе оружие.</msgSelfNoRib>
-  <msgSelfWear>Ты вооружаешься %2$O5 как вторичным оружием.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear a second weapon.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить второе оружие.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити другу зброю.</msgSelfNoRib>
+  <msgSelfWear l="en">You arm yourself with %2$O5 as a secondary weapon.</msgSelfWear>
+  <msgSelfWear l="ru">Ты вооружаешься %2$O5 как вторичным оружием.</msgSelfWear>
+  <msgSelfWear l="ua">Ти озброюєшся %2$O5 як другорядною зброєю.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>17</orderDisplay>
   <ribName>втор|ое|ого|ому|ое|ым|ом оружи|е|я|ю|е|ем|и</ribName>  

--- a/wearlocations/sheath.xml
+++ b/wearlocations/sheath.xml
@@ -6,21 +6,27 @@
       <msgDisplay l="ru">в ножнах</msgDisplay>
       <msgDisplay l="ua">у піхвах</msgDisplay>
       <msgRoomWear>%1$^C1 вкладыва%1$nет|ют %2$O4 в ножны.</msgRoomWear>
-      <msgSelfWear>Ты вкладываешь %2$O4 в ножны.</msgSelfWear>
+      <msgSelfWear l="en">You place %2$O4 in the sheath.</msgSelfWear>
+      <msgSelfWear l="ru">Ты вкладываешь %2$O4 в ножны.</msgSelfWear>
+      <msgSelfWear l="ua">Ти вкладаєш %2$O4 у піхви.</msgSelfWear>
       <msgRoomRemove>%1$^C1 выхватыва%1$nет|ют %2$O4 из ножен!</msgRoomRemove>
       <msgSelfRemove>Ты выхватываешь %2$O4 из ножен.</msgSelfRemove>
     </node>
     <node name="belt">
       <msgDisplay>за поясом</msgDisplay>
       <msgRoomWear>%1$^C1 затыка%1$nет|ют %2$O4 за пояс.</msgRoomWear>
-      <msgSelfWear>Ты затыкаешь %2$O4 себе за пояс.</msgSelfWear>
+      <msgSelfWear l="en">You tuck %2$O4 into your belt.</msgSelfWear>
+      <msgSelfWear l="ru">Ты затыкаешь %2$O4 себе за пояс.</msgSelfWear>
+      <msgSelfWear l="ua">Ти затикаєш %2$O4 собі за пояс.</msgSelfWear>
       <msgRoomRemove>%1$^C1 выхватыва%1$nет|ют %2$O4 из-за пояса!</msgRoomRemove>
       <msgSelfRemove>Ты выхватываешь %2$O4 из-за пояса.</msgSelfRemove>
     </node>
     <node name="back">
       <msgDisplay>за спиной</msgDisplay>
       <msgRoomWear>%1$^C1 веша%1$nет|ют за спину %2$O4.</msgRoomWear>
-      <msgSelfWear>Ты вешаешь %2$O4 себе за спину.</msgSelfWear>
+      <msgSelfWear l="en">You hang %2$O4 on your back.</msgSelfWear>
+      <msgSelfWear l="ru">Ты вешаешь %2$O4 себе за спину.</msgSelfWear>
+      <msgSelfWear l="ua">Ти вішаєш %2$O4 собі за спину.</msgSelfWear>
       <msgRoomRemove>%1$^C1 выхватыва%1$nет|ют %2$O4 из-за спины!</msgRoomRemove>
       <msgSelfRemove>Ты выхватываешь %2$O4 из-за спины.</msgSelfRemove>
     </node>

--- a/wearlocations/shield.xml
+++ b/wearlocations/shield.xml
@@ -10,8 +10,12 @@
   <msgDisplay l="ua">використовується як щит</msgDisplay>
   <msgRoomWear>%1$^C1 надевает %2$O4 как щит.</msgRoomWear>
   <msgSelfConflict>Ты не можешь использовать щит, вооружившись вторичным оружием.</msgSelfConflict>
-  <msgSelfNoRib>Ты не можешь носить щит.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 как щит.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear a shield.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить щит.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити щит.</msgSelfNoRib>
+  <msgSelfWear l="en">You put on %2$O4 as a shield.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 как щит.</msgSelfWear>
+  <msgSelfWear l="ua">Ти надягаєш %2$O4 як щит.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>15</orderDisplay>
   <orderWear>19</orderWear>

--- a/wearlocations/tail.xml
+++ b/wearlocations/tail.xml
@@ -8,8 +8,12 @@
   <msgRoomRemove>%1$^C1 снимает с хвоста %2$O4.</msgRoomRemove>
   <msgRoomWear>%1$^C1 надевает %2$O4 себе на хвост.</msgRoomWear>
   <msgSelfRemove>Ты снимаешь с хвоста %2$O4.</msgSelfRemove>
-  <msgSelfWear>Ты надеваешь %2$O4 на хвост.</msgSelfWear>
-  <msgSelfNoRib>Увы, у тебя нет хвоста.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 on your tail.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 на хвост.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 на хвіст.</msgSelfWear>
+  <msgSelfNoRib l="en">Alas, you have no tail.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Увы, у тебя нет хвоста.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">На жаль, у тебе немає хвоста.</msgSelfNoRib>
   <needRib>true</needRib>
   <orderDisplay>22</orderDisplay>
   <orderWear>7</orderWear>

--- a/wearlocations/tattoo.xml
+++ b/wearlocations/tattoo.xml
@@ -6,8 +6,12 @@
   <msgDisplay l="ru">на челе</msgDisplay>
   <msgDisplay l="ua">на чолі</msgDisplay>
   <msgRoomWear>%1$^C1 теперь использует %2$O4 как знак %1$Gего|его|её религии.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь носить знак религии.</msgSelfNoRib>
-  <msgSelfWear>Ты теперь используешь %2$O4 как знак своей религии.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear a religious symbol.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить знак религии.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити знак релігії.</msgSelfNoRib>
+  <msgSelfWear l="en">You now use %2$O4 as the symbol of your religion.</msgSelfWear>
+  <msgSelfWear l="ru">Ты теперь используешь %2$O4 как знак своей религии.</msgSelfWear>
+  <msgSelfWear l="ua">Ти тепер використовуєш %2$O4 як знак своєї релігії.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>1</orderDisplay>
   <orderWear>23</orderWear>

--- a/wearlocations/waist.xml
+++ b/wearlocations/waist.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">оперізує тіло</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается опоясаться %2$O5, но ничего не получается.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 опоясывается %2$O5.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь ничем опоясаться.</msgSelfNoRib>
-  <msgSelfWear>Ты опоясываешься %2$O5.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot belt yourself with anything.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь ничем опоясаться.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш нічим підперезатися.</msgSelfNoRib>
+  <msgSelfWear l="en">You belt yourself with %2$O5.</msgSelfWear>
+  <msgSelfWear l="ru">Ты опоясываешься %2$O5.</msgSelfWear>
+  <msgSelfWear l="ua">Ти підперезуєшся %2$O5.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>19</orderDisplay>
   <orderWear>16</orderWear>

--- a/wearlocations/wield.xml
+++ b/wearlocations/wield.xml
@@ -6,8 +6,12 @@
   <msgDisplay l="ru">вооружение</msgDisplay>
   <msgDisplay l="ua">озброєння</msgDisplay>
   <msgRoomWear>%1$^C1 вооружается %2$O5.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь носить оружие.</msgSelfNoRib>
-  <msgSelfWear>Ты вооружаешься %2$O5.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear a weapon.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь носить оружие.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш носити зброю.</msgSelfNoRib>
+  <msgSelfWear l="en">You arm yourself with %2$O5.</msgSelfWear>
+  <msgSelfWear l="ru">Ты вооружаешься %2$O5.</msgSelfWear>
+  <msgSelfWear l="ua">Ти озброюєшся %2$O5.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>16</orderDisplay>
   <orderWear>20</orderWear>

--- a/wearlocations/wrist_l.xml
+++ b/wearlocations/wrist_l.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на запʼясток</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующее запястье.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг левого запястья.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующее запястье.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 вокруг левого запястья.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear %2$O4 on a nonexistent wrist.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь надеть %2$O4 на несуществующее запястье.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш вдягти %2$O4 на неіснуюче запʼястя.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 around your left wrist.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 вокруг левого запястья.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 навколо лівого запʼястя.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>11</orderDisplay>
   <orderWear>17</orderWear>

--- a/wearlocations/wrist_r.xml
+++ b/wearlocations/wrist_r.xml
@@ -9,8 +9,12 @@
   <msgDisplay l="ua">вдягнено на запʼясток</msgDisplay>
   <msgRoomNoRib>%1$^C1 пытается надеть %2$O4 на несуществующее запястье.</msgRoomNoRib>
   <msgRoomWear>%1$^C1 надевает %2$O4 вокруг правого запястья.</msgRoomWear>
-  <msgSelfNoRib>Ты не можешь надеть %2$O4 на несуществующее запястье.</msgSelfNoRib>
-  <msgSelfWear>Ты надеваешь %2$O4 вокруг правого запястья.</msgSelfWear>
+  <msgSelfNoRib l="en">You cannot wear %2$O4 on a nonexistent wrist.</msgSelfNoRib>
+  <msgSelfNoRib l="ru">Ты не можешь надеть %2$O4 на несуществующее запястье.</msgSelfNoRib>
+  <msgSelfNoRib l="ua">Ти не можеш вдягти %2$O4 на неіснуюче запʼястя.</msgSelfNoRib>
+  <msgSelfWear l="en">You wear %2$O4 around your right wrist.</msgSelfWear>
+  <msgSelfWear l="ru">Ты надеваешь %2$O4 вокруг правого запястья.</msgSelfWear>
+  <msgSelfWear l="ua">Ти вдягаєш %2$O4 навколо правого запʼястя.</msgSelfWear>
   <needRib>true</needRib>
   <orderDisplay>12</orderDisplay>
   <orderWear>18</orderWear>


### PR DESCRIPTION
Adds UA+EN to all 12 ByLevel profession title ladders (maleUa/femaleUa/maleEn/femaleEn per node; RU untouched, immortal titles stay EN via fallback) + druid's constant title, and makes wearloc/craft-tattoo self-messages (msgSelfWear/msgSelfNoRib) trilingual l=ru/ua/en. EN from Anatolia's original title tables where the classic ladder survived, translated from RU where Dreamland diverged. Rides the titles-keystone reboot (dreamland_code #634/#635/#636, drone green). 45 files, RU content byte-preserved.