### PR TITLE
oscore: hint -> 'classic detailed layout'

### DIFF
--- a/commands/oscore.xml
+++ b/commands/oscore.xml
@@ -4,9 +4,9 @@
   <extra>keep_hide ghost manacles afk</extra>
   <help id="5011" level="-1" refby="score" type="CommandHelp">
   </help>
-  <hint l="en">see your parameters (old format)</hint>
-  <hint l="ru">увидеть свои параметры (старый формат)</hint>
-  <hint l="ua">побачити свої параметри (старий формат)</hint>
+  <hint l="en">see your parameters (classic detailed layout)</hint>
+  <hint l="ru">увидеть свои параметры (классический подробный вид)</hint>
+  <hint l="ua">побачити свої параметри (класичний детальний вигляд)</hint>
   <name l="en">oscore</name>
   <name l="ru">ссчет</name>
   <name l="ua">срахунок</name>


### PR DESCRIPTION
Phase 2 of the score revamp (Trello 2584), config side.

`oscore` now renders the classic framed ASCII score (see dreamland_code #640). Update the trilingual `<hint>` from "(old format)" to "(classic detailed layout)" so it reads as the deliberate detailed alternative to the new accessible `score` panel.

Reboot-gated with the rest of the batch.