### PR TITLE
l10n: spell mechanical + hard lane translations (673 phrases)

### DIFF
--- a/config/translations/spell.json
+++ b/config/translations/spell.json
@@ -1,0 +1,3082 @@
+{
+ "spell/acute vision/runVict": {
+  "Твое зрение обостряется, и ты начинаешь замечать замаскированных существ.": {
+   "en": "Your eyesight sharpens, and you begin to notice disguised creatures.",
+   "ua": "Твій зір загострюється, і ти починаєш помічати замаскованих істот."
+  },
+  "Твое зрение уже обострено до предела.": {
+   "en": "Your eyesight is already sharpened to the limit.",
+   "ua": "Твій зір вже загострений до межі."
+  },
+  "Зрачки %C2 на мгновение вспыхивают {1{Gз{gе{Gл{gе{Gн{gы{Gм{2.": {
+   "en": "The pupils of %C2 flash {1{Gg{gr{Ge{ge{Gn{2 for a moment.",
+   "ua": "Зіниці %C2 на мить спалахують {1{Gз{gе{Gл{gе{Gн{gи{Gм{2."
+  }
+ },
+ "spell/adamantite golem/runArg": {
+  "%^C1 что-то пишет на клочке бумаги и кладет его в открытый рот статуи.": {
+   "en": "%^C1 writes something on a scrap of paper and puts it into the statue's open mouth.",
+   "ua": "%^C1 щось пише на клаптику паперу і кладе його у відкритий рот статуї."
+  },
+  "На твоих глазах %C1 оживает и начинает двигаться!": {
+   "en": "Before your eyes, %C1 comes to life and starts moving!",
+   "ua": "У тебе на очах %C1 оживає і починає рухатися!"
+  },
+  "Ты пишешь на клочке бумаги свое имя и кладешь его в открытый рот статуи.": {
+   "en": "You write your name on a scrap of paper and place it in the statue's open mouth.",
+   "ua": "Ти пишеш своє імʼя на клаптику паперу і кладеш його у відкритий рот статуї."
+  }
+ },
+ "spell/aid/runVict": {
+  "%^C2 согревает тепло, дарованное {1{C%N5{2.": {
+   "en": "%^C2 feels the warmth granted by {1{C%N5{2.",
+   "ua": "%^C2 зігрівається теплом, дарованим {1{C%N5{2."
+  },
+  "%^C2 согревает тепло, дарованное {1{C%N5{2. {D[{G%d{D]{x": {
+   "en": "%^C2 is warmed by the warmth granted by {1{C%N5{2. {D[{G%d{D]{x",
+   "ua": "%^C2 зігрівається теплом, дарованим {1{C%N5{2. {D[{G%d{D]{x"
+  },
+  "Перед повторным использованием этого заклинания надо немного подождать.": {
+   "en": "You need to wait a bit before using this spell again.",
+   "ua": "Перед повторним використанням цього заклинання треба трохи почекати."
+  },
+  "Тебя согревает тепло, дарованное {1{C%N5{2! {D[{G%d{D]{x": {
+   "en": "Warmth granted by {1{C%N5{2 spreads through you! {D[{G%d{D]{x",
+   "ua": "Тебе зігріває тепло, дароване {1{C%N5{2! {D[{G%d{D]{x"
+  },
+  "Тебя согревает тепло, дарованное {1{C%N5{2. {D[{G%d{D]{x": {
+   "en": "Warmth granted by {1{C%N5{2 spreads through you. {D[{G%d{D]{x",
+   "ua": "Тебе зігріває тепло, даровано {1{C%N5{2. {D[{G%d{D]{x"
+  }
+ },
+ "spell/anathema/runVict": {
+  "%^C1 пытается предать %C4 анафеме, но безуспешно.": {
+   "en": "%^C1 tries to anathematize %C4, but fails.",
+   "ua": "%^C1 намагається піддати %C4 анафемі, але марно."
+  },
+  "%^C1 пытается предать тебя анафеме, но безуспешно.": {
+   "en": "%^C1 tries to anathematize you, but fails.",
+   "ua": "%^C1 намагається піддати тебе анафемі, але безуспішно."
+  },
+  "%^C4 уже предали анафеме.": {
+   "en": "%^C4 has already been anathematized.",
+   "ua": "%^C4 вже піддали анафемі."
+  },
+  "Тебя уже предали анафеме.": {
+   "en": "You've already been anathematized.",
+   "ua": "Тебе вже піддали анафемі."
+  },
+  "Ты пытаешься предать %C4 анафеме, но безуспешно.": {
+   "en": "You try to damn %C4 to anathema, but fail.",
+   "ua": "Ти намагаєшся віддати %C4 анафемі, але безуспішно."
+  }
+ },
+ "spell/ancestral spirits/runArg": {
+  "Дух предков отказывается нападать на игроков.": {
+   "en": "The spirit of ancestors refuses to attack players.",
+   "ua": "Дух предків відмовляється нападати на гравців."
+  },
+  "Дух предков отказывается нападать на чужих последователей.": {
+   "en": "The ancestral spirit refuses to attack another's followers.",
+   "ua": "Дух предків відмовляється нападати на чужих послідовників."
+  },
+  "Какого из духов предков ты хочешь призвать?": {
+   "en": "Which of the ancestral spirits do you want to summon?",
+   "ua": "Якого з духів предків ти хочеш призвати?"
+  },
+  "Найди Фламинику -- она сможет помочь тебе расти.": {
+   "en": "Find Flaminika -- she'll be able to help you grow.",
+   "ua": "Знайди Фламініку -- вона зможе допомогти тобі рости."
+  },
+  "Но ведь у тебя уже есть %C1!": {
+   "en": "But you already have %C1!",
+   "ua": "Та в тебе ж вже є %C1!"
+  },
+  "Этого духа ты сможешь призывать только достигнув второго ранга.": {
+   "en": "You will only be able to summon this spirit once you reach second rank.",
+   "ua": "Цього духа ти зможеш закликати лише досягнувши другого рангу."
+  },
+  "Этого духа ты сможешь призывать только достигнув высшего ранга.": {
+   "en": "You will be able to summon this spirit only once you reach the highest rank.",
+   "ua": "Цього духа ти зможеш закликати лише досягнувши найвищого рангу."
+  },
+  "{DИспользуй {y{hcк духи саламандра{x{D, {y{hcк духи сокол{x{D или {y{hcк духи кабан{x{D.{x": {
+   "en": "{DUse {y{hcк духи саламандра{x{D, {y{hcк духи сокол{x{D or {y{hcк духи кабан{x{D.{x",
+   "ua": "{DВикористай {y{hcк духи саламандра{x{D, {y{hcк духи сокол{x{D або {y{hcк духи кабан{x{D.{x"
+  }
+ },
+ "spell/animate dead/runObj": {
+  "Из квестовых мобов зомби поднимать пока что запрещено.": {
+   "en": "Raising zombies from quest mobs is forbidden for now.",
+   "ua": "З квестових мобів зомбі піднімати поки що заборонено."
+  },
+  "Некромантией нельзя оживлять объекты -- только трупы одушевлённых существ.": {
+   "en": "You cannot animate objects with necromancy -- only the corpses of animate creatures.",
+   "ua": "Некромантією не можна оживляти предмети -- лише трупи одухотворених істот."
+  },
+  "Некромантия с трупами игроков запрещена богами.": {
+   "en": "Necromancy on player corpses is forbidden by the gods.",
+   "ua": "Некромантія з трупами гравців заборонена богами."
+  },
+  "ОШИБКА: труп из неизвестного моба (сообщи об ошибке богам).": {
+   "en": "ERROR: corpse from an unknown mob (report this bug to the gods).",
+   "ua": "ПОМИЛКА: труп невідомого моба (повідом про помилку богам)."
+  },
+  "Оживить некромантией можно только труп моба, а не %s.": {
+   "en": "You can only raise a mob's corpse with necromancy, not %s.",
+   "ua": "Оживити некромантією можна лише труп моба, а не %s."
+  },
+  "С помощью сил Тьмы и Хаоса %C1 оживляет %O4!": {
+   "en": "With the powers of Darkness and Chaos, %C1 animates %O4!",
+   "ua": "За допомогою сил Тьми і Хаосу %C1 оживляє %O4!"
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/assist/runVict": {
+  "Пронизывающий холод наполняет тебя новыми силами. {D[{G%d{D]{x": {
+   "en": "A piercing cold fills you with new strength. {D[{G%d{D]{x",
+   "ua": "Пронизливий холод наповнює тебе новими силами. {D[{G%d{D]{x"
+  }
+ },
+ "spell/astral projection/runVict": {
+  "{C%^C1 {Bсоздает проекцию своего астрального тела, которая защитит от нежданного удара.{x": {
+   "en": "{C%^C1 {Bcreates a projection of their astral body, which will protect against an unexpected blow.{x",
+   "ua": "{C%^C1 {Bстворює проекцію свого астрального тіла, яка захистить від несподіваного удару.{x"
+  },
+  "Твоя астральная проекция уже используется для других целей.": {
+   "en": "Your astral projection is already being used for other purposes.",
+   "ua": "Твоя астральна проекція вже використовується для інших цілей."
+  },
+  "Твоя астральная проекция уже совмещена с текущими координатами.": {
+   "en": "Your astral projection is already aligned with your current coordinates.",
+   "ua": "Твоя астральна проекція вже суміщена з поточними координатами."
+  }
+ },
+ "spell/astral walk/runVict": {
+  "%^C1 открывает {1{Bастральный путь{2 в {1{Y%N4{2.": {
+   "en": "%^C1 opens an {1{Bastral path{2 to {1{Y%N4{2.",
+   "ua": "%^C1 відкриває {1{Bастральний шлях{2 до {1{Y%N4{2."
+  },
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your teleportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чар."
+  },
+  "Перейти на сам{Smого{Sfу{Sx себя? Но как узнать, где настоящ{Smий{Sfая{Sx ты -- здесь или там?": {
+   "en": "Move onto yourself? But how would you know where the real you is -- here or there?",
+   "ua": "Перейти на сам{Smого{Sfу{Sx себе? Але як дізнатися, де справжн{Smій{Sfя{Sx ти -- тут чи там?"
+  }
+ },
+ "spell/attract other/runVict": {
+  "%1$^C1 не подда%1$nется|ются твоим чарам.": {
+   "en": "%1$^C1 do%1$nes| not succumb to your charms.",
+   "ua": "%1$^C1 не підда%1$nється|ються твоїм чарам."
+  },
+  "%^C1 пытается {1{mочаровать{2 %C4, но безуспешно.": {
+   "en": "%^C1 tries to {1{mcharm{2 %C4, but fails.",
+   "ua": "%^C1 намагається {1{mзачарувати{2 %C4, але марно."
+  },
+  "%^C1 пытается {1{mочаровать{2 тебя, но безуспешно.": {
+   "en": "%^C1 tries to {1{mcharm{2 you, but fails.",
+   "ua": "%^C1 намагається {1{mзачарувати{2 тебе, але безуспішно."
+  },
+  "Ты пытаешься {1{mочаровать{2 %C4, но безуспешно.": {
+   "en": "You try to {1{mcharm{2 %C4, but fail.",
+   "ua": "Ти намагаєшся {1{mзачарувати{2 %C4, але марно."
+  },
+  "Увы, %s пол неподвластен твоим любовным чарам.": {
+   "en": "Alas, the %s sex is immune to your love spells.",
+   "ua": "На жаль, %s стать не піддається твоїм любовним чарам."
+  },
+  "Эти любовные чары подействуют только на разумных существ.": {
+   "en": "These love charms only work on sentient creatures.",
+   "ua": "Ці любовні чари подіють лише на розумних істот."
+  }
+ },
+ "spell/awakening/runVict": {
+  "%1$^C1 все еще спит нездоровым сном.": {
+   "en": "%1$^C1 is still sleeping an unhealthy sleep.",
+   "ua": "%1$^C1 усе ще спить нездоровим сном."
+  },
+  "Кажется, %C1 уже не спит.": {
+   "en": "It seems %C1 is already awake.",
+   "ua": "Здається, %C1 вже не спить."
+  },
+  "%1$^C1 спит обычным сном, попробуй просто %1$P2 {hhразбудить{x.": {
+   "en": "%1$^C1 is just sleeping normally, try to {hhwake{x %1$C4 up.",
+   "ua": "%1$^C1 просто спить звичайним сном, спробуй просто {hhрозбудити{x %1$C4."
+  }
+ },
+ "spell/banishment/runVict": {
+  "%C1 сопротивляется священному символу изгнания!": {
+   "en": "%C1 resists the holy symbol of banishment!",
+   "ua": "%C1 опирається священному символу вигнання!"
+  },
+  "К сожалению, %C1 -- {hhспецмоб{x, их изгонять запрещено.": {
+   "en": "Unfortunately, %C1 is a {hhspecial mob{x, and banishing them is forbidden.",
+   "ua": "На жаль, %C1 -- {hhспецмоб{x, їх виганяти заборонено."
+  }
+ },
+ "spell/bat swarm/runVict": {
+  "Вокруг %C2 уже кружится стая летучих мышей.": {
+   "en": "A swarm of bats is already circling around %C2.",
+   "ua": "Навколо %C2 вже кружляє зграя кажанів."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  },
+  "Стая {1{Dлетучих м{rы{Dш{rей{2 прибывает по зову %1$C2 и окружает %2$C4 живым облаком.": {
+   "en": "A swarm of {1{Db{ra{Dt{rs{2 answers %1$C2's call and surrounds %2$C4 in a living cloud.",
+   "ua": "Зграя {1{Dка{rжа{Dні{rв{2 прибуває на поклик %1$C2 і оточує %2$C4 живою хмарою."
+  },
+  "Стая {1{Dлетучих м{rы{Dш{rей{2 прибывает по твоему зову и окружает %C4 живым облаком.": {
+   "en": "A swarm of {1{Dfly{ri{Dng b{rats{2 arrives at your call and surrounds %C4 in a living cloud.",
+   "ua": "Зграя {1{Dлетючих к{rа{Dж{rанів{2 прибуває на твій поклик і оточує %C4 живою хмарою."
+  }
+ },
+ "spell/befriend/runVict": {
+  "%1$^C1 не захо%1$nчет|тят с тобой подружиться.": {
+   "en": "%1$^C1 do%1$nes| not want to be friends with you.",
+   "ua": "%1$^C1 не захо%1$nче|чуть з тобою дружити."
+  },
+  "%1$^C1 с обожанием смотр%1$nит|ят на %2$C4.": {
+   "en": "%1$^C1 look%1$ns| at %2$C4 with adoration.",
+   "ua": "%1$^C1 із захопленням див%1$nиться|ляться на %2$C4."
+  },
+  "%^C1 пытается {1{Gподружиться{2 с тобой, но безуспешно.": {
+   "en": "%^C1 tries to {1{Gbefriend{2 you, but fails.",
+   "ua": "%^C1 намагається {1{Gпотоваришувати{2 з тобою, але безуспішно."
+  },
+  "На разумных существ это заклинание не сработает.": {
+   "en": "This spell won't work on sentient creatures.",
+   "ua": "На розумних істот це заклинання не подіє."
+  },
+  "Ты слишком устал{Sfа{Sx от проявлений дружбы, надо отдохнуть.": {
+   "en": "You are too tired of displays of friendship, you need to rest.",
+   "ua": "Ти надто втомлен{Smий{Sfа{Sx від проявів дружби, треба відпочити."
+  },
+  "Чтобы подружиться с игроками, попробуй с ними просто поговорить.": {
+   "en": "To befriend players, try just talking to them.",
+   "ua": "Щоб потоваришувати з гравцями, спробуй просто поговорити з ними."
+  },
+  "%^C1 пытается {1{Gподружиться{2 %s %C5, но безуспешно.": {
+   "en": "%^C1 tries to {1{Gbefriend{2 %s %C5, but fails.",
+   "ua": "%^C1 намагається {1{Gподружитися{2 %s %C5, але безуспішно."
+  },
+  "Ты хочешь {1{Gподружиться{2 %2$s %1$C5, но %1$P1 грубо отверга%1$nет|ют тебя! Какой удар!": {
+   "en": "You want to {1{Gbefriend{2 %2$s %1$C5, but %1$C1 rudely reject%1$ns| you! What a blow!",
+   "ua": "Ти хочеш {1{Gподружитися{2 %2$s %1$C5, але %1$C1 грубо відкида%1$nє|ють тебе! Який удар!"
+  }
+ },
+ "spell/benediction/runVict": {
+  "Ты ощущаешь дарованную {1{C%N5{2 благость!": {
+   "en": "You feel the grace granted by {1{C%N5{2!",
+   "ua": "Ти відчуваєш даровану {1{C%N5{2 благодать!"
+  }
+ },
+ "spell/black death/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You cannot cast most affects and charms on this peaceful terrain.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чарів."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать чумные миазмы.": {
+   "en": "You need to rest before you can use plague miasma again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову використати чумні міазми."
+  },
+  "Эта местность уже наполнена чумными миазмами.": {
+   "en": "This area is already filled with plague miasma.",
+   "ua": "Ця місцевість вже наповнена чумними міазмами."
+  }
+ },
+ "spell/bless/runObj": {
+  "Зловещая аура вокруг %O2 пропадает.": {
+   "en": "The ominous aura around %O2 fades away.",
+   "ua": "Зловісна аура навколо %O2 зникає."
+  },
+  "Зловещая аура вокруг %O2 сильнее твоего благословения.": {
+   "en": "The sinister aura around %O2 is stronger than your blessing.",
+   "ua": "Зловісна аура навколо %O2 сильніша за твоє благословення."
+  }
+ },
+ "spell/bless/runVict": {
+  "Благословение {1{C%N2{2 снисходит на %C4.": {
+   "en": "The blessing of {1{C%N2{2 descends upon %C4.",
+   "ua": "Благословення {1{C%N2{2 сходить на %C4."
+  },
+  "Благословение {1{C%N2{2 снисходит на тебя.": {
+   "en": "The blessing of {1{C%N2{2 descends upon you.",
+   "ua": "Благословення {1{C%N2{2 сходить на тебе."
+  },
+  "Ты чувствуешь благословение {1{C%N2{2!": {
+   "en": "You feel the blessing of {1{C%N2{2!",
+   "ua": "Ти відчуваєш благословення {1{C%N2{2!"
+  }
+ },
+ "spell/blindness/runVict": {
+  "%^C1 пытается ослепить %C4 внезапной вспышкой, но безуспешно.": {
+   "en": "%^C1 tries to blind %C4 with a sudden flash, but fails.",
+   "ua": "%^C1 намагається засліпити %C4 раптовим спалахом, але безуспішно."
+  },
+  "%^C1 пытается ослепить тебя внезапной вспышкой, но безуспешно.": {
+   "en": "%^C1 tries to blind you with a sudden flash, but fails.",
+   "ua": "%^C1 намагається засліпити тебе раптовим спалахом, але безуспішно."
+  },
+  "Ты {1{Wослепляешь{2 %C4 внезапной вспышкой!": {
+   "en": "You {1{Wblind{2 %C4 with a sudden flash!",
+   "ua": "Ти {1{Wосліплюєш{2 %C4 раптовим спалахом!"
+  },
+  "Ты пытаешься ослепить %C4 внезапной вспышкой, но безуспешно.": {
+   "en": "You try to blind %C4 with a sudden flash, but fail.",
+   "ua": "Ти намагаєшся засліпити %C4 раптовим спалахом, але безуспішно."
+  }
+ },
+ "spell/bluefire/runVict": {
+  "Твой Голубой Огонь %1$s %2$C4!": {
+   "en": "Your Blue Fire %1$s %2$C4!",
+   "ua": "Твій Блакитний Вогонь %1$s %2$C4!"
+  },
+  "Голубой Огонь %1$C2 %2$s %1$P2 сам%1$Gого|ого|у!": {
+   "en": "The Blue Fire of %1$C2 %2$s %1$C4 -- itself!",
+   "ua": "Блакитний Вогонь %1$C2 %2$s %1$C4 сам%1$Go|ого|у!"
+  },
+  "Голубой Огонь %1$C2 %2$s %3$C4!": {
+   "en": "%1$C2's Blue Fire %2$s %3$C4!",
+   "ua": "Блакитний Вогонь %1$C2 %2$s %3$C4!"
+  },
+  "Голубой Огонь %1$C2 %2$s тебя!": {
+   "en": "%1$C2's Blue Fire %2$s you!",
+   "ua": "Блакитний Вогонь %1$C2 %2$s тебе!"
+  }
+ },
+ "spell/brew/runObj": {
+  "По слухам найти его можно в Высшей Башне Колдовства.": {
+   "en": "Rumor has it you can find one in the High Tower of Sorcery.",
+   "ua": "За чутками, знайти його можна у Вищій Вежі Чаклунства."
+  },
+  "Положи в патронташ пустую пробирку и один из компонентов: ключи, сокровища,": {
+   "en": "Put an empty vial and one of the components into your bandolier: keys, treasure,",
+   "ua": "Поклади в патронташ порожню пробірку і один з компонентів: ключі, скарби,"
+  },
+  "отмычки или просто мусор. Затем {yиспользуй{x патронташ.": {
+   "en": "lockpicks or just junk. Then {yuse{x the bandolier.",
+   "ua": "відмички або просто сміття. Потім {yвикористай{x патронташ."
+  }
+ },
+ "spell/broom ritual/runArg": {
+  "%^C1 крепко связывает прутья в пучок.": {
+   "en": "%^C1 tightly binds the twigs into a bundle.",
+   "ua": "%^C1 міцно звʼязує прутики в пучок."
+  },
+  "%^C1 собирает подходящие прутья и раскладывает их перед собой.": {
+   "en": "%^C1 gathers suitable twigs and lays them out in front of themselves.",
+   "ua": "%^C1 збирає придатні прутики і розкладає їх перед собою."
+  },
+  "Ты взмахиваешь руками и создаёшь %O4!": {
+   "en": "You wave your hands and create %O4!",
+   "ua": "Ти змахуєш руками і створюєш %O4!"
+  },
+  "Ты крепко связываешь прутья в пучок.": {
+   "en": "You tightly bind the twigs into a bundle.",
+   "ua": "Ти міцно звʼязуєш прутики у пучок."
+  },
+  "Ты пока не можешь создать новую метлу, надо немного подождать.": {
+   "en": "You cannot create a new broom yet, you need to wait a bit.",
+   "ua": "Ти поки не можеш створити нову мітлу, треба трохи почекати."
+  },
+  "Ты собираешь подходящие прутья и раскладываешь их перед собой.": {
+   "en": "You gather suitable twigs and lay them out in front of you.",
+   "ua": "Ти збираєш підходящі прути і розкладаєш їх перед собою."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/call lightning/runRoom": {
+  "Призвать гром и молнию удастся только под открытым небом.": {
+   "en": "You can only call forth thunder and lightning under open sky.",
+   "ua": "Закликати грім і блискавку вдасться лише під відкритим небом."
+  },
+  "Призвать гром и молнию удастся только при плохой погоде.": {
+   "en": "You can only summon thunder and lightning in bad weather.",
+   "ua": "Прикликати грім і блискавку вдасться лише за поганої погоди."
+  }
+ },
+ "spell/calm/runRoom": {
+  "%^C1 сопротивляется твоей умиротворяющей молитве.": {
+   "en": "%^C1 resists your calming prayer.",
+   "ua": "%^C1 опирається твоїй заспокійливій молитві."
+  },
+  "Бездумную нежить или конструкцию вроде %C2 не удастся умиротворить.": {
+   "en": "You can't calm mindless undead or a construct like %C2.",
+   "ua": "Бездумну нежить чи конструкт на кшталт %C2 не вдасться умиротворити."
+  },
+  "Будучи в ярости, тебе гораздо сложнее умиротворять окружающих.": {
+   "en": "While enraged, it's much harder for you to calm those around you.",
+   "ua": "Перебуваючи в люті, тобі набагато складніше заспокоювати оточуючих."
+  },
+  "Тут тебе сейчас некого умиротворять.": {
+   "en": "There's no one here for you to pacify right now.",
+   "ua": "Тут зараз нема кого замирювати."
+  }
+ },
+ "spell/cancellation/runVict": {
+  "%^C1 пытается отменить воздействия на %C6, но безуспешно.": {
+   "en": "%^C1 tries to cancel the effects on %C6, but fails.",
+   "ua": "%^C1 намагається скасувати ефекти на %C6, але безуспішно."
+  },
+  "%^C1 пытается отменить воздействия на себе, но безуспешно.": {
+   "en": "%^C1 tries to cancel the effects on themselves, but fails.",
+   "ua": "%^C1 намагається скасувати ефекти на собі, але безуспішно."
+  },
+  "%^C1 пытается отменить воздействия на тебе, но безуспешно.": {
+   "en": "%^C1 tries to cancel the effects on you, but fails.",
+   "ua": "%^C1 намагається скасувати ефекти на тобі, але марно."
+  },
+  "На %C6 нет воздействий, которые можно было бы отменить.": {
+   "en": "There are no effects on %C6 that could be removed.",
+   "ua": "На %C6 немає впливів, які можна було б скасувати."
+  },
+  "Ты пытаешься отменить воздействия на %C6, но безуспешно.": {
+   "en": "You try to cancel the effects on %C6, but fail.",
+   "ua": "Ти намагаєшся зняти вплив на %C6, але безуспішно."
+  },
+  "Ты пытаешься отменить воздействия на себе, но безуспешно.": {
+   "en": "You try to cancel the effects on yourself, but fail.",
+   "ua": "Ти намагаєшся скасувати впливи на собі, але безуспішно."
+  }
+ },
+ "spell/chain lightning/runVict": {
+  "Разряд молнии, созданный %C5, поражает %C4.": {
+   "en": "A bolt of lightning created by %C5 strikes %C4.",
+   "ua": "Розряд блискавки, створений %C5, вражає %C4."
+  },
+  "Разряд молнии, созданный %C5, поражает тебя!": {
+   "en": "A bolt of lightning conjured by %C5 strikes you!",
+   "ua": "Розряд блискавки, створений %C5, вражає тебе!"
+  },
+  "Разряд цепной молнии поражает тебя!": {
+   "en": "A bolt of chain lightning strikes you!",
+   "ua": "Розряд ланцюгової блискавки вражає тебе!"
+  },
+  "Созданный тобой разряд молнии поражает %C4.": {
+   "en": "The lightning bolt you created strikes %C4.",
+   "ua": "Створений тобою розряд блискавки вражає %C4."
+  }
+ },
+ "spell/chaos blade/runArg": {
+  "%^O1 медленно растворяется и исчезает.": {
+   "en": "%^O1 slowly dissolves and vanishes.",
+   "ua": "%^O1 повільно розчиняється і зникає."
+  },
+  "Из {1{Mпружинки{2 ты вылепляешь %O4.": {
+   "en": "From the {1{Mspring{2 you shape %O4.",
+   "ua": "З {1{Mпружинки{2 ти виліплюєш %O4."
+  },
+  "Перед тем, как ты сможешь снова призвать клинок Хаоса, придётся немного подождать.": {
+   "en": "Before you can summon the Blade of Chaos again, you'll have to wait a bit.",
+   "ua": "Перш ніж ти зможеш знову призвати клинок Хаосу, доведеться трохи почекати."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  },
+  "Ты сжимаешь {1{Rп{yе{Yр{yе{Gл{gи{Cв{cа{Bю{bщ{Mу{mю{Wс{wя{2 пружинку и начинаешь менять её форму.": {
+   "en": "You clench the {1{Ri{yr{Yi{yd{Ge{gs{Cc{ce{Bn{bt {Ms{mp{Wr{wing{2 and begin to change its shape.",
+   "ua": "Ти стискаєш {1{Rм{yе{Yр{yе{Gх{gт{Cл{cи{Bв{bу {Mп{mр{Wу{wжинку{2 і починаєш змінювати її форму."
+  }
+ },
+ "spell/charm person/runVict": {
+  "%1$^C1 не подда%1$nется|ются твоим чарам.": {
+   "en": "%1$^C1 resist%1$ns| your charms.",
+   "ua": "%1$^C1 не піддаєт%1$nься|ься твоїм чарам."
+  },
+  "%1$^C1 с обожанием смотр%1$nит|ят на тебя.": {
+   "en": "%1$^C1 look%1$ns| at you with adoration.",
+   "ua": "%1$^C1 із захопленням див%1$nиться|ляться на тебе."
+  },
+  "%^C1 пытается {1{mочаровать{2 %C4, но безуспешно.": {
+   "en": "%^C1 tries to {1{mcharm{2 %C4, but fails.",
+   "ua": "%^C1 намагається {1{mзачарувати{2 %C4, але безуспішно."
+  },
+  "%^C1 пытается {1{mочаровать{2 тебя, но безуспешно.": {
+   "en": "%^C1 tries to {1{mcharm{2 you, but fails.",
+   "ua": "%^C1 намагається {1{mзачарувати{2 тебе, але безуспішно."
+  },
+  "Ты пытаешься {1{mочаровать{2 %C4, но безуспешно.": {
+   "en": "You try to {1{mcharm{2 %C4, but fail.",
+   "ua": "Ти намагаєшся {1{mзачарувати{2 %C4, але марно."
+  },
+  "{mТы очарован{Sfа{Sx и с обожанием смотришь на %C4.{x": {
+   "en": "{mYou are charmed and gaze at %C4 with adoration.{x",
+   "ua": "{mТи зачарован{Smий{Sfа{Sx і з обожнюванням дивишся на %C4.{x"
+  }
+ },
+ "spell/chill touch/runObj": {
+  "%1$^O1 покрыва%1$nется|ются изморозью и застыва%1$nет|ют, прекращая портиться.": {
+   "en": "%1$^O1 %1$nbecomes|become coated in frost and %1$nfreezes|freeze solid, no longer spoiling.",
+   "ua": "%1$^O1 вкрива%1$nється|ються інеєм і застига%1$nє|ють, перестаючи псуватися."
+  },
+  "%^N4 в %O6 не удастся заморозить.": {
+   "en": "%^N4 in %O6 cannot be frozen.",
+   "ua": "%^N4 у %O6 не вдасться заморозити."
+  },
+  "%^O1 не удастся заморозить этим заклинанием.": {
+   "en": "%^O1 can't be frozen with this spell.",
+   "ua": "%^O1 не вдасться заморозити цим закляттям."
+  },
+  "%^O1 отвергает твои попытки замораживания.": {
+   "en": "%^O1 rejects your attempts to freeze it.",
+   "ua": "%^O1 відкидає твої спроби заморозити."
+  },
+  "В %O6 пусто -- нечего замораживать.": {
+   "en": "There is nothing in %O6 -- nothing to freeze.",
+   "ua": "У %O6 порожньо -- нічого заморожувати."
+  },
+  "Накал %O2 сильнее твоего заклинания.": {
+   "en": "The heat of %O2 is stronger than your spell.",
+   "ua": "Жар %O2 сильніший за твоє заклинання."
+  },
+  "Похоже, %1$O1 защище%1$Gно|н|на|ны от замораживания.": {
+   "en": "Looks like %1$O1 is already protected from freezing.",
+   "ua": "Схоже, %1$O1 захищ%1$Gене|ений|ена|ені від замерзання."
+  },
+  "Похоже, %1$O1 уже замороже%1$Gно|н|на|ны.": {
+   "en": "Looks like %1$O1 is already frozen.",
+   "ua": "Схоже, %1$O1 вже заморож%1$Gене|ений|ена|ені."
+  }
+ },
+ "spell/compound/runObj": {
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова утяжелить оружие.": {
+   "en": "You need to rest before you can weigh down a weapon again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову обтяжити зброю."
+  }
+ },
+ "spell/confuse/runVict": {
+  "%^C1 лишает тебя способности логически мыслить!": {
+   "en": "%^C1 strips you of the ability to think logically!",
+   "ua": "%^C1 позбавляє тебе здатності логічно мислити!"
+  },
+  "%^C1 пытается сконфузить %C4 силами Хаоса, но безуспешно.": {
+   "en": "%^C1 tries to confuse %C4 with the powers of Chaos, but fails.",
+   "ua": "%^C1 намагається спантеличити %C4 силами Хаосу, але безуспішно."
+  },
+  "%^C1 пытается сконфузить тебя силами Хаоса, но безуспешно.": {
+   "en": "%^C1 tries to confound you with the powers of Chaos, but fails.",
+   "ua": "%^C1 намагається спантеличити тебе силами Хаосу, але безуспішно."
+  },
+  "Ты и так уже плохо соображаешь.": {
+   "en": "You are already having trouble thinking straight.",
+   "ua": "Ти й так вже погано міркуєш."
+  },
+  "Ты пытаешься сконфузить %C4 силами Хаоса, но безуспешно.": {
+   "en": "You try to confuse %C4 with the powers of Chaos, but fail.",
+   "ua": "Ти намагаєшся спантеличити %C4 силами Хаосу, але марно."
+  }
+ },
+ "spell/continual light/runArg": {
+  "В руках %C2 внезапно вспыхивает %O1.": {
+   "en": "%O1 suddenly flares to life in %C2's hands.",
+   "ua": "У руках %C2 раптово спалахує %O1."
+  }
+ },
+ "spell/continual light/runObj": {
+  "%1$^O1 вспыхив%1$nает|ают и проявля%1$nется|ются из ниоткуда.": {
+   "en": "%1$^O1 %1$nflares|flare up and %1$nappears|appear out of nowhere.",
+   "ua": "%1$^O1 спалаху%1$nє|ють і зʼявля%1$nється|ються нізвідки."
+  },
+  "%1$^O1 уже свет%1$nится|ятся.": {
+   "en": "%1$^O1 already glow%1$ns|.",
+   "ua": "%1$^O1 вже %1$nсвітиться|світяться."
+  },
+  "Аура невидимости вокруг %O2 сильнее твоего заклинания.": {
+   "en": "The aura of invisibility around %O2 is stronger than your spell.",
+   "ua": "Аура невидимості навколо %O2 сильніша за твоє закляття."
+  }
+ },
+ "spell/control undead/runVict": {
+  "%^C1 подчиняется и молча следует за %C5.": {
+   "en": "%^C1 submits and silently follows %C5.",
+   "ua": "%^C1 підкоряється і мовчки йде за %C5."
+  },
+  "%^C1 подчиняется и молча следует за тобой.": {
+   "en": "%^C1 submits and silently follows you.",
+   "ua": "%^C1 підкоряється і мовчки йде за тобою."
+  },
+  "%^C1 пытается {1{Dподчинить{2 %C4, но безуспешно.": {
+   "en": "%^C1 tries to {1{Dsubjugate{2 %C4, but fails.",
+   "ua": "%^C1 намагається {1{Dпідкорити{2 %C4, але безуспішно."
+  },
+  "%^C1 пытается {1{Dподчинить{2 тебя, но безуспешно.": {
+   "en": "%^C1 tries to {1{Dsubjugate{2 you, but fails.",
+   "ua": "%^C1 намагається {1{Dпідкорити{2 тебе, але марно."
+  },
+  "{DТы подчиняешься и и молча следует за %C5.{x": {
+   "en": "{DYou submit and silently follow %C5.{x",
+   "ua": "{DТи підкоряєшся і мовчки йдеш за %C5.{x"
+  },
+  "С помощью этого заклятия можно подчинить только нежить или объекты.": {
+   "en": "This spell can only be used to control undead or objects.",
+   "ua": "За допомогою цього закляття можна підкорити лише нежить або обʼєкти."
+  },
+  "Ты пытаешься {1{Dподчинить{2 %C4, но безуспешно.": {
+   "en": "You try to {1{Dsubjugate{2 %C4, but fail.",
+   "ua": "Ти намагаєшся {1{Dпідкорити{2 %C4, але безуспішно."
+  }
+ },
+ "spell/control weather/runArg": {
+  "Но ведь погода уже прекрасная и безоблачная!": {
+   "en": "But the weather's already wonderful and cloudless!",
+   "ua": "Але ж погода вже чудова і безхмарна!"
+  },
+  "Твоя попытка изменить погоду окончилась неудачей.": {
+   "en": "Your attempt to change the weather has failed.",
+   "ua": "Твоя спроба змінити погоду закінчилася невдачею."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова менять погоду.": {
+   "en": "You need to rest before you can change the weather again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову змінювати погоду."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайня{Smтий{Sfта{Sx подібним ритуалом."
+  },
+  "Ты хочешь сделать погоду хуже или лучше?": {
+   "en": "Do you want to make the weather worse or better?",
+   "ua": "Ти хочеш зробити погоду гіршою чи кращою?"
+  },
+  "{DИспользуй {y{hcк погода лучше{x{D или {y{hcк погода хуже{x{D.{x": {
+   "en": "{DUse {y{hcк погода лучше{x{D or {y{hcк погода хуже{x{D.{x",
+   "ua": "{DВикористай {y{hcк погода лучше{x{D або {y{hcк погода хуже{x{D.{x"
+  },
+  "Ты замечаешь, что погода внезапно становится %s.": {
+   "en": "You notice that the weather suddenly turns %s.",
+   "ua": "Ти помічаєш, що погода раптово стає %s."
+  }
+ },
+ "spell/converge/runArg": {
+  "Воссоединиться удастся не со всяким питомцем, а только с духом предков.": {
+   "en": "You can only reunite with the ancestral spirit, not just any pet.",
+   "ua": "Воззʼєднатися вдасться не з будь-яким улюбленцем, а лише з духом предків."
+  },
+  "Ты закрываешь глаза и устанавливаешь ментальную связь с %C5.": {
+   "en": "You close your eyes and establish a mental link with %C5.",
+   "ua": "Ти заплющуєш очі і встановлюєш ментальний звʼязок з %C5."
+  },
+  "Чтобы воссоединиться с питомцем, его нужно сначала завести.": {
+   "en": "To reunite with your pet, you must first acquire one.",
+   "ua": "Щоб воззʼєднатися з улюбленцем, його спершу треба завести."
+  }
+ },
+ "spell/converge/runVict": {
+  "Воссоединиться удастся не со всяким питомцем, а только с духом предков.": {
+   "en": "You won't be able to reunite with just any pet -- only with an ancestral spirit.",
+   "ua": "Воззʼєднатися вдасться не з будь-яким улюбленцем, а лише з духом предків."
+  },
+  "Ты закрываешь глаза и устанавливаешь ментальную связь с %C5.": {
+   "en": "You close your eyes and establish a mental link with %C5.",
+   "ua": "Ти заплющуєш очі і встановлюєш ментальний звʼязок з %C5."
+  },
+  "Чтобы воссоединиться с питомцем, его нужно сначала завести.": {
+   "en": "To reunite with a pet, you first need to acquire one.",
+   "ua": "Щоб воззʼєднатися з улюбленцем, його спершу треба завести."
+  },
+  "Ты тянешься сквозь пространство, чтобы воссоединиться со сво%1$Gим|им|ей|ими любим%1$Gцем|цем|ицей|цами.": {
+   "en": "You reach through space to reunite with your beloved companion.",
+   "ua": "Ти тягнешся крізь простір, щоб воззʼєднатися зі сво%1$Gїм|їм|єю|їми %1$Gулюбленцем|улюбленцем|улюбленицею|улюбленцями."
+  }
+ },
+ "spell/corruption/runVict": {
+  "Конструкции этому заклинанию неподвластны.": {
+   "en": "Constructs are immune to this spell.",
+   "ua": "Конструкти цьому заклинанню непідвладні."
+  },
+  "Ты пытаешься заставить %C4 гнить заживо, но безуспешно.": {
+   "en": "You try to make %C4 rot alive, but fail.",
+   "ua": "Ти намагаєшся змусити %C4 гнити живцем, але безуспішно."
+  },
+  "Ты уже гниешь заживо.": {
+   "en": "You are already rotting alive.",
+   "ua": "Ти вже гниєш заживо."
+  }
+ },
+ "spell/create food/runArg": {
+  "В руки %C3 внезапно падает %O1.": {
+   "en": "%O1 suddenly drops into %C3's hands.",
+   "ua": "%O1 раптово падає в руки %C3."
+  }
+ },
+ "spell/create spring/runArg": {
+  "В этой местности и так есть чем напиться.": {
+   "en": "There's already something to drink around here.",
+   "ua": "У цій місцевості й так є чим напитися."
+  },
+  "Из земли внезапно пробивается %O1.": {
+   "en": "%O1 suddenly bursts from the ground.",
+   "ua": "Із землі раптово пробивається %O1."
+  },
+  "Из земли пробивается %O1.": {
+   "en": "From the ground, %O1 bursts forth.",
+   "ua": "Із землі проривається %O1."
+  },
+  "Используя свои знания природы %C3 удается отыскать %O1.": {
+   "en": "Drawing on their knowledge of nature, %C3 manages to find %O1.",
+   "ua": "Використовуючи свої знання природи, %C3 вдається відшукати %O1."
+  },
+  "Используя свои знания природы тебе удается отыскать %O4.": {
+   "en": "Using your knowledge of nature, you manage to find %O4.",
+   "ua": "Використовуючи свої знання природи, тобі вдається відшукати %O4."
+  },
+  "Кажется, здесь есть вода где-то поблизости.": {
+   "en": "It seems there's water somewhere nearby.",
+   "ua": "Здається, тут десь поблизу є вода."
+  },
+  "Найти родник в пустыне могут только мастера природной магии.": {
+   "en": "Only masters of nature magic can find a spring in the desert.",
+   "ua": "Знайти джерело в пустелі можуть тільки майстри природної магії."
+  }
+ },
+ "spell/create water/runObj": {
+  "%1$O1 закры%1$Gто|т|та|ты, попробуй сначала открыть.": {
+   "en": "%1$O1 is closed, try opening it first.",
+   "ua": "%1$O1 зачинен%1$Go|ий|а|і, спробуй спершу відчинити."
+  },
+  "%1$^C1 создает струю воды и заливает %2$O4.": {
+   "en": "%1$^C1 creates a jet of water and douses %2$O4.",
+   "ua": "%1$^C1 створює струмінь води і заливає %2$O4."
+  },
+  "%1$^C1 создает струю воды и поливает раскаленн%2$Gое|ый|ую|ые %2$O4.": {
+   "en": "%1$^C1 creates a jet of water and douses the white-hot %2$O4.",
+   "ua": "%1$^C1 створює струмінь води і поливає розпечен%2$Gе|ий|у|і %2$O4."
+  },
+  "%1$^O1 уже полностью заполне%1$Gно|н|на.": {
+   "en": "%1$^O1 is already completely full.",
+   "ua": "%1$^O1 вже повністю заповнен%1$Gо|ий|а."
+  },
+  "%^C1 щелкает пальцами и наполняет %O4 водой.": {
+   "en": "%^C1 snaps their fingers and fills %O4 with water.",
+   "ua": "%^C1 клацає пальцями і наповнює %O4 водою."
+  },
+  "%^O1 внезапно заполняется водой.": {
+   "en": "%^O1 suddenly fills with water.",
+   "ua": "%^O1 раптово наповнюється водою."
+  },
+  "%^O1 отвергает твои попытки колдовства.": {
+   "en": "%^O1 rejects your attempts at spellcasting.",
+   "ua": "%^O1 відкидає твої спроби чаклунства."
+  },
+  "В %O6 уже что-то плещется.": {
+   "en": "There is already something splashing in %O6.",
+   "ua": "У %O6 вже щось хлюпочеться."
+  },
+  "Милостью %N2 ты наполняешь %O4 святой водой.": {
+   "en": "By the grace of %N2, you fill %O4 with holy water.",
+   "ua": "Милістю %N2 ти наповнюєш %O4 святою водою."
+  },
+  "На %O4 не удастся подействовать этим заклинанием.": {
+   "en": "This spell won't work on %O4.",
+   "ua": "На %O4 не вдасться подіяти цим заклинанням."
+  },
+  "Под потоком воды %1$O1 шип%1$nит|ят и остыва%1$nет|ют.": {
+   "en": "Under the stream of water, %1$O1 hiss%1$nes| and cool%1$ns|.",
+   "ua": "Під потоком води %1$O1 шип%1$nить|лять і остига%1$nє|ють."
+  },
+  "Тебе не удается создать достаточно воды, чтобы остудить %1$O4.": {
+   "en": "You fail to create enough water to cool %1$O4.",
+   "ua": "Тобі не вдається створити достатньо води, щоб охолодити %1$O4."
+  },
+  "Ты создаешь струю воды и заливаешь %1$O4.": {
+   "en": "You conjure a jet of water and douse %1$O4.",
+   "ua": "Ти створюєш струмінь води і заливаєш %1$O4."
+  },
+  "Ты щелкаешь пальцами и наполняешь %O4 водой.": {
+   "en": "You snap your fingers and fill %O4 with water.",
+   "ua": "Ти клацаєш пальцями і наповнюєш %O4 водою."
+  }
+ },
+ "spell/cultivate/runRoom": {
+  "Вокруг тебя друидская роща -- здесь возделывать точно нечего.": {
+   "en": "You're standing in a druidic grove -- there is certainly nothing to cultivate here.",
+   "ua": "Навколо тебе друїдський гай -- тут точно нічого обробляти."
+  },
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You can't apply most effects and charms to this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість ефектів і чарів."
+  },
+  "Придется подождать -- пока что тут ничего не удастся сделать.": {
+   "en": "You'll have to wait -- there's nothing you can do here just yet.",
+   "ua": "Доведеться зачекати -- поки що тут нічого не вдасться зробити."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова возделывать природу.": {
+   "en": "You need to rest before you can cultivate nature again.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш знову обробляти природу."
+  },
+  "Ты рад{Sfа{Sx вновь продолжить работу над этой местностью.": {
+   "en": "You're glad to continue working on this land again.",
+   "ua": "Ти рад{Smий{Sfа{Sx знову продовжити роботу над цією місцевістю."
+  },
+  "Ты уже возделываешь природу.": {
+   "en": "You are already cultivating nature.",
+   "ua": "Ти вже обробляєш природу."
+  },
+  "Этот лес прекрасен и не нуждается в дальнейшем возделывании.": {
+   "en": "This forest is already beautiful and needs no further cultivating.",
+   "ua": "Цей ліс прекрасний і не потребує подальшого культивування."
+  },
+  "Ты с удивлением наблюдаешь как %s вокруг %s": {
+   "en": "You watch in amazement as %s around %s",
+   "ua": "Ти зі здивуванням спостерігаєш як %s навколо %s"
+  }
+ },
+ "spell/cure disease/runVict": {
+  "Болезнь отступает... но лишь на мгновение.": {
+   "en": "The disease recedes... but only for a moment.",
+   "ua": "Хвороба відступає... але лише на мить."
+  }
+ },
+ "spell/cure poison/runVict": {
+  "Тошнота отступает... но лишь на мгновение.": {
+   "en": "The nausea subsides... but only for a moment.",
+   "ua": "Нудота відступає... але лише на мить."
+  }
+ },
+ "spell/curse/runObj": {
+  "%^O1 отвергает твои попытки проклятия.": {
+   "en": "%^O1 rejects your attempts at cursing.",
+   "ua": "%^O1 відкидає твої спроби прокляття."
+  },
+  "%^O1 уже имеет зловещую ауру.": {
+   "en": "%^O1 already has an ominous aura.",
+   "ua": "%^O1 вже має зловісну ауру."
+  },
+  "Аура благословения вокруг %O2 пропадает.": {
+   "en": "The aura of blessing around %O2 fades away.",
+   "ua": "Аура благословення навколо %O2 зникає."
+  },
+  "Аура благословения вокруг %O2 сильнее твоего проклятия.": {
+   "en": "The aura of blessing around %O2 is stronger than your curse.",
+   "ua": "Аура благословення навколо %O2 сильніша за твоє прокляття."
+  }
+ },
+ "spell/curse/runVict": {
+  "%^C1 накладывает проклятие на %C4.": {
+   "en": "%^C1 casts a curse on %C4.",
+   "ua": "%^C1 накладає прокляття на %C4."
+  },
+  "%^C1 пытается наложить проклятие на %C4, но безуспешно.": {
+   "en": "%^C1 tries to place a curse on %C4, but fails.",
+   "ua": "%^C1 намагається накласти прокляття на %C4, але безуспішно."
+  },
+  "%^C1 пытается наложить проклятие на тебя, но безуспешно.": {
+   "en": "%^C1 tries to place a curse on you, but fails.",
+   "ua": "%^C1 намагається накласти прокляття на тебе, але безуспішно."
+  },
+  "%^C1 уже под гнетом проклятия.": {
+   "en": "%^C1 is already under the weight of a curse.",
+   "ua": "%^C1 вже під гнітом прокляття."
+  },
+  "Ты накладываешь {1{rпроклятие{2 на %C4!": {
+   "en": "You place a {1{rcurse{2 on %C4!",
+   "ua": "Ти накладаєш {1{rпрокляття{2 на %C4!"
+  },
+  "Ты пытаешься наложить проклятие на %C4, но безуспешно.": {
+   "en": "You try to place a curse on %C4, but fail.",
+   "ua": "Ти намагаєшся накласти прокляття на %C4, але безуспішно."
+  },
+  "Ты уже под гнетом проклятия.": {
+   "en": "You're already under the weight of a curse.",
+   "ua": "Ти вже під тягарем прокляття."
+  }
+ },
+ "spell/cursed lands/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "Most affects and charms cannot be placed on this peaceful land.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чар."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова проклясть земли.": {
+   "en": "You need to rest before you can curse the land again.",
+   "ua": "Тобі треба відпочити перш ніж ти зможеш знову прокляти землі."
+  },
+  "Эта местность уже проклята.": {
+   "en": "This land is already cursed.",
+   "ua": "Ця місцевість вже проклята."
+  }
+ },
+ "spell/dark shroud/runVict": {
+  "{DТемная аура{x окружает %C4.": {
+   "en": "{DA dark aura{x surrounds %C4.",
+   "ua": "{DТемна аура{x оточує %C4."
+  },
+  "{DТемная аура{x окружает тебя.": {
+   "en": "{DA dark aura{x surrounds you.",
+   "ua": "{DТемна аура{x оточує тебе."
+  }
+ },
+ "spell/deadly venom/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "Most effects and spells cannot be placed on this peaceful land.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чар."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать ядовитые пары.": {
+   "en": "You need to rest before you can use poisonous fumes again.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш знову використати отруйні випари."
+  },
+  "Эта местность уже наполнена ядовитыми парами.": {
+   "en": "This area is already filled with poisonous fumes.",
+   "ua": "Ця місцевість вже наповнена отруйними випарами."
+  }
+ },
+ "spell/deafen/runVict": {
+  "%^C1 оглушает %C4 пронзительным звоном!": {
+   "en": "%^C1 deafens %C4 with a piercing ring!",
+   "ua": "%^C1 оглушує %C4 пронизливим дзвоном!"
+  },
+  "%^C1 пытается оглушить %C4 пронзительным звоном, но безуспешно.": {
+   "en": "%^C1 tries to deafen %C4 with a piercing ring, but fails.",
+   "ua": "%^C1 намагається оглушити %C4 пронизливим дзвоном, але безуспішно."
+  },
+  "%^C1 пытается оглушить тебя пронзительным звоном, но безуспешно.": {
+   "en": "%^C1 tries to deafen you with a piercing ring, but fails.",
+   "ua": "%^C1 намагається оглушити тебе пронизливим дзвоном, але марно."
+  },
+  "%^C1 уже ничего не слышит.": {
+   "en": "%^C1 can't hear a thing anymore.",
+   "ua": "%^C1 вже нічого не чує."
+  },
+  "Ты пытаешься оглушить %C4 пронзительным звоном, но безуспешно.": {
+   "en": "You try to deafen %C4 with a piercing ring, but fail.",
+   "ua": "Ти намагаєшся оглушити %C4 пронизливим дзвоном, але безуспішно."
+  },
+  "Ты уже ничего не слышишь.": {
+   "en": "You already can't hear a thing.",
+   "ua": "Ти вже нічого не чуєш."
+  }
+ },
+ "spell/dematerialize/runVict": {
+  "Тебя уже и так совсем не видно.": {
+   "en": "You're already completely invisible as it is.",
+   "ua": "Тебе вже й так зовсім не видно."
+  }
+ },
+ "spell/desert fist/runVict": {
+  "Здесь недостаточно песка, чтобы сформировать кулак.": {
+   "en": "There isn't enough sand here to form a fist.",
+   "ua": "Тут недостатньо піску, щоб сформувати кулак."
+  },
+  "Ты взываешь к %N3, прося сотворить вихрь песка.": {
+   "en": "You call upon %N3, asking them to conjure a whirl of sand.",
+   "ua": "Ти звертаєшся до %N3, просячи створити вихор піску."
+  }
+ },
+ "spell/detect evil/runVict": {
+  "Ты уже способ%1$Gно|ен|на|но увидеть красную ауру Зла.": {
+   "en": "You can already see the red aura of Evil.",
+   "ua": "Ти вже здатн%1$Gо|ий|а|і побачити червону ауру Зла."
+  }
+ },
+ "spell/detect good/runVict": {
+  "Теперь ты можешь различить {1{Yзолотую ауру{2 Добра.": {
+   "en": "Now you can perceive the {1{Ygolden aura{2 of Good.",
+   "ua": "Тепер ти можеш розрізнити {1{Yзолоту ауру{2 Добра."
+  },
+  "Ты уже способ%1$Gно|ен|на|но увидеть золотую ауру Добра.": {
+   "en": "You're already able to see the golden aura of Good.",
+   "ua": "Ти вже здатн%1$Go|ий|а|і побачити золоту ауру Добра."
+  }
+ },
+ "spell/detect hidden/runVict": {
+  "Теперь ты можешь увидеть скрытое.": {
+   "en": "Now you can see what is hidden.",
+   "ua": "Тепер ти можеш побачити приховане."
+  }
+ },
+ "spell/detect invis/runVict": {
+  "Теперь ты можешь увидеть невидимое.": {
+   "en": "Now you can see the invisible.",
+   "ua": "Тепер ти можеш бачити невидиме."
+  },
+  "Ты уже видишь невидимое.": {
+   "en": "You can already see the invisible.",
+   "ua": "Ти вже бачиш невидиме."
+  }
+ },
+ "spell/detect magic/runVict": {
+  "Теперь ты чувствуешь {1{cауру магии{2 вокруг предметов и существ.": {
+   "en": "Now you sense the {1{caura of magic{2 around objects and creatures.",
+   "ua": "Тепер ти відчуваєш {1{cауру магії{2 навколо предметів і істот."
+  }
+ },
+ "spell/detect undead/runVict": {
+  "Теперь ты можешь отличить гнилую ауру {1{Dнежити{2 от яркой ауры живых.": {
+   "en": "Now you can tell the rotten aura of {1{Dundead{2 from the bright aura of the living.",
+   "ua": "Тепер ти можеш відрізнити гнилу ауру {1{Dнежиті{2 від яскравої аури живих."
+  },
+  "Ты уже способ%1$Gно|ен|на|ны отличить нежить от других существ.": {
+   "en": "You can already tell the undead apart from other creatures.",
+   "ua": "Ти вже здатн%1$Gе|ий|а|і відрізнити нежить від інших істот."
+  }
+ },
+ "spell/dispel affects/runVict": {
+  "На %C6 нет воздействий, которые можно развеять.": {
+   "en": "There are no effects on %C6 that can be dispelled.",
+   "ua": "На %C6 немає впливів, які можна розвіяти."
+  },
+  "На тебе нет воздействий, которые можно развеять.": {
+   "en": "You have no effects on you that can be dispelled.",
+   "ua": "На тобі немає впливів, які можна розвіяти."
+  },
+  "Твоя попытка развеять чары на %C6 закончилась неудачей.": {
+   "en": "Your attempt to dispel the magic on %C6 has failed.",
+   "ua": "Твоя спроба розвіяти чари на %C6 закінчилася невдачею."
+  },
+  "Ты пытаешься развеять воздействия на %C6, но безуспешно.": {
+   "en": "You try to dispel the effects on %C6, but fail.",
+   "ua": "Ти намагаєшся розвіяти впливи на %C6, але безуспішно."
+  },
+  "Ты пытаешься развеять воздействия на себе, но безуспешно.": {
+   "en": "You try to dispel the effects on yourself, but fail.",
+   "ua": "Ти намагаєшся розвіяти ефекти на собі, але безуспішно."
+  }
+ },
+ "spell/dispel evil/runVict": {
+  "Эта молитва не сможет навредить %C3.": {
+   "en": "This prayer cannot harm %C3.",
+   "ua": "Ця молитва не зможе нашкодити %C3."
+  }
+ },
+ "spell/dispel good/runVict": {
+  "Эта молитва не сможет навредить %C3.": {
+   "en": "This prayer cannot harm %C3.",
+   "ua": "Ця молитва не зможе нашкодити %C3."
+  }
+ },
+ "spell/disperse/runRoom": {
+  "Несмотря на твои усилия, окружающий мир противостоит Хаосу.": {
+   "en": "Despite your efforts, the surrounding world resists Chaos.",
+   "ua": "Попри твої зусилля, навколишній світ протистоїть Хаосу."
+  },
+  "Тебе нужно подождать перед тем, как ты снова сможешь использовать это умение.": {
+   "en": "You need to wait before you can use this ability again.",
+   "ua": "Тобі потрібно почекати, перш ніж ти зможеш знову використати цю здібність."
+  }
+ },
+ "spell/dragonplate/runArg": {
+  "Сначала сними %O4.": {
+   "en": "First take off %O4.",
+   "ua": "Спершу зніми %O4."
+  },
+  "Ты пока не можешь использовать это умение, надо немного подождать.": {
+   "en": "You can't use this skill yet, you need to wait a bit.",
+   "ua": "Ти поки що не можеш використати це вміння, треба трохи почекати."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/dragonsword/runArg": {
+  "%^C1 обращается к Золотому Дракону Бахамуту, прося о помощи.": {
+   "en": "%^C1 turns to the Golden Dragon Bahamut, asking for help.",
+   "ua": "%^C1 звертається до Золотого Дракона Бахамута, просячи допомоги."
+  },
+  "Золотое сияние окутывает твои руки.": {
+   "en": "A golden glow envelops your hands.",
+   "ua": "Золоте сяйво огортає твої руки."
+  },
+  "Какое именно оружие Золотого Дракона ты хочешь призвать?": {
+   "en": "Which weapon of the Golden Dragon exactly do you want to summon?",
+   "ua": "Яку саме зброю Золотого Дракона ти хочеш призвати?"
+  },
+  "Сначала сними %O4.": {
+   "en": "First take off %O4.",
+   "ua": "Спочатку зніми %O4."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь призвать оружие Дракона.": {
+   "en": "You need to rest before you can summon the Dragon's weapon.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш призвати зброю Дракона."
+  },
+  "Ты обращаешься к Золотому Дракону Бахамуту, прося о помощи.": {
+   "en": "You turn to the Golden Dragon Bahamut, asking for help.",
+   "ua": "Ти звертаєшся до Золотого Дракона Бахамута, просячи допомоги."
+  },
+  "Ты чувствуешь себя намного лучше!": {
+   "en": "You feel much better!",
+   "ua": "Ти почуваєшся набагато краще!"
+  },
+  "Напиши {y{hcк оружие кинжал{x, {y{hcк оружие булава{x, {y{hcк оружие кистень{x, {y{hcк оружие меч{x или {y{hcк оружие пика{x.": {
+   "en": "Type {y{hcк оружие кинжал{x, {y{hcк оружие булава{x, {y{hcк оружие кистень{x, {y{hcк оружие меч{x or {y{hcк оружие пика{x.",
+   "ua": "Напиши {y{hcк оружие кинжал{x, {y{hcк оружие булава{x, {y{hcк оружие кистень{x, {y{hcк оружие меч{x або {y{hcк оружие пика{x."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/druid staff/runArg": {
+  "Из подаренной ветви %C1 создаёт %O4.": {
+   "en": "From the gifted branch, %C1 creates %O4.",
+   "ua": "З подарованої гілки %C1 створює %O4."
+  },
+  "Создать посох друида можно только в лесу.": {
+   "en": "You can only create a druid staff in a forest.",
+   "ua": "Створити посох друїда можна лише в лісі."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь создать посох.": {
+   "en": "You need to rest before you can create a staff.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш створити посох."
+  },
+  "Ты стоишь среди деревьев и обращаешься к самому древнему из них.": {
+   "en": "You stand among the trees and turn to the oldest of them.",
+   "ua": "Ти стоїш серед дерев і звертаєшся до найдавнішого з них."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/earthquake/runRoom": {
+  "В воздухе твое землетрясение не сможет никому навредить.": {
+   "en": "In midair, your earthquake can't harm anyone.",
+   "ua": "У повітрі твій землетрус нікому не зможе нашкодити."
+  },
+  "Твое землетрясение не наносит никакого вреда летучему противнику.": {
+   "en": "Your earthquake deals no damage to flying opponents.",
+   "ua": "Твій землетрус не завдає жодної шкоди літаючому супротивнику."
+  }
+ },
+ "spell/empathize/runVict": {
+  "{/{1{C%^C1{2 -- это {W%N1 {C%d{x уровня.": {
+   "en": "{/{1{C%^C1{2 is a {W%N1{C, level %d{x.",
+   "ua": "{/{1{C%^C1{2 -- це {W%N1{C %d{x рівня."
+  },
+  "Боевые особенности: %s.": {
+   "en": "Combat traits: %s.",
+   "ua": "Бойові особливості: %s."
+  },
+  "Больше ты ничего не можешь почувствовать.": {
+   "en": "You can't sense anything more.",
+   "ua": "Більше ти нічого не можеш відчути."
+  },
+  "Обладает {Cиммунитетом{x к %s.": {
+   "en": "Has {Cimmunity{x to %s.",
+   "ua": "Має {Cімунітет{x до %s."
+  },
+  "Обладает {Rуязвимостью{x к %s.": {
+   "en": "Has {Rvulnerability{x to %s.",
+   "ua": "Має {Rвразливість{x до %s."
+  },
+  "Обладает {cсопротивляемостью{x к %s.": {
+   "en": "Has {cresistance{x to %s.",
+   "ua": "Має {cопірність{x до %s."
+  },
+  "Особенности: %s.": {
+   "en": "Traits: %s.",
+   "ua": "Особливості: %s."
+  },
+  "Слоты экипировки: %s.": {
+   "en": "Equipment slots: %s.",
+   "ua": "Слоти екіпіровки: %s."
+  },
+  "Способ%1$Gно|ен|на|ны {Yувидеть{x %2$s.": {
+   "en": "Able to {Ysee{x %2$s.",
+   "ua": "Здатн%1$Gо|ий|а|і {Yпобачити{x %2$s."
+  },
+  "Тебе надо отдохнуть перед тем, как ты снова сможешь сопереживать кому-либо.": {
+   "en": "You need to rest before you can empathize with anyone again.",
+   "ua": "Тобі треба відпочити, перш ніж ти знову зможеш співпереживати комусь."
+  },
+  "Ты закрываешь глаза и настраиваешься на свою собственную ауру.": {
+   "en": "You close your eyes and attune yourself to your own aura.",
+   "ua": "Ти заплющуєш очі і налаштовуєшся на власну ауру."
+  },
+  "Ты прикасаешься к %1$C3, настраиваясь на %1$P2 ауру.": {
+   "en": "You touch %1$C3, attuning yourself to the aura of %1$C2.",
+   "ua": "Ти торкаєшся %1$C3, налаштовуючись на ауру %1$C2."
+  },
+  "Ты чувствуешь, что можешь по-настоящему доверять %1$P3.": {
+   "en": "You feel that you can truly trust %1$C3.",
+   "ua": "Ти відчуваєш, що можеш по-справжньому довіряти %1$C3."
+  },
+  "Формы тела: %s.": {
+   "en": "Body forms: %s.",
+   "ua": "Форми тіла: %s."
+  },
+  "У %1$P4 напрочь отсутствует аура, как и прочих объектов.": {
+   "en": "It has absolutely no aura, just like other objects.",
+   "ua": "У нього цілком відсутня аура, як і в інших обʼєктів."
+  }
+ },
+ "spell/enchant armor/runObj": {
+  "Ты слишком устал{Sfа{Sx, тебе надо подождать перед тем, как ты снова сможешь зачаровывать.": {
+   "en": "You're too tired; you need to wait before you can enchant again.",
+   "ua": "Ти занадто втоми{Smвся{Sfлася{Sx, тобі треба зачекати перед тим, як ти знову зможеш зачаровувати."
+  },
+  "%1$^C1 прикасается к %2$O3 и %2$P1 окутыва%2$nется|ются {1{Bсиней аурой{2 зачарования.": {
+   "en": "%1$^C1 touches %2$O3, and it become%2$ns| wrapped in {1{Ba blue aura{2 of enchantment.",
+   "ua": "%1$^C1 торкається %2$O3, і %2$O1 огорта%2$nється|ються {1{Bсиньою аурою{2 зачарування."
+  }
+ },
+ "spell/enchant weapon/runObj": {
+  "%1$^O1 теперь выглядит более угрожающ%1$Gим|им|ей|ими.": {
+   "en": "%1$^O1 now looks more threatening.",
+   "ua": "%1$^O1 тепер виглядає більш загрозлив%1$Gим|им|ою|ими."
+  },
+  "%1$^O1 уже улучше%1$Gно|н|на|ны.": {
+   "en": "%1$^O1 is already improved.",
+   "ua": "%1$^O1 вже покращен%1$Ge|ий|а|і."
+  },
+  "%^O1 -- не оружие, а %s.": {
+   "en": "%^O1 is not a weapon, but %s.",
+   "ua": "%^O1 -- не зброя, а %s."
+  },
+  "Тебе надо набраться опыта, чтобы зачаровать %O4.": {
+   "en": "You need to gain more experience before you can enchant %O4.",
+   "ua": "Тобі треба набратися досвіду, щоб зачарувати %O4."
+  },
+  "Ты слишком устал{Sfа{Sx, тебе надо подождать перед тем, как ты снова сможешь зачаровывать.": {
+   "en": "You're too tired; you need to wait before you can enchant again.",
+   "ua": "Ти занадто втоми{Smвся{Sfлася{Sx, тобі треба зачекати перед тим, як ти знову зможеш зачаровувати."
+  },
+  "Уникальные свойства %O2 препятствуют зачарованию.": {
+   "en": "The unique properties of %O2 prevent enchantment.",
+   "ua": "Унікальні властивості %O2 перешкоджають зачаруванню."
+  }
+ },
+ "spell/energy drain/runVict": {
+  "У нежити и бездушных конструкций отобрать энергию не получится.": {
+   "en": "You can't drain energy from the undead or soulless constructs.",
+   "ua": "У нежиті та бездушних конструктів забрати енергію не вийде."
+  }
+ },
+ "spell/enhanced armor/runVict": {
+  "Тебя окружает силовое поле, дарованное {1{C%N5{2.": {
+   "en": "A force field, granted by {1{C%N5{2, surrounds you.",
+   "ua": "Тебе оточує силове поле, дароване {1{C%N5{2."
+  },
+  "Тебя окружает силовое поле, помогающее уходить от ударов.": {
+   "en": "A force field surrounds you, helping you dodge blows.",
+   "ua": "Тебе оточує силове поле, що допомагає ухилятися від ударів."
+  }
+ },
+ "spell/entangle/runObj": {
+  "Это умение можно использовать только на лоне природы.": {
+   "en": "This ability can only be used out in nature.",
+   "ua": "Цю здібність можна використати тільки на лоні природи."
+  }
+ },
+ "spell/entangle/runVict": {
+  "Побеги терновника не смогут навредить летучему противнику.": {
+   "en": "Thornbush shoots cannot harm a flying opponent.",
+   "ua": "Пагони терну не зможуть нашкодити летючому супротивнику."
+  },
+  "Терновник растет только в лесу, поле, горах или на холмах.": {
+   "en": "Thorn bushes only grow in forests, fields, mountains, or hills.",
+   "ua": "Терновник росте тільки в лісі, полі, горах або на пагорбах."
+  }
+ },
+ "spell/evil spirit/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You can't apply most effects and charms to this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість ефектів і чарів."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова вызвать Первородное Зло.": {
+   "en": "You need to rest before you can summon the Primordial Evil again.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш знову викликати Первородне Зло."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  },
+  "Это умение доступно только для игроков.": {
+   "en": "This ability is available to players only.",
+   "ua": "Ця здатність доступна лише гравцям."
+  }
+ },
+ "spell/faerie fire/runVict": {
+  "%1$^s не поможет %2$C3, пока %2$P1 {1{Mсвет%2$nится|ятся.{2": {
+   "en": "%1$^s won't help %2$C3 while %2$C1 glow%2$ns|.",
+   "ua": "%1$^s не допоможе %2$C3, поки %2$C1 світ%2$nиться|яться."
+  },
+  "%^s не поможет тебе, пока ты {1{Mсветишься.{2": {
+   "en": "%^s won't help you while you're {1{Mglowing.{2",
+   "ua": "%^s не допоможе тобі, поки ти {1{Mсвітишся.{2"
+  },
+  "{MРозовая аура{x уже окружает %C4.": {
+   "en": "{MA pink aura{x already surrounds %C4.",
+   "ua": "{MРожева аура{x вже оточує %C4."
+  },
+  "{MРозовая аура{x уже окружает тебя.": {
+   "en": "{MA pink aura{x already surrounds you.",
+   "ua": "{MРожева аура{x вже оточує тебе."
+  }
+ },
+ "spell/farsight/runArg": {
+  "В какую именно сторону ты хочешь посмотреть?": {
+   "en": "Which direction exactly do you want to look?",
+   "ua": "У який саме бік ти хочеш подивитися?"
+  },
+  "В этом направлении тебе ничего не удается разглядеть.": {
+   "en": "You can't make out anything in that direction.",
+   "ua": "У цьому напрямку тобі нічого не вдається розгледіти."
+  },
+  "Тебе ничего не удается разглядеть.": {
+   "en": "You can't make out anything.",
+   "ua": "Тобі нічого не вдається розгледіти."
+  },
+  "Глаза %1$C2 ярко вспыхивают, когда %1$P1 смотрит %2$s.": {
+   "en": "%1$C2's eyes flash brightly as %1$C1 looks %2$s.",
+   "ua": "Очі %1$C2 яскраво спалахують, коли %1$C1 дивиться %2$s."
+  },
+  "Используя магию, ты пристально смотришь %2$s.": {
+   "en": "Using magic, you gaze intently %2$s.",
+   "ua": "Використовуючи магію, ти пильно дивишся %2$s."
+  }
+ },
+ "spell/fear/runVict": {
+  "%^C1 пытается запугать %C4, но безуспешно.": {
+   "en": "%^C1 tries to frighten %C4, but fails.",
+   "ua": "%^C1 намагається залякати %C4, але безуспішно."
+  },
+  "%1$^C4 насылает {1{rж{Rу{rт{Rк{rи{Rе {Bв{bи{Bд{bе{Bн{bи{Bя{2 на %2$C4, заставляя %2$P2 дрожать от ужаса!": {
+   "en": "%1$^C4 sends {1{rG{RH{rA{RS{rT{RL{rY {BV{bI{BS{bI{BO{bN{BS{2 upon %2$C4, making them tremble in terror!",
+   "ua": "%1$^C4 насилає {1{rж{Rа{rх{Rл{rи{Rв{rі {Bв{bи{Bд{bі{Bн{bн{Bя{2 на %2$C4, змушуючи %2$C4 тремтіти від жаху!"
+  },
+  "%1$^C4 насылает {1{rж{Rу{rт{Rк{rи{Rе {Bв{bи{Bд{bе{Bн{bи{Bя{2 на тебя, заставляя тебя дрожать от ужаса!": {
+   "en": "%1$^C4 sends {1{re{Re{rr{Ri{re {Bv{bi{Bs{bi{Bo{bn{Bs{2 upon you, making you shudder in terror!",
+   "ua": "%1$^C4 насилає {1{rл{Rя{rч{Rн{rі {Bв{bі{Bд{bі{Bн{bн{Bя{2 на тебе, змушуючи тебе тремтіти від жаху!"
+  },
+  "Ты насылаешь {1{rж{Rу{rт{Rк{rи{Rе {Bв{bи{Bд{bе{Bн{bи{Bя{2 на %1$C4, заставляя %1$P2 дрожать от ужаса!": {
+   "en": "You send {1{rG{RH{rA{RS{rT{RL{rY {BV{bI{BS{bI{BO{bN{BS{2 upon %1$C4, making them tremble in terror!",
+   "ua": "Ти насилаєш {1{rж{Rа{rх{Rл{rи{Rв{rі {Bв{bи{Bд{bі{Bн{bн{Bя{2 на %1$C4, змушуючи %1$C4 тремтіти від жаху!"
+  }
+ },
+ "spell/fireproof/runObj": {
+  "%1$^O1 окутыва%1$nется|ются {Rогнеупорной аурой.{x": {
+   "en": "%1$^O1 %1$nis|are wrapped in a {Rfireproof aura.{x",
+   "ua": "%1$^O1 огорта%1$nється|ються {Rвогнетривкою аурою.{x"
+  }
+ },
+ "spell/firestorm/runRoom": {
+  "В этой местности создать огненный шторм не удастся.": {
+   "en": "You can't conjure a firestorm in this area.",
+   "ua": "У цій місцевості створити вогняний шторм не вийде."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь использовать это умение.": {
+   "en": "You need to rest before you can use this ability.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш використати це вміння."
+  },
+  "Эта местность уже пылает!": {
+   "en": "This terrain is already ablaze!",
+   "ua": "Ця місцевість вже палає!"
+  }
+ },
+ "spell/floating disc/runArg": {
+  "Вокруг тебя уже что-то крутится.": {
+   "en": "Something is already spinning around you.",
+   "ua": "Навколо тебе вже щось крутиться."
+  },
+  "Ты взмахиваешь руками и создаешь из пустоты %O4.": {
+   "en": "You wave your hands and conjure %O4 out of the void.",
+   "ua": "Ти змахуєш руками і створюєш із порожнечі %O4."
+  }
+ },
+ "spell/flood/runRoom": {
+  "Здесь уже достаточно жидкости.": {
+   "en": "There's already enough liquid here.",
+   "ua": "Тут уже достатньо рідини."
+  },
+  "Земля под ногами начинает заметно увлажняться.": {
+   "en": "The ground beneath your feet begins to grow noticeably damp.",
+   "ua": "Земля під ногами починає помітно зволожуватися."
+  },
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You cannot cast most affects and charms on this peaceful terrain.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чарів."
+  },
+  "Ошибка: у этой местности неподходящий тип, сообщи Богам.": {
+   "en": "Error: this area has the wrong type, report it to the Gods.",
+   "ua": "Помилка: ця місцевість має невідповідний тип, повідом Богам."
+  },
+  "Под твоими ногами начинают возникать тонкие струйки.": {
+   "en": "Thin trickles of water begin to appear beneath your feet.",
+   "ua": "Під твоїми ногами починають зʼявлятися тоненькі струмочки."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь использовать это умение.": {
+   "en": "You need to rest before you can use this ability.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш використати це вміння."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/flux state/runVict": {
+  "В состояние потока удастся войти только в сражении.": {
+   "en": "You can only enter the flow state during combat.",
+   "ua": "У стан потоку вдасться увійти лише в бою."
+  },
+  "Ты уже находишься в состоянии потока.": {
+   "en": "You are already in a state of flow.",
+   "ua": "Ти вже перебуваєш у стані потоку."
+  }
+ },
+ "spell/garble/runVict": {
+  "%1$^C1 %2$s твой язык %3$s! Ты не можешь говорить!": {
+   "en": "%1$^C1 %2$s your tongue %3$s! You can't speak!",
+   "ua": "%1$^C1 %2$s твій язик %3$s! Ти не можеш говорити!"
+  },
+  "%^C1 пытается связать язык %C4 силами Хаоса, но безуспешно.": {
+   "en": "%^C1 tries to bind %C4's tongue with the powers of Chaos, but fails.",
+   "ua": "%^C1 намагається звʼязати язик %C4 силами Хаосу, але марно."
+  },
+  "Ты и так уже ничего не можешь внятно произнести.": {
+   "en": "You already can't say anything intelligible as it is.",
+   "ua": "Ти й так вже нічого не можеш виразно вимовити."
+  },
+  "%1$^C1 %3$s язык %2$C2 %4$s!": {
+   "en": "%1$^C1 %3$s %2$C2's tongue %4$s!",
+   "ua": "%1$^C1 %3$s язик %2$C2 %4$s!"
+  },
+  "%1$^C1 зачем-то %2$s %3$s свой собственный язык!": {
+   "en": "%1$^C1 inexplicably %2$s %3$s their own tongue!",
+   "ua": "%1$^C1 чомусь %2$s %3$s свій власний язик!"
+  },
+  "Ты зачем-то %1$s %2$s свой собственный язык!": {
+   "en": "You somehow %1$s %2$s your own tongue!",
+   "ua": "Ти чомусь %1$s %2$s свою власну мову!"
+  }
+ },
+ "spell/gaseous form/runVict": {
+  "В этой зоне тебе некуда скрыться туманными путями.": {
+   "en": "In this zone there is nowhere for you to hide via misty paths.",
+   "ua": "У цій зоні тобі нема куди сховатися туманними шляхами."
+  },
+  "{D%^C1 {Dрассеивается в {wкл{Wу{wб{Wа{wх тум{Wа{wна{D, ненадолго принимая туманную форму.{x": {
+   "en": "{D%^C1 {Ddissolves into {ws{Ww{wi{Wr{wls of {Wm{wi{Ws{wt{D, briefly taking on a misty form.{x",
+   "ua": "{D%^C1 {Dрозчиняється в {wкл{Wу{wб{Wа{wх тум{Wа{wну{D, ненадовго набуваючи туманної форми.{x"
+  },
+  "{DТы рассеиваешься в {wкл{Wу{wб{Wа{wх тум{Wа{wна{D, ненадолго принимая туманную форму.{x": {
+   "en": "{DYou dissolve into {wb{Wi{wl{Wl{wo{Ww{ws{D of fog, briefly taking on a hazy form.{x",
+   "ua": "{DТи розсіюєшся в {wкл{Wу{wб{Wа{wх тум{Wа{wну{D, ненадовго набуваючи туманної форми.{x"
+  }
+ },
+ "spell/gate/runVict": {
+  "%^C1 открывает временный портал.": {
+   "en": "%^C1 opens a temporary portal.",
+   "ua": "%^C1 відкриває тимчасовий портал."
+  },
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your teleportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чар."
+  },
+  "Ты открываешь временный портал к %C3.": {
+   "en": "You open a temporary portal to %C3.",
+   "ua": "Ти відкриваєш тимчасовий портал до %C3."
+  },
+  "Перейти на сам{Smого{Sfу{Sx себя? Но как узнать, где настоящ{Smий{Sfая{Sx ты -- здесь или там?": {
+   "en": "Move onto yourself? But how would you know where the real you is -- here or there?",
+   "ua": "Перейти на сам{Smого{Sfу{Sx себе? Але як дізнатися, де справжн{Smій{Sfя{Sx ти -- тут чи там?"
+  }
+ },
+ "spell/giant strength/runVict": {
+  "Ты становишься намного сильнее!": {
+   "en": "You become much stronger!",
+   "ua": "Твоя сила значно зростає!"
+  }
+ },
+ "spell/group defense/runRoom": {
+  "Эту молитву можно использовать только при наличии группы.": {
+   "en": "This prayer can only be used while in a group.",
+   "ua": "Цю молитву можна використати тільки за наявності групи."
+  }
+ },
+ "spell/group heal/runRoom": {
+  "Эту молитву можно использовать только при наличии группы.": {
+   "en": "This prayer can only be used while in a group.",
+   "ua": "Цю молитву можна використовувати лише за наявності групи."
+  }
+ },
+ "spell/grove/runRoom": {
+  "%^C1 закапывает %O4 в землю и начинает ритуал.": {
+   "en": "%^C1 buries %O4 in the ground and begins the ritual.",
+   "ua": "%^C1 закопує %O4 в землю і починає ритуал."
+  },
+  "{gТы закапываешь {1%O4{2 в землю и начинаешь ритуал.{x": {
+   "en": "{gYou bury {1%O4{2 in the ground and begin the ritual.{x",
+   "ua": "{gТи закопуєш {1%O4{2 у землю і починаєш ритуал.{x"
+  },
+  "Вырастить рощу удастся только на лоне природы.": {
+   "en": "You can only grow a grove out in nature.",
+   "ua": "Виростити гай вдасться лише на лоні природи."
+  },
+  "Здесь уже растёт друидская роща.": {
+   "en": "A druidic grove is already growing here.",
+   "ua": "Тут вже росте друїдський гай."
+  },
+  "Из разных яблок можно вырастить разные яблони.": {
+   "en": "Different apples can grow into different apple trees.",
+   "ua": "З різних яблук можна виростити різні яблуні."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь вырастить рощу.": {
+   "en": "You need to rest before you can grow a grove.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш виростити гай."
+  },
+  "Ты уже вырастил{Sfа{Sx друидскую рощу в этой зоне.": {
+   "en": "You've already grown a druidic grove in this zone.",
+   "ua": "Ти вже вирости{Smв{Sfла{Sx друїдський гай у цій зоні."
+  },
+  "Чтобы вырастить рощу, тебе понадобятся яблочные семена.": {
+   "en": "To grow a grove, you will need apple seeds.",
+   "ua": "Щоб виростити гай, тобі знадобляться яблучні насінини."
+  },
+  "Эта местность неподвластна твоим заклинаниям.": {
+   "en": "This land is beyond the reach of your spells.",
+   "ua": "Ця місцевість непідвладна твоїм заклинанням."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/harm/runVict": {
+  "{R%1$^C1 впада%1$nет|ют в болевой шок!{x": {
+   "en": "{R%1$^C1 fall%1$ns| into shock from the pain!{x",
+   "ua": "{R%1$^C1 впада%1$nє|ють в больовий шок!{x"
+  }
+ },
+ "spell/haste/runVict": {
+  "Движения %C2 становятся быстрыми и порывистыми.": {
+   "en": "%C2's movements become quick and jerky.",
+   "ua": "Рухи %C2 стають швидкими і поривчастими."
+  },
+  "Движения %C2 ускоряются, но лишь на мгновение.": {
+   "en": "%C2's movements quicken, but only for a moment.",
+   "ua": "Рухи %C2 прискорюються, але лише на мить."
+  },
+  "Твои движения и метаболизм ускоряются!": {
+   "en": "Your movements and metabolism speed up!",
+   "ua": "Твої рухи і метаболізм прискорюються!"
+  },
+  "Твои движения ускоряются, но лишь на мгновение.": {
+   "en": "Your movements speed up, but only for a moment.",
+   "ua": "Твої рухи прискорюються, але лише на мить."
+  }
+ },
+ "spell/heal/runVict": {
+  "%1$^C1 выглядит здоровее!": {
+   "en": "%1$^C1 looks healthier!",
+   "ua": "%1$^C1 виглядає здоровіше!"
+  },
+  "%^C1 выглядит здоровее! {D[{G%d{D]{x": {
+   "en": "%^C1 looks healthier! {D[{G%d{D]{x",
+   "ua": "%^C1 виглядає здоровіше! {D[{G%d{D]{x"
+  },
+  "Волна тепла согревает твое тело. {D[{G%d{D]{x": {
+   "en": "A wave of warmth heats your body. {D[{G%d{D]{x",
+   "ua": "Хвиля тепла зігріває твоє тіло. {D[{G%d{D]{x"
+  },
+  "%1$^C1 {Gабсолютно здоро%1$Gво|в|ва,{2 на %1$P6 ни царапины!": {
+   "en": "%1$^C1 {Gis in perfect health,{2 not a scratch on them!",
+   "ua": "%1$^C1 {Gабсолютно здоров%1$Gо|ий|а,{2 на %1$C6 жодної подряпини!"
+  }
+ },
+ "spell/healing light/runRoom": {
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова зажечь целебный свет.": {
+   "en": "You need to rest before you can kindle the healing light again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову запалити цілюще світло."
+  },
+  "Эта комната уже освещена целебным светом.": {
+   "en": "This room is already lit with healing light.",
+   "ua": "Ця кімната вже освітлена цілющим світлом."
+  }
+ },
+ "spell/heating/runObj": {
+  "Руки %1$^C1 нагреваются священным теплом, и %1$P1 прикасается к %2$O3.": {
+   "en": "%1$^C1's hands warm with holy heat, and they touch %2$O3.",
+   "ua": "Руки %1$^C1 нагріваються священним теплом, і %1$C1 торкається до %2$O3."
+  },
+  "Твои руки нагреваются священным теплом, и ты прикасаешься к %O3.": {
+   "en": "Your hands warm up with sacred heat as you touch %O3.",
+   "ua": "Твої руки нагріваються священним теплом, і ти торкаєшся %O3."
+  }
+ },
+ "spell/holy armor/runVict": {
+  "Тебя окружает {1{Wсвященная броня,{2 дарованная {1{C%N5{2.": {
+   "en": "{1{WHoly armor{2 granted by {1{C%N5{2 surrounds you.",
+   "ua": "Тебе оточує {1{Wсвященна броня,{2 дарована {1{C%N5{2."
+  },
+  "Ты уже защище%1$Gно|н|на священной броней.": {
+   "en": "You are already protected by holy armor.",
+   "ua": "Ти вже захищен%1$Gо|ий|а священною бронею."
+  }
+ },
+ "spell/holy word/runRoom": {
+  "%1$^C1 выглядит опустошенн%1$Gым|ым|ой.": {
+   "en": "%1$^C1 looks drained.",
+   "ua": "%1$^C1 виглядає спустошен%1$Gим|им|ою|ими."
+  },
+  "%1$^C1 уже воодушевле%1$Gно|н|на|ны.": {
+   "en": "%1$^C1 is already inspired.",
+   "ua": "%1$^C1 вже натхнен%1$Gо|ий|а|і."
+  },
+  "%^C1 уже в неистовстве.": {
+   "en": "%^C1 is already in a frenzy.",
+   "ua": "%^C1 вже у нестямі."
+  },
+  "Ты уже в неистовстве.": {
+   "en": "You're already in a frenzy.",
+   "ua": "Ти вже в нестямі."
+  },
+  "Ты уже воодушевле%1$Gно|н|на|ны.": {
+   "en": "You are already inspired.",
+   "ua": "Ти вже натхнен%1$Gне|ний|на|ні."
+  }
+ },
+ "spell/hurricane/runRoom": {
+  "В этой местности создать ураган не удастся.": {
+   "en": "You cannot conjure a hurricane in this area.",
+   "ua": "У цій місцевості викликати ураган не вдасться."
+  },
+  "Бушующий ураган вырывает с корнем %1$Iодно|два|несколько дерев%1$Iо|а|ьев!": {
+   "en": "The raging hurricane rips %1$Ione|a couple of|several tree%1$I|s|s out by the roots!",
+   "ua": "Шалений ураган вириває з коренем %1$Iодне|два|кілька дерев%1$Iо|а| з корінням!"
+  }
+ },
+ "spell/hydroblast/runVict": {
+  "Здесь недостаточно водных молекул, чтобы сформировать кулак.": {
+   "en": "There aren't enough water molecules here to form a fist.",
+   "ua": "Тут недостатньо водних молекул, щоб сформувати кулак."
+  }
+ },
+ "spell/improved detect/runVict": {
+  "Глаза %C2 моргают и резко сужаются в узкие щелочки.": {
+   "en": "%C2's eyes blink and narrow sharply into thin slits.",
+   "ua": "Очі %C2 кліпають і різко звужуються у вузькі щілинки."
+  },
+  "Теперь ты можешь увидеть {1{bочень невидимое{2.": {
+   "en": "Now you can see {1{bthe very invisible{2.",
+   "ua": "Тепер ти можеш побачити {1{bдуже невидиме{2."
+  },
+  "Ты уже видишь очень невидимое.": {
+   "en": "You can already see the very invisible.",
+   "ua": "Ти вже бачиш дуже невидиме."
+  }
+ },
+ "spell/improved invis/runVict": {
+  "%^C2 уже и так совсем не видно.": {
+   "en": "%^C2 is already completely invisible as it is.",
+   "ua": "%^C2 вже і так зовсім не видно."
+  },
+  "{b%1$^C1 становится {Dсовсем невидим%1$Gым|ым|ой.{x": {
+   "en": "{b%1$^C1 becomes {Dcompletely invisible.{x",
+   "ua": "{b%1$^C1 стає {Dцілком невидим%1$Gим|им|ою.{x"
+  },
+  "{b%^C1 накладывает {Dулучшенную невидимость {bна %C4.{x": {
+   "en": "{b%^C1 casts {Dimproved invisibility{b on %C4.{x",
+   "ua": "{b%^C1 накладає {Dполіпшену невидимість {bна %C4.{x"
+  },
+  "{bТы становишься {Dсовсем невидим%1$Gым|ым|ой.{x": {
+   "en": "{bYou become {Dcompletely invisible.{x",
+   "ua": "{bТи стаєш {Dповністю невидим%1$Gим|им|ою|ими.{x"
+  },
+  "Тебя уже и так совсем не видно.": {
+   "en": "You're already completely invisible as it is.",
+   "ua": "Тебе вже й так зовсім не видно."
+  }
+ },
+ "spell/inaction/runVict": {
+  "Сначала тебе придется успокоиться.": {
+   "en": "First you'll have to calm down.",
+   "ua": "Спершу тобі доведеться заспокоїтися."
+  },
+  "Ты уже практикуешь недеяние.": {
+   "en": "You are already practicing inaction.",
+   "ua": "Ти вже практикуєш недіяння."
+  }
+ },
+ "spell/insanity/runVict": {
+  "%^C1 пытается навести безумие на %C4, но безуспешно.": {
+   "en": "%^C1 tries to inflict madness on %C4, but fails.",
+   "ua": "%^C1 намагається наслати божевілля на %C4, але безуспішно."
+  },
+  "%^C1 пытается навести безумие на тебя, но безуспешно.": {
+   "en": "%^C1 tries to inflict madness upon you, but fails.",
+   "ua": "%^C1 намагається навести божевілля на тебе, але безуспішно."
+  },
+  "В этой местности кровожадность запрещена Богами.": {
+   "en": "Bloodlust is forbidden by the Gods in this area.",
+   "ua": "У цій місцевості кровожерність заборонена Богами."
+  },
+  "Все создания родом из зоны {1{W%s{2 защищены от этого заклятия.": {
+   "en": "All creatures native to the {1{W%s{2 zone are protected from this spell.",
+   "ua": "Усі створіння родом із зони {1{W%s{2 захищені від цього закляття."
+  },
+  "Ты пытаешься навести безумие на %C4, но безуспешно.": {
+   "en": "You try to inflict madness on %C4, but fail.",
+   "ua": "Ти намагаєшся наслати божевілля на %C4, але безуспішно."
+  }
+ },
+ "spell/inspire/runRoom": {
+  "%1$^C1 мол%1$nит|ят о воодушевлении, но ты уже воодушевле%2$Gно|н|на.": {
+   "en": "%1$^C1 beg%1$ns| for inspiration, but you are already inspired.",
+   "ua": "%1$^C1 мол%1$nить|ять про натхнення, але ти вже натхненн%2$Gе|ий|а|і."
+  }
+ },
+ "spell/invisibility/runObj": {
+  "%1$^O1 станов%1$nится|ятся невиди%1$Gмым|мым|мой|мыми.": {
+   "en": "%1$^O1 becom%1$nes|e invisible.",
+   "ua": "%1$^O1 ста%1$nє|ють невидим%1$Gим|им|ою|ими."
+  },
+  "%1$^O1 уже невиди%1$Gмо|м|ма|мы.": {
+   "en": "%1$^O1 is already invisible.",
+   "ua": "%1$^O1 вже невидим%1$Gе|ий|а|і."
+  },
+  "%1$^O1 свет%1$nится|ятся и не мо%1$nжет|гут стать невиди%1$Gмым|мым|мой|мыми.": {
+   "en": "%1$^O1 glow%1$ns| and can%1$n| not become invisible.",
+   "ua": "%1$^O1 світ%1$nиться|яться і не мо%1$nже|жуть стати невиди%1$Gмим|мим|мою|мими."
+  }
+ },
+ "spell/invisibility/runVict": {
+  "%1$^C1 становится невидим%1$Gым|ым|ой.": {
+   "en": "%1$^C1 becomes invisible.",
+   "ua": "%1$^C1 стає невидим%1$Gим|им|ою."
+  },
+  "%^C1 накладывает невидимость на %C4.": {
+   "en": "%^C1 casts invisibility on %C4.",
+   "ua": "%^C1 накладає невидимість на %C4."
+  },
+  "%^C1 уже под воздействием невидимости.": {
+   "en": "%^C1 is already affected by invisibility.",
+   "ua": "%^C1 вже під дією невидимості."
+  },
+  "Ты становишься невидим%1$Gым|ым|ой.": {
+   "en": "You become invisible.",
+   "ua": "Ти стаєш невидим%1$Gим|им|ою."
+  },
+  "Ты уже под воздействием невидимости.": {
+   "en": "You are already under the effect of invisibility.",
+   "ua": "Ти вже під дією невидимості."
+  }
+ },
+ "spell/kassandra/runVict": {
+  "%1$^O1 загора%1$nется|ются {Cлечебным голубым светом.{x": {
+   "en": "%1$^O1 %1$nignites|ignite with {Ca healing blue light.{x",
+   "ua": "%1$^O1 займа%1$nється|ються {Cцілющим блакитним світлом.{x"
+  }
+ },
+ "spell/knock/runArg": {
+  "%^N4 невозможно выбить.": {
+   "en": "%^N4 cannot be broken down.",
+   "ua": "%^N4 неможливо вибити."
+  },
+  "Кажется, туда уже можно пройти.": {
+   "en": "It looks like you can already get through there.",
+   "ua": "Здається, туди вже можна пройти."
+  },
+  "Кажется, через %N4 уже можно пройти.": {
+   "en": "It seems you can already pass through %N4.",
+   "ua": "Здається, крізь %N4 вже можна пройти."
+  },
+  "Магический удар сотрясает все вокруг, но открыть %N4 никак не удается.": {
+   "en": "A magical blast shakes everything around, but %N4 simply won't open.",
+   "ua": "Магічний удар струшує все навколо, але відкрити %N4 ніяк не вдається."
+  },
+  "Тут не заперто, попробуй просто {y{hcоткрыть %N1{x.": {
+   "en": "It's not locked here, just try {y{hcopen %N1{x.",
+   "ua": "Тут не замкнено, спробуй просто {y{hcвідкрити %N1{x."
+  }
+ },
+ "spell/learning/runVict": {
+  "Взгляд %C2 становится более сосредоточенным.": {
+   "en": "%C2's gaze grows more focused.",
+   "ua": "Погляд %C2 стає більш зосередженим."
+  },
+  "Ты концентрируешься на учебе.": {
+   "en": "You focus on your studies.",
+   "ua": "Ти зосереджуєшся на навчанні."
+  }
+ },
+ "spell/lethargic mist/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "Most affects and charms cannot be cast on this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чарів."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать замедляющий туман.": {
+   "en": "You need to rest before you can use the slowing mist again.",
+   "ua": "Тобі треба відпочити перш ніж ти зможеш знову використати уповільнюючий туман."
+  },
+  "Эта местность уже наполнена замедляющим туманом.": {
+   "en": "This area is already filled with slowing mist.",
+   "ua": "Ця місцевість вже наповнена сповільнюючим туманом."
+  }
+ },
+ "spell/lightning ward/runRoom": {
+  "Здесь начертать оберег молний не получится.": {
+   "en": "You can't inscribe a lightning ward here.",
+   "ua": "Тут накреслити оберіг блискавок не вийде."
+  },
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "Most effects and spells cannot be placed on this peaceful land.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чар."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать оберег молний.": {
+   "en": "You need to rest before you can use the lightning ward again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову використати оберіг блискавок."
+  },
+  "Эта местность уже защищена оберегом молний.": {
+   "en": "This area is already protected by a ward against lightning.",
+   "ua": "Ця місцевість вже захищена оберегом блискавок."
+  }
+ },
+ "spell/link/runVict": {
+  "%^C1 выглядит совсем опустошенно.": {
+   "en": "%^C1 looks utterly drained.",
+   "ua": "%^C1 виглядає геть спустошено."
+  },
+  "Энки помогает тебе перелить энергию более экономно.": {
+   "en": "Enki helps you channel your energy more efficiently.",
+   "ua": "Енкі допомагає тобі перелити енергію більш економно."
+  }
+ },
+ "spell/lion shield/runArg": {
+  "%^C1 одаривает %O5 %C4.": {
+   "en": "%^C1 gifts %C4 with %O5.",
+   "ua": "%^C1 обдаровує %C4 %O5."
+  },
+  "Здесь таких нет. Кому ты хочешь подарить щит Прайда?": {
+   "en": "There's no one like that here. Who do you want to give the Shield of Pride to?",
+   "ua": "Тут таких немає. Кому ти хочеш подарувати щит Прайда?"
+  },
+  "Одарить щитом Прайда можно только игроков-новичков.": {
+   "en": "You can only grant the Shield of the Pride to novice players.",
+   "ua": "Обдарувати щитом Прайду можна лише гравців-новачків."
+  },
+  "Ты взмахиваешь руками и создаёшь %O4!": {
+   "en": "You wave your hands and create %O4!",
+   "ua": "Ти змахуєш руками і створюєш %O4!"
+  },
+  "Ты концентрируешься на образе золотого щита Прайда.": {
+   "en": "You focus on the image of the Pride's golden shield.",
+   "ua": "Ти зосереджуєшся на образі золотого щита Прайда."
+  },
+  "Ты пока не можешь создать щит, надо немного подождать.": {
+   "en": "You can't create the shield yet, you need to wait a bit.",
+   "ua": "Ти поки що не можеш створити щит, треба трохи почекати."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/liturgy/runVict": {
+  "Твоя литургия {1{C%N3{2 принесла тебе только защиту.": {
+   "en": "Your liturgy to {1{C%N3{2 brought you only protection.",
+   "ua": "Твоя літургія {1{C%N3{2 принесла тобі лише захист."
+  },
+  "Тебе потребуется больше здоровья, энергии и движений для литургии.": {
+   "en": "You will need more health, energy, and moves for the liturgy.",
+   "ua": "Тобі знадобиться більше здоровʼя, енергії та рухів для літургії."
+  }
+ },
+ "spell/locate object/runArg": {
+  "\\n{cВсего магический локатор нашел {G%1$d{c объект%1$I|а|ов.{x": {
+   "en": "\\n{cIn total, the magic locator found {G%1$d{c object%1$I|s|s.{x",
+   "ua": "\\n{cЗагалом магічний локатор знайшов {G%1$d{c обʼєкт%1$I|и|ів.{x"
+  },
+  "\\n{cНашлось более {G%1$d{c объект%1$Iа|ов|ов, попробуй уточнить поиск.{x": {
+   "en": "\\n{cFound more than {G%1$d{c object%1$I|s|s, try narrowing your search.{x",
+   "ua": "\\n{cЗнайдено більше {G%1$d{c обʼєкт%1$Iа|и|ів, спробуй уточнити пошук.{x"
+  },
+  "{cЛокатор выдает следующие ориентиры:{x\\n": {
+   "en": "{cThe locator shows the following landmarks:{x\n",
+   "ua": "{cЛокатор видає такі орієнтири:{x\n"
+  },
+  "{cТы отправляешь магический локатор на поиски {g'{G%s{g'{c.{x": {
+   "en": "{cYou send a magical locator to search for {g'{G%s{g'{c.{x",
+   "ua": "{cТи відправляєш магічний локатор на пошуки {g'{G%s{g'{c.{x"
+  },
+  "Какую вещь ты хочешь найти локатором?": {
+   "en": "What item do you want to locate with the locator?",
+   "ua": "Яку річ ти хочеш знайти локатором?"
+  }
+ },
+ "spell/magic concentrate/runVict": {
+  "Ты уже гото%1$Gво|в|ва фокусировать магию.": {
+   "en": "You are already prepared to focus magic.",
+   "ua": "Ти вже готов%1$Gе|ий|а|і фокусувати магію."
+  }
+ },
+ "spell/matandra/runVict": {
+  "{1%1$^O1 испуска%1$nет|ют {Wослепительный луч{2 в сторону %2$C2!": {
+   "en": "{1%1$^O1 %1$nemits|emit a {Wblinding ray{2 toward %2$C2!",
+   "ua": "{1%1$^O1 випуска%1$nє|ють {Wосліплюючий промінь{2 у бік %2$C2!"
+  }
+ },
+ "spell/mend/runObj": {
+  "Улучшить состояние %O2 не удалось.": {
+   "en": "Failed to improve the condition of %O2.",
+   "ua": "Покращити стан %O2 не вдалося."
+  },
+  "%1$^O1 окутыва%1$nется|ются мягкой дымкой, избавляясь от {1{yк{gо{yр{gр{yо{gз{yи{gи{2.": {
+   "en": "%1$^O1 %1$nis|are wrapped in a soft haze, shedding its {1{yc{go{yr{gr{yo{gs{yi{go{yn{2.",
+   "ua": "%1$^O1 огорта%1$nється|ються мʼякою імлою, позбуваючись {1{yк{gо{yр{gо{yз{gі{yї{2."
+  }
+ },
+ "spell/mind light/runRoom": {
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова зажечь сияние разума.": {
+   "en": "You need to rest before you can light the radiance of the mind again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову запалити сяйво розуму."
+  },
+  "Эта комната уже освещена сиянием разума.": {
+   "en": "This room is already lit by the glow of the mind.",
+   "ua": "Ця кімната вже освітлена сяйвом розуму."
+  }
+ },
+ "spell/mind wrench/runVict": {
+  "{1{BГлаза %C2 на мгновение затуманиваются и теряют осмысленность.{2": {
+   "en": "{1{B%C2's eyes cloud over for a moment and lose their focus.{2",
+   "ua": "{1{BОчі %C2 на мить затуманюються і втрачають осмисленість.{2"
+  },
+  "%1$^C1 зачем-то насылает {1{Cи{Dс{Cк{Dа{Cж{Dе{Cн{Dи{Cе {Bразума{2 на себя сам%1$Gого|ого|у!": {
+   "en": "%1$^C1 inexplicably unleashes a {1{Cd{Di{Cs{Dt{Co{Dr{Ct{Di{Co{Dn{B of mind{2 upon themselves!",
+   "ua": "%1$^C1 чомусь насилає {1{Cс{Dп{Cо{Dт{Cв{Dо{Cр{Dе{Cн{Dн{Cя {Bрозуму{2 на себе сам%1$Gого|ого|у!"
+  },
+  "Ты зачем-то насылаешь {1{Cи{Dс{Cк{Dа{Cж{Dе{Cн{Dи{Cе {Bразума{2 на себя сам%1$Gого|ого|у!": {
+   "en": "You unleash a {1{Cd{Di{Cs{Dt{Co{Dr{Ct{Di{Co{Dn of {Bmind{2 upon yourself for some reason!",
+   "ua": "Ти чомусь насилаєш {1{Cс{Dп{Cо{Dт{Cв{Dо{Cр{Dе{Cн{Dн{Cя {Bрозуму{2 на себе сам%1$Go|ого|у!"
+  }
+ },
+ "spell/mist walk/runVict": {
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your teleportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чар."
+  },
+  "Сквозь туман проглядывается {1{W%s{2 в {1{Y%N6{2.": {
+   "en": "Through the mist, {1{W%s{2 can be glimpsed in {1{Y%N6{2.",
+   "ua": "Крізь туман проглядається {1{W%s{2 у {1{Y%N6{2."
+  },
+  "{1{DТ{wу{Dман{2 сгущается вокруг %C2, формируя призрачное подобие ворот.": {
+   "en": "{1{DM{wi{Dst{2 thickens around %C2, forming a ghostly semblance of a gate.",
+   "ua": "{1{DТ{wу{Dман{2 згущується навколо %C2, формуючи примарну подобу воріт."
+  },
+  "Ты открываешь {1{Dт{wу{Dм{wа{Dнный путь{2 к %C3.": {
+   "en": "You open a {1{Dm{wi{Ds{wt{Dy path{2 to %C3.",
+   "ua": "Ти відкриваєш {1{Dт{wу{Dм{wа{Dнний шлях{2 до %C3."
+  }
+ },
+ "spell/mosquito swarm/runVict": {
+  "В этих краях мошки и комары не водятся.": {
+   "en": "Gnats and mosquitoes are not found in these parts.",
+   "ua": "У цих краях мошва і комарі не водяться."
+  },
+  "К сожалению, у %C2 иммунитет к комариному яду.": {
+   "en": "Unfortunately, %C2 is immune to mosquito venom.",
+   "ua": "На жаль, %C2 має імунітет до комариної отрути."
+  },
+  "{1{RГнус облепляет тебя с головы до ног%s!{2": {
+   "en": "{1{RGnats swarm you from head to toe%s!{2",
+   "ua": "{1{RГнус облипає тебе з голови до ніг%s!{2"
+  },
+  "Ты слышишь {1{Cоглушительное {yж{Cу{yжж{Cа{yн{Cи{yе,{2 когда огромная стая гнуса появляется из ниоткуда.": {
+   "en": "You hear a deafening {1{Cb{yu{Cz{yz{Ci{yn{Cg{2, as a huge swarm of midges appears out of nowhere.",
+   "ua": "Ти чуєш оглушливе {1{Cд{yз{Cи{yж{Cч{yа{Cн{yн{Cя{2, коли величезна зграя гнусу зʼявляється нізвідки."
+  }
+ },
+ "spell/mystical leap/runVict": {
+  "Эта цель не находится в пределах одной зоны с тобой.": {
+   "en": "This target is not within the same zone as you.",
+   "ua": "Ця ціль не перебуває в межах однієї зони з тобою."
+  }
+ },
+ "spell/narcotic mist/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "Most affects and charms cannot be cast on this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чарів."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать усыпляющий туман.": {
+   "en": "You need to rest before you can use the sleep-inducing mist again.",
+   "ua": "Тобі треба відпочити перш ніж ти зможеш знову використати присипляючий туман."
+  },
+  "Эта местность уже наполнена усыпляющим туманом.": {
+   "en": "This area is already filled with sleep-inducing mist.",
+   "ua": "Ця місцевість вже наповнена присипляючим туманом."
+  }
+ },
+ "spell/nexus/runVict": {
+  "%^C3 удаётся избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your transportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чарів."
+  },
+  "%^O1 в руке %C2 вспыхивает и исчезает!": {
+   "en": "%^O1 flares up in %C2's hand and vanishes!",
+   "ua": "%^O1 в руці %C2 спалахує і зникає!"
+  },
+  "Двусторонний разрыв в реальности готов открыться.": {
+   "en": "A two-way rift in reality is ready to open.",
+   "ua": "Двосторонній розрив у реальності готовий відкритися."
+  },
+  "Для использования этого заклинания надо зажать в руках искажающий камень.": {
+   "en": "To use this spell, you need to hold a warping stone in your hands.",
+   "ua": "Щоб використати це заклинання, треба затиснути в руках спотворюючий камінь."
+  },
+  "Связь между двумя точками пространства постепенно крепнет.": {
+   "en": "The connection between the two points in space gradually strengthens.",
+   "ua": "Звʼязок між двома точками простору поступово міцніє."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/nightfall/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You can't apply most effects and charms to this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чарів."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь затемнить местность.": {
+   "en": "You need to rest before you can darken the area again.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш затемнити місцевість."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  },
+  "Чтобы использовать это умение, тебе понадобится черная роза.": {
+   "en": "To use this ability, you will need a black rose.",
+   "ua": "Щоб використати цю здібність, тобі знадобиться чорна троянда."
+  },
+  "Эта местность уже затемнена.": {
+   "en": "This area is already darkened.",
+   "ua": "Ця місцевість вже затемнена."
+  },
+  "Это умение доступно только для игроков.": {
+   "en": "This ability is only available to players.",
+   "ua": "Ця здатність доступна лише гравцям."
+  },
+  "Тьма сгущается у %1$P5 в ладонях, готовая хлынуть наружу.": {
+   "en": "Darkness gathers in %1$C2's palms, ready to burst forth.",
+   "ua": "Темрява згущується у %1$C2 в долонях, готова хлинути назовні."
+  }
+ },
+ "spell/nightwalker/runArg": {
+  "Днем вызвать ночную тень не получится.": {
+   "en": "You can't summon a night shade during the day.",
+   "ua": "Вдень викликати нічну тінь не вийде."
+  }
+ },
+ "spell/observation/runVict": {
+  "Теперь ты можешь диагностировать негативные аффекты других существ.": {
+   "en": "Now you can diagnose negative effects on other creatures.",
+   "ua": "Тепер ти можеш діагностувати негативні афекти інших істот."
+  },
+  "Ты уже можешь диагностировать негативные аффекты других существ.": {
+   "en": "You can already diagnose the negative effects of other creatures.",
+   "ua": "Ти вже можеш діагностувати негативні ефекти інших істот."
+  }
+ },
+ "spell/paralysis/runVict": {
+  "%1$^C1 уже парализова%1$Gно|н|на и не может пошевелить даже пальцем.": {
+   "en": "%1$^C1 is already paralyzed and can't move a single finger.",
+   "ua": "%1$^C1 вже паралізован%1$Gе|ий|а і не може поворухнути навіть пальцем."
+  },
+  "%^C1 пытается парализовать %C4, но безуспешно.": {
+   "en": "%^C1 tries to paralyze %C4, but fails.",
+   "ua": "%^C1 намагається паралізувати %C4, але безуспішно."
+  },
+  "%^C1 пытается парализовать тебя, но безуспешно.": {
+   "en": "%^C1 tries to paralyze you, but fails.",
+   "ua": "%^C1 намагається паралізувати тебе, але марно."
+  },
+  "В разгар боя %C4 парализовать не удастся.": {
+   "en": "You won't be able to paralyze %C4 in the heat of battle.",
+   "ua": "У розпал бою %C4 паралізувати не вдасться."
+  },
+  "Ты пытаешься парализовать %C4, но безуспешно.": {
+   "en": "You try to paralyze %C4, but fail.",
+   "ua": "Ти намагаєшся паралізувати %C4, але безуспішно."
+  },
+  "Ты уже парализова%1$Gно|н|на и не можешь пошевелить даже пальцем.": {
+   "en": "You're already paralyzed and can't move even a finger.",
+   "ua": "Ти вже паралізован%1$Gо|ий|а і не можеш поворухнути навіть пальцем."
+  },
+  "Эти чары нельзя сотворить, когда в жилах кипит адреналин.": {
+   "en": "This spell cannot be cast while adrenaline is pumping through your veins.",
+   "ua": "Ці чари не можна сотворити, коли в жилах кипить адреналін."
+  },
+  "Ты {1{Wпарализуешь{2 %1$C4, и %1$P1 не может пошевелить даже пальцем!": {
+   "en": "You {1{Wparalyze{2 %1$C4, and %1$C1 can't move a single finger!",
+   "ua": "Ти {1{Wпаралізуєш{2 %1$C4, і %1$C1 не може поворухнути навіть пальцем!"
+  }
+ },
+ "spell/pass door/runVict": {
+  "Ты становишься полупрозрачн%1$Gым|ым|ой|ыми, получая способность проходить сквозь преграды.": {
+   "en": "You become semi-transparent, gaining the ability to pass through obstacles.",
+   "ua": "Ти стаєш напівпрозор%1$Gим|им|ою|ими, отримуючи здатність проходити крізь перешкоди."
+  }
+ },
+ "spell/plague/runVict": {
+  "Ты чувствуешь легкое недомогание, но это проходит.": {
+   "en": "You feel a slight illness, but it passes.",
+   "ua": "Ти відчуваєш легке нездужання, але це минає."
+  },
+  "На лице %1$C2 появляется пара прыщей, но %1$P1 сопротивляется болезни.": {
+   "en": "A couple of pimples appear on %1$C2's face, but %1$C1 resists the disease.",
+   "ua": "На обличчі %1$C2 зʼявляється пара прищів, але %1$C1 опирається хворобі."
+  }
+ },
+ "spell/poison/runObj": {
+  "%^O4 отравить не удастся.": {
+   "en": "%^O4 cannot be poisoned.",
+   "ua": "%^O4 отруїти не вдасться."
+  },
+  "Благословение защищает %O4 от яда.": {
+   "en": "The blessing protects %O4 from poison.",
+   "ua": "Благословення захищає %O4 від отрути."
+  },
+  "Похоже, %1$O1 уже отравле%1$Gно|н|на|ны.": {
+   "en": "It looks like %1$O1 is already poisoned.",
+   "ua": "Схоже, %1$O1 вже отруєн%1$Gе|ий|а|і."
+  },
+  "Уникальные свойства %O2 препятствуют отравлению.": {
+   "en": "The unique properties of %O2 prevent poisoning.",
+   "ua": "Унікальні властивості %O2 перешкоджають отруєнню."
+  },
+  "Чтобы отравить %1$O4, %1$P2 придется сначала открыть.": {
+   "en": "To poison %1$O4, it will have to be opened first.",
+   "ua": "Щоб отруїти %1$O4, спершу доведеться відкрити %1$O4."
+  },
+  "Мощные свойства %1$O2 не позволяют %1$P2 отравить.": {
+   "en": "The powerful properties of %1$O2 don't allow it to be poisoned.",
+   "ua": "Потужні властивості %1$O2 не дозволяють %1$O4 отруїти."
+  }
+ },
+ "spell/poison/runVict": {
+  "Ты чувствуешь легкое отравление, но это сразу проходит.": {
+   "en": "You feel a slight poisoning, but it passes right away.",
+   "ua": "Ти відчуваєш легке отруєння, але це одразу минає."
+  },
+  "На лице %1$C2 появляется оскомина, но %1$P1 сопротивляется отравлению.": {
+   "en": "A grimace of bitterness crosses %1$C2's face, but %1$C1 resists the poison.",
+   "ua": "На обличчі %1$C2 зʼявляється оскома, але %1$C1 опирається отруєнню."
+  }
+ },
+ "spell/portal/runVict": {
+  "%^C3 удаётся избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your transportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чар."
+  },
+  "Воздух вокруг %C2 едва заметно искрится.": {
+   "en": "The air around %C2 sparkles faintly.",
+   "ua": "Повітря навколо %C2 ледь помітно іскриться."
+  },
+  "Для использования этого заклинания надо зажать в руках искажающий камень.": {
+   "en": "To use this spell, you need to clutch a distortion stone in your hands.",
+   "ua": "Щоб використати це заклинання, треба затиснути в руках спотворюючий камінь."
+  },
+  "Перейти на сам{Smого{Sfу{Sx себя? Но как узнать, где настоящ{Smий{Sfая{Sx ты -- здесь или там?": {
+   "en": "Switch to yourself? But how would you know which one is the real you -- here or there?",
+   "ua": "Перейти на сам{Smого{Sfу{Sx себе? Але як дізнатися, де справжн{Smій{Sfя{Sx ти -- тут чи там?"
+  },
+  "Ты сжимаешь %O4 и сосредотачиваешься на %C5.": {
+   "en": "You clutch %O4 and focus on %C5.",
+   "ua": "Ти стискаєш %O4 і зосереджуєшся на %C5."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/power word kill/runVict": {
+  "Созданный %C5 поток мрака пытается окутать %C4, но безуспешно.": {
+   "en": "The stream of gloom created by %C5 tries to envelop %C4, but fails.",
+   "ua": "Створений %C5 потік мороку намагається огорнути %C4, але безуспішно."
+  },
+  "Созданный %C5 поток мрака пытается окутать тебя, но безуспешно.": {
+   "en": "A stream of darkness created by %C5 tries to envelop you, but fails.",
+   "ua": "Створений %C5 потік мороку намагається огорнути тебе, але безуспішно."
+  },
+  "Ты не можешь прицелиться в %1$C4, пока %1$P1 сража%1$nется|ются.": {
+   "en": "You can't take aim at %1$C4 while they're fighting.",
+   "ua": "Ти не можеш прицілитися в %1$C4, поки %1$C1 бор%1$nеться|ються."
+  }
+ },
+ "spell/protection cold/runObj": {
+  "%^O1 и так не пострадает от холода.": {
+   "en": "%^O1 won't be harmed by the cold anyway.",
+   "ua": "%^O1 і так не постраждає від холоду."
+  },
+  "%^O1 окутывается термоизоляционной пленкой, защищающей от замораживания.": {
+   "en": "%^O1 becomes wrapped in a thermal-insulating film that protects against freezing.",
+   "ua": "%^O1 огортається термоізоляційною плівкою, що захищає від заморожування."
+  },
+  "%^O1 отвергает твои чары.": {
+   "en": "%^O1 rejects your magic.",
+   "ua": "%^O1 відкидає твої чари."
+  },
+  "%^O1 уже имеет защиту от замораживания.": {
+   "en": "%^O1 already has protection from freezing.",
+   "ua": "%^O1 вже має захист від замороження."
+  },
+  "%^O1 уже имеет защиту от тепла и жара.": {
+   "en": "%^O1 already has protection against heat.",
+   "ua": "%^O1 вже має захист від тепла та спеки."
+  }
+ },
+ "spell/protection evil/runVict": {
+  "Ты получаешь защиту от злых существ.": {
+   "en": "You gain protection from evil creatures.",
+   "ua": "Ти отримуєш захист від злих істот."
+  }
+ },
+ "spell/protection good/runVict": {
+  "Ты получаешь защиту от добрых существ.": {
+   "en": "You gain protection from good creatures.",
+   "ua": "Ти отримуєш захист від добрих істот."
+  },
+  "Ты уже защище%1$Gно|н|на|ны.": {
+   "en": "You are already protected.",
+   "ua": "Ти вже захищен%1$Gо|ий|а|і."
+  }
+ },
+ "spell/randomizer/runRoom": {
+  "Дороги в этой местности уже перепутаны силами Хаоса.": {
+   "en": "The roads in this area have already been scrambled by the powers of Chaos.",
+   "ua": "Дороги в цій місцевості вже переплутані силами Хаосу."
+  },
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You can't apply most effects and charms to this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість ефектів і чарів."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать это умение.": {
+   "en": "You need to rest before you can use this skill again.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш знову використати це вміння."
+  },
+  "Ты чувствуешь себя опустошенно.": {
+   "en": "You feel hollow inside.",
+   "ua": "Ти почуваєшся спустошено."
+  }
+ },
+ "spell/ranger staff/runArg": {
+  "Создать посох рейнджера можно только в лесу.": {
+   "en": "You can only create a ranger's staff in a forest.",
+   "ua": "Створити посох рейнджера можна лише в лісі."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь создать посох.": {
+   "en": "You need to rest before you can create a staff.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш створити посох."
+  },
+  "Ты подбираешь подходящую палку в лесу и осматриваешь её.": {
+   "en": "You pick up a suitable stick in the forest and examine it.",
+   "ua": "Ти підбираєш придатну палицю в лісі і оглядаєш її."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/ray of truth/runVict": {
+  "Твой {1{WЛуч Истины{2 не сможет навредить %C3.": {
+   "en": "Your {1{WRay of Truth{2 cannot harm %C3.",
+   "ua": "Твій {1{WПромінь Істини{2 не зможе нашкодити %C3."
+  }
+ },
+ "spell/recharge/runObj": {
+  "%1$^O1 вспыхива%1$nет|ют, начиная излучать мощную энергетическую ауру.": {
+   "en": "%1$^O1 flare%1$ns| up, beginning to radiate a powerful energetic aura.",
+   "ua": "%1$^O1 спалаху%1$nє|ють, починаючи випромінювати потужну енергетичну ауру."
+  },
+  "Тебе не хватает могущества для перезарядки %O2.": {
+   "en": "You lack the power to recharge %O2.",
+   "ua": "Тобі бракує могутності для перезарядки %O2."
+  },
+  "Теперь восстановить %1$P2 сможет только опытный артифайсер.": {
+   "en": "Now only an experienced artificer will be able to restore %1$O4.",
+   "ua": "Тепер відновити %1$O4 зможе лише досвідчений артифайсер."
+  }
+ },
+ "spell/reclaim/runRoom": {
+  "%1$^O1 рассыпа%1$nется|ются и исчеза%1$nет|ют.": {
+   "en": "%1$^O1 crumble%1$ns| and disappear%1$ns|.",
+   "ua": "%1$^O1 розсипа%1$nється|ються і зника%1$nє|ють."
+  },
+  "Городские пространства неподвластны силам Природы.": {
+   "en": "Urban spaces are beyond the reach of Nature's powers.",
+   "ua": "Міські простори непідвладні силам Природи."
+  },
+  "Эта местность не нуждается в окультуривании.": {
+   "en": "This area doesn't need cultivating.",
+   "ua": "Ця місцевість не потребує окультурення."
+  },
+  "Эта местность неподвластна твоим заклинаниям.": {
+   "en": "This area is beyond the reach of your spells.",
+   "ua": "Ця місцевість непідвладна твоїм заклинанням."
+  }
+ },
+ "spell/refresh/runVict": {
+  "%1$^C1 выглядит бодрее!": {
+   "en": "%1$^C1 looks more refreshed!",
+   "ua": "%1$^C1 виглядає бадьоріше!"
+  },
+  "%1$^C1 уже бодр%1$Gо||а|ы и пол%1$Gно|он|на|ны сил.": {
+   "en": "%1$^C1 is already energetic and full of strength.",
+   "ua": "%1$^C1 вже бадьор%1$Gе|ий|а|і і повн%1$Gе|ий|а|і сил."
+  },
+  "{1{G{1%^C1{2 чувству%1$nет|ют себя абсолютно бодр%1$Gым|ым|ой|ыми и полн%1$Gым|ым|ой|ыми сил!{2": {
+   "en": "{1{G{1%^C1{2 feel%1$ns| completely refreshed and full of energy!{2",
+   "ua": "{1{G{1%^C1{2 почува%1$nється|ються абсолютно бадьор%1$Gим|им|ою|ими і повн%1$Gим|им|ою|ими сил!{2"
+  },
+  "Усталость проходит... но лишь на мгновение.": {
+   "en": "The fatigue fades... but only for a moment.",
+   "ua": "Втома минає... але лише на мить."
+  }
+ },
+ "spell/remove curse/runObj": {
+  "%1$^O1 загора%1$nется|ются {1{Cголубым{2 светом!": {
+   "en": "%1$^O1 ignite%1$ns| with {1{Cblue{2 light!",
+   "ua": "%1$^O1 загора%1$nється|ються {1{Cблакитним{2 світлом!"
+  },
+  "%1$^O1 на мгновение окутыва%1$nется|ются сиянием, но тут же гасн%1$nет|ут.": {
+   "en": "%1$^O1 %1$nis|are briefly wrapped in a glow, but immediately fade%1$ns| away.",
+   "ua": "%1$^O1 на мить огорта%1$nється|ються сяйвом, але одразу ж гас%1$nне|нуть."
+  }
+ },
+ "spell/remove curse/runVict": {
+  "%1$^C1 качает головой: проклятье на %2$C6 нельзя снять этой молитвой.": {
+   "en": "%1$^C1 shakes their head: the curse on %2$C6 can't be lifted with this prayer.",
+   "ua": "%1$^C1 хитає головою: прокляття на %2$C6 не можна зняти цією молитвою."
+  },
+  "Проклятье на %1$C6 нельзя снять этой молитвой.": {
+   "en": "The curse on %1$C6 cannot be removed with this prayer.",
+   "ua": "Прокляття на %1$C6 не можна зняти цією молитвою."
+  },
+  "Проклятье, висящее на %1$C6, сопротивляется %1$P2 молитвам.": {
+   "en": "The curse hanging over %1$C6 resists %1$C2's prayers.",
+   "ua": "Прокляття, що висить на %1$C6, опирається молитвам %1$C2."
+  },
+  "Проклятье, висящее на %C6, сопротивляется молитвам %C2.": {
+   "en": "The curse hanging over %C6 resists %C2's prayers.",
+   "ua": "Прокляття, що висить на %C6, опирається молитвам %C2."
+  },
+  "Проклятье, висящее на тебе, нельзя снять этой молитвой.": {
+   "en": "The curse hanging over you cannot be lifted with this prayer.",
+   "ua": "Прокляття, що висить на тобі, не можна зняти цією молитвою."
+  }
+ },
+ "spell/remove fear/runVict": {
+  "%1$^C1 пока ничем не напуган%1$Gо||а|ы.": {
+   "en": "%1$^C1 isn't frightened by anything right now.",
+   "ua": "%1$^C1 поки нічим не налякан%1$Gе|ий|а|і."
+  },
+  "Ты пока ничем не напуган%1$Gо||а.": {
+   "en": "You aren't scared of anything yet.",
+   "ua": "Ти поки нічим не наляк%1$Gане|аний|ана."
+  }
+ },
+ "spell/resilience/runVict": {
+  "%^C1 получает устойчивость к энергетическим атакам.": {
+   "en": "%^C1 gains resistance to energy attacks.",
+   "ua": "%^C1 отримує стійкість до енергетичних атак."
+  }
+ },
+ "spell/restoring light/runVict": {
+  "%^C1 создает и направляет на тебя мощный поток голубого света.": {
+   "en": "%^C1 creates and directs a powerful stream of blue light at you.",
+   "ua": "%^C1 створює і спрямовує на тебе потужний потік блакитного світла."
+  },
+  "%1$^C1 здоро%1$Gво|в|ва как болотный тролль, на %1$P6 ни царапин, ни проклятий.": {
+   "en": "%1$^C1 is healthy as a swamp troll, not a scratch or a curse on them.",
+   "ua": "%1$^C1 здоров%1$Gо|ий|а як болотний троль, на %1$C6 жодної подряпини, жодного прокляття."
+  }
+ },
+ "spell/ruler aura/runVict": {
+  "Аура Правителя уже окружает тебя.": {
+   "en": "The Ruler's Aura already surrounds you.",
+   "ua": "Аура Правителя вже оточує тебе."
+  }
+ },
+ "spell/sanctify lands/runRoom": {
+  "%1$^C1 просит очистить местность от вредных воздействий.": {
+   "en": "%1$^C1 asks to cleanse the area of harmful effects.",
+   "ua": "%1$^C1 просить очистити місцевість від шкідливих впливів."
+  },
+  "Ты просишь очистить местность от вредных воздействий.": {
+   "en": "You ask for the land to be cleansed of harmful influences.",
+   "ua": "Ти просиш очистити місцевість від шкідливих впливів."
+  },
+  "Эта местность не нуждается в очищении.": {
+   "en": "This area doesn't need purifying.",
+   "ua": "Ця місцевість не потребує очищення."
+  },
+  "Эта местность неподвластна твоим молитвам.": {
+   "en": "This area is beyond the reach of your prayers.",
+   "ua": "Ця місцевість непідвладна твоїм молитвам."
+  }
+ },
+ "spell/sanctuary/runVict": {
+  "%^C1 уже под воздействием темной ауры, этого достаточно.": {
+   "en": "%^C1 is already under the effect of a dark aura, that's enough.",
+   "ua": "%^C1 вже під дією темної аури, цього досить."
+  },
+  "Аура святилища уже защищает %C4.": {
+   "en": "A sanctuary aura is already protecting %C4.",
+   "ua": "Аура святилища вже захищає %C4."
+  }
+ },
+ "spell/sand storm/runRoom": {
+  "Здесь недостаточно песка или пыли, чтобы сформировать бурю.": {
+   "en": "There isn't enough sand or dust here to form a storm.",
+   "ua": "Тут недостатньо піску чи пилу, щоб сформувати бурю."
+  }
+ },
+ "spell/seasonal aspect/runVict": {
+  "%^C1 окутывается аурой сезонных изменений.": {
+   "en": "%^C1 becomes wrapped in an aura of seasonal change.",
+   "ua": "%^C1 огортається аурою сезонних змін."
+  },
+  "{GИмболк,{g фестиваль весны, защищает тебя.{x": {
+   "en": "{GImbolc,{g the festival of spring, protects you.{x",
+   "ua": "{GІмболк,{g фестиваль весни, захищає тебе.{x"
+  }
+ },
+ "spell/sebat/runVict": {
+  "Тебя окружает таинственный щит, улучшающий другие защитные заклинания.": {
+   "en": "A mysterious shield surrounds you, enhancing your other protective spells.",
+   "ua": "Тебе оточує таємничий щит, що посилює інші захисні заклинання."
+  }
+ },
+ "spell/severity force/runVict": {
+  "В воздухе заставить землю разверзнуться не выйдет.": {
+   "en": "You can't make the ground split open while airborne.",
+   "ua": "У повітрі змусити землю розверзнутися не вийде."
+  },
+  "Подземные силы не смогут навредить летучему противнику.": {
+   "en": "Subterranean forces can't harm a flying opponent.",
+   "ua": "Підземні сили не зможуть нашкодити летючому противнику."
+  }
+ },
+ "spell/shadowblade/runArg": {
+  "Лишь анти-паладинам под силу призвать %s.": {
+   "en": "Only anti-paladins have the power to summon %s.",
+   "ua": "Лише анти-паладинам під силу призвати %s."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/shield/runVict": {
+  "%^C4 окружает {1{Cмагический щит,{2 помогающий блокировать удары.": {
+   "en": "%^C4 is surrounded by {1{Ca magical shield,{2 which helps block blows.",
+   "ua": "%^C4 оточує {1{Cмагічний щит,{2 що допомагає блокувати удари."
+  },
+  "Тебя окружает {1{Cмагический щит,{2 помогающий блокировать удары.": {
+   "en": "A {1{Cmagical shield{2 surrounds you, helping to block blows.",
+   "ua": "Тебе оточує {1{Cмагічний щит,{2 що допомагає блокувати удари."
+  }
+ },
+ "spell/shielding/runVict": {
+  "%^C1 пытается изолировать %C4 от магии, но безуспешно.": {
+   "en": "%^C1 tries to insulate %C4 from magic, but fails.",
+   "ua": "%^C1 намагається ізолювати %C4 від магії, але безуспішно."
+  },
+  "%^C1 пытается изолировать тебя от магии, но безуспешно.": {
+   "en": "%^C1 tries to isolate you from magic, but fails.",
+   "ua": "%^C1 намагається ізолювати тебе від магії, але безуспішно."
+  },
+  "Изолирующий магию экран вокруг %C2 усиливается.": {
+   "en": "The magic-isolating screen around %C2 grows stronger.",
+   "ua": "Ізолюючий магію екран навколо %C2 посилюється."
+  },
+  "Изолирующий магию экран вокруг тебя усиливается!": {
+   "en": "The magic-isolating shield around you intensifies!",
+   "ua": "Ізолюючий магію екран навколо тебе посилюється!"
+  },
+  "Ты пытаешься изолировать %C4 от магии, но безуспешно.": {
+   "en": "You try to isolate %C4 from magic, but fail.",
+   "ua": "Ти намагаєшся ізолювати %C4 від магії, але марно."
+  },
+  "Ты создаешь изолирующий магию экран вокруг %C2.": {
+   "en": "You create a magic-insulating screen around %C2.",
+   "ua": "Ти створюєш ізолюючий магію екран навколо %C2."
+  },
+  "Ты укрепляешь изолирующий магию экран вокруг %C2.": {
+   "en": "You reinforce a magic-insulating screen around %C2.",
+   "ua": "Ти зміцнюєш ізолюючий магію екран навколо %C2."
+  }
+ },
+ "spell/shocking grasp/runVict": {
+  "Искры пробегают по руке %1$C2, когда %1$P1 прикасается к тебе!": {
+   "en": "Sparks race along %1$C2's arm as they touch you!",
+   "ua": "Іскри пробігають по руці %1$C2, коли %1$C1 торкається до тебе!"
+  }
+ },
+ "spell/shocking trap/runRoom": {
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "You can't apply most effects and enchantments to this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість афектів і чар."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова использовать силовую ловушку.": {
+   "en": "You need to rest before you can use the shock trap again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову використати силову пастку."
+  },
+  "Ты активируешь {1{cсиловую ловушку,{2 которая сработает на входящих противников.": {
+   "en": "You activate a {1{cforce trap,{2 which will trigger on incoming enemies.",
+   "ua": "Ти активуєш {1{cсилову пастку,{2 яка спрацює на противників, що входять."
+  },
+  "Эта местность уже защищена силовой ловушкой.": {
+   "en": "This area is already protected by a force trap.",
+   "ua": "Ця місцевість вже захищена силовою пасткою."
+  }
+ },
+ "spell/skeleton/runArg": {
+  "Поднять скелета удастся только у могилы или на кладбище.": {
+   "en": "You can only raise a skeleton at a grave or in a cemetery.",
+   "ua": "Підняти скелета вдасться лише біля могили або на цвинтарі."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You are already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/sleep/runVict": {
+  "%C1 засыпает.": {
+   "en": "%C1 falls asleep.",
+   "ua": "%C1 засинає."
+  },
+  "%^C1 засыпа%1$nет|ют.": {
+   "en": "%^C1 fall%1$ns| asleep.",
+   "ua": "%^C1 засина%1$nє|ють."
+  },
+  "%^C1 пытается усыпить %C4, но безуспешно.": {
+   "en": "%^C1 tries to put %C4 to sleep, but fails.",
+   "ua": "%^C1 намагається приспати %C4, але безуспішно."
+  },
+  "%^C1 пытается усыпить тебя, но безуспешно.": {
+   "en": "%^C1 tries to put you to sleep, but fails.",
+   "ua": "%^C1 намагається приспати тебе, але безуспішно."
+  },
+  "{RТы засыпаешь!{x": {
+   "en": "{RYou fall asleep!{x",
+   "ua": "{RТи засинаєш!{x"
+  },
+  "В разгар боя %C4 усыпить не удастся.": {
+   "en": "In the heat of battle, %C4 cannot be put to sleep.",
+   "ua": "У розпалі бою %C4 приспати не вдасться."
+  },
+  "На %C6 уже лежат чары сна.": {
+   "en": "The sleep spell is already on %C6.",
+   "ua": "На %C6 вже лежать чари сну."
+  },
+  "Но %C1 уже спит!": {
+   "en": "But %C1 is already asleep!",
+   "ua": "Але %C1 вже спить!"
+  },
+  "Ты пытаешься усыпить %C4, но безуспешно.": {
+   "en": "You try to put %C4 to sleep, but fail.",
+   "ua": "Ти намагаєшся приспати %C4, але безуспішно."
+  }
+ },
+ "spell/slow/runVict": {
+  "%^C1 пытается замедлить %C4, но безуспешно.": {
+   "en": "%^C1 tries to slow %C4, but fails.",
+   "ua": "%^C1 намагається сповільнити %C4, але безуспішно."
+  },
+  "%^C1 пытается замедлить тебя, но безуспешно.": {
+   "en": "%^C1 tries to slow you down, but fails.",
+   "ua": "%^C1 намагається сповільнити тебе, але марно."
+  },
+  "Движения %C2 замедляются, но лишь на мгновение.": {
+   "en": "%C2's movements slow down, but only for a moment.",
+   "ua": "Рухи %C2 сповільнюються, але лише на мить."
+  },
+  "Твои движения замедляются, но лишь на мгновение.": {
+   "en": "Your movements slow, but only for a moment.",
+   "ua": "Твої рухи сповільнюються, але лише на мить."
+  },
+  "Ты пытаешься замедлить %C4, но безуспешно.": {
+   "en": "You try to slow %C4 down, but fail.",
+   "ua": "Ти намагаєшся сповільнити %C4, але марно."
+  }
+ },
+ "spell/solar flight/runVict": {
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your transportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чарів."
+  },
+  "В местность, где находится твоя цель, не проникают лучи солнца.": {
+   "en": "Sunlight doesn't reach the area where your target is.",
+   "ua": "У місцевість, де перебуває твоя ціль, не проникають промені сонця."
+  },
+  "В местность, где ты находишься, не проникают лучи солнца.": {
+   "en": "Sunlight cannot reach the area you are in.",
+   "ua": "У місцевість, де ти перебуваєш, не проникають промені сонця."
+  },
+  "Для использования этой молитвы тебе нужен солнечный свет.": {
+   "en": "You need sunlight to use this prayer.",
+   "ua": "Для використання цієї молитви тобі потрібне сонячне світло."
+  }
+ },
+ "spell/spell resistance/runVict": {
+  "%^C1 окутывается энергетическим коконом, защищающим от заклинаний.": {
+   "en": "%^C1 becomes wrapped in an energy cocoon that protects against spells.",
+   "ua": "%^C1 огортається енергетичним коконом, що захищає від заклинань."
+  },
+  "Ты окутываешься энергетическим коконом, защищающим от заклинаний.": {
+   "en": "You become wrapped in an energy cocoon that protects against spells.",
+   "ua": "Ти огортаєшся енергетичним коконом, що захищає від заклять."
+  }
+ },
+ "spell/stone golem/runArg": {
+  "Ты пишешь на клочке бумаги свое имя и кладешь его в открытый рот статуи.": {
+   "en": "You write your name on a scrap of paper and place it in the statue's open mouth.",
+   "ua": "Ти пишеш на клаптику паперу своє імʼя і кладеш його у відкритий рот статуї."
+  }
+ },
+ "spell/summon shadow/runArg": {
+  "Для вызова теневого двойника понадобится светильник.": {
+   "en": "Summoning a shadow double requires a light source.",
+   "ua": "Для виклику тіньового двійника знадобиться світильник."
+  },
+  "Днем вызвать теневого двойника не получится.": {
+   "en": "You can't summon a shadow double during the day.",
+   "ua": "Вдень викликати тіньового двійника не вийде."
+  },
+  "Попробуй сделать это ночью при свете %O2.": {
+   "en": "Try doing this at night by the light of %O2.",
+   "ua": "Спробуй зробити це вночі при світлі %O2."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  },
+  "Внезапно тень оживает и восстает, превращаясь в %P2 призрачного двойника!": {
+   "en": "Suddenly the shadow comes alive and rises, turning into your ghostly double!",
+   "ua": "Раптом тінь оживає і повстає, перетворюючись на твого примарного двійника!"
+  }
+ },
+ "spell/summon/runVict": {
+  "%^C1 {1{Cпризывает{2 %C4!.": {
+   "en": "%^C1 {1{Csummons{2 %C4!",
+   "ua": "%^C1 {1{Cпризиває{2 %C4!"
+  },
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your transportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чарів."
+  }
+ },
+ "spell/superior heal/runVict": {
+  "%1$^C1 выглядит {1{Cнамного{2 здоровее!": {
+   "en": "%1$^C1 looks {1{Cmuch{2 healthier!",
+   "ua": "%1$^C1 виглядає {1{Cнабагато{2 здоровіше!"
+  },
+  "%^C1 выглядит {1{Cнамного{2 здоровее! {D[{G%d{D]{x": {
+   "en": "%^C1 looks {1{Cmuch{2 healthier! {D[{G%d{D]{x",
+   "ua": "%^C1 виглядає {1{Cнабагато{2 здоровіше! {D[{G%d{D]{x"
+  },
+  "{CМощная волна тепла согревает твое тело.{x {D[{G%d{D]{x": {
+   "en": "{CA powerful wave of warmth heats your body.{x {D[{G%d{D]{x",
+   "ua": "{CПотужна хвиля тепла зігріває твоє тіло.{x {D[{G%d{D]{x"
+  }
+ },
+ "spell/teleport/runVict": {
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your transportation magic.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чар."
+  },
+  "Ты пытаешься найти случайную комнату для телепортации, но безуспешно.": {
+   "en": "You try to find a random room to teleport to, but fail.",
+   "ua": "Ти намагаєшся знайти випадкову кімнату для телепортації, але безуспішно."
+  },
+  "Ты телепортируешь %C4.": {
+   "en": "You teleport %C4.",
+   "ua": "Ти телепортуєш %C4."
+  }
+ },
+ "spell/tesla retribution/runVict": {
+  "Твоя жертва не поддастся этому заклинанию.": {
+   "en": "Your target won't succumb to this spell.",
+   "ua": "Твоя жертва не піддасться цьому заклинанню."
+  },
+  "Тебе надо отдохнуть перед тем как снова использовать Перст.": {
+   "en": "You need to rest before you can use the Finger again.",
+   "ua": "Тобі треба відпочити, перш ніж знову використати Перст."
+  },
+  "Ты не можешь обнаружить свою цель.": {
+   "en": "You cannot detect your target.",
+   "ua": "Ти не можеш виявити свою ціль."
+  },
+  "Это заклинание сработает только если твоя жертва при смерти.": {
+   "en": "This spell only works if your victim is at death's door.",
+   "ua": "Це закляття спрацює лише якщо твоя жертва при смерті."
+  },
+  "Это заклинание сработает только на расстоянии.": {
+   "en": "This spell only works at range.",
+   "ua": "Це заклинання спрацює лише на відстані."
+  }
+ },
+ "spell/tesseract/runVict": {
+  "%^C3 удается избежать твоих транспортных чар.": {
+   "en": "%^C3 manages to avoid your transport spell.",
+   "ua": "%^C3 вдається уникнути твоїх транспортних чарів."
+  }
+ },
+ "spell/tornado/runVict": {
+  "%1$C1 уже обездвижен%1$Gо||а|ы.": {
+   "en": "%1$C1 is already immobilized.",
+   "ua": "%1$C1 вже знерухомлен%1$Gо|ий|а|і."
+  },
+  "{WПровисев в воздухе целых {C%1$d{W раунд%1$I|а|ов, {1%2$C1{2 получа%2$nет|ют дополнительный урон!{x": {
+   "en": "{WAfter hanging in the air for {C%1$d{W round%1$I|s|s, {1%2$C1{2 take%2$ns| extra damage!{x",
+   "ua": "{WПровисівши в повітрі цілих {C%1$d{W раунд%1$I|и|ів, {1%2$C1{2 отриму%2$nє|ють додаткову шкоду!{x"
+  },
+  "Бестелесность %C2 предотвращает часть повреждений.": {
+   "en": "%C2's incorporeal form prevents part of the damage.",
+   "ua": "Безтілесність %C2 запобігає частині ушкоджень."
+  },
+  "К счастью, твоя бестелесность предотвращает часть повреждений.": {
+   "en": "Luckily, your incorporeal state prevents some of the damage.",
+   "ua": "На щастя, твоя безтілесність запобігає частині ушкоджень."
+  },
+  "Твой вес и размер усиливают повреждения.": {
+   "en": "Your weight and size amplify the damage.",
+   "ua": "Твоя вага і розмір посилюють ушкодження."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова создать торнадо.": {
+   "en": "You need to rest before you can create a tornado again.",
+   "ua": "Тобі треба відпочити, перш ніж ти зможеш знову створити торнадо."
+  },
+  "Это заклинание сработает только под открытым небом.": {
+   "en": "This spell only works under open sky.",
+   "ua": "Це закляття спрацює лише під відкритим небом."
+  }
+ },
+ "spell/totem/runArg": {
+  "{gТы кладешь ладони на землю, фокусируя свою силу в материальный объект.{x": {
+   "en": "{gYou place your palms on the ground, focusing your power into a physical object.{x",
+   "ua": "{gТи кладеш долоні на землю, фокусуючи свою силу в матеріальний обʼєкт.{x"
+  },
+  "Здесь воздвигнуть тотем не получится.": {
+   "en": "You cannot erect a totem here.",
+   "ua": "Тут звести тотем не вийде."
+  },
+  "Здесь уже воздвигнут такой тотем.": {
+   "en": "Such a totem is already erected here.",
+   "ua": "Тут вже споруджено такий тотем."
+  },
+  "Какой именно тотем ты хочешь воздвигнуть?": {
+   "en": "Which totem exactly do you want to raise?",
+   "ua": "Який саме тотем ти хочеш звести?"
+  },
+  "На эту мирную местность нельзя навесить большинство аффектов и чар.": {
+   "en": "Most effects and enchantments cannot be applied to this peaceful area.",
+   "ua": "На цю мирну місцевість не можна накласти більшість ефектів і чар."
+  },
+  "Тебе надо отдохнуть перед тем, как ты сможешь снова воздвигнуть тотем.": {
+   "en": "You need to rest before you can raise a totem again.",
+   "ua": "Тобі треба відпочити перед тим, як ти зможеш знову звести тотем."
+  },
+  "Ты не можешь контролировать больше двух тотемов по всему миру.": {
+   "en": "You cannot control more than two totems across the whole world.",
+   "ua": "Ти не можеш контролювати більше двох тотемів по всьому світу."
+  },
+  "Этот тотем ты сможешь воздвигнуть только достигнув второго ранга.": {
+   "en": "You'll be able to erect this totem only once you reach the second rank.",
+   "ua": "Цей тотем ти зможеш спорудити лише досягнувши другого рангу."
+  },
+  "Этот тотем ты сможешь воздвигнуть только достигнув высшего ранга.": {
+   "en": "You'll only be able to raise this totem once you reach the highest rank.",
+   "ua": "Цей тотем ти зможеш звести, лише досягнувши найвищого рангу."
+  },
+  "Почитай {y{hcсправка тотем{x, чтобы узнать возможные варианты.": {
+   "en": "Check {y{hchelp totem{x to see the available options.",
+   "ua": "Прочитай {y{hcдовідка тотем{x, щоб дізнатися можливі варіанти."
+  },
+  "Чтобы заменить тотем, попробуй {hhокультурить{x местность.": {
+   "en": "To replace the totem, try {hhокультурить{x the terrain.",
+   "ua": "Щоб замінити тотем, спробуй {hhокультурить{x місцевість."
+  }
+ },
+ "spell/turn/runRoom": {
+  "Ослепительный свет не причиняет тебе вреда.": {
+   "en": "The blinding light does you no harm.",
+   "ua": "Сліпуче світло не завдає тобі шкоди."
+  },
+  "Подожди пока ты снова сможешь обратить врагов в бегство.": {
+   "en": "Wait until you can rout your enemies again.",
+   "ua": "Зачекай, поки ти знову зможеш обернути ворогів у втечу."
+  },
+  "Эту молитву запрещено использовать на чужих клановых территориях.": {
+   "en": "This prayer is forbidden for use on other clans' territories.",
+   "ua": "Цю молитву заборонено використовувати на чужих кланових територіях."
+  }
+ },
+ "spell/weaken/runVict": {
+  "%1$^C1 пыта%1$nется|ются ослабить %2$C4, но безуспешно.": {
+   "en": "%1$^C1 tr%1$nies|y to weaken %2$C4, but without success.",
+   "ua": "%1$^C1 намага%1$nється|ються ослабити %2$C4, але безуспішно."
+  },
+  "%1$^C1 пыта%1$nется|ются ослабить тебя, но безуспешно.": {
+   "en": "%1$^C1 tr%1$nies|y to weaken you, but fails.",
+   "ua": "%1$^C1 намага%1$nється|ються ослабити тебе, але безуспішно."
+  },
+  "%1$^C1 уже ослабле%1$Gно|н|на|ны.": {
+   "en": "%1$^C1 is already weakened.",
+   "ua": "%1$^C1 вже ослаблен%1$Gе|ий|а|і."
+  },
+  "{1{m%1$^C1 ослабля%1$nет|ют тебя!{2{/Ты чувствуешь, как силы покидают тебя.": {
+   "en": "{1{m%1$^C1 weaken%1$ns| you!{2{/You feel your strength leaving you.",
+   "ua": "{1{m%1$^C1 ослаблю%1$nє|ють тебе!{2{/Ти відчуваєш, як сили покидають тебе."
+  },
+  "Ты {1{mослабляешь{2 %C4!": {
+   "en": "You {1{mweaken{2 %C4!",
+   "ua": "Ти {1{mослаблюєш{2 %C4!"
+  },
+  "Ты пытаешься ослабить %C4, но безуспешно.": {
+   "en": "You try to weaken %C4, but fail.",
+   "ua": "Ти намагаєшся ослабити %C4, але безуспішно."
+  },
+  "Ты уже ослабле%1$Gно|н|на|ны.": {
+   "en": "You are already weakened.",
+   "ua": "Ти вже ослабл%1$Gене|ений|ена|ені."
+  }
+ },
+ "spell/web/runVict": {
+  "%^C1 и так уже едва может пошевелиться!": {
+   "en": "%^C1 can barely move as it is!",
+   "ua": "%^C1 і так вже ледь може поворухнутися!"
+  },
+  "%^C1 пытается обездвижить %C4 густой паутиной, но безуспешно.": {
+   "en": "%^C1 tries to immobilize %C4 with thick webbing, but fails.",
+   "ua": "%^C1 намагається знерухомити %C4 густою павутиною, але безуспішно."
+  },
+  "Ты и так уже едва можешь пошевелиться!": {
+   "en": "You can barely move as it is!",
+   "ua": "Ти й так уже ледве можеш поворухнутися!"
+  },
+  "Ты пытаешься обездвижить %C4 густой паутиной, но безуспешно.": {
+   "en": "You try to immobilize %C4 with thick webbing, but without success.",
+   "ua": "Ти намагаєшся знерухомити %C4 густою павутиною, але безуспішно."
+  }
+ },
+ "spell/whirlwind/runRoom": {
+  "Создать вихрь удастся только под открытым небом.": {
+   "en": "You can only create a whirlwind under the open sky.",
+   "ua": "Створити вихор вдасться лише під відкритим небом."
+  }
+ },
+ "spell/wicker man/runVict": {
+  "%1$^C1 уже обездвижен%1$Gо||а|ы.": {
+   "en": "%1$^C1 is already immobilized.",
+   "ua": "%1$^C1 вже знерухомлен%1$Gо|ий|а|і."
+  },
+  "%1$^C4 сначала придется приземлить.": {
+   "en": "%1$^C4 will need to be grounded first.",
+   "ua": "%1$^C4 спершу доведеться приземлити."
+  },
+  "%^C1 пытается заключить тебя в Плетеного Человека, но безуспешно.": {
+   "en": "%^C1 tries to trap you inside the Wicker Man, but fails.",
+   "ua": "%^C1 намагається увʼязнити тебе в Плетеній Людині, але безуспішно."
+  },
+  "{RПлетеный человек разваливается и исчезает.{x": {
+   "en": "{RThe wicker man falls apart and vanishes.{x",
+   "ua": "{RПлетена людина розвалюється і зникає.{x"
+  },
+  "Перед тем как создать Плетеного Человека придется немного подождать.": {
+   "en": "You'll need to wait a bit before you can create the Wicker Man.",
+   "ua": "Перед тим як створити Плетеного Чоловіка доведеться трохи почекати."
+  },
+  "Плетеный человек разваливается от удара %C2 и исчезает!": {
+   "en": "The wicker man falls apart from %C2's blow and vanishes!",
+   "ua": "Плетена людина розвалюється від удару %C2 і зникає!"
+  },
+  "Ты пытаешься заключить %C4 в Плетеного Человека, но безуспешно.": {
+   "en": "You try to trap %C4 inside the Wicker Man, but fail.",
+   "ua": "Ти намагаєшся увʼязнити %C4 у Плетеній Людині, але безуспішно."
+  },
+  "Это заклинание можно применять только на непосредственных противников.": {
+   "en": "This spell can only be cast on direct opponents.",
+   "ua": "Це заклинання можна застосовувати лише на безпосередніх супротивників."
+  },
+  "%1$^C1 кричит от боли, когда острые шипы и прутья клетки впиваются в %1$P4!": {
+   "en": "%1$^C1 screams in pain as the sharp thorns and wicker bars dig into them!",
+   "ua": "%1$^C1 кричить від болю, коли гострі шипи й прутики клітки впиваються в %1$C4!"
+  }
+ },
+ "spell/witch curse/runVict": {
+  "%^C1 пытается наложить ведьминское проклятие на %C4, но безуспешно.": {
+   "en": "%^C1 tries to place a witch's curse on %C4, but fails.",
+   "ua": "%^C1 намагається накласти відьомське прокляття на %C4, але безуспішно."
+  },
+  "%^C1 пытается наложить на тебя ведьминское проклятие, но безуспешно.": {
+   "en": "%^C1 tries to place a witch's curse on you, but fails.",
+   "ua": "%^C1 намагається накласти на тебе відьомське прокляття, але безуспішно."
+  },
+  "На этой жертве уже лежит ведьминское проклятие.": {
+   "en": "This victim is already under a witch's curse.",
+   "ua": "На цій жертві вже лежить відьомське прокляття."
+  },
+  "Тебе надо подождать перед тем, как ты снова сможешь кого-то проклясть.": {
+   "en": "You need to wait before you can curse someone again.",
+   "ua": "Тобі треба почекати, перш ніж ти знову зможеш когось прокляти."
+  },
+  "Ты еще слишком молод{Sfа{x, чтобы умирать.": {
+   "en": "You are still too young to die.",
+   "ua": "Ти ще занадто молод{Smий{Sfа{Sx, щоб помирати."
+  },
+  "Ты пытаешься наложить ведьминское проклятие на %C4, но безуспешно.": {
+   "en": "You try to cast a witch's curse on %C4, but fail.",
+   "ua": "Ти намагаєшся накласти відьомське прокляття на %C4, але безуспішно."
+  }
+ },
+ "spell/wolf/runArg": {
+  "%^C1 приходит на твой зов!": {
+   "en": "%^C1 comes at your call!",
+   "ua": "%^C1 приходить на твій поклик!"
+  },
+  "Вызвать волка удастся лишь на лоне природы.": {
+   "en": "You can only summon a wolf out in nature.",
+   "ua": "Викликати вовка вдасться лише на лоні природи."
+  },
+  "Ты уже занят{Sfа{Sx подобным ритуалом.": {
+   "en": "You're already busy with a similar ritual.",
+   "ua": "Ти вже зайнят{Smий{Sfа{Sx подібним ритуалом."
+  }
+ },
+ "spell/wrath/runVict": {
+  "Эта молитва не сможет навредить %C3.": {
+   "en": "This prayer won't be able to harm %C3.",
+   "ua": "Ця молитва не зможе нашкодити %C3."
+  }
+ },
+ "spell/black feeble/runVict": {
+  "Леденящий душу {1{bш{rе{bпот пр{rо{bкл{bятий{2 окружает %C4, образуя защитную ауру.": {
+   "en": "A soul-chilling {1{bw{rh{bisper of c{ru{brs{bes{2 surrounds %C4, forming a protective aura.",
+   "ua": "Крижаний до кісток {1{bш{rе{bпіт пр{rо{bкл{bьонів{2 оточує %C4, утворюючи захисну ауру."
+  },
+  "Леденящий душу {1{bш{rе{bпот пр{rо{bкл{bятий{2 окружает тебя, образуя защитную ауру.": {
+   "en": "A soul-chilling {1{bw{rh{bisper {rc{bursed{2 surrounds you, forming a protective aura.",
+   "ua": "Крижаний до глибини душі {1{bш{rе{bпіт пр{rо{bклятий{2 огортає тебе, створюючи захисну ауру."
+  }
+ },
+ "spell/disintegrate/runVict": {
+  "Ты еще слишком молод{Sfа{x, чтобы умирать.": {
+   "en": "You're still too young to die.",
+   "ua": "Ти ще занадто молод{Smий{Sfа{Sx, щоб помирати."
+  },
+  "Ты не можешь прицелиться в %1$C4, пока %1$P1 сража%1$nется|ются.": {
+   "en": "You can't take aim at %1$C4 while %1$C1 %1$nis|are fighting.",
+   "ua": "Ти не можеш прицілитися в %1$C4, поки %1$C1 %1$nбʼється|бʼються."
+  }
+ },
+ "spell/hand of undead/runVict": {
+  "Рука умертвия не властна над нежитью.": {
+   "en": "The undead hand has no power over the undead.",
+   "ua": "Рука мерця не має влади над нежиттю."
+  }
+ },
+ "spell/infected mushroom/runArg": {
+  "%1$^C1 просит {1{C%2$N4{2 о просветлении, и %1$P4 на ладонь падает %3$O1.": {
+   "en": "%1$^C1 begs {1{C%2$N4{2 for enlightenment, and %3$O1 falls into the palm of %1$C2.",
+   "ua": "%1$^C1 просить {1{C%2$N4{2 про просвітлення, і на долоню %1$C2 падає %3$O1."
+  }
+ },
+ "spell/lightning bolt/runVict": {
+  "%1$^C1 зачем-то выпускает {1{Cр{Wа{Cз{Wр{Cя{Wд {Cмолнии{2 в себя сам%1$Gого|ого|у!": {
+   "en": "%1$^C1 for some reason unleashes a {1{Cc{Wh{Ca{Wr{Cg{We {Cof lightning{2 upon themselves!",
+   "ua": "%1$^C1 чомусь випускає {1{Wр{Yо{Rз{Gр{Cя{Bд {Wблискавки{2 у себе сам%1$Gого|ого|у!"
+  },
+  "Ты зачем-то выпускаешь {1{Cр{Wа{Cз{Wр{Cя{Wд {Cмолнии{2 в себя сам%1$Gого|ого|у!": {
+   "en": "For some reason you fire a {1{Cc{Wh{Ca{Wr{Cg{We of {Clightning{2 at yourself!",
+   "ua": "Ти чомусь випускаєш {1{Cр{Wо{Cз{Wр{Cя{Wд {Cблискавки{2 в себе сам%1$Gого|ого|у!"
+  }
+ },
+ "spell/master healing/runVict": {
+  "{YНечеловеческая энергия и {Cз{Gа{Cд{Cо{Cр {Yохватывают тебя!{x": {
+   "en": "{YSuperhuman energy and {Cv{Gi{Cg{Co{Cr {Yoverwhelm you!{x",
+   "ua": "{YНелюдська енергія і {Cз{Gа{Cп{Cа{Cл {Yохоплюють тебе!{x"
+  }
+ },
+ "spell/mental knife/runVict": {
+  "%1$^C1 зачем-то повреждает собственный разум {1{Cм{cентальным {Cн{cожом{2!": {
+   "en": "%1$^C1 inexplicably damages their own mind with a {1{Cm{cental {Ck{cnife{2!",
+   "ua": "%1$^C1 чомусь пошкоджує власний розум {1{Cм{cентальним {Cн{cожем{2!"
+  },
+  "%1$^C1 ошеломленно тряс%1$nет|ут головой, будто не понимая, где наход%1$nится|ятся.": {
+   "en": "%1$^C1 shake%1$ns| their head in a daze, as if not understanding where %1$C1 %1$nis|are.",
+   "ua": "%1$^C1 приголомшено тряс%1$nе|уть головою, ніби не розуміючи, де знахо%1$nдиться|дяться."
+  },
+  "%1$^C1 повреждает разум %2$C2 {1{Cм{cентальным {Cн{cожом{2!": {
+   "en": "%1$^C1 damages %2$C2's mind with a {1{Cm{cental {Ck{cnife{2!",
+   "ua": "%1$^C1 ушкоджує розум %2$C2 {1{Cм{cентальним {Cн{cожем{2!"
+  },
+  "%1$^C1 повреждает твой разум {1{Cм{cентальным {Cн{cожом{2!": {
+   "en": "%1$^C1 damages your mind with a {1{Cm{cental {Ck{cnife{2!",
+   "ua": "%1$^C1 ушкоджує твій розум {1{Cм{cентальним {Cн{cожем{2!"
+  },
+  "{1{c%1$^C1 ошеломленно тряс%1$nет|ут головой, будто не понимая, где наход%1$nится|ятся.{2": {
+   "en": "{1{c%1$^C1 shake%1$ns| their head in a daze, as if unsure where they are.{2",
+   "ua": "{1{c%1$^C1 приголомшено тряс%1$nе|уть головою, ніби не розуміючи, де %1$nзнаходиться|знаходяться.{2"
+  },
+  "Ты зачем-то повреждаешь собственный разум {1{Cм{cентальным {Cн{cожом{2!": {
+   "en": "You inexplicably damage your own mind with a {1{Cm{cental {Ck{cnife{2!",
+   "ua": "Ти чомусь пошкоджуєш власний розум {1{Cм{cентальним {Cн{cожем{2!"
+  },
+  "Ты повреждаешь разум %1$C2 {1{Cм{cентальным {Cн{cожом{2!": {
+   "en": "You damage %1$C2's mind with a {1{Cm{cental {Ck{cnife{2!",
+   "ua": "Ти ушкоджуєш розум %1$C2 {1{Cм{cентальним {Cн{cожем{2!"
+  }
+ },
+ "spell/protection cold/runVict": {
+  "%1$^C1 теперь лучше защище%1$Gно|н|на от воздействия {1{Cн{Wи{Cз{Wк{Cи{Wх температур{2.": {
+   "en": "%1$^C1 is now better protected against {1{Cc{Wh{Ci{Wl{Cl{Wy{2 temperatures.",
+   "ua": "%1$^C1 тепер краще захище%1$Gно|ний|на від впливу {1{Cн{Wи{Cз{Wь{Cк{Wи{Cх температур{2."
+  },
+  "Ты теперь лучше защище%1$Gно|н|на от воздействия {1{Cн{Wи{Cз{Wк{Cи{Wх температур{2.": {
+   "en": "You are now better protected against {1{Cl{Wo{Cw{2 temperatures.",
+   "ua": "Ти тепер краще захищ%1$Gене|ений|ена від впливу {1{Cн{Wи{Cз{Wь{Cк{Wих температур{2."
+  }
+ },
+ "spell/protection heat/runVict": {
+  "%1$^C1 теперь лучше защище%1$Gно|н|на от воздействия {1{Rв{Yы{Rс{Yо{Rк{Yи{Rх температур{2.": {
+   "en": "%1$^C1 is now better protected against {1{Rh{Yi{Rg{Yh{R temperatures{2.",
+   "ua": "%1$^C1 тепер краще захищ%1$Gене|ений|ена від впливу {1{Rв{Yи{Rс{Yо{Rк{Yих температур{2."
+  },
+  "Ты теперь лучше защище%1$Gно|н|на от воздействия {1{Rв{Yы{Rс{Yо{Rк{Yи{Rх температур{2.": {
+   "en": "You are now better protected against {1{Rh{Yi{Rg{Yh{R temperatures{2.",
+   "ua": "Ти тепер краще захищен%1$Gе|ий|а від впливу {1{Rв{Yи{Rс{Yо{Rк{Yи{Rх температур{2."
+  }
+ },
+ "spell/sonic resonance/runVict": {
+  "%1$^C1 зачем-то ударяет {1{Wк{Yа{Rк{Gо{Cф{Bо{Wн{Mи{Gе{Yй{2 звуков себя сам%1$Gого|ого|у!": {
+   "en": "%1$^C1 for some reason strikes themselves with a {1{Wc{Ya{Rc{Go{Cp{Bh{Wo{Mn{Gy{Y{2 of sound!",
+   "ua": "%1$^C1 чомусь вдаряє {1{Wк{Yа{Rк{Gо{Cф{Bо{Wн{Mі{Gє{Yю{2 звуків себе сам%1$Gого|ого|у!"
+  },
+  "Ты зачем-то ударяешь {1{Wк{Yа{Rк{Gо{Cф{Bо{Wн{Mи{Gе{Yй{2 звуков себя сам%1$Gого|ого|у!": {
+   "en": "For some reason you strike yourself with a {1{Wc{Ya{Rc{Go{Cp{Bh{Wo{Mn{Gy{2 of sound!",
+   "ua": "Ти чомусь ударяєш {1{Wк{Yа{Rк{Gо{Cф{Bо{Wн{Mі{Gє{Yю{2 звуків себе сам%1$Gого|ого|у!"
+  }
+ },
+ "spell/spectral furor/runVict": {
+  "%1$^C1 зачем-то выпускает сгусток {1{Mх{Cа{Mо{Cт{Mи{Cч{Mн{Cо{Mй{2 энергии в себя сам%1$Gого|ого|у!": {
+   "en": "%1$^C1 for some reason releases a burst of {1{Mc{Ch{Ma{Co{Mt{Ci{Mc{2 energy into themselves!",
+   "ua": "%1$^C1 чомусь випускає згусток {1{Mх{Cа{Mо{Cт{Mи{Cч{Mн{Cо{Mї{2 енергії в себе сам%1$Gого|ого|у!"
+  },
+  "Ты зачем-то выпускаешь сгусток {1{Mх{Cа{Mо{Cт{Mи{Cч{Mн{Cо{Mй{2 энергии в себя сам%1$Gого|ого|у!": {
+   "en": "You unleash a burst of {1{Mc{Ch{Ma{Co{Mt{Ci{Mc{2 energy into yourself for some reason!",
+   "ua": "Ти чомусь випускаєш згусток {1{Mх{Cа{Mо{Cт{Mи{Cч{Mн{Cо{Mї{2 енергії в себе сам%1$Go|ого|у!"
+  }
+ },
+ "spell/stardust/runVict": {
+  "Мерцающая {Wз{wве{Wзд{wная {Wп{wыль закружилась вокруг %C2.": {
+   "en": "Shimmering {Ws{wtar{Wdu{wst swirled around %C2.",
+   "ua": "Мерехтливий {Wз{wор{Wян{wий {Wп{wил закружляв навколо %C2."
+  },
+  "Мерцающая {Wз{wве{Wзд{wная {Wп{wыль закружилась вокруг тебя.": {
+   "en": "Twinkling {Ws{wta{Wrr{wy {Wdu{wst swirled around you.",
+   "ua": "Мерехтливий {Wзо{wря{Wни{wй {Wп{wил закружляв навколо тебе."
+  }
+ }
+}


### PR DESCRIPTION
Bulk cycle 6 (spell) translation half. Wrap already merged (dreamland_fenia#220, 1564 sites/247 files); this adds the `config/translations/spell.json` catalog shard for the **mechanical (589)** and **hard (84)** lanes. Voice lane (807) held for separate review.

- Keys byte-identical to runtime `._()` FILE-capture keys; each phrase resolves to viewer's `config lang` via the regfmt hook, RU = key + fallback.
- `lint-l10n.py`: **0 HARD** across all 6 shards.
- Fixed 23 female-only UA gender pads (RU zero-suffix masc has no UA equivalent) -> full `{Sm{Sf{Sx` splits.
- Hard lane verified engine-safe: command/help-links use registered UA aliases or RU-kept (guaranteed click); no dead clicks, no `%P`/`%p`/`%T` leaks.

Shard: 673 phrases / 194 files, 184K UTF-8 (under fedit guard).