### PR TITLE
wearloc/sheath: trilingual belt/back slot labels

### DIFF
--- a/wearlocations/sheath.xml
+++ b/wearlocations/sheath.xml
@@ -13,7 +13,9 @@
       <msgSelfRemove>Ты выхватываешь %2$O4 из ножен.</msgSelfRemove>
     </node>
     <node name="belt">
-      <msgDisplay>за поясом</msgDisplay>
+      <msgDisplay l="en">at the belt</msgDisplay>
+      <msgDisplay l="ru">за поясом</msgDisplay>
+      <msgDisplay l="ua">за поясом</msgDisplay>
       <msgRoomWear>%1$^C1 затыка%1$nет|ют %2$O4 за пояс.</msgRoomWear>
       <msgSelfWear l="en">You tuck %2$O4 into your belt.</msgSelfWear>
       <msgSelfWear l="ru">Ты затыкаешь %2$O4 себе за пояс.</msgSelfWear>
@@ -22,7 +24,9 @@
       <msgSelfRemove>Ты выхватываешь %2$O4 из-за пояса.</msgSelfRemove>
     </node>
     <node name="back">
-      <msgDisplay>за спиной</msgDisplay>
+      <msgDisplay l="en">on the back</msgDisplay>
+      <msgDisplay l="ru">за спиной</msgDisplay>
+      <msgDisplay l="ua">за спиною</msgDisplay>
       <msgRoomWear>%1$^C1 веша%1$nет|ют за спину %2$O4.</msgRoomWear>
       <msgSelfWear l="en">You hang %2$O4 on your back.</msgSelfWear>
       <msgSelfWear l="ru">Ты вешаешь %2$O4 себе за спину.</msgSelfWear>


### PR DESCRIPTION
scabbard node was already l=en/ru/ua; belt/back were single-RU. With SheathConfig.msgDisplay now XMLMultiString (code #641), EN/UA viewers fell back to RU. Adds l=en/ru/ua to belt (at the belt / за поясом / за поясом) and back (on the back / за спиной / за спиною). Reboot-gated (wearloc XML loads at boot).