### PR TITLE
help: document corrosion flag letter in objflag legend (EN/RU/UA)

### DIFF
--- a/helps/help.xml
+++ b/helps/help.xml
@@ -3566,14 +3566,15 @@ Objects, mobs, or rooms in the house can be given unique behaviour -- for exampl
     <text l="en">%FMT% {y{hcconfig objflag yes{hx{x.
 
 A compact display of flags on objects.
-%PAUSE%[{DI{RN{CB{wM{MG{cV{x]%RESUME%
+%PAUSE%[{DI{RN{CB{wM{MG{cV{yC{x]%RESUME%
 
 {DI{x  ({DInvisible{x)
 {RN{x  ({RRed aura{x)
 {CB{x  ({CBlue aura{x)
 {wM{x  (Magic)
 {MG{x  ({MGlowing{x)
-{cV{x  ({cVibratingx)
+{cV{x  ({cVibrating{x)
+{yC{x  ({yCorrosion{x)
 
 If a flag is absent, a dot is drawn in its place.
 
@@ -3582,7 +3583,7 @@ For the meaning of these and other object flags, read {hh96help flags{x.
     <text l="ru">%FMT% {y{hcconfig objflag yes{hx{x.
 
 Краткое отображение флагов на предметах. 
-%PAUSE%[{DН{RЗ{CБ{wМ{MП{cВ{x]%RESUME%
+%PAUSE%[{DН{RЗ{CБ{wМ{MП{cВ{yК{x]%RESUME%
 
 {DН{x  ({DНевидимо{x)
 {RЗ{x  ({RКрасная аура{x) 
@@ -3590,6 +3591,7 @@ For the meaning of these and other object flags, read {hh96help flags{x.
 {wМ{x  (Магическое)
 {MП{x  ({MПылает{x)
 {cВ{x  ({cВибрирует{x)
+{yК{x  ({yКоррозия{x)
 
 Если флаг отсутствует, на его месте рисуется точка.
 
@@ -3598,7 +3600,7 @@ For the meaning of these and other object flags, read {hh96help flags{x.
     <text l="ua">%FMT% {y{hcconfig objflag yes{hx{x.
 
 Короткий показ прапорів на предметах.
-%PAUSE%[{DН{RЗ{CБ{wМ{MП{cВ{x]%RESUME%
+%PAUSE%[{DН{RЗ{CБ{wМ{MП{cВ{yК{x]%RESUME%
 
 {DН{x  ({DНевидимо{x)
 {RЗ{x  ({RЧервона аура{x)
@@ -3606,6 +3608,7 @@ For the meaning of these and other object flags, read {hh96help flags{x.
 {wМ{x  (Магічне)
 {MП{x  ({MПалає{x)
 {cВ{x  ({cВібрує{x)
+{yК{x  ({yКорозія{x)
 
 Якщо прапор відсутній, на його місці малюється крапка.
 


### PR DESCRIPTION
Adds the corrosion marker (letter C/К, colour {y) to the compact object-flag legend (help 53) in all three languages, matching the new format_obj_to_char corrosion bit (code #642 / card 2094). Fixes a stray '(Vibratingx)' EN typo.