### PR TITLE
l10n: EN/UA catalog for plug-ins/comm/exits.cpp

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -1,4 +1,42 @@
 {
+ "plug-ins/comm/exits.cpp": {
+  "Выходы": {
+   "en": "Exits",
+   "ua": "Виходи"
+  },
+  "Видимые выходы:": {
+   "en": "Visible exits:",
+   "ua": "Видимі виходи:"
+  },
+  "Видимые выходы из комнаты ": {
+   "en": "Visible exits from room ",
+   "ua": "Видимі виходи з кімнати "
+  },
+  "нет": {
+   "en": "none",
+   "ua": "немає"
+  },
+  "Дорога ведет в темноту и неизвестность...": {
+   "en": "The road leads off into darkness and the unknown...",
+   "ua": "Дорога веде в темряву й невідомість..."
+  },
+  "заперто": {
+   "en": "locked",
+   "ua": "замкнено"
+  },
+  "закрыто": {
+   "en": "closed",
+   "ua": "зачинено"
+  },
+  "Дополнительные выходы:": {
+   "en": "Additional exits:",
+   "ua": "Додаткові виходи:"
+  },
+  "Интуиция подсказывает тебе, что тут есть невидимые выходы.": {
+   "en": "Your intuition tells you there are hidden exits here.",
+   "ua": "Інтуїція підказує тобі, що тут є невидимі виходи."
+  }
+ },
  "plug-ins/movement/directions.cpp": {
   "Ты не видишь $T здесь.": {
    "en": "You don't see $T here.",


### PR DESCRIPTION
9 EN/UA phrases for the trilingual `exits` command + exit-line label. lint-l10n 0 HARD. Pairs with dreamland_code exits.cpp wrapping.