### PR TITLE
l10n: translate final 5 spell guard strings (Fenia bulk tail)

### DIFF
--- a/config/translations/spell.json
+++ b/config/translations/spell.json
@@ -3013,6 +3013,10 @@
   "%1$^O3 не пригодится термоустойчивость.": {
    "en": "%1$^O3 has no use for heat resistance.",
    "ua": "%1$^O3 не знадобиться термостійкість."
+  },
+  "Этому предмету уже ничего не поможет.": {
+   "en": "Nothing can help this item anymore.",
+   "ua": "Цьому предмету вже ніщо не допоможе."
   }
  },
  "spell/firestorm/runRoom": {
@@ -3509,6 +3513,28 @@
   "Это умение можно использовать только на лоне природы.": {
    "en": "This ability can only be used out in nature.",
    "ua": "Цю здібність можна використати тільки на лоні природи."
+  }
+ },
+ "spell/fireproof/runObj": {
+  "Этому предмету уже ничего не поможет.": {
+   "en": "Nothing can help this item anymore.",
+   "ua": "Цьому предмету вже ніщо не допоможе."
+  }
+ },
+ "spell/meld into stone/runVict": {
+  "%1$^C1 уже под воздействием этого заклинания.": {
+   "en": "%1$^C1 is already affected by this spell.",
+   "ua": "%1$^C1 вже під впливом цього закляття."
+  },
+  "Ты уже под воздействием этого заклинания.": {
+   "en": "You are already affected by this spell.",
+   "ua": "Ти вже під впливом цього закляття."
+  }
+ },
+ "spell/protection evil/runVict": {
+  "Ты уже защище%1$Gно|н|на|ны.": {
+   "en": "You are already protected.",
+   "ua": "Ти вже захищен%1$Gо|ий|а|і."
   }
  }
 }


### PR DESCRIPTION
Adds catalog entries for the last 5 untranslated wrapped `._()` strings in the spell subsystem, aligned to existing canonical translations for sibling files. Closes Fenia (Phase 3) translation coverage: every subsystem now at 0 untranslated. `lint-l10n`: 0 HARD.