### PR TITLE
l10n: fix EN 3sg flashs->flashes in mirror/onUse

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -223,11 +223,11 @@
  },
  "behaviors/mirror/onUse": {
   "%1$^C1 доста%1$nет|ют %2$O4 и игриво пуска%1$nет|ют солнечные зайчики %3$C3 в глаза!": {
-   "en": "%1$^C1 take%1$ns| out %2$O4 and playfully flash%1$ns| sunbeams into the eyes of %3$C3!",
+   "en": "%1$^C1 take%1$ns| out %2$O4 and playfully flash%1$nes| sunbeams into the eyes of %3$C3!",
    "ua": "%1$^C1 діста%1$nє|ють %2$O4 й грайливо пуска%1$nє|ють сонячні зайчики %3$C3 в очі!"
   },
   "%1$^C1 доста%1$nет|ют %2$O4 и игриво пуска%1$nет|ют солнечные зайчики тебе в глаза! Ай!": {
-   "en": "%1$^C1 take%1$ns| out %2$O4 and playfully flash%1$ns| sunbeams into your eyes! Ow!",
+   "en": "%1$^C1 take%1$ns| out %2$O4 and playfully flash%1$nes| sunbeams into your eyes! Ow!",
    "ua": "%1$^C1 діста%1$nє|ють %2$O4 й грайливо пуска%1$nє|ють сонячні зайчики тобі в очі! Ай!"
   },
   "%1$^C1 шип%1$nит|ят и с отвращением прикрыва%1$nет|ют глаза рукой.": {


### PR DESCRIPTION
lint-l10n's new EN 3sg-verb WARN caught two live batch-5 instances: `flash%ns|`->'flashs', fixed to `flash%nes|` ('flashes'). Same class as #210.