### PR TITLE
l10n: behaviors hard-lane translations (64 phrases)

### DIFF
--- a/config/translations/behaviors.json
+++ b/config/translations/behaviors.json
@@ -525,6 +525,10 @@
   "Не нужно давать мне вещи, просто произнеси вслух их название.": {
    "en": "No need to give me things, just say their name out loud.",
    "ua": "Не треба давати мені речі, просто скажи вголос їхню назву."
+  },
+  "В данном случае, напиши '{1{y{hcсказать %s{x{2'.": {
+   "en": "In this case, type '{1{y{hcsay %s{x{2'.",
+   "ua": "У цьому випадку напиши '{1{y{hcсказать %s{x{2'."
   }
  },
  "behaviors/amix/onGreet": {
@@ -561,6 +565,18 @@
   "Я не вижу у тебя предмета с таким названием.": {
    "en": "I don't see an item like that on you.",
    "ua": "Я не бачу в тебе предмета з такою назвою."
+  },
+  "Если соглас{Smен{Sfна{Sx, скажи '{1{Wда{2' или '{1{Wуверен{Sfа{Sx{2'.": {
+   "en": "If you agree, say '{1{Wyes{2' or '{1{Wsure{2'.",
+   "ua": "Якщо згод{Smен{Sfна{Sx, скажи '{1{Wтак{2' або '{1{Wпевн{Smен{Sfа{Sx{2'."
+  },
+  "Погоди, а куда подевалась вещь, которую ты хотел{Sfа{Sx уничтожить?": {
+   "en": "Hold on, where did the thing you wanted to destroy go?",
+   "ua": "Зачекай, а куди поділася річ, яку тобі хотілося знищити?"
+  },
+  "Ты уверен{Sfа{Sx что хочешь уничтожить %1$P2? Это стоит 200 квестовых очков.": {
+   "en": "Are you sure you want to destroy %1$O4? That costs 200 quest points.",
+   "ua": "Ти точно хочеш знищити %1$O4? Це коштує 200 квестових очок."
   }
  },
  "behaviors/ashes/onSpec": {
@@ -599,6 +615,10 @@
   "Ты не видишь здесь предмета под названием {g%s{x.": {
    "en": "You don't see an item called {g%s{x here.",
    "ua": "Ти не бачиш тут предмета під назвою {g%s{x."
+  },
+  "%1$^C1 широко размахивае%1$ется|ются и нанос%1$ит|ят удар %2$O5 по дереву!": {
+   "en": "%1$^C1 winds up and lands a blow with %2$O5 against the tree!",
+   "ua": "%1$^C1 широко розмахує%1$ється|ються і завда%1$ит|ять удар %2$O5 по дереву!"
   }
  },
  "behaviors/baker/onGreet": {
@@ -623,6 +643,10 @@
   "Я не понимаю, о чем ты.": {
    "en": "I don't know what you're on about.",
    "ua": "Я не розумію, про що ти."
+  },
+  "Чтобы подтвердить услугу %1$N2 на %2$O4 за %3$s надо {1{y{hcсказать да{x{2.": {
+   "en": "To confirm the service %1$N2 on %2$O4 for %3$s, you need to {1{y{hcsay yes{x{2.",
+   "ua": "Щоб підтвердити послугу %1$N2 на %2$O4 за %3$s, треба {1{y{hcсказать да{x{2."
   }
  },
  "behaviors/bloodthirst/onSpec": {
@@ -733,6 +757,10 @@
   "Ты активируешь %1$O4, и %1$P1 внезапно окутыва%1$nется|ются голубым светом!": {
    "en": "You activate %1$O4, and it suddenly become%1$ns| wrapped in a blue glow!",
    "ua": "Ти активуєш %1$O4, і %1$O1 раптово огорта%1$nється|ються блакитним світлом!"
+  },
+  "Ты очень устал{Sfа{Sx. Перед следующей варкой надо немного отдохнуть.": {
+   "en": "You're completely worn out. You need to rest a bit before the next brew.",
+   "ua": "Тебе геть виснажило. Перед наступною варкою треба трохи відпочити."
   }
  },
  "behaviors/chessboard/engine": {
@@ -819,6 +847,90 @@
   "Ходят чёрные": {
    "en": "Black to move",
    "ua": "Хід чорних"
+  },
+  "=                                  {WИ да пребудет с тобой Сила!{x                 =": {
+   "en": "=                                  {WMay the Force be with you!{x                 =",
+   "ua": "=                                  {WІ хай буде з тобою Сила!{x                 ="
+  },
+  "=  {Duse chess play black{x - низвергнет с Небес в армию Люцифера.                 =": {
+   "en": "=  {Duse chess play black{x - will cast you down from the Heavens into Lucifer's army.        =",
+   "ua": "=  {Duse chess play black{x - скине тебе з Небес у військо Люцифера.                    ="
+  },
+  "=  {Wuse chess <[a-h][1-8]>-<[a-h][1-8]>{x, например {Wuse chess e2-e4{x               =": {
+   "en": "=  {Wuse chess <[a-h][1-8]>-<[a-h][1-8]>{x, for example {Wuse chess e2-e4{x               =",
+   "ua": "=  {Wuse chess <[a-h][1-8]>-<[a-h][1-8]>{x, наприклад {Wuse chess e2-e4{x               ="
+  },
+  "=  {Wuse chess <[a-h][1-8]>:<[a-h][1-8]>{x, например {Wuse chess d5:e4{x               =": {
+   "en": "=  {Wuse chess <[a-h][1-8]>:<[a-h][1-8]>{x, for example {Wuse chess d5:e4{x               =",
+   "ua": "=  {Wuse chess <[a-h][1-8]>:<[a-h][1-8]>{x, наприклад {Wuse chess d5:e4{x               ="
+  },
+  "=  {Wuse chess play white{x - даст тебе крылья и сверкающий меч, в то время как    =": {
+   "en": "=  {Wuse chess play white{x - gives you wings and a shining sword, while         =",
+   "ua": "=  {Wuse chess play white{x - дає тобі крила та осяйний меч, тоді як            ="
+  },
+  "=  Дабы армией управлять на поле брани, набрать команду нужно:                 =": {
+   "en": "=  To command an army on the field of battle, you must recruit a squad:        =",
+   "ua": "=  Щоб армією керувати на полі брані, набрати команду треба:                   ="
+  },
+  "=  Дабы солдаты в атаку пошли священную, набери:                               =": {
+   "en": "=  For your soldiers to march off on holy attack, type:                        =",
+   "ua": "=  Щоб солдати пішли у священну атаку, набери:                                ="
+  },
+  "=  Доску вывести на экран можно в любой момент:                                =": {
+   "en": "= You can bring up the board on screen at any time:                            =",
+   "ua": "= Дошку можна вивести на екран у будь-який момент:                             ="
+  },
+  "=  Игру начать дабы, сторону выбрать следует - пойдёшь ли ты дорогой {WСвета{x,    =": {
+   "en": "=  To start the game, a side you must choose - will you walk the path of {WLight{x,    =",
+   "ua": "=  Щоб гру почати, сторону обрати слід - чи підеш ти дорогою {WСвітла{x,    ="
+  },
+  "=  Очерёдность хода увидишь, набрав:                                           =": {
+   "en": "=  You'll see whose turn it is by typing:                                           =",
+   "ua": "=  Черговість ходу побачиш, набравши:                                           ="
+  },
+  "=  играя: {Wuse chess play self{x                                                  = ": {
+   "en": "=  by playing: {Wuse chess play self{x                                                  = ",
+   "ua": "=  граючи: {Wuse chess play self{x                                                  = "
+  },
+  "=  или канешь во {DТьму{x - решение за тобой!                                      =": {
+   "en": "=  or you sink into the {DDarkness{x - the choice is yours!                       =",
+   "ua": "=  або підеш у {DТемряву{x - рішення за тобою!                                    ="
+  },
+  "= За тренировочный поединок с самим собой воин, однако, награды не дождется.   =": {
+   "en": "= For a training duel against yourself, though, no warrior shall get a reward. =",
+   "ua": "= За тренувальний поєдинок із самим собою воїн, однак, нагороди не дочекається.="
+  },
+  "= Когда двое на поле брани сошлись, третий помешать не может, команды чужим    =": {
+   "en": "= When two meet in battle, a third can't interfere -- orders to someone else's =",
+   "ua": "= Коли двоє зійшлися на полі бою, третій втручатися не може, команди чужим     ="
+  },
+  "= После того, как обе стороны путь свой выберут, битва начнётся великая, в     =": {
+   "en": "= Once both sides have chosen their path, a great battle shall begin, in     =",
+   "ua": "= Після того, як обидві сторони свій шлях оберуть, битва почнеться велика, в     ="
+  },
+  "= как игрок новый.                                                             =": {
+   "en": "= as a new player.                                                             =",
+   "ua": "= як гравець новий.                                                             ="
+  },
+  "= сутки дана ему будет.                                                        =": {
+   "en": "= for a full day.                                                              =",
+   "ua": "= на добу йому буде надано.                                                    ="
+  },
+  "= ходе которой победитель будет определён. За победу над противником будет он  =": {
+   "en": "= over which a winner shall be determined. For defeating the enemy he shall    =",
+   "ua": "= в ході якої переможця буде визначено. За перемогу над супротивником буде він ="
+  },
+  "Атака по фигуре: 'use chess <откуда>:<куда>', например 'use chess d5:e4'.": {
+   "en": "Attacking a piece: 'use chess <from>:<to>', for example 'use chess d5:e4'.",
+   "ua": "Атака фігури: 'use chess <звідки>:<куди>', наприклад 'use chess d5:e4'."
+  },
+  "Показать доску: 'use chess show'. Чья очередь хода: 'use chess turn'. Начать заново: 'use chess restart'.": {
+   "en": "Show the board: 'use chess show'. Whose turn is it: 'use chess turn'. Start over: 'use chess restart'.",
+   "ua": "Показати дошку: 'use chess show'. Чия черга ходити: 'use chess turn'. Почати заново: 'use chess restart'."
+  },
+  "Слононоска пуста!": {
+   "en": "The elephant-square is empty!",
+   "ua": "Слоноклітка порожня!"
   }
  },
  "behaviors/clan guard/onGreet": {
@@ -847,6 +959,10 @@
   "%1^O1 падает {1{Rрешкой{2 вверх.": {
    "en": "%1^O1 lands {1{Rtails{2 up.",
    "ua": "%1^O1 падає {1{Rрешкою{2 догори."
+  },
+  "%1^O1 падает {1{Cна ребро!{2 Ого, вот это неожиданность!": {
+   "en": "%1^O1 lands {1{Con its edge!{2 Wow, now that's a surprise!",
+   "ua": "%1^O1 падає {1{Cна ребро!{2 Ого, оце несподіванка!"
   }
  },
  "behaviors/cuisinart/onUse": {
@@ -911,6 +1027,10 @@
   "Я не понимаю, что ты от меня хочешь.": {
    "en": "I don't understand what you want from me.",
    "ua": "Я не розумію, чого ти від мене хочеш."
+  },
+  "Будет интересно -- почитай на досуге справку ({1{W{hc? религия{x{2).": {
+   "en": "Could be interesting -- read up on it in your free time ({1{W{hc? religion{x{2).",
+   "ua": "Буде цікаво -- почитай на дозвіллі довідку ({1{W{hc? религия{x{2)."
   }
  },
  "behaviors/dice/onDrop": {
@@ -931,6 +1051,10 @@
   "Я не понимаю, о чем ты.": {
    "en": "I don't understand what you're talking about.",
    "ua": "Я не розумію, про що ти."
+  },
+  "Чтобы подтвердить услугу %1$N2 на %2$O4 за %3$s надо {1{y{hcсказать да{x{2.": {
+   "en": "To confirm the %1$N2 service on %2$O4 for %3$s, you need to {1{y{hcsay yes{x{2.",
+   "ua": "Щоб підтвердити послугу %1$N2 на %2$O4 за %3$s, треба {1{y{hcсказать да{x{2."
   }
  },
  "behaviors/fire/onArea": {
@@ -941,6 +1065,14 @@
   "Пламя уменьшается, %1$O1 скоро погасн%1$nет|ут.": {
    "en": "The flame is dying down -- %1$O1 %1$nis|are about to go out.",
    "ua": "Полумʼя слабшає, %1$O1 незабаром згас%1$nне|нуть."
+  },
+  "%1^O1 раскаля%1$nется|ются и пыш%1$nет|ут жаром.": {
+   "en": "%1^O1 glow%1$ns| red hot and radiate%1$ns| heat.",
+   "ua": "%1^O1 розжарює%1$nється|ються і паш%1$nить|ать жаром."
+  },
+  "Пламя %1$O2 затихает, превращаясь в {Rя{Yр{Wк{Rие, кр{Yа{rсо{Wч{Dн{rы{Rе {Dу{Yг{Dл{rи{x,{/переливающиеся всеми оттенками {Rкрасного {xи {Yоранжевого{x.": {
+   "en": "The flame of %1$O2 dies down, turning into {Rb{Yr{Wi{Rg{Yh{rt, {Wg{Dl{ro{Rw{Di{Yn{Dg {rcoals{x,{/ shimmering in every shade of {Rred{x and {Yorange{x.",
+   "ua": "Полумʼя %1$O2 згасає, перетворюючись на {Rя{Yс{Wк{Rр{Yа{rв{Wе, {Dб{rа{Rр{Dв{Yи{Dс{rте вугілля{x,{/ що переливається всіма відтінками {Rчервоного{x і {Yоранжевого{x."
   }
  },
  "behaviors/fire/onCantFetch": {
@@ -957,6 +1089,10 @@
   "Ты вытаскиваешь %1$O4 из %2$O2, но обжигаешься и роняешь %1$P2 %3$s.": {
    "en": "You pull %1$O4 out of %2$O2, but burn yourself and drop it %3$s.",
    "ua": "Ти витягуєш %1$O4 з %2$O2, але обпікаєшся і впускаєш %1$O4 %3$s."
+  },
+  "%1$^C1 вытаскива%1$nет|ют %2$O4 из %3$O2, но обжига%1$nется|ются и роня%1$nет|ют %2$P2 %4$s.": {
+   "en": "%1$^C1 pull%1$ns| %2$O4 out of %3$O2, but get%1$ns| burned and drop%1$ns| it %4$s.",
+   "ua": "%1$^C1 витяга%1$nє|ють %2$O4 з %3$O2, але обпіка%1$nється|ються і впуска%1$nє|ють %2$O4 %4$s."
   }
  },
  "behaviors/fire/onUse": {
@@ -989,6 +1125,10 @@
   "Похоже, теперь %1$P2 запас энергии снова на максимуме.": {
    "en": "Looks like %1$C1's energy reserve is back to full again.",
    "ua": "Схоже, запас енергії %1$C2 знову на максимумі."
+  },
+  "Сначала надо переподчинить голема: попробуй {1{y{hcсказать 'за мной'{x{2.": {
+   "en": "First you'll need to rebind the golem: try {1{y{hcsay 'follow me'{x{2.",
+   "ua": "Спершу треба перепідпорядкувати голема: спробуй {1{y{hcсказать 'за мной'{x{2."
   }
  },
  "behaviors/jailer/onGreet": {
@@ -1121,6 +1261,10 @@
   "Я не понимаю, о чем ты.": {
    "en": "I don't understand what you mean.",
    "ua": "Я не розумію, про що ти."
+  },
+  "Чтобы подтвердить услугу %1$N2 на %2$O4 за %3$s надо {1{y{hcсказать да{x{2.": {
+   "en": "To confirm the %1$N2 service on %2$O4 for %3$s, you need to {1{y{hcsay yes{x{2.",
+   "ua": "Щоб підтвердити послугу %1$N2 на %2$O4 за %3$s, треба {1{y{hcсказать да{x{2."
   }
  },
  "behaviors/set master scout/onEquip": {
@@ -1145,6 +1289,10 @@
   "Лишь те, кто следуют по пути Добра или Зла, смогут завершить комплект.": {
    "en": "Only those who follow the Path of Good or Evil can complete the set.",
    "ua": "Лише ті, хто йде шляхом Добра чи Зла, зможуть завершити комплект."
+  },
+  "{WНа{wб{Wо{wр{W си{wдх{Wийск{wо{Wй б{wр{Wони на{wч{Wина{wет{W светиться ровным се{wр{Wе{wбр{Wист{wы{Wм светом.{x": {
+   "en": "{WThe {wsidhe {Warmor {wset {Wbegins {wto {Wshine {wwith {Wan {weven {Wsilvery {wlight.{x",
+   "ua": "{WКомплект {wсидхійської {Wброні {wпочинає {Wсвітитися {wрівним {Wсріблястим {wсвітлом.{x"
   }
  },
  "behaviors/set shevale reykaris/onEquip": {
@@ -1199,6 +1347,10 @@
   "Ты устанавливаешь %O4 и с нетерпением ждешь.": {
    "en": "You set %O4 and wait impatiently.",
    "ua": "Ти встановлюєш %O4 і нетерпляче чекаєш."
+  },
+  "Сейчас %1$O1 пуст%1$Gо||а|ы, возможно стоит {hhположить{x внутрь приманку?": {
+   "en": "Right now %1$O1 is empty, maybe you should {hhput{x some bait inside?",
+   "ua": "Зараз %1$O1 порожн%1$Gє|ій|я|і, можливо, варто {hhположить{x всередину приманку?"
   }
  },
  "behaviors/snare/onSpec": {
@@ -1409,6 +1561,18 @@
   "Этот рисунок слишком сложен для тебя.": {
    "en": "This design is too complex for you.",
    "ua": "Цей малюнок надто складний для тебе."
+  },
+  "Например: {y{hcисп рисунок персонаж плечо{x.": {
+   "en": "For example: {y{hcuse picture character shoulder{x.",
+   "ua": "Наприклад: {y{hcисп рисунок персонаж плечо{x."
+  },
+  "Примеры: правое запястье, плечо, лев зап.": {
+   "en": "Examples: right wrist, shoulder, l. wrist.",
+   "ua": "Приклади: праве запʼястя, плече, ліве зап."
+  },
+  "Татуировка -- тяжкий труд, а ты так устал{Sfа{Sx...": {
+   "en": "Getting a tattoo is hard work, and you're so tired...",
+   "ua": "Татуювання -- важка праця, а ти так втомлюєшся..."
   }
  },
  "behaviors/teacher/onCantTeach": {
@@ -1419,6 +1583,10 @@
   "Тебе, %C3, тренировки и практики не нужны.": {
    "en": "You, %C3, don't need training or practice.",
    "ua": "Тобі, %C3, тренування і практика не потрібні."
+  },
+  "Прочитай {1{y{hcсправка %d{x{2 -- там указан учитель для группы {1{hh%s{x{2.": {
+   "en": "Read {1{y{hchelp %d{x{2 -- it lists the teacher for the {1{hh%s{x{2 group.",
+   "ua": "Прочитай {1{y{hcдовідка %d{x{2 -- там вказаний вчитель для групи {1{hh%s{x{2."
   }
  },
  "behaviors/teacher/onCantTrain": {
@@ -1431,6 +1599,10 @@
   "%^C1 что-то произносит, обращаясь к %C3.": {
    "en": "%^C1 says something, addressing %C3.",
    "ua": "%^C1 щось промовляє, звертаючись до %C3."
+  },
+  "Чтобы ответить, просто набери '{W{hcсказать ДА{x{g' или '{W{hcсказать НЕТ{x{g'.{x": {
+   "en": "To answer, just type '{W{hcsay YES{x{g' or '{W{hcsay NO{x{g'.{x",
+   "ua": "Щоб відповісти, просто введи '{W{hcсказать ДА{x{g' або '{W{hcсказать НЕТ{x{g'.{x"
   }
  },
  "behaviors/templeperson/postSpeech": {
@@ -1465,6 +1637,18 @@
   "Я ничего не знаю о такой религии, назови имя божества полностью.": {
    "en": "I don't know anything about a religion like that -- give me the deity's full name.",
    "ua": "Я нічого не знаю про таку релігію, назви імʼя божества повністю."
+  },
+  "Будет интересно -- почитай на досуге справку ({1{W{hc? религия{x{2).": {
+   "en": "It'll be interesting -- read up on the help article ({1{W{hc? religion{x{2) sometime.",
+   "ua": "Буде цікаво -- почитай колись на дозвіллі довідку ({1{W{hc? религия{x{2)."
+  },
+  "Когда будешь {1готов{Sfа{x{2, просто скажи ({1{W{hhsay{x{2) имя бога, которому хочешь поклоняться.": {
+   "en": "Once you're {1ready{x{2, just say ({1{W{hhsay{x{2) the name of the god you wish to worship.",
+   "ua": "Коли будеш {1готов{Smий{Sfа{Sx{x{2, просто скажи ({1{W{hhsay{x{2) імʼя бога, якому хочеш поклонятися."
+  },
+  "Не забудь прочитать справку ({1{W{hc? религия{x{2).": {
+   "en": "Don't forget to read the help article ({1{W{hc? religion{x{2).",
+   "ua": "Не забудь прочитати довідку ({1{W{hc? религия{x{2)."
   }
  },
  "behaviors/thief/onSpec": {
@@ -1489,6 +1673,106 @@
   "Ты подносишь зажженн%1$Gое|ый|ую|ые %1$O4 к %2$O3.": {
    "en": "You hold the lit %1$O4 up to %2$O3.",
    "ua": "Ти підносиш запален%1$Gе|ий|у|і %1$O4 до %2$O3."
+  }
+ },
+ "behaviors/blacksmith/onGive": {
+  "Просто укажи, какая тебе нужна {1{y{hcуслуга{x{2.": {
+   "en": "Just tell me what {1{y{hcservice{x{2 you need.",
+   "ua": "Просто вкажи, яка тобі потрібна {1{y{hcпослуга{x{2."
+  }
+ },
+ "behaviors/blacksmith/onGreet": {
+  "Эх, скучно мне! Тебе случайно {1{y{hcуслуга{x{2 кузнеца не нужна?": {
+   "en": "Eh, I'm bored! You wouldn't happen to need a smith's {1{y{hcservice{x{2, would you?",
+   "ua": "Ех, нудно мені! Тобі часом не потрібна {1{y{hcпослуга{x{2 коваля?"
+  }
+ },
+ "behaviors/enchanter/onGive": {
+  "Просто укажи, какая тебе нужна {1{y{hcуслуга{x{2.": {
+   "en": "Just tell me which {1{y{hcservice{x{2 you need.",
+   "ua": "Просто вкажи, яка тобі потрібна {1{y{hcпослуга{x{2."
+  }
+ },
+ "behaviors/enchanter/onGreet": {
+  "С тебя -- деньги, с меня -- {1{y{hcуслуга{x{2 опытно%1$Gго|го|й чароде%1$Gя|я|йки.": {
+   "en": "You give the money, I give the {1{y{hcservice{x{2 of an experienced enchanter.",
+   "ua": "З тебе -- гроші, з мене -- {1{y{hcпослуга{x{2 досвідчен%1$Gого|ого|ої чароді%1$Gя|я|йки."
+  }
+ },
+ "behaviors/lust room/onSpec": {
+  "Аромат {Gв{Wе{Cс{gн{Gы{x и {Yсч{Wа{Mст{yь{Yя{x будоражит тебя!": {
+   "en": "The scent of {Gs{Wp{Cr{gi{Gng{x and {Yha{Wp{Mpi{yn{Yess{x stirs you up!",
+   "ua": "Аромат {Gв{Wе{Cс{gн{Gи{x і {Yщ{Wа{Mс{yт{Yя{x хвилює тебе!"
+  },
+  "От ароматов {Gв{Wе{Cс{gн{Gы{x и {Yсч{Wа{Mст{yь{Yя{x %1$C1 выгляд%1$nит|ят окрыленными!": {
+   "en": "From the scents of {Gb{Wl{Co{go{Gm{x and {Yel{Wa{Mti{yo{Yn{x, %1$C1 look%1$ns| positively uplifted!",
+   "ua": "Від ароматів {Gв{Wе{Cс{gн{Gи{x і {Yщ{Wа{Mс{yт{Yя{x %1$C1 вигляда%1$nє|ють окриленими!"
+  }
+ },
+ "behaviors/master vampire/onGreet": {
+  "Я чую в тебе нашу кровь, %1$^C1, но обряд над тобой ещё не свершён. Когда будешь готов%1$Gо||а -- скажи мне: {1{yпосвящение{x{2.": {
+   "en": "I sense our blood in you, %1$^C1, but the rite over you has not yet been performed. When you are ready -- tell me: {1{yinitiation{x{2.",
+   "ua": "Я чую в тобі нашу кров, %1$^C1, але обряд над тобою ще не звершений. Коли будеш готов%1$Gе|ий|а|і -- скажи мені: {1{yпосвячення{x{2."
+  }
+ },
+ "behaviors/municipality/onGreet": {
+  "Как получить? Вы что, говорить разучились? Надо просто {1{y{hcсказать да{x{2.": {
+   "en": "How do you get it? What, have you forgotten how to talk? You just need to {1{y{hcsay yes{x{2.",
+   "ua": "Як отримати? Ти що, говорити розучився? Треба просто {1{y{hcсказать да{x{2."
+  },
+  "Продлевать будем? Напоминаю для особо одаренных, надо просто {1{y{hcсказать да{x{2.": {
+   "en": "Shall we renew? Reminder for the especially gifted: all you need to do is {1{y{hcsay yes{x{2.",
+   "ua": "Продовжуємо? Нагадую для особливо обдарованих, треба просто {1{y{hcсказать да{x{2."
+  }
+ },
+ "behaviors/newbie weapon/onFight": {
+  "%1$^O1 шепч%1$nет|ут тебе {Y'Тебе лучше {y{hcубежать{x{Yпрочь, подальше отсюда!'{x": {
+   "en": "%1$^O1 whisper%1$ns| to you, {Y'You'd better {y{hcflee{x{Yfar away from here!'{x",
+   "ua": "%1$^O1 шепч%1$nе|уть тобі {Y'Тобі краще {y{hcвтекти{x{Yгеть, подалі звідси!'{x"
+  }
+ },
+ "behaviors/ogre member/onSpec": {
+  "Ну, понеслась Варда по кочкам.": {
+   "en": "Well, there goes Varda, off to the races.",
+   "ua": "Ну, понеслася Варда по купинах."
+  }
+ },
+ "behaviors/sage/onGive": {
+  "Просто укажи, какая тебе нужна {1{y{hcуслуга{x{2.": {
+   "en": "Just tell me which {1{y{hcservice{x{2 you need.",
+   "ua": "Просто вкажи, яка тобі потрібна {1{y{hcпослуга{x{2."
+  }
+ },
+ "behaviors/sage/onGreet": {
+  "Тебе наверняка пригодится {1{y{hcуслуга{x{2 мудреца.": {
+   "en": "You could surely use the sage's {1{y{hcservice{x{2.",
+   "ua": "Тобі точно знадобиться {1{y{hcпослуга{x{2 мудреця."
+  }
+ },
+ "behaviors/shovel/onEquip": {
+  "Нетрудно догадаться, что %O4 можно {hh238использовать{x, чтобы копать.": {
+   "en": "It's not hard to guess that %O4 can be {hh238used{x to dig.",
+   "ua": "Неважко здогадатися, що %O4 можна {hh238використати{x, щоб копати."
+  }
+ },
+ "behaviors/suicideroom/onDive": {
+  "Единственный способ продолжить -- {y{hcсамоубийство{x.": {
+   "en": "The only way to continue is {y{hcsuicide{x.",
+   "ua": "Єдиний спосіб продовжити -- {y{hcсамогубство{x."
+  },
+  "Напиши {y{hh286справка суицид{x и... вперед, волею Варды.": {
+   "en": "Type {y{hh286help suicide{x and... go on, by Varda's will.",
+   "ua": "Напиши {y{hh286довідка суїцид{x і... вперед, волею Варди."
+  }
+ },
+ "behaviors/teacher/onGreet": {
+  "Я помогу тебе {1{y{hcтренировать{x{2 характеристики или {1{y{hcпрактиковать{x{2 умения.": {
+   "en": "I'll help you {1{y{hctrain{x{2 your stats or {1{y{hcpractice{x{2 your skills.",
+   "ua": "Я допоможу тобі {1{y{hcтренувати{x{2 характеристики або {1{y{hcпрактикувати{x{2 уміння."
+  },
+  "Я помогу тебе {1{y{hcтренировать{x{2 характеристики.": {
+   "en": "I'll help you {1{y{hctrain{x{2 your stats.",
+   "ua": "Я допоможу тобі {1{y{hcтренувати{x{2 характеристики."
   }
  }
 }


### PR DESCRIPTION
64 hard-flagged behavior phrases (Trello 2594, bulk cycle 5). Command-link safety: registered verb-aliases + {hh vnum-anchors stay UA; keyword-argument links (speech triggers, keyword help, example cmd) kept RU so clicks resolve; flee link fixed to registered втекти. lint-l10n 0 HARD. Follow-up: add UA speech-keyword matching to onSpeech handlers to let speech-trigger links go full UA.