### PR TITLE
l10n: skillcommand catalog (5 hard command-link phrases)

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -2429,6 +2429,10 @@
   "%^C1 входит в транс, превращаясь в зеленого ящера!": {
    "en": "%^C1 slips into a trance, transforming into a green lizard!",
    "ua": "%^C1 впадає в транс, перетворюючись на зеленого ящера!"
+  },
+  "Напиши {y{hcформа медведь{x, {y{hcформа росомаха{x или {y{hcформа ящер{x.": {
+   "en": "Type {y{hcshape bear{x, {y{hcshape wolverine{x or {y{hcshape lizard{x.",
+   "ua": "Напиши {y{hcформа ведмідь{x, {y{hcформа росомаха{x або {y{hcформа ящір{x."
   }
  },
  "skillcommand/slice/run": {
@@ -2709,6 +2713,10 @@
   "На зов %C2 неспешно приходит %C1 и шумно чешется.": {
    "en": "At %C2's call, %C1 saunters over, unhurried, and scratches noisily.",
    "ua": "На поклик %C2 неквапом приходить %C1 і гучно чухається."
+  },
+  "Напиши {y{hcоруженосец пехотинец{x или {y{hcоруженосец монах{x.": {
+   "en": "Type {y{hcsquire footman{x or {y{hcsquire monk{x.",
+   "ua": "Напиши {y{hcзброєносець піхотинець{x або {y{hcзброєносець монах{x."
   }
  },
  "skillcommand/steal/run": {
@@ -2919,6 +2927,10 @@
   "Твоя жажда творить помогает наделить %O4 дополнительными свойствами.": {
    "en": "Your thirst to create helps imbue %O4 with additional properties.",
    "ua": "Твоя спрага творити допомагає наділити %O4 додатковими властивостями."
+  },
+  "Ты слишком устал{Sfа{Sx. Перед тем, как ты снова сможешь закалять сталь, надо подождать.": {
+   "en": "You're too tired to temper steel again right now. Wait a bit.",
+   "ua": "Ти занадто стоми{Sfлася{Smвся{Sx. Перш ніж ти знову зможеш гартувати сталь, треба почекати."
   }
  },
  "skillcommand/throwing weapon/run": {
@@ -3085,6 +3097,10 @@
   "Неизвестно откуда прилетевший %O1 метко ударяет прямо в %s %C2!": {
    "en": "%O1, flying in from who-knows-where, strikes true right into %C2's %s!",
    "ua": "%O1, що прилетів казна-звідки, влучно б'є просто в %s %C2!"
+  },
+  "Напиши {yметнуть {D<предмет> <направление> <жертва>{x. Например: {yметнуть {Dкинжал север гоблин{x.": {
+   "en": "Type {ythrow {D<item> <direction> <target>{x. For example: {ythrow {Ddagger north goblin{x.",
+   "ua": "Напиши {yметнути {D<предмет> <напрямок> <жертва>{x. Наприклад: {yметнути {Dкинджал північ гоблін{x."
   }
  },
  "skillcommand/tiger power/run": {
@@ -3227,6 +3243,10 @@
   "Насвистывая гимн Клана Ярости, %1$C1 шь%1$nет|ют %2$O4.": {
    "en": "Whistling the Clan Rage anthem, %1$C1 sew%1$ns| %2$O4.",
    "ua": "Насвистуючи гімн Клану Люті, %1$C1 ши%1$nє|ють %2$O4."
+  },
+  "Напиши {yтрофей {Dчастьтела труп{x.": {
+   "en": "Type {ytrophy {Dbodypart corpse{x.",
+   "ua": "Напиши {yтрофей {Dчастинатіла труп{x."
   }
  },
  "skillcommand/vampire/run": {


### PR DESCRIPTION
Final skillcommand batch: the 5 hard usage-hint/command-link phrases. Paired with fenia #209 (UA is_name keywords for shapeshift/squire) so the translated {hc} links resolve. lint-l10n 0 HARD. Catalog 66 blocks / 794 phrases -- skillcommand fully translated (671 phrases).