### PR TITLE
l10n: EN/UA catalog for needle postUse

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -255,6 +255,160 @@
       "ua": "Щоб пускати сонячні зайчики, вийди надвір сонячного дня."
     }
   },
+  "behaviors/needle/postUse": {
+    "Ты колешь %C4 %O5.": {
+      "en": "You prick %C4 with %O5.",
+      "ua": "Ти колеш %C4 %O5."
+    },
+    "%^C1 колет тебя %O5, ай!": {
+      "en": "%^C1 pricks you with %O5, ow!",
+      "ua": "%^C1 коле тебе %O5, ай!"
+    },
+    "%^C1 колет %C4 %O5.": {
+      "en": "%^C1 pricks %C4 with %O5.",
+      "ua": "%^C1 коле %C4 %O5."
+    },
+    "Что именно ты хочешь зашить с помощью %O2?": {
+      "en": "What exactly do you want to mend with %O2?",
+      "ua": "Що саме ти хочеш зашити за допомогою %O2?"
+    },
+    "Зашить %O5 можно вещи из ткани и кожи.": {
+      "en": "You can only mend things made of cloth and leather with %O5.",
+      "ua": "Зашити %O5 можна лише речі з тканини та шкіри."
+    },
+    "Но %O1 и так в прекрасном состоянии.": {
+      "en": "But %O1 is already in excellent condition.",
+      "ua": "Але %O1 і так у чудовому стані."
+    },
+    "%1$^O1 долж%1$Gно|ен|на|ны находиться у тебя в инвентаре.": {
+      "en": "%1$^O1 must be in your inventory.",
+      "ua": "%1$^O1 повин%1$Gно|ен|на|ні бути у тебе в інвентарі."
+    },
+    "Сперва надо зажать %O4 в руках.": {
+      "en": "First you need to grip %O4 in your hands.",
+      "ua": "Спершу треба затиснути %O4 в руках."
+    },
+    "Ты старательно орудуешь иглой, зашивая все дырки на %O6.": {
+      "en": "You diligently ply the needle, mending every hole in %O6.",
+      "ua": "Ти старанно орудуєш голкою, зашиваючи всі дірки на %O6."
+    },
+    "%^C1 старательно орудует иглой, зашивая все дырки на %O6.": {
+      "en": "%^C1 diligently plies a needle, mending every hole in %O6.",
+      "ua": "%^C1 старанно орудує голкою, зашиваючи всі дірки на %O6."
+    },
+    "Украдкой поковырявшись в носу, ты продолжаешь залатывать %O4.": {
+      "en": "After a sneaky pick of your nose, you keep patching up %O4.",
+      "ua": "Крадькома поколупавшись у носі, ти продовжуєш латати %O4."
+    },
+    "Украдкой поковырявшись в носу, %C1 продолжает залатывать %O4.": {
+      "en": "After a sneaky pick of the nose, %C1 keeps patching up %O4.",
+      "ua": "Крадькома поколупавшись у носі, %C1 продовжує латати %O4."
+    },
+    "Ты убеждаешься, что как мудро ни шей, а шов на %O6 все равно виден.": {
+      "en": "You realize that no matter how cleverly you sew, the seam on %O6 still shows.",
+      "ua": "Ти переконуєшся, що хоч як мудро ший, а шов на %O6 все одно видно."
+    },
+    "%^C1 убеждается, что как мудро ни шей, а шов на %O6 все равно виден.": {
+      "en": "%^C1 realizes that no matter how cleverly one sews, the seam on %O6 still shows.",
+      "ua": "%^C1 переконується, що хоч як мудро ший, а шов на %O6 все одно видно."
+    },
+    "Ты распарываешь неудачный стежок и продолжаешь зашивать %O4.": {
+      "en": "You rip out a botched stitch and keep mending %O4.",
+      "ua": "Ти розпорюєш невдалий стібок і продовжуєш зашивати %O4."
+    },
+    "%^C1 распарывает неудачный стежок и продолжает зашивать %O4.": {
+      "en": "%^C1 rips out a botched stitch and keeps mending %O4.",
+      "ua": "%^C1 розпорює невдалий стібок і продовжує зашивати %O4."
+    },
+    "Ты задумываешься, сколько ангелов влезет на острие иглы, но возвращаешься к %O3.": {
+      "en": "You wonder how many angels can dance on the point of a needle, then return to %O3.",
+      "ua": "Ти замислюєшся, скільки янголів вміститься на вістрі голки, але повертаєшся до %O3."
+    },
+    "%^C1 задумывается, сколько ангелов влезет на острие иглы, но возвращается к %O3.": {
+      "en": "%^C1 wonders how many angels can dance on the point of a needle, then returns to %O3.",
+      "ua": "%^C1 замислюється, скільки янголів вміститься на вістрі голки, але повертається до %O3."
+    },
+    "Ты входишь в транс и невольно располагаешь стежки на %O6 в виде множества Мандельброта.": {
+      "en": "You slip into a trance and unwittingly lay the stitches on %O6 in the shape of the Mandelbrot set.",
+      "ua": "Ти впадаєш у транс і мимоволі викладаєш стібки на %O6 у формі множини Мандельброта."
+    },
+    "%^C1 входит в транс и невольно располагает стежки на %O6 в виде множества Мандельброта.": {
+      "en": "%^C1 slips into a trance and unwittingly lays the stitches on %O6 in the shape of the Mandelbrot set.",
+      "ua": "%^C1 впадає у транс і мимоволі викладає стібки на %O6 у формі множини Мандельброта."
+    },
+    "Ты напеваешь 'В лесу родилась елочка', и стежки на %O6 получаются в той же форме.": {
+      "en": "You hum 'Jingle Bells', and the stitches on %O6 come out in the very same shape.",
+      "ua": "Ти наспівуєш 'Щедрика', і стібки на %O6 виходять тієї ж форми."
+    },
+    "%^C1 напевает 'В лесу родилась елочка', и стежки на %O6 получаются в той же форме.": {
+      "en": "%^C1 hums 'Jingle Bells', and the stitches on %O6 come out in the very same shape.",
+      "ua": "%^C1 наспівує 'Щедрика', і стібки на %O6 виходять тієї ж форми."
+    },
+    "Тебя мотивирует мысль о том, как прекрасно ты будешь выглядеть, заштопав %O4.": {
+      "en": "You're spurred on by the thought of how fine you'll look once %O4 is darned.",
+      "ua": "Тебе надихає думка про те, який гарний вигляд ти матимеш, заштопавши %O4."
+    },
+    "%^C1 будет прекрасно выглядеть, заштопав %O4.": {
+      "en": "%^C1 will look splendid once %O4 is darned.",
+      "ua": "%^C1 матиме чудовий вигляд, заштопавши %O4."
+    },
+    "Увлекшись, ты пришиваешь на %O4 заплатку с названием любимой группы.": {
+      "en": "Getting carried away, you sew a patch with your favorite band's name onto %O4.",
+      "ua": "Захопившись, ти пришиваєш на %O4 латку з назвою улюбленого гурту."
+    },
+    "Увлекшись, %C1 пришивает на %O4 заплатку с названием любимой группы.": {
+      "en": "Getting carried away, %C1 sews a patch with a favorite band's name onto %O4.",
+      "ua": "Захопившись, %C1 пришиває на %O4 латку з назвою улюбленого гурту."
+    },
+    "Ты хихикаешь и зашиваешь дыры на %O6 белыми нитками.": {
+      "en": "You giggle and sew the holes in %O6 shut with white thread.",
+      "ua": "Ти хихочеш і зашиваєш дірки на %O6 білими нитками."
+    },
+    "%^C1 хихикает и зашивает дыры на %O6 белыми нитками.": {
+      "en": "%^C1 giggles and sews the holes in %O6 shut with white thread.",
+      "ua": "%^C1 хихоче і зашиває дірки на %O6 білими нитками."
+    },
+    "{yТы прикидываешь, что шитье займет {W%1$d{y секунд%1$Iу|ы| и приступаешь к работе.{x": {
+      "en": "{yYou reckon the sewing will take {W%1$d{y second%1$I|s|s and get to work.{x",
+      "ua": "{yТи прикидаєш, що шиття займе {W%1$d{y секунд%1$Iу|и| і бересся до роботи.{x"
+    },
+    "Процесс починки прерван, а жаль.": {
+      "en": "The mending is interrupted, more's the pity.",
+      "ua": "Процес лагодження перервано, а шкода."
+    },
+    "Ты делаешь неуклюжий стежок и колешь себя в палец. Ай!": {
+      "en": "You make a clumsy stitch and prick your finger. Ow!",
+      "ua": "Ти робиш незграбний стібок і колеш себе в палець. Ай!"
+    },
+    "%^C1 делает неуклюжий стежок и колет себя в палец.": {
+      "en": "%^C1 makes a clumsy stitch and pricks a finger.",
+      "ua": "%^C1 робить незграбний стібок і коле себе в палець."
+    },
+    "{WПожалуй, стоило бы надеть наперсток.{x": {
+      "en": "{WPerhaps a thimble would have been wise.{x",
+      "ua": "{WМабуть, варто було б надіти наперсток.{x"
+    },
+    "Игла проходит насквозь через %O4 и втыкается в твое тело. Ай!": {
+      "en": "The needle passes clean through %O4 and jabs into your flesh. Ow!",
+      "ua": "Голка проходить наскрізь через %O4 і встромляється в твоє тіло. Ай!"
+    },
+    "{WПожалуй, шить на себе -- не самая лучшая идея.{x": {
+      "en": "{WSewing on yourself is perhaps not the brightest idea.{x",
+      "ua": "{WМабуть, шити на собі -- не найкраща ідея.{x"
+    },
+    "%^C1 делает неуклюжий стежок и колет себя.": {
+      "en": "%^C1 makes a clumsy stitch and pricks themselves.",
+      "ua": "%^C1 робить незграбний стібок і коле себе."
+    },
+    "%1$^O1 выгляд%1$nит|ят как нов%1$Gое|ый|ая|ые!": {
+      "en": "%1$^O1 look%1$ns| as good as new!",
+      "ua": "%1$^O1 вигляда%1$nє|ють як нов%1$Gе|ий|а|і!"
+    },
+    "%1$^O1 выгляд%1$nит|ят почти как нов%1$Gое|ый|ая|ые. Надо бы еще дошить...": {
+      "en": "%1$^O1 look%1$ns| almost as good as new. A little more stitching wouldn't hurt...",
+      "ua": "%1$^O1 вигляда%1$nє|ють майже як нов%1$Gе|ий|а|і. Треба б ще дошити..."
+    }
+  },
   "behaviors/perfume/onUse": {
     "%1$^C1 пшика%1$nет|ют из %2$O2 на %3$C4.": {
       "en": "%1$^C1 spritz%1$nes| %2$O2 on %3$C4.",


### PR DESCRIPTION
Batch 6 catalog (Trello 2594). 38 EN/UA entries keyed byte-exact to the `._()` RU literals in dreamland_fenia #207 (incl. the 20 whimsical sewing messages). %G/%n/%I count-inflection branches per-language; carol reference localized per-language. Passes scripts/lint-l10n.py (0 HARD). Catalog: 12 blocks / 123 phrases.