### PR TITLE
bell/ashes/feather EN/UA translations — trilinguality batch 2 (Trello 2594)

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -1,4 +1,74 @@
 {
+  "behaviors/ashes/onUse": {
+    "%1$^C1 посыпает {Dпеплом{x голову %2$C2.": {
+      "en": "%1$^C1 sprinkles {Dashes{x on %2$C2's head.",
+      "ua": "%1$^C1 посипає {Dпопелом{x голову %2$C2."
+    },
+    "%1$^C1 посыпает голову {Dпеплом{x.": {
+      "en": "%1$^C1 sprinkles {Dashes{x on their head.",
+      "ua": "%1$^C1 посипає голову {Dпопелом{x."
+    },
+    "%1$^C1 посыпает твою голову {Dпеплом{x.": {
+      "en": "%1$^C1 sprinkles {Dashes{x on your head.",
+      "ua": "%1$^C1 посипає твою голову {Dпопелом{x."
+    },
+    "Ты посыпаешь {Dпеплом{x голову %1$C2.": {
+      "en": "You sprinkle {Dashes{x on %1$C2's head.",
+      "ua": "Ти посипаєш {Dпопелом{x голову %1$C2."
+    },
+    "Ты посыпаешь голову {Dпеплом{x.": {
+      "en": "You sprinkle {Dashes{x on your head.",
+      "ua": "Ти посипаєш голову {Dпопелом{x."
+    }
+  },
+  "behaviors/bell/onUse": {
+    "%^C1 взмахивает %O5.": {
+      "en": "%^C1 rings %O5.",
+      "ua": "%^C1 дзвонить %O5."
+    },
+    "%^C1 пинает %O4.": {
+      "en": "%^C1 kicks %O4.",
+      "ua": "%^C1 копає %O4."
+    },
+    "До тебя доносится мелодичный звон чьего-то колокольчика: %s": {
+      "en": "You hear the melodic chime of someone's bell: %s",
+      "ua": "До тебе долинає мелодійний дзвін чийогось дзвіночка: %s"
+    },
+    "Ты взмахиваешь %O5.": {
+      "en": "You ring %O5.",
+      "ua": "Ти дзвониш %O5."
+    },
+    "Ты пинаешь %O4.": {
+      "en": "You kick %O4.",
+      "ua": "Ти копаєш %O4."
+    }
+  },
+  "behaviors/feather/onUse": {
+    "%^C1 щекочет %C4 %O5!": {
+      "en": "%^C1 tickles %C4 with %O5!",
+      "ua": "%^C1 лоскоче %C4 %O5!"
+    },
+    "%^C1 щекочет себя %O5!": {
+      "en": "%^C1 tickles themselves with %O5!",
+      "ua": "%^C1 лоскоче себе %O5!"
+    },
+    "%^C1 щекочет тебя %O5!": {
+      "en": "%^C1 tickles you with %O5!",
+      "ua": "%^C1 лоскоче тебе %O5!"
+    },
+    "Тут таких нет.": {
+      "en": "There's no one like that here.",
+      "ua": "Тут таких немає."
+    },
+    "Ты щекочешь %C4 %O5.": {
+      "en": "You tickle %C4 with %O5.",
+      "ua": "Ти лоскочеш %C4 %O5."
+    },
+    "Ты щекочешь себя %O5.": {
+      "en": "You tickle yourself with %O5.",
+      "ua": "Ти лоскочеш себе %O5."
+    }
+  },
   "behaviors/perfume/onUse": {
     "%1$^C1 пшика%1$nет|ют из %2$O2 на %3$C4.": {
       "en": "%1$^C1 spritz%1$nes| %2$O2 on %3$C4.",


### PR DESCRIPTION
16 catalog entries (companion to dreamland_fenia#203) -> 28 phrases across 4 behaviors. No gender/plural markers this batch; name/object placeholders preserved verbatim. Verified on localdev: catalog loads 28.