### PR TITLE
l10n: add public.json shard with armor (public repo) trilingual

### DIFF
--- a/config/translations/public.json
+++ b/config/translations/public.json
@@ -1,0 +1,20 @@
+{
+ "public/spell/armor/runVict": {
+  "Тебя окружает священная броня, дарованная {1{C%N5{2.": {
+   "en": "A sacred armor, granted by {1{C%N5{2, surrounds you.",
+   "ua": "Тебе оточує священна броня, дарована {1{C%N5{2."
+  },
+  "%^C4 окружает священная броня, дарованная {1{C%N5{2.": {
+   "en": "%^C4 is surrounded by a sacred armor, granted by {1{C%N5{2.",
+   "ua": "%^C4 оточує священна броня, дарована {1{C%N5{2."
+  },
+  "Тебя окружает магическая броня, улучшающая защитные навыки.": {
+   "en": "A magical armor surrounds you, improving your defensive skills.",
+   "ua": "Тебе оточує магічна броня, що покращує захисні навички."
+  },
+  "%^C4 окружает магическая броня, улучшающая защитные навыки.": {
+   "en": "%^C4 is surrounded by a magical armor, improving defensive skills.",
+   "ua": "%^C4 оточує магічна броня, що покращує захисні навички."
+  }
+ }
+}


### PR DESCRIPTION
First catalog entries for the public Fenia repo. armor lives in `dreamland_fenia_public` and was missed by all 6 cycles. 4 phrases keyed under `public/spell/armor/runVict`. Confirms the public FILE-key format empirically (verifying live next). lint 0 HARD.