### PR TITLE
l10n: behaviors mechanical translations (215 phrases)

### DIFF
--- a/config/translations/behaviors.json
+++ b/config/translations/behaviors.json
@@ -514,5 +514,981 @@
    "en": "You peer through %1$O4, aiming it %2$s.",
    "ua": "Ти зазираєш у %1$O4, скеровуючи погляд %2$s."
   }
+ },
+ "behaviors/adept/onSpec": {
+  "%^C1 молится %N3.": {
+   "en": "%^C1 prays to %N3.",
+   "ua": "%^C1 молиться %N3."
+  }
+ },
+ "behaviors/amix/onGive": {
+  "Не нужно давать мне вещи, просто произнеси вслух их название.": {
+   "en": "No need to give me things, just say their name out loud.",
+   "ua": "Не треба давати мені речі, просто скажи вголос їхню назву."
+  }
+ },
+ "behaviors/amix/onGreet": {
+  "Чтобы начать, просто произнеси название вещи или татуировки.": {
+   "en": "To begin, just say the name of the item or tattoo.",
+   "ua": "Щоб почати, просто скажи назву речі чи татуювання."
+  }
+ },
+ "behaviors/amix/postSpeech": {
+  "Какое-то время совершенно ничего не происходит...": {
+   "en": "For a while, absolutely nothing happens...",
+   "ua": "Якийсь час геть нічого не відбувається..."
+  },
+  "На %1$O6 нету неснимаемого проклятия -- воспользуйся услугами лекаря.": {
+   "en": "There is no unremovable curse on %1$O6 -- go see a healer.",
+   "ua": "На %1$O6 немає невіддільного прокляття -- скористайся послугами лікаря."
+  },
+  "На {1%1$O6{2 нету проклятия, просто выбрось %1$P2.": {
+   "en": "There's no curse on {1%1$O6{2, just throw it away.",
+   "ua": "На {1%1$O6{2 нема прокляття, просто викинь %1$O4."
+  },
+  "Назови ее еще раз.": {
+   "en": "Name it again.",
+   "ua": "Назви її ще раз."
+  },
+  "Не понимаю.": {
+   "en": "I don't understand.",
+   "ua": "Я не розумію."
+  },
+  "Тогда какую вещь ты хотел{Sfа{Sx бы уничтожить?": {
+   "en": "Then which item did you want to destroy?",
+   "ua": "Тоді яку річ ти хотів{Sfа{Sx би знищити?"
+  },
+  "Я не вижу у тебя предмета с таким названием.": {
+   "en": "I don't see an item like that on you.",
+   "ua": "Я не бачу в тебе предмета з такою назвою."
+  }
+ },
+ "behaviors/ashes/onSpec": {
+  "%1$^O1 растворя%1$nется|ются и исчеза%1$nет|ют.": {
+   "en": "%1$^O1 dissolve%1$ns| and disappear%1$ns|.",
+   "ua": "%1$^O1 розчиня%1$nється|ються і зника%1$nє|ють."
+  }
+ },
+ "behaviors/axe lumberjack/onEquip": {
+  "Нетрудно догадаться, что %O4 можно {hh238использовать{x, чтобы рубить деревья.": {
+   "en": "It's not hard to guess that %O4 can be {hh238used{x to chop down trees.",
+   "ua": "Неважко здогадатися, що %O4 можна {hh238використати{x, щоб рубати дерева."
+  }
+ },
+ "behaviors/axe lumberjack/onUse": {
+  "%^O4 не стоит рубить твоим %O5 -- дерева там нет.": {
+   "en": "%^O4 isn't worth chopping with your %O5 -- there's no tree there.",
+   "ua": "%^O4 не варто рубати твоїм %O5 -- дерева там немає."
+  },
+  "Дерево имеет глубокий надруб и уже не восстановится.": {
+   "en": "The tree has a deep gash cut into it and won't recover now.",
+   "ua": "Дерево має глибокий надруб і вже не відновиться."
+  },
+  "Дерево имеет несколько небольших зарубин и царапин.": {
+   "en": "The wood has a few small nicks and scratches.",
+   "ua": "Дерево має кілька невеликих зарубок і подряпин."
+  },
+  "Дерево имеет очень глубокий надруб и вот-вот упадёт.": {
+   "en": "The tree has a very deep cut and is about to fall.",
+   "ua": "Дерево має дуже глибокий надруб і от-от впаде."
+  },
+  "Дерево имеет пару засечек.": {
+   "en": "The tree has a couple of notches in it.",
+   "ua": "На дереві є кілька зарубок."
+  },
+  "Ты не видишь здесь предмета под названием {g%s{x.": {
+   "en": "You don't see an item called {g%s{x here.",
+   "ua": "Ти не бачиш тут предмета під назвою {g%s{x."
+  }
+ },
+ "behaviors/baker/onGreet": {
+  "Добро пожаловать в мою лавку, %C1.": {
+   "en": "Welcome to my shop, %C1.",
+   "ua": "Ласкаво прошу до моєї крамниці, %C1."
+  },
+  "Добро пожаловать в мою лавку, %N1.": {
+   "en": "Welcome to my shop, %N1.",
+   "ua": "Ласкаво просимо до моєї крамниці, %N1."
+  }
+ },
+ "behaviors/blacksmith/onSpeech": {
+  "%1$^C1 что-то говор%1$nит|ят %2$C3.": {
+   "en": "%1$^C1 say%1$ns| something to %2$C3.",
+   "ua": "%1$^C1 щось говор%1$nить|ять %2$C3."
+  },
+  "Похоже, что-то пошло не так, придется отменить.": {
+   "en": "Looks like something went wrong, better cancel.",
+   "ua": "Схоже, щось пішло не так, доведеться скасувати."
+  },
+  "Я не понимаю, о чем ты.": {
+   "en": "I don't know what you're on about.",
+   "ua": "Я не розумію, про що ти."
+  }
+ },
+ "behaviors/bloodthirst/onSpec": {
+  "{GБоги запрещают вещи с кровожадностью в мирных зонах.{x": {
+   "en": "{GThe Gods forbid bloodthirsty items in peaceful zones.{x",
+   "ua": "{GБоги забороняють речі з кровожерністю в мирних зонах.{x"
+  }
+ },
+ "behaviors/bouquet/onCantPut": {
+  "%1$^C1 безуспешно пытается запихнуть %2$O4 в %3$O4.": {
+   "en": "%1$^C1 unsuccessfully tries to stuff %2$O4 into %3$O4.",
+   "ua": "%1$^C1 безуспішно намагається запхати %2$O4 в %3$O4."
+  }
+ },
+ "behaviors/bouquet/onPut": {
+  "%1$^O1 превращается в красивый букет.": {
+   "en": "%1$^O1 turns into a beautiful bouquet.",
+   "ua": "%1$^O1 перетворюється на гарний букет."
+  }
+ },
+ "behaviors/bouquet/smell": {
+  "Каркас пуст -- пахнуть пока нечему.": {
+   "en": "The frame is empty -- there's nothing to smell yet.",
+   "ua": "Каркас порожній -- поки що нічому пахнути."
+  }
+ },
+ "behaviors/bucket/engine": {
+  "%1$^C1 деловито пристраивает %2$O4 под %3$C4.": {
+   "en": "%1$^C1 efficiently sets %2$O4 under %3$C4.",
+   "ua": "%1$^C1 діловито пристроює %2$O4 під %3$C4."
+  },
+  "Ты пристраиваешь %1$O4 куда следует.": {
+   "en": "You put %1$O4 where it belongs.",
+   "ua": "Ти пристроюєш %1$O4 куди слід."
+  },
+  "Часть %1$N2 попадает прямо в ловко подставленн%2$Gое|ый|ую %2$O4.": {
+   "en": "Part of %1$N2 lands right in the deftly held-out %2$O4.",
+   "ua": "Частина %1$N2 потрапляє прямо у вправно підставлен%2$Gе|ий|у|і %2$O4."
+  }
+ },
+ "behaviors/captain/onSpec": {
+  "%1$^C1 ложится и засыпает.": {
+   "en": "%1$^C1 lies down and falls asleep.",
+   "ua": "%1$^C1 лягає і засинає."
+  },
+  "%1$^C1 резко просыпается и зевает.": {
+   "en": "%1$^C1 wakes up with a start and yawns.",
+   "ua": "%1$^C1 різко прокидається і позіхає."
+  },
+  "Пожалуйста, поддерживайте порядок на улицах. Содержите Утеху в чистоте.": {
+   "en": "Please maintain order in the streets. Keep Utekha clean.",
+   "ua": "Будь ласка, підтримуйте порядок на вулицях. Тримайте Утіху в чистоті."
+  },
+  "Приветствую вас, жители Утехи!": {
+   "en": "Greetings, citizens of Solace!",
+   "ua": "Вітаю вас, жителі Утіхи!"
+  }
+ },
+ "behaviors/cauldron/postUse": {
+  "{/%1$^O1 на секунду окутыва%1$nется|ются голубым светом и тут же угаса%1$nет|ют.": {
+   "en": "{/%1$^O1 glow%1$ns| with blue light for a second, then immediately fade%1$ns| out.",
+   "ua": "{/%1$^O1 на мить огорта%1$nється|ються блакитним світлом і одразу ж згаса%1$nє|ють."
+  },
+  "{/%^O1 не поддастся алхимической реакции.": {
+   "en": "{/%^O1 won't respond to the alchemical reaction.",
+   "ua": "{/%^O1 не піддасться алхімічній реакції."
+  },
+  "Без профессионального навыка варки зелий процесс займет гораздо больше времени.": {
+   "en": "Without professional potion-brewing skill, the process will take much longer.",
+   "ua": "Без професійного навику варіння зіль процес займе набагато більше часу."
+  },
+  "Для варки зелий костер нужно растопить пожарче.": {
+   "en": "To brew potions, the fire needs to be stoked hotter.",
+   "ua": "Щоб варити зілля, багаття треба розпалити сильніше."
+  },
+  "Для варки зелий нужно сначала развести костер.": {
+   "en": "To brew potions, you first need to light a fire.",
+   "ua": "Щоб варити зілля, спершу треба розвести багаття."
+  },
+  "Из %1$O2 {C%2$C2{x доносится таинственное бульканье.": {
+   "en": "Mysterious bubbling drifts from %1$O2 belonging to {C%2$C2{x.",
+   "ua": "Із %1$O2 {C%2$C2{x доноситься таємниче булькотіння."
+  },
+  "Кажется не хватает какого-то компонента...": {
+   "en": "Looks like some component is missing...",
+   "ua": "Здається, бракує якогось компонента..."
+  },
+  "Компоненты внутри %O2 вспыхивают и исчезают!": {
+   "en": "The components inside %O2 flare up and vanish!",
+   "ua": "Компоненти всередині %O2 спалахують і зникають!"
+  },
+  "Попробуй использовать компоненты поустойчивее, чем %1$O1.": {
+   "en": "Try using components sturdier than %1$O1.",
+   "ua": "Спробуй використати стійкіші компоненти, ніж %1$O1."
+  },
+  "Попробуй положить в котел ключ, сокровище, отмычку или просто мусор.": {
+   "en": "Try putting a key, a treasure, a lockpick, or just some junk into the cauldron.",
+   "ua": "Спробуй покласти в казан ключ, скарб, відмичку або просто сміття."
+  },
+  "Процесс варки зелья прерван, а жаль.": {
+   "en": "The potion-brewing process has been interrupted, what a shame.",
+   "ua": "Процес варіння зілля перервано, а шкода."
+  },
+  "Тебе приходит в голову, что для %1$O2 использования вероятно нужна пробирка.": {
+   "en": "It occurs to you that using %1$O2 probably requires a vial.",
+   "ua": "Тобі спадає на думку, що для використання %1$O2 напевно потрібна пробірка."
+  },
+  "Ты активируешь %1$O4, и %1$P1 внезапно окутыва%1$nется|ются голубым светом!": {
+   "en": "You activate %1$O4, and it suddenly become%1$ns| wrapped in a blue glow!",
+   "ua": "Ти активуєш %1$O4, і %1$O1 раптово огорта%1$nється|ються блакитним світлом!"
+  }
+ },
+ "behaviors/chessboard/engine": {
+  "%1$^C1 бережно кладет %2$^O4 на место": {
+   "en": "%1$^C1 carefully puts %2$^O4 back in place",
+   "ua": "%1$^C1 дбайливо кладе %2$^O4 на місце"
+  },
+  "%1$^C1 делает рокировку": {
+   "en": "%1$^C1 castles",
+   "ua": "%1$^C1 робить рокіровку"
+  },
+  "Если хочешь поиграть с самим собой, используй команду play self.": {
+   "en": "If you want to play against yourself, use the command play self.",
+   "ua": "Якщо хочеш пограти сам із собою, використай команду play self."
+  },
+  "За победу над живым противником дают 200 опыта, но не чаще раза в сутки. За игру с собой награды нет.": {
+   "en": "You get 200 experience for beating a live opponent, but no more than once a day. There's no reward for playing against yourself.",
+   "ua": "За перемогу над живим супротивником дають 200 досвіду, але не частіше разу на добу. За гру із самим собою нагороди немає."
+  },
+  "За победу над своим противником ты получаешь 200 очков опыта.": {
+   "en": "For defeating your opponent, you receive 200 experience points.",
+   "ua": "За перемогу над своїм противником ти отримуєш 200 очок досвіду."
+  },
+  "Зарегистрируйся как игрок, или жди своей очереди!": {
+   "en": "Register as a player, or wait your turn!",
+   "ua": "Зареєструйся як гравець, або чекай своєї черги!"
+  },
+  "Игра закончена. Для начала новой партии используйте команду restart": {
+   "en": "The game is over. To start a new match, use the command restart",
+   "ua": "Гру закінчено. Щоб почати нову партію, використай команду restart"
+  },
+  "Игра между %1$^C5 и %2$^C5 началась. Традиционно первый ход за белыми!": {
+   "en": "The game between %1$^C5 and %2$^C5 has begun. Tradition says the first move goes to white!",
+   "ua": "Гра між %1$^C5 та %2$^C5 почалася. За традицією перший хід за білими!"
+  },
+  "Клетка, на которую ты пытаешься пойти, занята фигурой. Может стоит попробовать её сбить?": {
+   "en": "The square you're trying to move to is occupied by a piece. Maybe try capturing it instead?",
+   "ua": "Клітинка, на яку ти намагаєшся піти, зайнята фігурою. Може, варто спробувати її збити?"
+  },
+  "Куда? Королю шах!": {
+   "en": "Where to? The king is in check!",
+   "ua": "Куди? Королю шах!"
+  },
+  "Не все игроки ещё готовы.": {
+   "en": "Not all players are ready yet.",
+   "ua": "Не всі гравці ще готові."
+  },
+  "Неверный ход.": {
+   "en": "Invalid move.",
+   "ua": "Невірний хід."
+  },
+  "Невозможно произвести рокировку!": {
+   "en": "Cannot castle!",
+   "ua": "Неможливо зробити рокіровку!"
+  },
+  "Но ты уже играешь с собой. Используй команду 'restart' для начала новой партии.": {
+   "en": "But you're already playing against yourself. Use the 'restart' command to start a new game.",
+   "ua": "Але ти вже граєш сам із собою. Використай команду 'restart', щоб почати нову партію."
+  },
+  "Партия еще не началась.": {
+   "en": "The game hasn't started yet.",
+   "ua": "Партія ще не почалася."
+  },
+  "Пока двое играют, третий вмешаться не может -- дождись конца партии.": {
+   "en": "While two are playing, a third can't join in -- wait for the game to end.",
+   "ua": "Поки двоє грають, третій втрутитися не може -- дочекайся кінця партії."
+  },
+  "Тренировка с самим собой за обе стороны: 'use chess play self'.": {
+   "en": "Practice against yourself, playing both sides: 'use chess play self'.",
+   "ua": "Тренування сам із собою за обидві сторони: 'use chess play self'."
+  },
+  "Ты делаешь рокировку": {
+   "en": "You castle.",
+   "ua": "Ти робиш рокіровку"
+  },
+  "Ход фигурой: 'use chess <откуда>-<куда>', например 'use chess e2-e4'.": {
+   "en": "Moving a piece: 'use chess <from>-<to>', for example 'use chess e2-e4'.",
+   "ua": "Хід фігурою: 'use chess <звідки>-<куди>', наприклад 'use chess e2-e4'."
+  },
+  "Ходят белые": {
+   "en": "White to move",
+   "ua": "Хід білих"
+  },
+  "Ходят чёрные": {
+   "en": "Black to move",
+   "ua": "Хід чорних"
+  }
+ },
+ "behaviors/clan guard/onGreet": {
+  "%1$^C1 окидыва%1$nет|ют %2$C4 внимательным взглядом и кача%1$nет|ют головой.": {
+   "en": "%1$^C1 give%1$ns| %2$C4 a careful look and shake%1$ns| their head.",
+   "ua": "%1$^C1 окида%1$nє|ють %2$C4 уважним поглядом і хита%1$nє|ють головою."
+  },
+  "%1$^C1 почтительно кланя%1$nется|ются, пропуская %2$C4.": {
+   "en": "%1$^C1 bow%1$ns| respectfully, letting %2$C4 pass.",
+   "ua": "%1$^C1 шанобливо вклоня%1$nється|ються, пропускаючи %2$C4."
+  },
+  "%1$^C1 почтительно кланя%1$nется|ются, пропуская тебя.": {
+   "en": "%1$^C1 bow%1$ns| respectfully, letting you through.",
+   "ua": "%1$^C1 шанобливо вклоня%1$nється|ються, пропускаючи тебе."
+  },
+  "Только наличие у тебя %O2 оправдывает твое присутствие здесь, %C1.": {
+   "en": "Only the fact that you have %O2 justifies your presence here, %C1.",
+   "ua": "Лише наявність у тебе %O2 виправдовує твою присутність тут, %C1."
+  }
+ },
+ "behaviors/coin/onDrop": {
+  "%1^O1 падает {1{Gгербом{2 вверх.": {
+   "en": "%1^O1 lands {1{Gheads{2 up.",
+   "ua": "%1^O1 падає {1{Gгербом{2 догори."
+  },
+  "%1^O1 падает {1{Rрешкой{2 вверх.": {
+   "en": "%1^O1 lands {1{Rtails{2 up.",
+   "ua": "%1^O1 падає {1{Rрешкою{2 догори."
+  }
+ },
+ "behaviors/cuisinart/onUse": {
+  "%1$^C1 безуспешно пыта%1$nется|ются запустить %2$O4 без содержимого.": {
+   "en": "%1$^C1 unsuccessfully tr%1$nies|y to start %2$O4 with nothing inside.",
+   "ua": "%1$^C1 безуспішно намага%1$nється|ються запустити %2$O4 без вмісту."
+  },
+  "%1$^C1 безуспешно пыта%1$nется|ются запустить %2$O4 с открытой крышкой.": {
+   "en": "%1$^C1 unsuccessfully tr%1$nies|y to start %2$O4 with the lid open.",
+   "ua": "%1$^C1 безуспішно намага%1$nється|ються запустити %2$O4 з відкритою кришкою."
+  },
+  "%1$^C1 безуспешно пыта%1$nется|ются запустить %2$O4.": {
+   "en": "%1$^C1 unsuccessfully tr%1$nies|y to start %2$O4.",
+   "ua": "%1$^C1 безуспішно намага%1$nється|ються запустити %2$O4."
+  },
+  "%1$^C1 безуспешно пыта%1$nется|ются остановить %2$O4 в процессе работы.": {
+   "en": "%1$^C1 unsuccessfully tr%1$nies|y to stop %2$O4 while it's running.",
+   "ua": "%1$^C1 безуспішно намага%1$nється|ються зупинити %2$O4 у процесі роботи."
+  },
+  "%1$^O1 работа%1$nет|ют -- не трогай!": {
+   "en": "%1$^O1 work%1$ns| -- don't touch it!",
+   "ua": "%1$^O1 працю%1$nє|ють -- не чіпай!"
+  },
+  "Сначала закрой крышку!": {
+   "en": "Close the lid first!",
+   "ua": "Спершу закрий кришку!"
+  },
+  "Ты осторожно запускаешь %^O4 и делаешь шаг назад.": {
+   "en": "You carefully start %^O4 and take a step back.",
+   "ua": "Ти обережно запускаєш %^O4 і робиш крок назад."
+  }
+ },
+ "behaviors/cuisinart/postUse": {
+  "%1$^O1 аккуратно прессу%1$nет|ют %2$s, не трогая остальное.": {
+   "en": "%1$^O1 carefully press%1$nes| %2$s without touching the rest.",
+   "ua": "%1$^O1 акуратно пресу%1$nє|ють %2$s, не чіпаючи решту."
+  },
+  "%1$^O1 начина%1$nет|ют гудеть и медленно раскручиваться.": {
+   "en": "%1$^O1 start%1$ns| humming and slowly spinning up.",
+   "ua": "%1$^O1 почина%1$nє|ють гудіти і повільно розкручуватися."
+  },
+  "Гул из %1$O2 усиливается и достигает максимума громкости!": {
+   "en": "The hum from %1$O2 grows and reaches maximum volume!",
+   "ua": "Гул з %1$O2 посилюється і досягає максимуму гучності!"
+  },
+  "Гул стихает так же внезапно, как и начался, а %1$^O1 замедля%1$nется|ются и останавлива%1$nется|ются.": {
+   "en": "The hum fades as suddenly as it started, and %1$^O1 slow%1$ns| down and come%1$ns| to a stop.",
+   "ua": "Гул стихає так само раптово, як і почався, а %1$^O1 уповільню%1$nється|ються і зупиня%1$nється|ються."
+  }
+ },
+ "behaviors/cult adept/onGreet": {
+  "Приветствую, %C1.": {
+   "en": "Greetings, %C1.",
+   "ua": "Вітаю, %C1."
+  }
+ },
+ "behaviors/cult adept/postSpeech": {
+  "Ты возносишь хвалу твоему новому божеству!": {
+   "en": "You offer praise to your new deity!",
+   "ua": "Ти возносиш хвалу своєму новому божеству!"
+  },
+  "Я не понимаю, что ты от меня хочешь.": {
+   "en": "I don't understand what you want from me.",
+   "ua": "Я не розумію, чого ти від мене хочеш."
+  }
+ },
+ "behaviors/dice/onDrop": {
+  "После броска на верхней грани кубика видна цифра {Y%d{x.": {
+   "en": "After the roll, the number {Y%d{x is showing on the die's top face.",
+   "ua": "Після кидка на верхній грані кубика видно цифру {Y%d{x."
+  }
+ },
+ "behaviors/enchanter/onSpeech": {
+  "%1$^C1 что-то говор%1$nит|ят %2$C3.": {
+   "en": "%1$^C1 say%1$ns| something to %2$C3.",
+   "ua": "%1$^C1 говор%1$nить|ять щось до %2$C3."
+  },
+  "Похоже, что-то пошло не так, придется отменить.": {
+   "en": "Looks like something went wrong, I'll have to cancel.",
+   "ua": "Схоже, щось пішло не так, доведеться скасувати."
+  },
+  "Я не понимаю, о чем ты.": {
+   "en": "I don't understand what you're talking about.",
+   "ua": "Я не розумію, про що ти."
+  }
+ },
+ "behaviors/fire/onArea": {
+  "%1^O1 согрева%1$nет|ют тебя, восстанавливая силы.": {
+   "en": "%1^O1 warm%1$ns| you up, restoring your strength.",
+   "ua": "%1^O1 зігріва%1$nє|ють тебе, відновлюючи сили."
+  },
+  "Пламя уменьшается, %1$O1 скоро погасн%1$nет|ут.": {
+   "en": "The flame is dying down -- %1$O1 %1$nis|are about to go out.",
+   "ua": "Полумʼя слабшає, %1$O1 незабаром згас%1$nне|нуть."
+  }
+ },
+ "behaviors/fire/onCantFetch": {
+  "%1$^C1 пыта%1$nется|ются вытащить %2$O4 из %3$O2, не мо%1$nжет|гут ухватиться из-за жара.": {
+   "en": "%1$^C1 tr%1$nies|y to pull %2$O4 out of %3$O2 but fail%1$ns| to get a grip because of the heat.",
+   "ua": "%1$^C1 намага%1$nється|ються витягнути %2$O4 з %3$O2, не мо%1$nже|жуть вхопитися через спеку."
+  },
+  "Ты пытаешься вытащить %1$O4 из %2$O2, но не можешь ухватиться из-за жара.": {
+   "en": "You try to pull %1$O4 out of %2$O2, but can't get a grip because of the heat.",
+   "ua": "Ти намагаєшся витягти %1$O4 з %2$O2, але не можеш вхопитися через жар."
+  }
+ },
+ "behaviors/fire/onFetch": {
+  "Ты вытаскиваешь %1$O4 из %2$O2, но обжигаешься и роняешь %1$P2 %3$s.": {
+   "en": "You pull %1$O4 out of %2$O2, but burn yourself and drop it %3$s.",
+   "ua": "Ти витягуєш %1$O4 з %2$O2, але обпікаєшся і впускаєш %1$O4 %3$s."
+  }
+ },
+ "behaviors/fire/onUse": {
+  "Ты протягиваешь руки к %O3, ощущая {Yприятное тепло{x.": {
+   "en": "You stretch your hands out to %O3, feeling {Ya pleasant warmth{x.",
+   "ua": "Ти простягаєш руки до %O3, відчуваючи {Yприємне тепло{x."
+  }
+ },
+ "behaviors/fountain/onArea": {
+  "%1$^O1 понемногу высыха%1$nет|ют.": {
+   "en": "%1$^O1 gradually dr%1$nies|y up.",
+   "ua": "%1$^O1 потроху висиха%1$nє|ють."
+  },
+  "%1$^O1 понемногу наполня%1$nется|ются %2$N5.": {
+   "en": "%1$^O1 slowly fill%1$ns| up with %2$N5.",
+   "ua": "%1$^O1 потроху наповню%1$nється|ються %2$N5."
+  }
+ },
+ "behaviors/golem/onArea": {
+  "ОШИБКА: неверный внум исходного материала для %1$C4, сообщи Богам.": {
+   "en": "ERROR: invalid source material vnum for %1$C4, report to the Gods.",
+   "ua": "ПОМИЛКА: невірний внум вихідного матеріалу для %1$C4, повідом Богам."
+  }
+ },
+ "behaviors/golem/onGive": {
+  "ОШИБКА: неверный внум исходного материала, сообщи Богам.": {
+   "en": "ERROR: invalid vnum for source material, report to the Gods.",
+   "ua": "ПОМИЛКА: невірний внум вихідного матеріалу, повідом Богам."
+  },
+  "Похоже, теперь %1$P2 запас энергии снова на максимуме.": {
+   "en": "Looks like %1$C1's energy reserve is back to full again.",
+   "ua": "Схоже, запас енергії %1$C2 знову на максимумі."
+  }
+ },
+ "behaviors/jailer/onGreet": {
+  "%1$^C1 окидыва%1$nет|ют %2$C4 внимательным взглядом и кача%1$nет|ют головой.": {
+   "en": "%1$^C1 give%1$ns| %2$C4 a careful once-over and shake%1$ns| their head.",
+   "ua": "%1$^C1 окида%1$nє|ють %2$C4 уважним поглядом і хита%1$nє|ють головою."
+  },
+  "%1$^C1 окидыва%1$nет|ют тебя внимательным взглядом и кача%1$nет|ют головой.": {
+   "en": "%1$^C1 give%1$ns| you a careful look and shake%1$ns| their head.",
+   "ua": "%1$^C1 окида%1$nє|ють тебе уважним поглядом і хита%1$nє|ють головою."
+  }
+ },
+ "behaviors/janitor/onSpec": {
+  "%1$^C1 поднимает с пола какой-то мусор.": {
+   "en": "%1$^C1 picks some trash up off the floor.",
+   "ua": "%1$^C1 підбирає з підлоги якесь сміття."
+  }
+ },
+ "behaviors/master samurai/onGive": {
+  "Я не принимаю подарков.": {
+   "en": "I don't accept gifts.",
+   "ua": "Я не приймаю подарунків."
+  }
+ },
+ "behaviors/master vampire/onSpeech": {
+  "Тебе потребуется 50 квестовых очков для обряда посвящения.": {
+   "en": "You'll need 50 quest points for the initiation rite.",
+   "ua": "Тобі знадобиться 50 квестових очок для обряду посвяти."
+  }
+ },
+ "behaviors/matches/onUse": {
+  "%1$^C1 доста%1$nет|ют спичку из %2$O2, чирка%1$nет|ют и поджига%1$nет|ют.": {
+   "en": "%1$^C1 take%1$ns| a match out of %2$O2, strike%1$ns| it and light%1$ns| it.",
+   "ua": "%1$^C1 діста%1$nє|ють сірник із %2$O2, чирка%1$nє|ють і підпалю%1$nє|ють."
+  },
+  "%1$^C1 поднос%1$nит|ят зажженную спичку к %2$O3.": {
+   "en": "%1$^C1 hold%1$ns| a lit match up to %2$O3.",
+   "ua": "%1$^C1 підно%1$nсить|сять запалений сірник до %2$O3."
+  },
+  "%1$^O5 не выйдет никого поймать, это не ловушка.": {
+   "en": "You won't catch anyone with %1$^O5, it's not a trap.",
+   "ua": "За допомогою %1$^O5 нікого не спіймаєш, це не пастка."
+  },
+  "Или просто напиши {y{hcиспользовать %1$s{x, чтобы высыпать все спички.": {
+   "en": "Or just type {y{hcuse %1$s{x to dump out all the matches.",
+   "ua": "Або просто напиши {y{hcвикористати %1$s{x, щоб висипати всі сірники."
+  },
+  "Используй %1$O4 на предметы, чтобы их поджечь -- по одной спичке за раз.": {
+   "en": "Use %1$O4 on items to set them on fire -- one match at a time.",
+   "ua": "Використовуй %1$O4 на предмети, щоб їх підпалити -- по одному сірнику за раз."
+  },
+  "Используй %O4 на объект, чтобы его поджечь, или на насекомое, чтобы его поймать.": {
+   "en": "Use %O4 on an object to set it on fire, or on an insect to catch it.",
+   "ua": "Використай %O4 на обʼєкт, щоб його підпалити, або на комаху, щоб її впіймати."
+  },
+  "Сначала освободи %1$O4 от спичек -- их там еще {Y%2$d{x.": {
+   "en": "First empty %1$O4 of matches -- there are still {Y%2$d{x left.",
+   "ua": "Спершу звільни %1$O4 від сірників -- їх там ще {Y%2$d{x."
+  },
+  "Ты высыпаешь все спички из %1$O2 %2$s.": {
+   "en": "You dump out all the matches from %1$O2 %2$s.",
+   "ua": "Ти висипаєш усі сірники з %1$O2 %2$s."
+  },
+  "Ты достаешь спичку из %1$O2, чиркаешь и поджигаешь.": {
+   "en": "You pull a match out of %1$O2, strike it, and light up.",
+   "ua": "Ти дістаєш сірник із %1$O2, чиркаєш і підпалюєш."
+  },
+  "Ты подносишь зажженную спичку к %1$O3.": {
+   "en": "You bring a lit match up to %1$O3.",
+   "ua": "Ти підносиш запалений сірник до %1$O3."
+  },
+  "Учти, ты использова%1$Gло|л|ла последнюю спичку.": {
+   "en": "Keep in mind, you just used your last match.",
+   "ua": "Май на увазі, ти використа%1$Gло|в|ла останній сірник."
+  }
+ },
+ "behaviors/mayor/onSpec": {
+  "%1$^C1 ложится и засыпает.": {
+   "en": "%1$^C1 lies down and falls asleep.",
+   "ua": "%1$^C1 лягає і засинає."
+  },
+  "Добрый день, горожане!": {
+   "en": "Good day, citizens!",
+   "ua": "Доброго дня, городяни!"
+  }
+ },
+ "behaviors/money changer/onBribe": {
+  "%^C1 пытается дать тебе деньги, но ты не можешь их удержать.": {
+   "en": "%^C1 tries to give you money, but you can't hold onto it.",
+   "ua": "%^C1 намагається дати тобі гроші, але ти не можеш їх утримати."
+  },
+  "Извини, %^C1, но эта сумма слишком мала для обмена.": {
+   "en": "Sorry, %^C1, but that amount is too small to exchange.",
+   "ua": "Вибач, %^C1, але ця сума занадто мала для обміну."
+  }
+ },
+ "behaviors/money changer/onGreet": {
+  "Чтобы обменять золото на серебро или наоборот, просто дай мне сумму для обмена.": {
+   "en": "To exchange gold for silver or vice versa, just give me the amount to exchange.",
+   "ua": "Щоб обміняти золото на срібло або навпаки, просто дай мені суму для обміну."
+  }
+ },
+ "behaviors/municipality/postSpeech": {
+  "%1$^C1 достает из ящика реестр ремесленных лицензий и вносит туда твое имя.": {
+   "en": "%1$^C1 takes out the register of craft licenses from the drawer and enters your name into it.",
+   "ua": "%1$^C1 дістає із шухляди реєстр ремісничих ліцензій і вносить туди твоє імʼя."
+  },
+  "%1$^C1 достает из ящика реестр ремесленных лицензий и что-то туда записывает.": {
+   "en": "%1$^C1 takes the craft license register out of the drawer and writes something in it.",
+   "ua": "%1$^C1 дістає з шухляди реєстр ремісничих ліцензій і щось туди записує."
+  },
+  "Ваша лицензия будет активна еще 30 дней.": {
+   "en": "Your license will remain active for another 30 days.",
+   "ua": "Твоя ліцензія буде активна ще 30 днів."
+  },
+  "Не задерживайте очередь, проходите.": {
+   "en": "Don't hold up the line, keep moving.",
+   "ua": "Не затримуйте чергу, проходьте."
+  }
+ },
+ "behaviors/sage/onSpeech": {
+  "%1$^C1 что-то говор%1$nит|ят %2$C3.": {
+   "en": "%1$^C1 say%1$ns| something to %2$C3.",
+   "ua": "%1$^C1 щось говор%1$nить|ять %2$C3."
+  },
+  "Похоже, что-то пошло не так, придется отменить.": {
+   "en": "Looks like something went wrong, I'll have to cancel.",
+   "ua": "Схоже, щось пішло не так, доведеться скасувати."
+  },
+  "Я не понимаю, о чем ты.": {
+   "en": "I don't understand what you mean.",
+   "ua": "Я не розумію, про що ти."
+  }
+ },
+ "behaviors/set master scout/onEquip": {
+  "Ты внезапно осознаешь как {Cвидеть камуфляж{x.": {
+   "en": "You suddenly realize how to {Csee through camouflage{x.",
+   "ua": "Ти раптово усвідомлюєш, як {Cбачити камуфляж{x."
+  }
+ },
+ "behaviors/set myrvale noriva/onEquip": {
+  "Этот комплект предназначен только для клериков.": {
+   "en": "This set is meant for clerics only.",
+   "ua": "Цей комплект призначений лише для клериків."
+  }
+ },
+ "behaviors/set pixie/onEquip": {
+  "Ты внезапно получаешь способность {Cулучшенной невидимости{x.": {
+   "en": "You suddenly gain the ability of {Cenhanced invisibility{x.",
+   "ua": "Ти раптово отримуєш здатність {Cпокращеної невидимості{x."
+  }
+ },
+ "behaviors/set secret of sidhe/onEquip": {
+  "Лишь те, кто следуют по пути Добра или Зла, смогут завершить комплект.": {
+   "en": "Only those who follow the Path of Good or Evil can complete the set.",
+   "ua": "Лише ті, хто йде шляхом Добра чи Зла, зможуть завершити комплект."
+  }
+ },
+ "behaviors/set shevale reykaris/onEquip": {
+  "Этот комплект предназначен только для некромантов.": {
+   "en": "This set is intended for necromancers only.",
+   "ua": "Цей комплект призначений лише для некромантів."
+  }
+ },
+ "behaviors/shovel/onUse": {
+  "%^O4 не стоит пытаться закопать.": {
+   "en": "%^O4 isn't worth trying to bury.",
+   "ua": "%^O4 не варто намагатися закопати."
+  },
+  "В мире нет никого с таким именем.": {
+   "en": "There's no one in the world with that name.",
+   "ua": "У світі немає нікого з таким іменем."
+  },
+  "В этой местности раскопки и другие изменения запрещены.": {
+   "en": "Digging and other changes are forbidden in this area.",
+   "ua": "У цій місцевості розкопки та інші зміни заборонені."
+  },
+  "Для обуздания мобов есть много иных методов.": {
+   "en": "There are plenty of other ways to bring mobs to heel.",
+   "ua": "Для приборкання мобів є багато інших методів."
+  },
+  "Копать желательно стоя.": {
+   "en": "It's best to dig while standing.",
+   "ua": "Копати бажано стоячи."
+  },
+  "Сперва лопату нужно взять в руки.": {
+   "en": "First you need to take the shovel in your hands.",
+   "ua": "Спершу лопату треба взяти до рук."
+  },
+  "Ты не видишь на земле ничего похожего.": {
+   "en": "You don't see anything like that on the ground.",
+   "ua": "Ти не бачиш на землі нічого схожого."
+  },
+  "Ты пытаешься поковырять %1$O5 в твердом полу и %1$P1 изрядно затупливается.": {
+   "en": "You try to poke at %1$O5 in the hard floor, and it gets considerably duller.",
+   "ua": "Ти намагаєшся поколупати %1$O5 у твердій підлозі, і %1$O1 неабияк тупиться."
+  },
+  "Ты старательно зарываешь %O4 в землю.": {
+   "en": "You carefully bury %O4 in the ground.",
+   "ua": "Ти старанно закопуєш %O4 в землю."
+  }
+ },
+ "behaviors/snare/onDrop": {
+  "%1$^C1 устанавлива%1$nет|ют %2$O4 и с нетерпением жд%1$nет|ут.": {
+   "en": "%1$^C1 set%1$ns| up %2$O4 and wait%1$ns| impatiently.",
+   "ua": "%1$^C1 встановлю%1$nє|ють %2$O4 і нетерпляче чека%1$nє|ють."
+  },
+  "Ты устанавливаешь %O4 и с нетерпением ждешь.": {
+   "en": "You set %O4 and wait impatiently.",
+   "ua": "Ти встановлюєш %O4 і нетерпляче чекаєш."
+  }
+ },
+ "behaviors/snare/onSpec": {
+  "%1$^C1 съеда%1$nет|ют часть %2$O2.": {
+   "en": "%1$^C1 eat%1$ns| part of %2$O2.",
+   "ua": "%1$^C1 зʼїда%1$nє|ють частину %2$O2."
+  }
+ },
+ "behaviors/suave moose/onSpeech": {
+  "Может, ты хочешь попросить у меня что-то?": {
+   "en": "Maybe you'd like to ask me for something?",
+   "ua": "Може, ти хочеш попросити в мене щось?"
+  }
+ },
+ "behaviors/tattoo picture/postUse": {
+  "%1$^C1 долж%1$Gно|ен|на сперва сесть.": {
+   "en": "%1$^C1 needs to sit down first.",
+   "ua": "%1$^C1 повин%1$Gно|ен|на спершу сісти."
+  },
+  "%1$^C1 не оценит твоих усилий.": {
+   "en": "%1$^C1 won't appreciate your efforts.",
+   "ua": "%1$^C1 не оцінить твоїх зусиль."
+  },
+  "%1$^C1 обмакивает %2$O4 в %3$O4.": {
+   "en": "%1$^C1 dips %2$O4 into %3$O4.",
+   "ua": "%1$^C1 занурює %2$O4 у %3$O4."
+  },
+  "%1$^C1 прекращает наносить татуировку.": {
+   "en": "%1$^C1 stops applying the tattoo.",
+   "ua": "%1$^C1 припиняє наносити татуювання."
+  },
+  "%1$^C1 прикладывает %2$O4 к %3$N3 %4$C2.": {
+   "en": "%1$^C1 presses %2$O4 to the %3$N3 of %4$C2.",
+   "ua": "%1$^C1 прикладає %2$O4 до %3$N3 %4$C2."
+  },
+  "%1$^C1 прикладывает %2$O4 к своему %3$N3.": {
+   "en": "%1$^C1 presses %2$O4 against their own %3$N3.",
+   "ua": "%1$^C1 прикладає %2$O4 до свого %3$N3."
+  },
+  "%1$^C1 прикладывает %2$O4 к твоему %3$N3.": {
+   "en": "%1$^C1 presses %2$O4 to your %3$N3.",
+   "ua": "%1$^C1 прикладає %2$O4 до твого %3$N3."
+  },
+  "%1$^C1 проводит %2$O5 по коже %3$C2, оставляя царапины.": {
+   "en": "%1$^C1 runs %2$O5 across %3$C2's skin, leaving scratches.",
+   "ua": "%1$^C1 проводить %2$O5 по шкірі %3$C2, залишаючи подряпини."
+  },
+  "%1$^C1 проводит %2$O5 по своей коже, оставляя царапины.": {
+   "en": "%1$^C1 draws %2$O5 across their own skin, leaving scratches.",
+   "ua": "%1$^C1 проводить %2$O5 по своїй шкірі, залишаючи подряпини."
+  },
+  "%1$^C1 проводит %2$O5 по твоей коже, оставляя царапины.": {
+   "en": "%1$^C1 runs %2$O5 across your skin, leaving scratches.",
+   "ua": "%1$^C1 проводить %2$O5 по твоїй шкірі, залишаючи подряпини."
+  },
+  "%1$^C1 пытается отковырять с %3$C2 %2$O4.": {
+   "en": "%1$^C1 tries to pick %2$O4 off of %3$C2.",
+   "ua": "%1$^C1 намагається відколупати з %3$C2 %2$O4."
+  },
+  "%1$^C1 пытается отковырять с себя %2$O4.": {
+   "en": "%1$^C1 tries to pick %2$O4 off themselves.",
+   "ua": "%1$^C1 намагається відколупати з себе %2$O4."
+  },
+  "%1$^C1 пытается отковырять с тебя %2$O4.": {
+   "en": "%1$^C1 tries to pick %2$O4 off of you.",
+   "ua": "%1$^C1 намагається відколупати з тебе %2$O4."
+  },
+  "%1$^O1 -- это не нож для татуировок.": {
+   "en": "%1$^O1 -- this isn't a tattoo knife.",
+   "ua": "%1$^O1 -- це не ніж для татуювань."
+  },
+  "%^C1 тычет %O5 в %O4.": {
+   "en": "%^C1 jabs %O5 into %O4.",
+   "ua": "%^C1 тиче %O5 у %O4."
+  },
+  "Без зеркала не удастся нанести татуировку на %N6, а ты в них не отражаешься.": {
+   "en": "Without a mirror you won't manage to tattoo your %N6, and you don't reflect in them.",
+   "ua": "Без дзеркала не вдасться нанести татуювання на %N6, а ти в них не відображаєшся."
+  },
+  "В %O6 совсем пусто.": {
+   "en": "There's nothing at all in %O6.",
+   "ua": "У %O6 зовсім порожньо."
+  },
+  "Куда-то пропал рисунок.": {
+   "en": "The picture has vanished somewhere.",
+   "ua": "Малюнок кудись зник."
+  },
+  "Поглядывая на рисунок, %1$C1 наносит %2$C3 татуировку %3$N1.": {
+   "en": "Glancing at the picture, %1$C1 applies the %3$N1 tattoo to %2$C3.",
+   "ua": "Поглядаючи на малюнок, %1$C1 наносить %2$C3 татуювання %3$N1."
+  },
+  "Поглядывая на рисунок, %1$C1 наносит себе татуировку %2$N1.": {
+   "en": "Glancing at the picture, %1$C1 gives themselves a %2$N1 tattoo.",
+   "ua": "Поглядаючи на малюнок, %1$C1 наносить собі татуювання %2$N1."
+  },
+  "Поглядывая на рисунок, %1$C1 наносит тебе татуировку %2$N1.": {
+   "en": "Glancing at the picture, %1$C1 gives you a %2$N1 tattoo.",
+   "ua": "Поглядаючи на малюнок, %1$C1 наносить тобі татуювання %2$N1."
+  },
+  "Поглядывая на рисунок, ты наносишь %1$C3 татуировку %2$N1.": {
+   "en": "Glancing at the picture, you give %1$C3 a %2$N1 tattoo.",
+   "ua": "Поглядаючи на малюнок, ти наносиш %1$C3 татуювання %2$N1."
+  },
+  "Поглядывая на рисунок, ты наносишь себе татуировку %1$N1.": {
+   "en": "Glancing at the picture, you give yourself the %1$N1 tattoo.",
+   "ua": "Поглядаючи на малюнок, ти наносиш собі татуювання %1$N1."
+  },
+  "Получить ее можно в ратуше Мидгаарда.": {
+   "en": "You can get one at Midgaard's town hall.",
+   "ua": "Отримати її можна в ратуші Мідгаарда."
+  },
+  "Присядь -- так наносить татуировку будет гораздо удобнее.": {
+   "en": "Sit down -- it'll be much easier to apply the tattoo that way.",
+   "ua": "Присядь -- так наносити татуювання буде значно зручніше."
+  },
+  "Секрет нанесения татуировки на это место пока недоступен.": {
+   "en": "The secret of tattooing this spot is not yet available.",
+   "ua": "Секрет нанесення татуювання на це місце поки що недоступний."
+  },
+  "Сперва вооружись татуировочным ножом.": {
+   "en": "First, arm yourself with a tattoo knife.",
+   "ua": "Спершу озбройся татуювальним ножем."
+  },
+  "Тебе необходимо зеркало, чтобы нанести себе татуировку на %N6.": {
+   "en": "You need a mirror to tattoo your own %N6.",
+   "ua": "Тобі потрібне дзеркало, щоб нанести собі татуювання на %N6."
+  },
+  "Тебе необходимо иметь в инвентаре специальные чернила.": {
+   "en": "You need to have special ink in your inventory.",
+   "ua": "Тобі потрібно мати в інвентарі спеціальне чорнило."
+  },
+  "Тщательно надавливая, %1$C1 выводит на коже %2$C2 %3$O4.": {
+   "en": "Pressing carefully, %1$C1 etches %3$O4 onto %2$C2's skin.",
+   "ua": "Ретельно натискаючи, %1$C1 виводить на шкірі %2$C2 %3$O4."
+  },
+  "Тщательно надавливая, %1$C1 выводит на твоей коже %2$O4.": {
+   "en": "Pressing carefully, %1$C1 traces %2$O4 onto your skin.",
+   "ua": "Ретельно натискаючи, %1$C1 виводить на твоїй шкірі %2$O4."
+  },
+  "Тщательно надавливая, ты выводишь на коже %1$C2 %2$O4.": {
+   "en": "Pressing carefully, you trace %2$O4 onto %1$C2's skin.",
+   "ua": "Ретельно натискаючи, ти виводиш на шкірі %1$C2 %2$O4."
+  },
+  "Ты безуспешно пытаешься нанести татуировку поверх %O2.": {
+   "en": "You unsuccessfully try to tattoo over %O2.",
+   "ua": "Ти безуспішно намагаєшся нанести татуювання поверх %O2."
+  },
+  "Ты не видишь на своем теле места под татуировку на %N6.": {
+   "en": "You don't see any space on your body for a tattoo on %N6.",
+   "ua": "Ти не бачиш на своєму тілі місця під татуювання на %N6."
+  },
+  "Ты не видишь на теле %C2 места под татуировку на %N6.": {
+   "en": "You don't see any room on %C2's body for a tattoo on %N6.",
+   "ua": "Ти не бачиш на тілі %C2 місця під татуювання на %N6."
+  },
+  "Ты не владеешь искусством '%N1'.": {
+   "en": "You don't know the art of '%N1'.",
+   "ua": "Ти не володієш мистецтвом '%N1'."
+  },
+  "Ты обмакиваешь %1$O4 в %2$O4.": {
+   "en": "You dip %1$O4 into %2$O4.",
+   "ua": "Ти вмочуєш %1$O4 у %2$O4."
+  },
+  "Ты прекращаешь наносить татуировку.": {
+   "en": "You stop tattooing.",
+   "ua": "Ти припиняєш наносити татуювання."
+  },
+  "Ты прикладываешь %1$O4 к %2$N3 %3$C2.": {
+   "en": "You press %1$O4 to %3$C2's %2$N3.",
+   "ua": "Ти прикладаєш %1$O4 до %2$N3 %3$C2."
+  },
+  "Ты прикладываешь %1$O4 к %N3.": {
+   "en": "You press %1$O4 against %N3.",
+   "ua": "Ти прикладаєш %1$O4 до %N3."
+  },
+  "Ты проводишь %1$O5 по коже %2$C2, оставляя царапины.": {
+   "en": "You run %1$O5 across %2$C2's skin, leaving scratches.",
+   "ua": "Ти проводиш %1$O5 по шкірі %2$C2, залишаючи подряпини."
+  },
+  "Ты проводишь %1$O5 по своей коже, оставляя царапины.": {
+   "en": "You run %1$O5 across your own skin, leaving scratches.",
+   "ua": "Ти проводиш %1$O5 по своїй шкірі, залишаючи подряпини."
+  },
+  "У %C2 кончились чернила.": {
+   "en": "%C2 has run out of ink.",
+   "ua": "У %C2 закінчилося чорнило."
+  },
+  "У %C2 уже есть татуировка %O2.": {
+   "en": "%C2 already has the %O2 tattoo.",
+   "ua": "У %C2 вже є татуювання %O2."
+  },
+  "У тебя уже есть татуировка %O2.": {
+   "en": "You already have a %O2 tattoo.",
+   "ua": "У тебе вже є татуювання %O2."
+  },
+  "Укажи, куда именно ты хочешь нанести татуировку.": {
+   "en": "Specify exactly where you want the tattoo.",
+   "ua": "Вкажи, куди саме ти хочеш нанести татуювання."
+  },
+  "Чтобы наносить татуировки, тебе нужна действующая ремесленная лицензия.": {
+   "en": "To give tattoos, you need a valid crafting license.",
+   "ua": "Щоб наносити татуювання, тобі потрібна чинна реміснича ліцензія."
+  },
+  "Этот рисунок можно наносить только на тех, кто достиг %1$dго уровня.": {
+   "en": "This design can only be applied to those who've reached level %1$d.",
+   "ua": "Цей малюнок можна наносити лише на тих, хто досяг %1$dго рівня."
+  },
+  "Этот рисунок слишком сложен для тебя.": {
+   "en": "This design is too complex for you.",
+   "ua": "Цей малюнок надто складний для тебе."
+  }
+ },
+ "behaviors/teacher/onCantTeach": {
+  "Извини, %1$^C1, но я могу обучать тебя только до {1{Y%d{2 уровня.": {
+   "en": "Sorry, %1$^C1, but I can only teach you up to level {1{Y%d{2.",
+   "ua": "Вибач, %1$^C1, але я можу навчати тебе лише до {1{Y%d{2 рівня."
+  },
+  "Тебе, %C3, тренировки и практики не нужны.": {
+   "en": "You, %C3, don't need training or practice.",
+   "ua": "Тобі, %C3, тренування і практика не потрібні."
+  }
+ },
+ "behaviors/teacher/onCantTrain": {
+  "Тебе, %C3, тренировки и практики не нужны.": {
+   "en": "You, %C3, don't need training or practice.",
+   "ua": "Тобі, %C3, тренування і практика не потрібні."
+  }
+ },
+ "behaviors/templeperson/onGreet": {
+  "%^C1 что-то произносит, обращаясь к %C3.": {
+   "en": "%^C1 says something, addressing %C3.",
+   "ua": "%^C1 щось промовляє, звертаючись до %C3."
+  }
+ },
+ "behaviors/templeperson/postSpeech": {
+  "{1{C%^C1{2 проводит ладонью над Книгой, и ты решаешь посмотреть повнимательнее.{/": {
+   "en": "{1{C%^C1{2 runs a hand over the Book, and you decide to take a closer look.{/",
+   "ua": "{1{C%^C1{2 проводить долонею над Книгою, і ти вирішуєш придивитися уважніше.{/"
+  },
+  "Благодарю за усердие, но ты и так поклоняешься {1{C%N3.{2": {
+   "en": "Thanks for the effort, but you already worship {1{C%N3.{2",
+   "ua": "Дякую за старання, але ти й так поклоняєшся {1{C%N3.{2"
+  },
+  "К сожалению, я не адепт культа {1{C%N2,{2 поищи кого-нибудь еще.": {
+   "en": "Unfortunately, I'm not an adept of the cult of {1{C%N2,{2 look for someone else.",
+   "ua": "На жаль, я не адепт культу {1{C%N2,{2 пошукай когось іншого."
+  },
+  "Но ты уже выбра%1$Gло|л|ла свой путь! Твоя религия -- {1{C%2$N1.{2": {
+   "en": "But you've already chosen your path! Your religion is {1{C%2$N1.{2",
+   "ua": "Але ти вже виб%1$Gрало|рав|рала свій шлях! Твоя релігія -- {1{C%2$N1.{2"
+  },
+  "Сожалею, %^C1, но ты уже второй раз пытаешься отречься от своей религии.": {
+   "en": "Sorry, %^C1, but this is already the second time you've tried to renounce your religion.",
+   "ua": "Шкода, %^C1, але ти вже вдруге намагаєшся зректися своєї релігії."
+  },
+  "Тебе не от кого отрекаться, %C1.": {
+   "en": "You have no one to renounce, %C1.",
+   "ua": "Тобі нема від кого зрікатися, %C1."
+  },
+  "Это возможно сделать только один раз за все перерождения.": {
+   "en": "This can only be done once, across all your rebirths.",
+   "ua": "Це можна зробити лише один раз за всі переродження."
+  },
+  "Я ничего не знаю о такой религии, назови имя божества полностью.": {
+   "en": "I don't know anything about a religion like that -- give me the deity's full name.",
+   "ua": "Я нічого не знаю про таку релігію, назви імʼя божества повністю."
+  }
+ },
+ "behaviors/thief/onSpec": {
+  "%1$^C1 пытается ограбить %2$C4!": {
+   "en": "%1$^C1 tries to rob %2$C4!",
+   "ua": "%1$^C1 намагається пограбувати %2$C4!"
+  },
+  "%1$^C1 пытается ограбить тебя!": {
+   "en": "%1$^C1 tries to rob you!",
+   "ua": "%1$^C1 намагається пограбувати тебе!"
+  }
+ },
+ "behaviors/torch/onUse": {
+  "%1$^C1 поднос%1$nит|ят зажженн%2$Gое|ый|ую|ые %2$O4 к %3$O3.": {
+   "en": "%1$^C1 bring%1$ns| the lit %2$O4 close to %3$O3.",
+   "ua": "%1$^C1 піднос%1$nить|ять запал%2$Gене|ений|ену|ені %2$O4 до %3$O3."
+  },
+  "%1$^O1 сначала надо подобрать.": {
+   "en": "%1$^O1 needs to be picked up first.",
+   "ua": "%1$^O1 спершу треба підняти."
+  },
+  "Ты подносишь зажженн%1$Gое|ый|ую|ые %1$O4 к %2$O3.": {
+   "en": "You hold the lit %1$O4 up to %2$O3.",
+   "ua": "Ти підносиш запален%1$Gе|ий|у|і %1$O4 до %2$O3."
+  }
  }
 }


### PR DESCRIPTION
215 mechanical-flagged behavior output phrases translated EN/UA (Trello 2594, trilingual runtime bulk cycle 5). Into config/translations/behaviors.json, +215 new / 0 overwritten (pilot entries untouched). lint-l10n 0 HARD. Voice (269) + hard (64) lanes follow separately.