### PR TITLE
l10n: affect hard-lane translations (+7)

### DIFF
--- a/config/translations.json
+++ b/config/translations.json
@@ -5995,6 +5995,10 @@
   "{RКомары и мошки пьют твою кровь, {1{mослабляя{2 тебя!{x": {
    "en": "{RMosquitoes and midges drink your blood, {1{mweakening{2 you!{x",
    "ua": "{RКомарі та мошки пʼють твою кров, {1{mослаблюючи{2 тебе!{x"
+  },
+  "Комары и мошки кусают %1$C2, {1{Gотравляя{2 %1$P2!": {
+   "en": "Mosquitoes and midges bite %1$C2, {1{Gpoisoning{2 them!",
+   "ua": "Комарі та мошка кусають %1$C2, {1{Gотруюючи{2 %1$C2!"
   }
  },
  "affect/mosquito swarm/onUpdateChar": {
@@ -6175,6 +6179,10 @@
   "Ты прекращаешь ритуал, останавливая трансформацию.": {
    "en": "You stop the ritual, halting the transformation.",
    "ua": "Ти припиняєш ритуал, зупиняючи трансформацію."
+  },
+  "{gТы кусаешь {1%1$C4{2, и %1$P2 раны начинают гнить!{x": {
+   "en": "{gYou bite {1%1$C4{2, and %1$C2's wounds start to rot!{x",
+   "ua": "{gТи кусаєш {1%1$C4{2, і рани %1$C2 починають гнити!{x"
   }
  },
  "affect/shield/onImmune": {
@@ -6259,6 +6267,10 @@
   "Хлопанье крыльев производит много шума, и тебе не удается двигаться бесшумно.": {
    "en": "The flapping of wings makes a lot of noise, and you fail to move silently.",
    "ua": "Лопотіння крил створює багато шуму, і тобі не вдається рухатися безшумно."
+  },
+  "Ты слышишь тихий плеск %1$C2, плывущ%1$Gего|его|ей|их в %2$N6.": {
+   "en": "You hear the quiet splash of %1$C2 swimming in %2$N6.",
+   "ua": "Ти чуєш тихий плескіт %1$C2, пливуч%1$Gого|ого|ої|их, у %2$N6."
   }
  },
  "affect/stone skin/onHit": {
@@ -6363,6 +6375,26 @@
   "{1{bВедьминское проклятие{2 безжалостно отнимает жизнь у %C2!": {
    "en": "{1{bThe witch's curse{2 mercilessly drains the life from %C2!",
    "ua": "{1{bВідьомське прокляття{2 нещадно забирає життя у %C2!"
+  }
+ },
+ "affect/love potion/onLook": {
+  "{MГлаза {1%1$C2{2 стекленеют, и %1$P1 начинает следовать за %1$C5.{x.": {
+   "en": "{MThe eyes of {1%1$C2{2 glaze over, and %1$C1 starts following %1$C5.{x.",
+   "ua": "{MОчі {1%1$C2{2 скляніють, і %1$C1 починає слідувати за %1$C5.{x."
+  },
+  "{mТы полностью очарован{Sfа{Sx и готов{Sfа{Sx всюду следовать за %1$P5.{x": {
+   "en": "{mYou are completely enchanted and ready to follow %1$C5 everywhere.{x",
+   "ua": "{mТи повністю зачарован{Sfа{Smий{Sx і готов{Sfа{Smий{Sx всюди слідувати за %1$C5.{x"
+  }
+ },
+ "affect/stardust/onRefresh": {
+  "Мерцающая {Wз{wве{Wзд{wная {Wп{wыль закружилась вокруг %C2.": {
+   "en": "Shimmering {Ws{wta{Wrd{wust swirls around %C2.",
+   "ua": "Мерехтливий {Wз{wоря{Wни{wй {Wп{wил закружляв навколо %C2."
+  },
+  "Мерцающая {Wз{wве{Wзд{wная {Wп{wыль закружилась вокруг тебя.": {
+   "en": "Shimmering {Wst{war{Wdu{wst swirled around you.",
+   "ua": "Мерехтливий {Wзо{wря{Wний {wп{Wил закружляв навколо тебе."
   }
  }
 }


### PR DESCRIPTION
Bulk cycle 4 (affect), hard lane. 7 markup/%P-heavy messages, verified engine-correct: 0 stray %P (resolved to %C/hardcoded), arg-safe, colour codes preserved. Catalog 1501->1508. lint 0 HARD.