### PR TITLE
l10n: drop catalog blocks for deleted lessons + smith

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -5161,44 +5161,6 @@
    "ua": "Замість цієї команди скористайся {y{hcуслуга опознание{x."
   }
  },
- "command/lessons/runFunc": {
-  "\\nПодробности про каждый урок покажет команда '{yурок {Dномер{x'.": {
-   "en": "\\nThe command '{ylesson {Dnumber{x' will show details for each lesson.",
-   "ua": "\\nПодробиці про кожен урок покаже команда '{yурок {Dномер{x'."
-  },
-  "{YСписок всех уроков{x \\n": {
-   "en": "{YList of all lessons{x \n",
-   "ua": "{YСписок усіх уроків{x \n"
-  },
-  "{gПояснение{x:": {
-   "en": "{gExplanation{x:",
-   "ua": "{gПояснення{x:"
-  },
-  "Использование: урок, урок номер, урок все.": {
-   "en": "Usage: lessons, lessons number, lessons all.",
-   "ua": "Використання: уроки, уроки номер, уроки все."
-  },
-  "Уроки начнутся, как будто ты только что сош%Gло|ел|ла с корабля.\\n": {
-   "en": "Lessons will start as though you'd just stepped off the ship.\\n",
-   "ua": "Уроки почнуться, наче ти щойно зійш%Gло|ов|ла з корабля.\\n"
-  },
-  "\\nСписок всех уроков можно посмотреть по команде {y{hcурок все{x.": {
-   "en": "\nYou can see the list of all lessons with the {y{hclessons all{x.",
-   "ua": "\nСписок усіх уроків можна переглянути за командою {y{hcурок все{x."
-  },
-  "Начать выполнять уроки можно по команде {y{hcурок начать{x.": {
-   "en": "You can start doing lessons with the {y{hclesson start{x command.",
-   "ua": "Розпочати уроки можна командою {y{hcурок почати{x."
-  },
-  "Твой текущий урок можно быстро посмотреть, выполнив команду {y{hcурок{x без параметров.": {
-   "en": "You can quickly check your current lesson by running the {y{hcурок{x command with no arguments.",
-   "ua": "Свій поточний урок можна швидко подивитися, виконавши команду {y{hcурок{x без параметрів."
-  },
-  "У тебя нет текущего урока. Используй {y{hcурок все{x для списка.": {
-   "en": "You don't have a current lesson. Use {y{hclessons all{x for the list.",
-   "ua": "У тебе немає поточного уроку. Використай {y{hcурок все{x для списку."
-  }
- },
  "command/map/runFunc": {
   "В {CМире Мечты{x для карт зон не нужно особых команд.": {
    "en": "In {CDreamland{x, zone maps don't need any special commands.",
@@ -5451,16 +5413,6 @@
   "Похоже, здесь никто не слышал об услуге под названием {g%s.{x": {
    "en": "Looks like nobody here has heard of a service called {g%s.{x",
    "ua": "Схоже, тут ніхто не чув про послугу під назвою {g%s.{x"
-  }
- },
- "command/smith/runFunc": {
-  "Прочитай справку про {hh275платные услуги{x, чтобы узнать больше.": {
-   "en": "Read the {hh275paid services{x} article to learn more.",
-   "ua": "Прочитай довідку про {hh275платні послуги{x, щоб дізнатися більше."
-  },
-  "Вместо этой команды используй команду {y{hc{lrуслуга{leservice{lx{x.": {
-   "en": "Instead of this command, use the {y{hc{lrуслуга{leservice{lx{x command.",
-   "ua": "Замість цієї команди використовуй команду {y{hc{lrуслуга{leservice{lx{x."
   }
  },
  "command/suicide/runFunc": {


### PR DESCRIPTION
Companion to dreamland_fenia#217 (removed the dead lessons + smith command handlers). Drops their now-orphaned catalog entries (9 lessons + 2 smith). Also clears the smith stray-`}` artifact that the new lint-l10n HARD check flags. Catalog 1359 -> 1348, lint 0 HARD.