### PR TITLE
Affect-panel web labels: webColumn + trilingual webLabel on 99 skills

### DIFF
--- a/clan-skills/bandage.xml
+++ b/clan-skills/bandage.xml
@@ -45,4 +45,8 @@
   <name l="en">bandage</name>
   <name l="ru">повязка</name>
   <name l="ua">пов'язка</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Bandag</webLabel>
+  <webLabel l="ru">Повязк</webLabel>
+  <webLabel l="ua">Повʼязк</webLabel>
 </skill>

--- a/clan-skills/bloodthirst.xml
+++ b/clan-skills/bloodthirst.xml
@@ -53,4 +53,8 @@ Some creatures in the world possess innate bloodthirstiness. Unlike ordinary agg
   <name l="en">bloodthirst</name>
   <name l="ru">жажда крови</name>
   <name l="ua">жажда крові</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">BldLst</webLabel>
+  <webLabel l="ru">ЖажКрв</webLabel>
+  <webLabel l="ua">КровСпр</webLabel>
 </skill>

--- a/clan-skills/confuse.xml
+++ b/clan-skills/confuse.xml
@@ -44,4 +44,8 @@ The one on whom this spell is cast completely loses the ability to orient, and t
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Confus</webLabel>
+  <webLabel l="ru">Конфуз</webLabel>
+  <webLabel l="ua">Плутан</webLabel>
 </skill>

--- a/clan-skills/detect trap.xml
+++ b/clan-skills/detect trap.xml
@@ -47,4 +47,8 @@ The spell also warns of any active trap in a neighbouring room: a set trap, a hi
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">DetTrp</webLabel>
+  <webLabel l="ru">ОбнЛов</webLabel>
+  <webLabel l="ua">ВиявПст</webLabel>
 </skill>

--- a/clan-skills/disgrace.xml
+++ b/clan-skills/disgrace.xml
@@ -43,4 +43,8 @@ A spell that turns a player into something that even the ugliest troll would loo
     <target>char_room</target>
     <type>offensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Disgr</webLabel>
+  <webLabel l="ru">Компро</webLabel>
+  <webLabel l="ua">Ганьба</webLabel>
 </skill>

--- a/clan-skills/dismiss.xml
+++ b/clan-skills/dismiss.xml
@@ -58,4 +58,8 @@ A dismissed Ruler cannot do much. The command considers the clan level of the di
   <name l="en">dismiss</name>
   <name l="ru">отстранение</name>
   <name l="ua">відсторонення</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Dismis</webLabel>
+  <webLabel l="ru">НеРули</webLabel>
+  <webLabel l="ua">НеПрав</webLabel>
 </skill>

--- a/clan-skills/doppelganger.xml
+++ b/clan-skills/doppelganger.xml
@@ -41,4 +41,8 @@
     <target>char_room</target>
     <type>none</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Doppel</webLabel>
+  <webLabel l="ru">Доппел</webLabel>
+  <webLabel l="ua">Двійник</webLabel>
 </skill>

--- a/clan-skills/evolve lion.xml
+++ b/clan-skills/evolve lion.xml
@@ -42,4 +42,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Lion</webLabel>
+  <webLabel l="ru">Лев</webLabel>
+  <webLabel l="ua">Лев</webLabel>
 </skill>

--- a/clan-skills/garble.xml
+++ b/clan-skills/garble.xml
@@ -43,4 +43,8 @@ Share a piece of Chaos with the enemy&apos;s tongue, causing it to trip over its
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Garble</webLabel>
+  <webLabel l="ru">Гарбл</webLabel>
+  <webLabel l="ua">Ґарбл</webLabel>
 </skill>

--- a/clan-skills/golden aura.xml
+++ b/clan-skills/golden aura.xml
@@ -38,4 +38,8 @@
     <target>people</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">GldAur</webLabel>
+  <webLabel l="ru">ЗолАур</webLabel>
+  <webLabel l="ua">ЗолОреол</webLabel>
 </skill>

--- a/clan-skills/holy armor.xml
+++ b/clan-skills/holy armor.xml
@@ -50,4 +50,8 @@ This spell enhances the {hh83protection class{x of the character, increases the 
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">HlyArm</webLabel>
+  <webLabel l="ru">СвщБрн</webLabel>
+  <webLabel l="ua">СвятБрон</webLabel>
 </skill>

--- a/clan-skills/jail.xml
+++ b/clan-skills/jail.xml
@@ -59,4 +59,8 @@ A set imprisonment duration is assigned to the specified player. After serving t
   <name l="en">jail</name>
   <name l="ru">тюрьма</name>
   <name l="ua">в&apos;язниця</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Jail</webLabel>
+  <webLabel l="ru">Тюрьма</webLabel>
+  <webLabel l="ua">Тюрма</webLabel>
 </skill>

--- a/clan-skills/manacles.xml
+++ b/clan-skills/manacles.xml
@@ -62,4 +62,8 @@ A criminal manacled is subject only to the order order &lt;target&gt; follow &lt
   <name l="en">manacles</name>
   <name l="ru">кандалы</name>
   <name l="ua">кайдани</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Manacl</webLabel>
+  <webLabel l="ru">Наруч</webLabel>
+  <webLabel l="ua">Кайдани</webLabel>
 </skill>

--- a/clan-skills/mirror.xml
+++ b/clan-skills/mirror.xml
@@ -46,4 +46,8 @@ Create mirror images next to you or another character. These mirrors confuse the
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Mirror</webLabel>
+  <webLabel l="ru">Зеркал</webLabel>
+  <webLabel l="ua">Дзеркал</webLabel>
 </skill>

--- a/clan-skills/prevent.xml
+++ b/clan-skills/prevent.xml
@@ -42,4 +42,8 @@
     <target>char_self room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Prevnt</webLabel>
+  <webLabel l="ru">Предот</webLabel>
+  <webLabel l="ua">Запоб</webLabel>
 </skill>

--- a/clan-skills/randomizer.xml
+++ b/clan-skills/randomizer.xml
@@ -51,4 +51,8 @@ The tentacles created by the chaotic can confuse all roads and exits from this a
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Random</webLabel>
+  <webLabel l="ru">Рандом</webLabel>
+  <webLabel l="ua">Рандом</webLabel>
 </skill>

--- a/clan-skills/resistance.xml
+++ b/clan-skills/resistance.xml
@@ -53,4 +53,8 @@ Does not protect against magical attacks -- except for {hh907mental attack{x Sha
   <name l="en">resistance</name>
   <name l="ru">сопротивляемость</name>
   <name l="ua">опір</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Resist</webLabel>
+  <webLabel l="ru">Сопрот</webLabel>
+  <webLabel l="ua">Опір</webLabel>
 </skill>

--- a/clan-skills/ruler aura.xml
+++ b/clan-skills/ruler aura.xml
@@ -41,4 +41,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">RulAur</webLabel>
+  <webLabel l="ru">АураПр</webLabel>
+  <webLabel l="ua">АурПрав</webLabel>
 </skill>

--- a/clan-skills/shadow shroud.xml
+++ b/clan-skills/shadow shroud.xml
@@ -28,4 +28,8 @@
       <name>killers</name>
     </node>
   </organizations>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Shroud</webLabel>
+  <webLabel l="ru">Плащ</webLabel>
+  <webLabel l="ua">Плащ</webLabel>
 </skill>

--- a/clan-skills/soul lust.xml
+++ b/clan-skills/soul lust.xml
@@ -28,4 +28,8 @@
       <name>adepts</name>
     </node>
   </organizations>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Shroud</webLabel>
+  <webLabel l="ru">Плащ</webLabel>
+  <webLabel l="ua">Плащ</webLabel>
 </skill>

--- a/clan-skills/spellbane.xml
+++ b/clan-skills/spellbane.xml
@@ -59,4 +59,8 @@ Offensive spells targeting the victim whom the clan member is fighting will also
   <name l="en">spellbane</name>
   <name l="ru">отражение магии</name>
   <name l="ua">відображення магії</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">SpBane</webLabel>
+  <webLabel l="ru">Спелба</webLabel>
+  <webLabel l="ua">ЧарЗгуб</webLabel>
 </skill>

--- a/clan-skills/suspect.xml
+++ b/clan-skills/suspect.xml
@@ -59,4 +59,8 @@ A summons is sent to the player, during the validity of which they cannot leave 
   <name l="en">suspect</name>
   <name l="ru">повестка</name>
   <name l="ua">повістка</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Suspct</webLabel>
+  <webLabel l="ru">Повест</webLabel>
+  <webLabel l="ua">Підозр</webLabel>
 </skill>

--- a/clan-skills/transform.xml
+++ b/clan-skills/transform.xml
@@ -30,4 +30,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Xform</webLabel>
+  <webLabel l="ru">Трансф</webLabel>
+  <webLabel l="ua">Транс</webLabel>
 </skill>

--- a/clan-skills/trophy.xml
+++ b/clan-skills/trophy.xml
@@ -50,4 +50,8 @@ Warriors of the Clan of Rage know how to cut off any {hh62body part{x from the c
   <name l="en">trophy</name>
   <name l="ru">трофей</name>
   <name l="ua">трофей</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Trophy</webLabel>
+  <webLabel l="ru">Трофей</webLabel>
+  <webLabel l="ua">Трофей</webLabel>
 </skill>

--- a/clan-skills/truesight.xml
+++ b/clan-skills/truesight.xml
@@ -40,4 +40,8 @@
   <name l="en">truesight</name>
   <name l="ru">истинное зрение</name>
   <name l="ua">істинне зір</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">TruSgt</webLabel>
+  <webLabel l="ru">Зрение</webLabel>
+  <webLabel l="ua">ІстЗір</webLabel>
 </skill>

--- a/config/affectpanel.json
+++ b/config/affectpanel.json
@@ -1,0 +1,50 @@
+{
+    "det": {
+        "infrared":    { "en": "Infra",  "ru": "Инфра",  "ua": "Інфра" },
+        "hidden":      { "en": "Hidden", "ru": "Скрыт",  "ua": "Схован" },
+        "invis":       { "en": "Invis",  "ru": "Невид",  "ua": "Невид" },
+        "imp_invis":   { "en": "ImpInv", "ru": "ОНевид", "ua": "ПокНев" },
+        "fade":        { "en": "Fade",   "ru": "Спрят",  "ua": "Схов" },
+        "acute":       { "en": "Acute",  "ru": "Камуф",  "ua": "Гострий" },
+        "evil":        { "en": "Evil",   "ru": "Зло",    "ua": "Зло" },
+        "good":        { "en": "Good",   "ru": "Добро",  "ua": "Добро" },
+        "undead":      { "en": "Undead", "ru": "Нежить", "ua": "Нежить" },
+        "magic":       { "en": "Magic",  "ru": "Магия",  "ua": "Магія" },
+        "observation": { "en": "Observ", "ru": "Диагн",  "ua": "Спостер" },
+        "life":        { "en": "Life",   "ru": "Жизнь",  "ua": "Життя" }
+    },
+    "trv": {
+        "invisible":  { "en": "Invis",  "ru": "Невид",  "ua": "Невид" },
+        "imp_invis":  { "en": "ImpInv", "ru": "УНевд",  "ua": "ПокНев" },
+        "hide":       { "en": "Hide",   "ru": "Скрыт",  "ua": "Схов" },
+        "sneak":      { "en": "Sneak",  "ru": "Подкр",  "ua": "Крадьк" },
+        "flying":     { "en": "Fly",    "ru": "Полет",  "ua": "Політ" },
+        "pass_door":  { "en": "PassDr", "ru": "Прозр",  "ua": "КрізьД" },
+        "fade":       { "en": "Fade",   "ru": "Спрят",  "ua": "Мляв" },
+        "camouflage": { "en": "Camo",   "ru": "Камуфл", "ua": "Камуфл" }
+    },
+    "pro": {
+        "sanctuary":    { "en": "Sanct",  "ru": "ЗащСвя", "ua": "Свят" },
+        "protect_evil": { "en": "vsEvil", "ru": "Зло",    "ua": "вЗла" },
+        "protect_good": { "en": "vsGood", "ru": "Добро",  "ua": "вДобра" }
+    },
+    "enh": {
+        "regeneration": { "en": "Regen", "ru": "Реген", "ua": "Реген" },
+        "haste":        { "en": "Haste", "ru": "Ускор", "ua": "Приск" }
+    },
+    "mal": {
+        "blind":       { "en": "Blind",   "ru": "Слеп",   "ua": "Сліп" },
+        "poison":      { "en": "Poison",  "ru": "Яд",     "ua": "Отрута" },
+        "plague":      { "en": "Plague",  "ru": "Чума",   "ua": "Чума" },
+        "corruption":  { "en": "Corrupt", "ru": "Гниени", "ua": "Гниль" },
+        "faerie_fire": { "en": "FaeFire", "ru": "ОгФей",  "ua": "ФейВог" },
+        "charm":       { "en": "Charm",   "ru": "Очаров", "ua": "Чари" },
+        "curse":       { "en": "Curse",   "ru": "Прокл",  "ua": "Прокл" },
+        "weaken":      { "en": "Weaken",  "ru": "Слабо",  "ua": "Слабк" },
+        "slow":        { "en": "Slow",    "ru": "Замедл", "ua": "Уповіл" },
+        "scream":      { "en": "Scream",  "ru": "Крик",   "ua": "Крик" },
+        "sleep":       { "en": "Sleep",   "ru": "Сон",    "ua": "Сон" },
+        "bloodthirst": { "en": "BldLst",  "ru": "ЖажКрв", "ua": "КровСпр" },
+        "stun":        { "en": "Stun",    "ru": "Оглуш",  "ua": "Оглуш" }
+    }
+}

--- a/generic-skills/acute vision.xml
+++ b/generic-skills/acute vision.xml
@@ -52,4 +52,8 @@ This spell allows rangers to notice camouflage against the backdrop of leaves, e
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Acute</webLabel>
+  <webLabel l="ru">Камуф</webLabel>
+  <webLabel l="ua">Гострий</webLabel>
 </skill>

--- a/generic-skills/anathema.xml
+++ b/generic-skills/anathema.xml
@@ -49,4 +49,8 @@ Sends a powerful divine curse on the opponent. When {hh2035saving throw{x fails,
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Anath</webLabel>
+  <webLabel l="ru">Анафем</webLabel>
+  <webLabel l="ua">Анафема</webLabel>
 </skill>

--- a/generic-skills/armor.xml
+++ b/generic-skills/armor.xml
@@ -83,4 +83,8 @@ This spell decreases (improves) the {hh83defense class{x of the character and sl
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Armor</webLabel>
+  <webLabel l="ru">Броня</webLabel>
+  <webLabel l="ua">Броня</webLabel>
 </skill>

--- a/generic-skills/bark skin.xml
+++ b/generic-skills/bark skin.xml
@@ -48,4 +48,8 @@ This spell covers your skin with tough tree bark, which reduces (enhances) the c
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">BarkSk</webLabel>
+  <webLabel l="ru">ДревКж</webLabel>
+  <webLabel l="ua">КораШк</webLabel>
 </skill>

--- a/generic-skills/bat swarm.xml
+++ b/generic-skills/bat swarm.xml
@@ -90,4 +90,8 @@ It should also be noted that the bat cloud cannot be confused by {hh933a living 
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Bats</webLabel>
+  <webLabel l="ru">ЛМыш</webLabel>
+  <webLabel l="ua">Кажани</webLabel>
 </skill>

--- a/generic-skills/benediction.xml
+++ b/generic-skills/benediction.xml
@@ -55,4 +55,8 @@ This powerful prayer enhances the {hh47accuracy{x, {hh2035spell resistance{x and
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Bened</webLabel>
+  <webLabel l="ru">Блгсть</webLabel>
+  <webLabel l="ua">Благосл</webLabel>
 </skill>

--- a/generic-skills/berserk.xml
+++ b/generic-skills/berserk.xml
@@ -75,4 +75,8 @@ Berserk rage does not work simultaneously with the prayer of {hh619fury{x.
   <name l="ru">берсерк</name>
   <name l="ua">берсерк</name>
   <raceBonuses registry="race">dwarf urukhai duergar</raceBonuses>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Bersrk</webLabel>
+  <webLabel l="ru">Берсрк</webLabel>
+  <webLabel l="ua">Берсерк</webLabel>
 </skill>

--- a/generic-skills/black feeble.xml
+++ b/generic-skills/black feeble.xml
@@ -42,4 +42,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Feeble</webLabel>
+  <webLabel l="ru">Немощь</webLabel>
+  <webLabel l="ua">Неміч</webLabel>
 </skill>

--- a/generic-skills/bless.xml
+++ b/generic-skills/bless.xml
@@ -75,4 +75,8 @@ The prayer can also be used to temporarily bless items, imbuing them with a sacr
     <target>char_room obj_inv obj_equip obj_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Bless</webLabel>
+  <webLabel l="ru">Благос</webLabel>
+  <webLabel l="ua">Благо</webLabel>
 </skill>

--- a/generic-skills/blindness.xml
+++ b/generic-skills/blindness.xml
@@ -85,4 +85,8 @@ Blindness can also be caused by the effects of some other skills: for example, a
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Blind</webLabel>
+  <webLabel l="ru">Слеп</webLabel>
+  <webLabel l="ua">Сліп</webLabel>
 </skill>

--- a/generic-skills/bonedagger.xml
+++ b/generic-skills/bonedagger.xml
@@ -56,4 +56,8 @@ Find out whose shadow we're stalking.
   <name l="en">bonedagger</name>
   <name l="ru">костяной нож</name>
   <name l="ua">кістяний ніж</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">BoneDg</webLabel>
+  <webLabel l="ru">КНож</webLabel>
+  <webLabel l="ua">КістКин</webLabel>
 </skill>

--- a/generic-skills/calm.xml
+++ b/generic-skills/calm.xml
@@ -64,4 +64,8 @@ Under calmness, one cannot gain the effect of {hh829berserk{x or the prayer {hh6
     <target>people</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Calm</webLabel>
+  <webLabel l="ru">Спокой</webLabel>
+  <webLabel l="ua">Спокій</webLabel>
 </skill>

--- a/generic-skills/caltraps.xml
+++ b/generic-skills/caltraps.xml
@@ -58,4 +58,8 @@ Success depends on the difference in {hh37agility{x between the attacker and the
   <name l="en">caltraps</name>
   <name l="ru">шипы</name>
   <name l="ua">шипи</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Caltrp</webLabel>
+  <webLabel l="ru">Шипы</webLabel>
+  <webLabel l="ua">Шипи</webLabel>
 </skill>

--- a/generic-skills/charm person.xml
+++ b/generic-skills/charm person.xml
@@ -126,4 +126,8 @@ The number of charmies depends, first of all, on your {hh28class{x:
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Charm</webLabel>
+  <webLabel l="ru">Очаров</webLabel>
+  <webLabel l="ua">Чари</webLabel>
 </skill>

--- a/generic-skills/concentrate.xml
+++ b/generic-skills/concentrate.xml
@@ -62,4 +62,8 @@ Preparing for battle, thinking through military strategy will increase your chan
   <name l="en">concentrate</name>
   <name l="ru">сосредоточиться</name>
   <name l="ua">зосередитися</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Concen</webLabel>
+  <webLabel l="ru">Концен</webLabel>
+  <webLabel l="ua">Концен</webLabel>
 </skill>

--- a/generic-skills/corruption.xml
+++ b/generic-skills/corruption.xml
@@ -65,4 +65,8 @@ The rate of decay and damage depends on the victim's constitution. Some opponent
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Corrupt</webLabel>
+  <webLabel l="ru">Гниени</webLabel>
+  <webLabel l="ua">Гниль</webLabel>
 </skill>

--- a/generic-skills/curse.xml
+++ b/generic-skills/curse.xml
@@ -86,4 +86,8 @@ This spell can also be cast on objects, adding a sinister aura ({hh96flag{x &quo
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Curse</webLabel>
+  <webLabel l="ru">Прокл</webLabel>
+  <webLabel l="ua">Прокл</webLabel>
 </skill>

--- a/generic-skills/dark shroud.xml
+++ b/generic-skills/dark shroud.xml
@@ -61,4 +61,8 @@ The aura reduces incoming damage by 40% and protects vampires from sunlight. Mor
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">DkAura</webLabel>
+  <webLabel l="ru">ТАура</webLabel>
+  <webLabel l="ua">ТемАур</webLabel>
 </skill>

--- a/generic-skills/detect evil.xml
+++ b/generic-skills/detect evil.xml
@@ -64,4 +64,8 @@ This spell will allow you to detect the aura around characters of evil {hh33natu
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Evil</webLabel>
+  <webLabel l="ru">Зло</webLabel>
+  <webLabel l="ua">Зло</webLabel>
 </skill>

--- a/generic-skills/detect good.xml
+++ b/generic-skills/detect good.xml
@@ -80,4 +80,8 @@ It also allows detecting a {Cblue aura{x around {hh96blessed{x items.
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Good</webLabel>
+  <webLabel l="ru">Добро</webLabel>
+  <webLabel l="ua">Добро</webLabel>
 </skill>

--- a/generic-skills/detect invis.xml
+++ b/generic-skills/detect invis.xml
@@ -81,4 +81,8 @@ If you don&apos;t have this spell, try purchasing a =detection potion= in Midgaa
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Invis</webLabel>
+  <webLabel l="ru">Невид</webLabel>
+  <webLabel l="ua">Невид</webLabel>
 </skill>

--- a/generic-skills/detect magic.xml
+++ b/generic-skills/detect magic.xml
@@ -70,4 +70,8 @@ This spell will help detect items enhanced with magic, as well as magical portal
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Magic</webLabel>
+  <webLabel l="ru">Магия</webLabel>
+  <webLabel l="ua">Магія</webLabel>
 </skill>

--- a/generic-skills/detect undead.xml
+++ b/generic-skills/detect undead.xml
@@ -47,4 +47,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Undead</webLabel>
+  <webLabel l="ru">Нежить</webLabel>
+  <webLabel l="ua">Нежить</webLabel>
 </skill>

--- a/generic-skills/dragon skin.xml
+++ b/generic-skills/dragon skin.xml
@@ -59,4 +59,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">DrgSkn</webLabel>
+  <webLabel l="ru">КжДрак</webLabel>
+  <webLabel l="ua">ДракШк</webLabel>
 </skill>

--- a/generic-skills/endure.xml
+++ b/generic-skills/endure.xml
@@ -44,4 +44,8 @@ The technique of resisting magic and prayers, based on meditation and self-contr
   <name l="en">endure</name>
   <name l="ru">выносливость</name>
   <name l="ua">витривалість</name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Endure</webLabel>
+  <webLabel l="ru">Выносл</webLabel>
+  <webLabel l="ua">Витрив</webLabel>
 </skill>

--- a/generic-skills/enhanced armor.xml
+++ b/generic-skills/enhanced armor.xml
@@ -73,4 +73,8 @@ The force field can also occasionally deflect {hh810arrows{x, {hh218throwing{x o
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">EnhArm</webLabel>
+  <webLabel l="ru">УлБрон</webLabel>
+  <webLabel l="ua">ПокБрон</webLabel>
 </skill>

--- a/generic-skills/entangle.xml
+++ b/generic-skills/entangle.xml
@@ -68,4 +68,8 @@ Wraps the {hh652grave{x in thickets, disturbing those who lie in it and forcing 
     <tier>4</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Entngl</webLabel>
+  <webLabel l="ru">Терн</webLabel>
+  <webLabel l="ua">Тернет</webLabel>
 </skill>

--- a/generic-skills/faerie fire.xml
+++ b/generic-skills/faerie fire.xml
@@ -69,4 +69,8 @@ Additionally, under the pink aura, the victim cannot hide or become invisible us
     <tier>4</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">FaeFire</webLabel>
+  <webLabel l="ru">ОгФей</webLabel>
+  <webLabel l="ua">ФейВог</webLabel>
 </skill>

--- a/generic-skills/farsight.xml
+++ b/generic-skills/farsight.xml
@@ -68,4 +68,8 @@ The binoculars that {hh2127newcomers{x can acquire on the {hh1560Galeon{x operat
     <target>ignore</target>
     <type>none</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Observ</webLabel>
+  <webLabel l="ru">Диагн</webLabel>
+  <webLabel l="ua">Спостер</webLabel>
 </skill>

--- a/generic-skills/fly.xml
+++ b/generic-skills/fly.xml
@@ -94,4 +94,8 @@ If you have been enchanted with a flight spell, or your race allows you to fly, 
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Fly</webLabel>
+  <webLabel l="ru">Полет</webLabel>
+  <webLabel l="ua">Політ</webLabel>
 </skill>

--- a/generic-skills/frenzy.xml
+++ b/generic-skills/frenzy.xml
@@ -60,4 +60,8 @@ By awakening rage within you, this prayer makes you more dangerous. But you also
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Frenzy</webLabel>
+  <webLabel l="ru">Неист</webLabel>
+  <webLabel l="ua">Шал</webLabel>
 </skill>

--- a/generic-skills/giant strength.xml
+++ b/generic-skills/giant strength.xml
@@ -72,4 +72,8 @@ This spell also allows removing effects of {hh704weakening{x.</text>
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">GntStr</webLabel>
+  <webLabel l="ru">ГигСил</webLabel>
+  <webLabel l="ua">ВелСил</webLabel>
 </skill>

--- a/generic-skills/haste.xml
+++ b/generic-skills/haste.xml
@@ -69,4 +69,8 @@ Haste and {hh705slowness{x effects cancel each other out. For example, if you ca
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Haste</webLabel>
+  <webLabel l="ru">Ускор</webLabel>
+  <webLabel l="ua">Приск</webLabel>
 </skill>

--- a/generic-skills/hide.xml
+++ b/generic-skills/hide.xml
@@ -84,4 +84,8 @@ It is said that somewhere in {hh2065Aarakocran{x there exists one of the oldest 
   <name l="ru">укрыться</name>
   <name l="ua">сховатися</name>
   <raceBonuses registry="race">node</raceBonuses>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Hide</webLabel>
+  <webLabel l="ru">Скрыт</webLabel>
+  <webLabel l="ua">Схов</webLabel>
 </skill>

--- a/generic-skills/improved invis.xml
+++ b/generic-skills/improved invis.xml
@@ -52,4 +52,8 @@ Only experienced witches and warlocks can hide beneath the shroud of advanced in
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">ImpInv</webLabel>
+  <webLabel l="ru">УНевд</webLabel>
+  <webLabel l="ua">ПокНев</webLabel>
 </skill>

--- a/generic-skills/infravision.xml
+++ b/generic-skills/infravision.xml
@@ -71,4 +71,8 @@
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Infra</webLabel>
+  <webLabel l="ru">Инфра</webLabel>
+  <webLabel l="ua">Інфра</webLabel>
 </skill>

--- a/generic-skills/inspire.xml
+++ b/generic-skills/inspire.xml
@@ -41,4 +41,8 @@
     <target>people</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Inspir</webLabel>
+  <webLabel l="ru">Вдохн</webLabel>
+  <webLabel l="ua">Натхн</webLabel>
 </skill>

--- a/generic-skills/invisibility.xml
+++ b/generic-skills/invisibility.xml
@@ -75,4 +75,8 @@ Invisibility can also be temporarily cast on any items, except {hh96burning{x on
     <target>char_room obj_inv obj_equip obj_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Invis</webLabel>
+  <webLabel l="ru">Невид</webLabel>
+  <webLabel l="ua">Невид</webLabel>
 </skill>

--- a/generic-skills/learning.xml
+++ b/generic-skills/learning.xml
@@ -59,4 +59,8 @@ Under the influence of this spell, you will gain more experience by improving yo
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Learn</webLabel>
+  <webLabel l="ru">Обуч</webLabel>
+  <webLabel l="ua">Навч</webLabel>
 </skill>

--- a/generic-skills/liturgy.xml
+++ b/generic-skills/liturgy.xml
@@ -47,4 +47,8 @@ Unfortunately, the liturgy is a tiresome and exhausting task. One can only perfo
     <target>char_self</target>
     <type>none</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Litany</webLabel>
+  <webLabel l="ru">Молит</webLabel>
+  <webLabel l="ua">Літанія</webLabel>
 </skill>

--- a/generic-skills/magic concentrate.xml
+++ b/generic-skills/magic concentrate.xml
@@ -51,4 +51,8 @@ Magical concentration enhances only long-range magic.</text>
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">MagFoc</webLabel>
+  <webLabel l="ru">МагФок</webLabel>
+  <webLabel l="ua">МагФок</webLabel>
 </skill>

--- a/generic-skills/magic jar.xml
+++ b/generic-skills/magic jar.xml
@@ -47,4 +47,8 @@ Don't forget to carry an empty vessel (a test tube) to drive the soul into.</tex
     <target>char_room</target>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Jar</webLabel>
+  <webLabel l="ru">Сосуд</webLabel>
+  <webLabel l="ua">Глек</webLabel>
 </skill>

--- a/generic-skills/mental block.xml
+++ b/generic-skills/mental block.xml
@@ -59,4 +59,8 @@ Protects you from other characters attempting to enter {hh584mental contact{x wi
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">MntBlk</webLabel>
+  <webLabel l="ru">МБлок</webLabel>
+  <webLabel l="ua">МентБл</webLabel>
 </skill>

--- a/generic-skills/nerve.xml
+++ b/generic-skills/nerve.xml
@@ -51,4 +51,8 @@ Success depends on the ninja's {hh37dexterity{x, {hh36constitution{x, and the {h
   <name l="en">nerve</name>
   <name l="ru">нервы</name>
   <name l="ua">нерви</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Nerve</webLabel>
+  <webLabel l="ru">Нервы</webLabel>
+  <webLabel l="ua">Нерви</webLabel>
 </skill>

--- a/generic-skills/pass door.xml
+++ b/generic-skills/pass door.xml
@@ -65,4 +65,8 @@ Additionally, semi-transparency is a racial trait of cave elves, known as rockse
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">PassDr</webLabel>
+  <webLabel l="ru">Прозр</webLabel>
+  <webLabel l="ua">КрізьД</webLabel>
 </skill>

--- a/generic-skills/plague.xml
+++ b/generic-skills/plague.xml
@@ -83,4 +83,8 @@ A victim dead from the plague you cast will count towards you -- in {hh32PK{x or
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Plague</webLabel>
+  <webLabel l="ru">Чума</webLabel>
+  <webLabel l="ua">Чума</webLabel>
 </skill>

--- a/generic-skills/poison.xml
+++ b/generic-skills/poison.xml
@@ -90,4 +90,8 @@ You can also poison food, {hh1075containers{x for drinks, {hh1075fountains{x, an
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Poison</webLabel>
+  <webLabel l="ru">Яд</webLabel>
+  <webLabel l="ua">Отрута</webLabel>
 </skill>

--- a/generic-skills/protection cold.xml
+++ b/generic-skills/protection cold.xml
@@ -75,4 +75,8 @@ Protection from low temperatures can also be temporarily applied to objects. Thi
     <target>char_self obj_inv obj_equip</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">vsCold</webLabel>
+  <webLabel l="ru">Холод</webLabel>
+  <webLabel l="ua">вМороз</webLabel>
 </skill>

--- a/generic-skills/protection evil.xml
+++ b/generic-skills/protection evil.xml
@@ -62,4 +62,8 @@ This powerful aura reduces almost any damage from evil characters to you by a qu
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">vsEvil</webLabel>
+  <webLabel l="ru">Зло</webLabel>
+  <webLabel l="ua">вЗла</webLabel>
 </skill>

--- a/generic-skills/protection good.xml
+++ b/generic-skills/protection good.xml
@@ -72,4 +72,8 @@ This powerful aura reduces almost any damage from good characters to you by a qu
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">vsGood</webLabel>
+  <webLabel l="ru">Добро</webLabel>
+  <webLabel l="ua">вДобра</webLabel>
 </skill>

--- a/generic-skills/protection heat.xml
+++ b/generic-skills/protection heat.xml
@@ -81,4 +81,8 @@ Protection from high temperatures or =thermostability= can also be temporarily a
     <target>char_self obj_inv obj_equip</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">vsHeat</webLabel>
+  <webLabel l="ru">Жар</webLabel>
+  <webLabel l="ua">вЖар</webLabel>
 </skill>

--- a/generic-skills/protection negative.xml
+++ b/generic-skills/protection negative.xml
@@ -44,4 +44,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">vsNeg</webLabel>
+  <webLabel l="ru">Негат</webLabel>
+  <webLabel l="ua">вТлін</webLabel>
 </skill>

--- a/generic-skills/protective shield.xml
+++ b/generic-skills/protective shield.xml
@@ -62,4 +62,8 @@ A protective shield that guards the caster against immobilizing skills such as {
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Shield</webLabel>
+  <webLabel l="ru">ЗащЩит</webLabel>
+  <webLabel l="ua">ЗахЩит</webLabel>
 </skill>

--- a/generic-skills/sanctuary.xml
+++ b/generic-skills/sanctuary.xml
@@ -58,4 +58,8 @@ The counterparts of this prayer are {hh760star dust{x and {hh571dark aura{x spel
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Sanct</webLabel>
+  <webLabel l="ru">ЗащСвя</webLabel>
+  <webLabel l="ua">Свят</webLabel>
 </skill>

--- a/generic-skills/scream.xml
+++ b/generic-skills/scream.xml
@@ -46,4 +46,8 @@ The scream spell is one of the mightiest tools in the self-defense arsenal of wa
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Scream</webLabel>
+  <webLabel l="ru">Крик</webLabel>
+  <webLabel l="ua">Крик</webLabel>
 </skill>

--- a/generic-skills/sense life.xml
+++ b/generic-skills/sense life.xml
@@ -54,4 +54,8 @@ Vampires and druids have the ability to sense the presence of life forms even in
   <name l="en">sense life</name>
   <name l="ru">чувствовать жизнь</name>
   <name l="ua">відчувати життя</name>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Life</webLabel>
+  <webLabel l="ru">Жизнь</webLabel>
+  <webLabel l="ua">Життя</webLabel>
 </skill>

--- a/generic-skills/shield.xml
+++ b/generic-skills/shield.xml
@@ -77,4 +77,8 @@ This spell enhances the character's {hh83defense class{x by surrounding them wit
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Shld</webLabel>
+  <webLabel l="ru">Щит</webLabel>
+  <webLabel l="ua">Щит</webLabel>
 </skill>

--- a/generic-skills/slice.xml
+++ b/generic-skills/slice.xml
@@ -66,4 +66,8 @@ Experienced clerics or druids can regrow a severed part through the prayer of {h
   <name l="en">slice</name>
   <name l="ru">отсекание части тела</name>
   <name l="ua">відсікання частини тіла</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Slice</webLabel>
+  <webLabel l="ru">НетРук</webLabel>
+  <webLabel l="ua">БезРук</webLabel>
 </skill>

--- a/generic-skills/slow.xml
+++ b/generic-skills/slow.xml
@@ -84,4 +84,8 @@ The {hh739speed{x and slow effects cancel each other out. For instance, if you c
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Slow</webLabel>
+  <webLabel l="ru">Замедл</webLabel>
+  <webLabel l="ua">Уповіл</webLabel>
 </skill>

--- a/generic-skills/sneak.xml
+++ b/generic-skills/sneak.xml
@@ -83,4 +83,8 @@ With this ability, you can move while being {hh798hidden{Sm}{Sf}{Sx{x or {hh893c
   <name l="ru">подкрадывание</name>
   <name l="ua">підкрадання</name>
   <raceBonuses registry="race">felar rockseer dark-elf hobbit kender elf</raceBonuses>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Sneak</webLabel>
+  <webLabel l="ru">Подкр</webLabel>
+  <webLabel l="ua">Крадьк</webLabel>
 </skill>

--- a/generic-skills/spell resistance.xml
+++ b/generic-skills/spell resistance.xml
@@ -54,4 +54,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">SpRes</webLabel>
+  <webLabel l="ru">Заклин</webLabel>
+  <webLabel l="ua">ЧарОпр</webLabel>
 </skill>

--- a/generic-skills/stardust.xml
+++ b/generic-skills/stardust.xml
@@ -46,4 +46,8 @@
     <target>char_room</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Stars</webLabel>
+  <webLabel l="ru">Звезд</webLabel>
+  <webLabel l="ua">Зорі</webLabel>
 </skill>

--- a/generic-skills/stone skin.xml
+++ b/generic-skills/stone skin.xml
@@ -69,4 +69,8 @@ This spell covers your skin with a stone crust that reduces (improves) {hh83defe
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">StnSkn</webLabel>
+  <webLabel l="ru">КамКж</webLabel>
+  <webLabel l="ua">КамШк</webLabel>
 </skill>

--- a/generic-skills/tiger power.xml
+++ b/generic-skills/tiger power.xml
@@ -42,4 +42,8 @@ Calls upon the power of ten tigers, making the ranger more accurate and deadly, 
   <name l="en">tiger power</name>
   <name l="ru">тигриная мощь</name>
   <name l="ua">тигряча міць</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Tiger</webLabel>
+  <webLabel l="ru">Тигр</webLabel>
+  <webLabel l="ua">Тигр</webLabel>
 </skill>

--- a/generic-skills/vampire.xml
+++ b/generic-skills/vampire.xml
@@ -78,4 +78,8 @@ Revert to ordinary appearance. The form can be switched at will.
   <name l="en">vampire</name>
   <name l="ru">вампиризм</name>
   <name l="ua">вампіризм</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Vamp</webLabel>
+  <webLabel l="ru">Вампир</webLabel>
+  <webLabel l="ua">Вампір</webLabel>
 </skill>

--- a/generic-skills/vampiric bite.xml
+++ b/generic-skills/vampiric bite.xml
@@ -67,4 +67,8 @@ The bite restores the vampire's health and mana. Vampire bite wounds can fester 
   <name l="en">vampiric bite</name>
   <name l="ru">укус вампира</name>
   <name l="ua">укус вампіра</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Bite</webLabel>
+  <webLabel l="ru">Укус</webLabel>
+  <webLabel l="ua">Укус</webLabel>
 </skill>

--- a/generic-skills/warcry.xml
+++ b/generic-skills/warcry.xml
@@ -68,4 +68,8 @@ If you want everyone in the same area to hear your formidable warcry, buy a rest
   <name l="en">warcry</name>
   <name l="ru">боевой клич</name>
   <name l="ua">бойовий клич</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">WarCry</webLabel>
+  <webLabel l="ru">Клич</webLabel>
+  <webLabel l="ua">Клич</webLabel>
 </skill>

--- a/generic-skills/weaken.xml
+++ b/generic-skills/weaken.xml
@@ -73,4 +73,8 @@ This insidious curse reduces the strength of the victim.</text>
     <tier>3</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Weaken</webLabel>
+  <webLabel l="ru">Слабо</webLabel>
+  <webLabel l="ua">Слабк</webLabel>
 </skill>

--- a/generic-skills/web.xml
+++ b/generic-skills/web.xml
@@ -61,4 +61,8 @@ This spell envelops the opponent in a thick web, restricting their movements. A 
     <tier>2</tier>
     <type>offensive</type>
   </spell>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Web</webLabel>
+  <webLabel l="ru">Паут</webLabel>
+  <webLabel l="ua">Павут</webLabel>
 </skill>

--- a/other-skills/demonic mantle.xml
+++ b/other-skills/demonic mantle.xml
@@ -9,4 +9,8 @@
   <name l="en">demonic mantle</name>
   <name l="ru">демоническая мантия</name>
   <name l="ua"></name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Mantle</webLabel>
+  <webLabel l="ru">Мантия</webLabel>
+  <webLabel l="ua">Мантія</webLabel>
 </skill>

--- a/other-skills/detect hidden.xml
+++ b/other-skills/detect hidden.xml
@@ -22,4 +22,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Hidden</webLabel>
+  <webLabel l="ru">Скрыт</webLabel>
+  <webLabel l="ua">Схован</webLabel>
 </skill>

--- a/other-skills/rainbow shield.xml
+++ b/other-skills/rainbow shield.xml
@@ -9,4 +9,8 @@
   <name l="en">rainbow shield</name>
   <name l="ru">радужный щит</name>
   <name l="ua"></name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Rnbw</webLabel>
+  <webLabel l="ru">Радуга</webLabel>
+  <webLabel l="ua">Райдуга</webLabel>
 </skill>

--- a/other-skills/sebat.xml
+++ b/other-skills/sebat.xml
@@ -19,4 +19,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Sebat</webLabel>
+  <webLabel l="ru">Себат</webLabel>
+  <webLabel l="ua">Себат</webLabel>
 </skill>

--- a/race-aptitudes/meld into stone.xml
+++ b/race-aptitudes/meld into stone.xml
@@ -38,4 +38,8 @@
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">Meld</webLabel>
+  <webLabel l="ru">СКамн</webLabel>
+  <webLabel l="ua">ЗлитКам</webLabel>
 </skill>

--- a/scripts/lint-affect-labels.py
+++ b/scripts/lint-affect-labels.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Lint the web-client affect-panel curation.
+
+The panel (plug-ins/web/impl.cpp AffectsWebPromptListener) shows every active affect,
+picking its column + short label from the skill profile fields <webColumn>/<webLabel>.
+A skill that applies a lasting affect but has no <webColumn> still shows -- auto-classified
+(offensive -> mal, else -> enh) and labelled from its own <name> -- so nothing is silently
+missing, but it lands in a guessed column with an un-abbreviated label.
+
+This script lists those skills so the gap is a visible TODO, not a silent omission.
+Run from the dreamland_world repo root:  python3 scripts/lint-affect-labels.py
+"""
+import os, re, sys
+
+DIRS = ["generic-skills", "clan-skills", "other-skills", "race-aptitudes", "card-skills"]
+VALID = {"pro", "det", "trv", "enh", "mal", "cln", "none"}
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+col_re = re.compile(r"<webColumn>([^<]*)</webColumn>")
+name_re = re.compile(r'<name l="en">([^<]*)</name>')
+
+uncurated, bad_col, curated = [], [], 0
+
+for d in DIRS:
+    dp = os.path.join(root, d)
+    if not os.path.isdir(dp):
+        continue
+    for fn in sorted(os.listdir(dp)):
+        if not fn.endswith(".xml"):
+            continue
+        p = os.path.join(dp, fn)
+        txt = open(p, encoding="utf-8", errors="replace").read()
+        # Only skills that apply a lasting affect are panel-relevant.
+        if "<affect type=" not in txt:
+            continue
+        rel = os.path.join(d, fn)
+        m = col_re.search(txt)
+        if not m:
+            names = name_re.findall(txt)
+            uncurated.append((rel, names[-1] if names else "?"))
+            continue
+        curated += 1
+        col = m.group(1).strip()
+        if col not in VALID:
+            bad_col.append((rel, col))
+
+print("Affect-panel curation lint")
+print("  curated skills (have <webColumn>): %d" % curated)
+print("  uncurated affect skills (auto-classified): %d" % len(uncurated))
+
+if bad_col:
+    print("\nINVALID <webColumn> values (must be pro/det/trv/enh/mal/cln/none):")
+    for rel, col in bad_col:
+        print("  %-45s %r" % (rel, col))
+
+if uncurated:
+    print("\nUncurated affect skills -- add <webColumn>+<webLabel> for a proper column/label:")
+    for rel, en in uncurated:
+        print("  %-45s (%s)" % (rel, en))
+
+# Non-zero exit only on hard errors (invalid column); uncurated is advisory.
+sys.exit(1 if bad_col else 0)


### PR DESCRIPTION
Data half of the data-driven affect panel (pairs with dreamland_code + mudjs).

- `<webColumn>` + `<webLabel l=en/ru/ua>` on the 99 affect-source skills the panel shows, so each lands in its column (pro/det/trv/enh/mal/cln) with a terse per-language label.
- `config/affectpanel.json`: trilingual labels for raw engine bits (detect column + equipment/racial AFF fallbacks) that have no owning skill.
- `scripts/lint-affect-labels.py`: lists affect skills without curation (163 currently auto-classify from their name -- advisory, not errors).

Reboot-gated (needs the dreamland_code engine change live); the store reloads via `plug reload most`.