### PR TITLE
l10n: command subsystem voice + hard (+60)

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -4883,6 +4883,10 @@
   "Что ты хочешь смастерить?": {
    "en": "What do you want to craft?",
    "ua": "Що ти хочеш змайструвати?"
+  },
+  "Что-то пошло не так, давай-ка запишем баг.": {
+   "en": "Something went wrong, let's log a bug.",
+   "ua": "Щось пішло не так, давай-но запишемо баг."
   }
  },
  "command/deposit/runFunc": {
@@ -4959,6 +4963,18 @@
   "Ты изящно соскакиваешь со спины %1$C2 и спешиваешься.": {
    "en": "You gracefully hop off the back of %1$C2 and dismount.",
    "ua": "Ти граційно зіскакуєш зі спини %1$C2 і спішуєшся."
+  },
+  "%1$^C1 сбрасыва%1$nет|ют %2$C2 со своей спины. Все, накатались!": {
+   "en": "%1$^C1 buck%1$ns| %2$C2 off their back. That's it, no more riding!",
+   "ua": "%1$^C1 скида%1$nє|ють %2$C2 зі своєї спини. Все, покаталися!"
+  },
+  "%1$^C1 сбрасыва%1$nет|ют тебя со своей спины. Все, накатались!": {
+   "en": "%1$^C1 throw%1$ns| you off its back. That's it, ride's over!",
+   "ua": "%1$^C1 скида%1$nє|ють тебе зі своєї спини. Все, накаталися!"
+  },
+  "Ты сбрасываешь %1$C2 со своей спины. Все, накатались!": {
+   "en": "You throw %1$C2 off your back. Well, that's enough riding for one day!",
+   "ua": "Ти скидаєш %1$C2 зі своєї спини. Все, накаталися!"
   }
  },
  "command/drop/runFunc": {
@@ -4985,6 +5001,14 @@
   "Чтобы бросить деньги, укажи название монеты полностью: {Yзолото{x или {Wсеребро{x.": {
    "en": "To drop money, specify the coin name in full: {Ygold{x or {Wsilver{x.",
    "ua": "Щоб кинути гроші, вкажи назву монети повністю: {Yзолото{x або {Wсрібло{x."
+  },
+  "Бросить {Y%d{x {g%s{x? Это как?": {
+   "en": "Drop {Y%d{x {g%s{x? Come again?",
+   "ua": "Кинути {Y%d{x {g%s{x? Це ти як?"
+  },
+  "Например, {y{hcбросить 5 серебро{x.": {
+   "en": "For example, {y{hcdrop 5 silver{x.",
+   "ua": "Наприклад, {y{hcкинути 5 срібло{x."
   }
  },
  "command/fenia/runFunc": {
@@ -5051,6 +5075,10 @@
   "У тебя нет прав писать скрипты.": {
    "en": "You don't have permission to write scripts.",
    "ua": "У тебе немає прав писати скрипти."
+  },
+  "Создаю первый в мире триггер типа %s.": {
+   "en": "Creating the world's first trigger of type %s.",
+   "ua": "Створюю перший у світі тригер типу %s."
   }
  },
  "command/flee/runFunc": {
@@ -5061,6 +5089,14 @@
   "У тебя не хватает сил, чтобы сбежать!": {
    "en": "You don't have enough strength left to flee!",
    "ua": "Тобі бракує сил, щоб втекти!"
+  },
+  "Смой свой позор {Rкровью.{x": {
+   "en": "Wash away your shame with {Rblood.{x",
+   "ua": "Змий свій сором {Rкров'ю.{x"
+  },
+  "Ты уже запятнал{Sfа{Sx себя позором -- куда уж больше!": {
+   "en": "You've already covered yourself in shame -- how much further could you sink!",
+   "ua": "Ти вже заплямува{Smв{Sfла{Sx себе ганьбою -- куди вже більше!"
   }
  },
  "command/fly/runFunc": {
@@ -5095,18 +5131,34 @@
   "Чтобы взлететь, тебе понадобится заклинание полета или вещь с этим аффектом.": {
    "en": "To take flight, you'll need a spell of flight or an item with that affect.",
    "ua": "Щоб злетіти, тобі знадобиться заклинання польоту або річ з цим ефектом."
+  },
+  "Ты взмываешь в воздух и начинаешь {Cлетать{x. Уиии!": {
+   "en": "You soar into the air and start to {Cfly{x. Wheee!",
+   "ua": "Ти злітаєш у повітря і починаєш {Cлітати{x. Віііі!"
+  },
+  "Напиши {y{hcвзлететь{x или {y{hcнелетать{x.": {
+   "en": "Type {y{hcfly{x or {y{hcunfly{x.",
+   "ua": "Напиши {y{hcзлетіти{x або {y{hcнелітати{x."
   }
  },
  "command/heal/runFunc": {
   "Прочитай справку про {hh275платные услуги{x, чтобы узнать больше.": {
    "en": "Read up on {hh275paid services{x to learn more.",
    "ua": "Прочитай довідку про {hh275платні послуги{x, щоб дізнатися більше."
+  },
+  "Вместо этой команды используй команду {y{hc{ууслуга{x.": {
+   "en": "Instead of this command, use the {y{hc{uservice{x command.",
+   "ua": "Замість цієї команди використовуй команду {y{hc{uпослуга{x."
   }
  },
  "command/identify/runFunc": {
   "Прочитай справку про {hh275платные услуги{x, чтобы узнать больше.": {
    "en": "Read the {hh275paid services{x help article to learn more.",
    "ua": "Прочитай довідку про {hh275платні послуги{x, щоб дізнатися більше."
+  },
+  "Вместо этой команды используй {y{hcуслуга опознание{x.": {
+   "en": "Instead of this command, use {y{hcуслуга опознание{x.",
+   "ua": "Замість цієї команди скористайся {y{hcуслуга опознание{x."
   }
  },
  "command/lessons/runFunc": {
@@ -5125,6 +5177,26 @@
   "Использование: урок, урок номер, урок все.": {
    "en": "Usage: lessons, lessons number, lessons all.",
    "ua": "Використання: уроки, уроки номер, уроки все."
+  },
+  "Уроки начнутся, как будто ты только что сош%Gло|ел|ла с корабля.\\n": {
+   "en": "Lessons will start as though you'd just stepped off the ship.\\n",
+   "ua": "Уроки почнуться, наче ти щойно зійш%Gло|ов|ла з корабля.\\n"
+  },
+  "\\nСписок всех уроков можно посмотреть по команде {y{hcурок все{x.": {
+   "en": "\nYou can see the list of all lessons with the {y{hclessons all{x.",
+   "ua": "\nСписок усіх уроків можна переглянути за командою {y{hcурок все{x."
+  },
+  "Начать выполнять уроки можно по команде {y{hcурок начать{x.": {
+   "en": "You can start doing lessons with the {y{hclesson start{x command.",
+   "ua": "Розпочати уроки можна командою {y{hcурок почати{x."
+  },
+  "Твой текущий урок можно быстро посмотреть, выполнив команду {y{hcурок{x без параметров.": {
+   "en": "You can quickly check your current lesson by running the {y{hcурок{x command with no arguments.",
+   "ua": "Свій поточний урок можна швидко подивитися, виконавши команду {y{hcурок{x без параметрів."
+  },
+  "У тебя нет текущего урока. Используй {y{hcурок все{x для списка.": {
+   "en": "You don't have a current lesson. Use {y{hclessons all{x for the list.",
+   "ua": "У тебе немає поточного уроку. Використай {y{hcурок все{x для списку."
   }
  },
  "command/map/runFunc": {
@@ -5143,6 +5215,10 @@
   "Удобно перемещаться также с помощью команды {1{hh2170путь{x{2.": {
    "en": "You can also move around conveniently using the {1{hh2170path{x{2 command.",
    "ua": "Зручно пересуватися також за допомогою команди {1{hh2170шлях{x{2."
+  },
+  "Чтобы почитать описания всех зон, набери {hc{yсправка карта{x.": {
+   "en": "To read the descriptions of all the zones, type {hc{yhelp map{x.",
+   "ua": "Щоб почитати описи всіх зон, набери {hc{yдовідка карта{x."
   }
  },
  "command/mount/runFunc": {
@@ -5229,6 +5305,34 @@
   "Чтобы сесть верхом на %1$C4, сначала нужно, чтобы %1$P1 встал%1$Gо||а|и.": {
    "en": "To mount %1$C4, %1$C1 needs to stand up first.",
    "ua": "Щоб сісти верхи на %1$C4, спершу потрібно, щоб %1$C1 вст%1$Gало|ав|ала|али."
+  },
+  "%1$^C1 непринужденно седлает тебя и запрыгивает на спину.": {
+   "en": "%1$^C1 casually saddles you up and hops onto your back.",
+   "ua": "%1$^C1 невимушено осідлує тебе і застрибує на спину."
+  },
+  "%1$^C1 пыта%1$nется|ются запрыгнуть верхом на %2$C4, но соскальзыва%1$nет|ют.": {
+   "en": "%1$^C1 tr%1$nies|y to jump onto %2$C4's back, but slip%1$ns| off.",
+   "ua": "%1$^C1 намага%1$nється|ються застрибнути верхи на %2$C4, але зісковзу%1$nє|ють."
+  },
+  "%1$^C1 пытается оседлать %2$C4. %2$^C1 строго смотрит на %1$C4.": {
+   "en": "%1$^C1 tries to mount %2$C4. %2$^C1 gives %1$C4 a stern look.",
+   "ua": "%1$^C1 намагається осідлати %2$C4. %2$^C1 суворо дивиться на %1$C4."
+  },
+  "%^C1 пытается оседлать тебя, но заметив твой строгий взгляд, останавливается.": {
+   "en": "%^C1 tries to mount you, but stops after catching your stern look.",
+   "ua": "%^C1 намагається осідлати тебе, але, помітивши твій суворий погляд, зупиняється."
+  },
+  "Да ты и так на коне.": {
+   "en": "Come on, you're already in the saddle.",
+   "ua": "Та ти й так у сідлі."
+  },
+  "Оседлать само{Smго{Sfму{Sx себя? Это как?": {
+   "en": "Mount yourself? How would that even work?",
+   "ua": "Осідлати сам{Smого{Sfу{Sx себе? Це як?"
+  },
+  "Ты пытаешься оседлать %C4, но никак не можешь найти стремена.": {
+   "en": "You try to saddle %C4, but you just can't find the stirrups.",
+   "ua": "Ти намагаєшся осідлати %C4, але ніяк не можеш знайти стремена."
   }
  },
  "command/nuke/runFunc": {
@@ -5239,6 +5343,18 @@
   "Среди твоих последователей нет никого по имени {g%s{x.": {
    "en": "There is no one named {g%s{x among your followers.",
    "ua": "Серед твоїх послідовників немає нікого на ім'я {g%s{x."
+  },
+  "Ты од{Smин{Sfна{Sx. Совершенно од{Smин{Sfна{Sx. Од{Smин{Sfна{Sx-одинешен{Smек{Sfька{Sx в этом огромном и жестоком мире.": {
+   "en": "You are alone. Completely alone. All alone in this vast and cruel world.",
+   "ua": "Ти од{Smин{Sfна{Sx. Цілком од{Smин{Sfна{Sx. Од{Smин{Sfна{Sx-однісіньк{Smий{Sfа{Sx у цьому величезному й жорстокому світі."
+  },
+  "Это существо -- уже не жилец.": {
+   "en": "This creature is already a goner.",
+   "ua": "Ця істота -- вже не житець."
+  },
+  "Ты уверенно и непримиримо выгоняешь сам{Smого{Sfу{Sx себя на мороз.": {
+   "en": "You confidently and unyieldingly throw yourself out into the cold.",
+   "ua": "Ти впевнено і непримиренно виганяєш сам{Smого{Sfу{Sx себе на мороз."
   }
  },
  "command/practice/runFunc": {
@@ -5293,6 +5409,18 @@
   "Я не могу обучить тебя умению {1{hh%d%s{x{2.": {
    "en": "I can't teach you the skill {1{hh%d%s{x{2.",
    "ua": "Я не можу навчити тебе умінню {1{hh%d%s{x{2."
+  },
+  "%^s? Я не знаю такого умения.": {
+   "en": "%^s? I don't know that skill.",
+   "ua": "%^s? Я не знаю такого вміння."
+  },
+  "Да ты сам{Sfа{Sx кого-угодно этому умению можешь {1{hh1358обучить{x{2!": {
+   "en": "Hell, you could {1{hh1358teach{x{2 this skill to just about anyone yourself!",
+   "ua": "Та ти сам{Sfа{Sx можеш {1{hh1358навчити{x{2 цьому вмінню кого завгодно!"
+  },
+  "Ты уже слишком хорошо владеешь умением {1{W%s{x{2, я не смогу ничем помочь.": {
+   "en": "You already know the skill {1{W%s{x{2 too well -- there's nothing more I can teach you.",
+   "ua": "Ти вже занадто добре володієш умінням {1{W%s{x{2, я нічим не зможу допомогти."
   }
  },
  "command/readall/runFunc": {
@@ -5303,6 +5431,10 @@
   "Чтобы заново пометить один из типов сообщений как непрочитанные,": {
    "en": "To mark one of the message types as unread again,",
    "ua": "Щоб знову позначити один з типів повідомлень як непрочитані,"
+  },
+  "напиши {D<тип сообщения> непрочитаны{x. Например: {y{hcизменения непрочитаны{x.": {
+   "en": "type {D<message type> unread{x. For example: {y{hcchanges unread{x.",
+   "ua": "напиши {D<тип повідомлення> непрочитані{x. Наприклад: {y{hcизменения непрочитаны{x."
   }
  },
  "command/repair/runFunc": {
@@ -5325,6 +5457,10 @@
   "Прочитай справку про {hh275платные услуги{x, чтобы узнать больше.": {
    "en": "Read the {hh275paid services{x} article to learn more.",
    "ua": "Прочитай довідку про {hh275платні послуги{x, щоб дізнатися більше."
+  },
+  "Вместо этой команды используй команду {y{hc{lrуслуга{leservice{lx{x.": {
+   "en": "Instead of this command, use the {y{hc{lrуслуга{leservice{lx{x command.",
+   "ua": "Замість цієї команди використовуй команду {y{hc{lrуслуга{leservice{lx{x."
   }
  },
  "command/suicide/runFunc": {
@@ -5339,6 +5475,70 @@
   "Милостью Варды твоя душа и труп переносятся в храм.": {
    "en": "By Varda's mercy, your soul and corpse are transported to a temple.",
    "ua": "Милістю Варди твоя душа і труп переносяться до храму."
+  },
+  "%1^C1 вздыхает и дрожащими руками осеняет себя святым знамением Ахурамазды.": {
+   "en": "%1^C1 sighs and with trembling hands makes the holy sign of Ahuramazda over themselves.",
+   "ua": "%1^C1 зітхає і тремтячими руками осіняє себе святим знаменням Ахурамазди."
+  },
+  "%1^C1 встает на колени и вспарывает себе живот, чтобы спастись от бесчестья.": {
+   "en": "%1^C1 drops to their knees and guts themselves to escape dishonor.",
+   "ua": "%1^C1 стає на коліна і розпорює собі живіт, щоб врятуватися від безчестя."
+  },
+  "%1^C1 перерезает себе вены и истекает кровью до смерти.": {
+   "en": "%1^C1 slits their wrists and bleeds to death.",
+   "ua": "%1^C1 перерізає собі вени і стікає кров'ю до смерті."
+  },
+  "%1^C1 уже {rТРУП!{x": {
+   "en": "%1^C1 is already a {rCORPSE!{x",
+   "ua": "%1^C1 вже {rТРУП!{x"
+  },
+  "%^O1 внезапно появляется в серебристой вспышке.": {
+   "en": "%^O1 suddenly appears in a silvery flash.",
+   "ua": "%^O1 раптово з'являється в сріблястому спалаху."
+  },
+  "{RТЫ УМИРАЕШЬ!{x": {
+   "en": "{RYOU ARE DYING!{x",
+   "ua": "{RТИ ПОМИРАЄШ!{x"
+  },
+  "{WСВЯЩЕННОЕ ПЛАМЯ ОХВАТЫВАЕТ ТЕБЯ И СЖИГАЕТ ЗАЖИВО!{x": {
+   "en": "{WHOLY FLAME ENGULFS YOU AND BURNS YOU ALIVE!{x",
+   "ua": "{WСВЯЩЕННЕ ПОЛУМʼЯ ОХОПЛЮЄ ТЕБЕ І СПАЛЮЄ ЖИВЦЕМ!{x"
+  },
+  "Вздохнув, ты перерезаешь себе вены и вскоре истекаешь кровью до смерти.": {
+   "en": "Sighing, you slit your wrists and soon bleed to death.",
+   "ua": "Зітхнувши, ти перерізаєш собі вени і незабаром стікаєш кров'ю до смерті."
+  },
+  "Один точный, жестокий жест -- и мир взрывается болью, словно внутри тебя раскрыли пламя.": {
+   "en": "One precise, brutal gesture -- and the world explodes in pain, as if a flame had been unleashed inside you.",
+   "ua": "Один точний, жорстокий жест -- і світ вибухає болем, ніби всередині тебе розкрили полум'я."
+  },
+  "Священное пламя охватывает %1$C4 и сжигает дотла!": {
+   "en": "Holy fire engulfs %1$C4 and burns them to ash!",
+   "ua": "Священне полум'я охоплює %1$C4 і спалює дотла!"
+  },
+  "Странно... местонахождение твоего тела нельзя определить.": {
+   "en": "Strange... your body's location cannot be determined.",
+   "ua": "Дивно... місцезнаходження твого тіла визначити неможливо."
+  },
+  "Ты вздыхаешь и дрожащими руками осеняешь себя святым знамением Ахурамазды.": {
+   "en": "You sigh and, with trembling hands, make the holy sign of Ahuramazda over yourself.",
+   "ua": "Ти зітхаєш і тремтячими руками осіняєш себе святим знаменням Ахурамазди."
+  },
+  "Ты падаешь вперёд, лицо касается земли... и с каждым мгновением позор уходит, растворяясь в тишине.": {
+   "en": "You fall forward, your face touching the ground... and with every passing moment the shame fades away, dissolving into silence.",
+   "ua": "Ти падаєш вперед, обличчя торкається землі... і з кожною миттю сором зникає, розчиняючись у тиші."
+  },
+  "Ты становишься на колени, подоткнув рукава и выпрямив спину -- поза покоя перед бурей.": {
+   "en": "You kneel down, tucking up your sleeves and straightening your back -- the pose of calm before the storm.",
+   "ua": "Ти стаєш на коліна, підіткнувши рукави і випрямивши спину -- поза спокою перед бурею."
+  },
+  "Холодное лезвие дрожит в руке, но ты уже не чувствуешь страха -- только тяжёлую ясность.": {
+   "en": "The cold blade trembles in your hand, but you no longer feel fear -- only a heavy clarity.",
+   "ua": "Холодне лезо тремтить у руці, але ти вже не відчуваєш страху -- тільки важку ясність."
+  },
+  "Чтобы продолжить, напиши {rсамоубийство {D<имяперсонажа>{x.": {
+   "en": "To continue, type {rsuicide {D<character name>{x.",
+   "ua": "Щоб продовжити, напиши {rсамоубийство {D<ім'я персонажа>{x."
   }
  },
  "command/train/runFunc": {
@@ -5349,6 +5549,22 @@
   "%1$^C1 развива%1$nет|ют красноречие %2$C2 и навыки общения, чтобы улучшить %2$P2 обаяние.": {
    "en": "%1$^C1 develop%1$ns| %2$C2's eloquence and social skills to improve their charm.",
    "ua": "%1$^C1 розвива%1$nє|ють красномовність %2$C2 і навички спілкування, щоб покращити чарівність %2$C2."
+  },
+  "%1$^C1 загружа%1$nет|ют %2$C4 сложными задачами и головоломками, заставляя ум работать на пределе и повышая %2$P2 интеллект.": {
+   "en": "%1$^C1 load%1$ns| %2$C4 down with complex tasks and puzzles, pushing the mind to its limit and raising their intelligence.",
+   "ua": "%1$^C1 завантажу%1$nє|ють %2$C4 складними завданнями та головоломками, змушуючи розум працювати на межі і піднімаючи інтелект."
+  },
+  "%1$^C1 заставля%1$nет|ют %2$C4 уклоняться от ударов и выполнять серию стремительных движений, улучшая %2$P2 ловкость.": {
+   "en": "%1$^C1 force%1$ns| %2$C4 to dodge blows and perform a series of swift movements, improving their dexterity.",
+   "ua": "%1$^C1 змушу%1$nє|ють %2$C4 ухилятися від ударів і виконувати серію стрімких рухів, покращуючи спритність %2$C2."
+  },
+  "%1$^C1 организу%1$nет|ют %2$C3 марафон тренировок на выносливость, постепенно укрепляя %2$P2 тело и закаляя дух.": {
+   "en": "%1$^C1 puts %2$C3 through an endurance training marathon, gradually toughening %2$C3's body and hardening their spirit.",
+   "ua": "%1$^C1 організовує для %2$C3 марафон тренувань на витривалість, поступово зміцнюючи тіло %2$C2 і гартуючи дух."
+  },
+  "%1$^C1 провод%1$nит|ят с %2$C5 время в философских размышлениях, помогая %2$P3 углубить понимание мира и обрести мудрость.": {
+   "en": "%1$^C1 spend%1$ns| time with %2$C5 in philosophical contemplation, helping %2$C3 deepen their understanding of the world and gain wisdom.",
+   "ua": "%1$^C1 провод%1$nить|ять час з %2$C5 у філософських роздумах, допомагаючи %2$C3 поглибити розуміння світу і набути мудрості."
   }
  },
  "command/unmorph/runFunc": {
@@ -5363,6 +5579,14 @@
   "Ты сейчас не находишься в состоянии трансформации.": {
    "en": "You are not currently in a transformed state.",
    "ua": "Ти зараз не перебуваєш у стані трансформації."
+  },
+  "Ты уменьшаешься, выходя из вампирьей трансформации и превращаясь назад в %1$N4.": {
+   "en": "You shrink back down, emerging from your vampire transformation and turning back into %1$N4.",
+   "ua": "Ти зменшуєшся, виходячи з вампірської трансформації і перетворюючись назад на %1$N4."
+  },
+  "Поклонись своему Гильдмастеру для вампирьей Инициации ({hc{yсправка инициация{x).": {
+   "en": "Bow to your Guildmaster for the vampire Initiation ({hc{yhelp initiation{x).",
+   "ua": "Вклонись своєму Гільдмайстру заради вампірської Ініціації ({hc{yдовідка инициация{x)."
   }
  },
  "command/wash/runFunc": {
@@ -5389,6 +5613,14 @@
   "Ты зачерпываешь воду %1$s и тщательно умываешься.": {
    "en": "You scoop up water %1$s and wash yourself thoroughly.",
    "ua": "Ти зачерпуєш воду %1$s і ретельно вмиваєшся."
+  },
+  "Твое личико и так в порядке.": {
+   "en": "Your pretty little face is already just fine.",
+   "ua": "Твоє личко і так у порядку."
+  },
+  "Ты пытаешься умыться %1$s, но руки дрожат и вода проливается мимо.": {
+   "en": "You try to wash your face with %1$s, but your hands are shaking and the water spills everywhere.",
+   "ua": "Ти намагаєшся вмитися %1$s, але руки тремтять і вода проливається повз."
   }
  },
  "command/withdraw/runFunc": {
@@ -5419,6 +5651,14 @@
   "Услуги банка составили %s.": {
    "en": "The bank's fees came to %s.",
    "ua": "Послуги банку становили %s."
+  },
+  "Извини, мы не даем взаймы.": {
+   "en": "Sorry, we don't extend loans.",
+   "ua": "Вибач, ми не даємо в борг."
+  },
+  "Очень щедро.": {
+   "en": "Very generous.",
+   "ua": "Дуже щедро."
   }
  }
 }


### PR DESCRIPTION
CYCLE 3 completion: voice (46, bulk-approved) + hard (14) lanes for the command subsystem. **command now 187/187 phrases fully trilingual.**

- Hard = `{hc}` command-links. UA aliases verified registered in commands/*.xml (злетіти/нелітати/послуга/довідка/кинути); RU-kept links are safe fallbacks (RU aliases resolve for all viewers).
- Fixed 8 agent stray-`}` artifacts; upgraded unmorph справка->довідка.
- lint-l10n 0 HARD. Loads via `plug reload most`.