### PR TITLE
translations: protect/ward EN/UA (batch 3) + batch-2 dispel fix

### DIFF
--- a/config/translations/spell.json
+++ b/config/translations/spell.json
@@ -2103,7 +2103,7 @@
    "ua": "Ти намагаєшся скасувати впливи на собі, але безуспішно."
   },
   "Отмена здесь бессильна, используй вместо этого {hhснятие воздействий{x.": {
-   "en": "Cancellation is powerless here, use {hhdispel magic{x instead.",
+   "en": "Cancellation is powerless here, use {hhdispel affects{x instead.",
    "ua": "Скасування тут безсиле, використай натомість {hhзняття впливів{x."
   },
   "На тебе нет воздействий, которые можно было бы отменить, %C1.": {
@@ -2563,6 +2563,14 @@
   "%^C4 окружает силовое поле, помогающее уходить от ударов.": {
    "en": "A force field surrounds %C4, helping them dodge blows.",
    "ua": "%^C4 оточує силове поле, що допомагає ухилятися від ударів."
+  },
+  "Ты уже под защитой силового поля.": {
+   "en": "You are already protected by enhanced armor.",
+   "ua": "Ти уже під захистом покращеної броні."
+  },
+  "%1$^C1 уже под защитой силового поля.": {
+   "en": "%1$^C1 is already protected by enhanced armor.",
+   "ua": "%1$^C1 уже під захистом покращеної броні."
   }
  },
  "spell/curse/runObj": {
@@ -2823,6 +2831,22 @@
   "Ты теперь лучше защище%1$Gно|н|на от воздействия {1{Rв{Yы{Rс{Yо{Rк{Yи{Rх температур{2.": {
    "en": "You are now better protected against {1{Rh{Yi{Rg{Yh{R temperatures{2.",
    "ua": "Ти тепер краще захищен%1$Gе|ий|а від впливу {1{Rв{Yи{Rс{Yо{Rк{Yи{Rх температур{2."
+  },
+  "%^C1 уже защище%1$Gно|н|на от огня.": {
+   "en": "%^C1 is already protected from fire.",
+   "ua": "%^C1 уже захищен%1$Gе|ий|а від вогню."
+  },
+  "%^C1 уже защище%1$Gно|н|на от холода вместо огня.": {
+   "en": "%^C1 is already protected from cold instead of fire.",
+   "ua": "%^C1 уже захищен%1$Gе|ий|а від холоду замість вогню."
+  },
+  "Ты уже защище%1$Gно|н|на от холода вместо огня.": {
+   "en": "You are already protected from cold instead of fire.",
+   "ua": "Ти уже захищен%1$Gе|ий|а від холоду замість вогню."
+  },
+  "Ты уже защище%1$Gно|н|на от огня.": {
+   "en": "You are already protected from fire.",
+   "ua": "Ти уже захищен%1$Gе|ий|а від вогню."
   }
  },
  "spell/protection negative/runVict": {
@@ -2833,6 +2857,10 @@
   "Ты окутываешься {1{rбагровым щитом,{2 получая сопротивляемость к темной энергии.": {
    "en": "You become wrapped in a {1{rcrimson shield,{2 gaining resistance to dark energy.",
    "ua": "Ти огортаєшся {1{rбагряним щитом,{2 отримуючи опірність до темної енергії."
+  },
+  "Ты уже защище%1$Gно|н|на|ны от темной энергии.": {
+   "en": "You are already protected from dark energy.",
+   "ua": "Ти уже захищен%1$Gе|ий|а|і від темної енергії."
   }
  },
  "spell/protection good/runVict": {
@@ -2885,6 +2913,22 @@
   "Твоя жажда творить наделяет %O4 дополнительной силой.": {
    "en": "Your thirst to create imbues %O4 with extra power.",
    "ua": "Твоя жага творити наділяє %O4 додатковою силою."
+  },
+  "Уникальные свойства %O2 препятствуют этому заклинанию.": {
+   "en": "The unique properties of %O2 resist this spell.",
+   "ua": "Унікальні властивості %O2 перешкоджають цьому закляттю."
+  },
+  "%1$^O1 уже име%1$nет|ют термоустойчивость.": {
+   "en": "%1$^O1 already ha%1$ns|ve heat resistance.",
+   "ua": "%1$^O1 уже ма%1$nє|ють термостійкість."
+  },
+  "%1$^O1 уже име%1$nет|ют защиту от замораживания.": {
+   "en": "%1$^O1 already ha%1$ns|ve protection from freezing.",
+   "ua": "%1$^O1 уже ма%1$nє|ють захист від заморожування."
+  },
+  "%1$^O3 не пригодится термоустойчивость.": {
+   "en": "%1$^O3 has no use for heat resistance.",
+   "ua": "%1$^O3 не знадобиться термостійкість."
   }
  },
  "spell/firestorm/runRoom": {
@@ -2963,6 +3007,14 @@
   "Твоя кожа становится {1{yбурой,{2 превращаясь в прочную древесную кору.": {
    "en": "Your skin turns {1{ybrown,{2 hardening into tough tree bark.",
    "ua": "Твоя шкіра стає {1{yбурою,{2 перетворюючись на міцну деревну кору."
+  },
+  "Твоя кожа уже имеет свойства древесной коры.": {
+   "en": "Your skin already has the properties of tree bark.",
+   "ua": "Твоя шкіра уже має властивості деревної кори."
+  },
+  "Кожа %1$C2 уже имеет свойства древесной коры.": {
+   "en": "%1$C2's skin already has the properties of tree bark.",
+   "ua": "Шкіра %1$C2 уже має властивості деревної кори."
   }
  },
  "spell/acid blast/runVict": {
@@ -3191,6 +3243,14 @@
   "Твоя кожа покрывается {1{gдраконьей чешуей{2.": {
    "en": "Your skin becomes covered in {1{gdragon scales{2.",
    "ua": "Твоя шкіра вкривається {1{gдраконячою лускою{2."
+  },
+  "Твоя кожа уже покрыта драконьей чешуей.": {
+   "en": "Your skin is already covered in dragon scales.",
+   "ua": "Твоя шкіра уже вкрита драконячою лускою."
+  },
+  "Кожа %1$C2 уже покрыта драконьей чешуей.": {
+   "en": "%1$C2's skin is already covered in dragon scales.",
+   "ua": "Шкіра %1$C2 уже вкрита драконячою лускою."
   }
  },
  "spell/detect hidden/runVict": {

--- a/config/translations/spell2.json
+++ b/config/translations/spell2.json
@@ -2313,6 +2313,14 @@
   "Тебя окружает тускло светящийся {1{cохранный щит,{2 отклоняющий резкие толчки и удары.": {
    "en": "A dimly glowing {1{cwarding shield{2 surrounds you, deflecting sharp blows and strikes.",
    "ua": "Тебе оточує тьмяно світний {1{cохоронний щит,{2 що відхиляє різкі поштовхи та удари."
+  },
+  "Ты уже под воздействием охранного щита.": {
+   "en": "You are already affected by protective shield.",
+   "ua": "Ти уже під захистом охоронного щита."
+  },
+  "%1$^C1 уже под воздействием охранного щита.": {
+   "en": "%1$^C1 is already affected by protective shield.",
+   "ua": "%1$^C1 уже під захистом охоронного щита."
   }
  },
  "spell/astral projection/runVict": {
@@ -2921,6 +2929,22 @@
   "Ты теперь лучше защище%1$Gно|н|на от воздействия {1{Cн{Wи{Cз{Wк{Cи{Wх температур{2.": {
    "en": "You are now better protected against {1{Cl{Wo{Cw{2 temperatures.",
    "ua": "Ти тепер краще захищ%1$Gене|ений|ена від впливу {1{Cн{Wи{Cз{Wь{Cк{Wих температур{2."
+  },
+  "Ты уже защище%1$Gно|н|на от огня вместо холода.": {
+   "en": "You are already protected from fire instead of cold.",
+   "ua": "Ти уже захищен%1$Gе|ий|а від вогню замість холоду."
+  },
+  "%^C1 уже защище%1$Gно|н|на от холода.": {
+   "en": "%^C1 is already protected from cold.",
+   "ua": "%^C1 уже захищен%1$Gе|ий|а від холоду."
+  },
+  "Ты уже защище%1$Gно|н|на от холода.": {
+   "en": "You are already protected from cold.",
+   "ua": "Ти уже захищен%1$Gе|ий|а від холоду."
+  },
+  "%^C1 уже защище%1$Gно|н|на от огня вместо холода.": {
+   "en": "%^C1 is already protected from fire instead of cold.",
+   "ua": "%^C1 уже захищен%1$Gе|ий|а від вогню замість холоду."
   }
  },
  "spell/whirlwind/runRoom": {
@@ -3151,6 +3175,10 @@
   "%^C1 на мгновение окутывается {1{Yсветлым щитом,{2 получая защиту от злых существ.": {
    "en": "%^C1 is briefly wrapped in {1{Ya shield of light,{2 gaining protection from evil creatures.",
    "ua": "%^C1 на мить огортається {1{Yсвітлим щитом,{2 отримуючи захист від злих істот."
+  },
+  "Твой нейтралитет не дает тебе получить защиту от злых существ.": {
+   "en": "Your neutrality prevents you from gaining protection against evil beings.",
+   "ua": "Твій нейтралітет не дає тобі отримати захист від злих істот."
   }
  },
  "spell/acid arrow/runVict": {
@@ -3247,6 +3275,14 @@
   "Твоя кожа становится {1{Dсерой,{2 превращаясь в камень.": {
    "en": "Your skin turns {1{Dgray,{2 turning to stone.",
    "ua": "Твоя шкіра стає {1{Dсірою,{2 перетворюючись на камінь."
+  },
+  "Кожа %1$C2 уже тверда как камень.": {
+   "en": "%1$C2's skin is already hard as stone.",
+   "ua": "Шкіра %1$C2 уже тверда як камінь."
+  },
+  "Твоя кожа уже тверда как камень.": {
+   "en": "Your skin is already hard as stone.",
+   "ua": "Твоя шкіра уже тверда як камінь."
   }
  },
  "spell/gills/runVict": {
@@ -3395,6 +3431,14 @@
   "%1$^O1 окутыва%1$nется|ются {Rогнеупорной аурой.{x": {
    "en": "%1$^O1 %1$nis|are wrapped in a {Rfireproof aura.{x",
    "ua": "%1$^O1 огорта%1$nється|ються {Rвогнетривкою аурою.{x"
+  },
+  "Уникальные свойства %O2 препятствуют этому заклинанию.": {
+   "en": "The unique properties of %O2 resist this spell.",
+   "ua": "Унікальні властивості %O2 перешкоджають цьому закляттю."
+  },
+  "%1$^O1 уже име%1$nет|ют огнеупорную ауру.": {
+   "en": "%1$^O1 already ha%1$ns|ve a fireproof aura.",
+   "ua": "%1$^O1 уже ма%1$nє|ють вогнетривку ауру."
   }
  }
 }


### PR DESCRIPTION
25 unique RU protection/skin strings (13 spells, deduped). EN/UA name the spell (protective shield, enhanced armor), not the RU flavour. Also corrects a batch-2 link: 'снятие воздействий' = dispel affects, not dispel magic. Pairs with dreamland_fenia #241. lint-l10n 0 HARD.