### PR TITLE
l10n: EN/UA catalog for wrapped plug-ins C++ strings (Phase 4 bulk, Trello 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -35,6 +35,10 @@
   "Интуиция подсказывает тебе, что тут есть невидимые выходы.": {
    "en": "Your intuition tells you there are hidden exits here.",
    "ua": "Інтуїція підказує тобі, що тут є невидимі виходи."
+  },
+  "Ты ослепле$gно|н|на и не видишь ничего вокруг себя!": {
+   "en": "You are blinded and can't see anything around you!",
+   "ua": "Ти осліпл$gено|ений|ена|ені і не бачиш нічого навколо себе!"
   }
  },
  "plug-ins/movement/directions.cpp": {
@@ -299,6 +303,14288 @@
   "Ты не можешь управлять $C5.": {
    "en": "You can't steer $C5.",
    "ua": "Ти не можеш керувати $C5."
+  }
+ },
+ "plug-ins/admin/confirm.cpp": {
+  "Найден%1$Iа|о|о %1$d нов%1$Iая|ые|ых заяв%1$Iка|ки|ок, всего заявок: %2$d.": {
+   "en": "Found %1$d new request%1$I|s|s, total requests: %2$d.",
+   "ua": "Знайдено %1$d нов%1$Iу|і|их заявк%1$Iу|и|, всього заявок: %2$d."
+  },
+  "Нерассмотренных заявок на подтверждение нет. Всего заявок: %1$d.": {
+   "en": "There are no pending confirmation requests. Total requests: %1$d.",
+   "ua": "Нерозглянутих заявок на підтвердження немає. Всього заявок: %1$d."
+  },
+  "Нет ни одной заявки на подтверждение персонажа.": {
+   "en": "There are no character-approval requests pending.",
+   "ua": "Немає жодної заявки на підтвердження персонажа."
+  },
+  "Нужно указать причину отказа.": {
+   "en": "You need to give a reason for the refusal.",
+   "ua": "Треба вказати причину відмови."
+  },
+  "От %s не было заявки на подтверждение персонажа.": {
+   "en": "There was no confirmation request from %s for a character.",
+   "ua": "Від %s не було заявки на підтвердження персонажа."
+  },
+  "Подтвердить кого?": {
+   "en": "Confirm whom?",
+   "ua": "Підтвердити кого?"
+  },
+  "Прочитай внимательно 'справка подтверждение' и 'справка описание'.": {
+   "en": "Read 'help confirm' and 'help description' carefully.",
+   "ua": "Уважно прочитай 'довідка підтвердження' і 'довідка опис'."
+  },
+  "Твое описание отправлено Бессмертным на рассмотрение.": {
+   "en": "Your description has been sent to the Immortals for review.",
+   "ua": "Твій опис надіслано Безсмертним на розгляд."
+  },
+  "Твой персонаж уже подтвержден.": {
+   "en": "Your character is already confirmed.",
+   "ua": "Твій персонаж вже підтверджений."
+  },
+  "Тебе нельзя.": {
+   "en": "You can't do that.",
+   "ua": "Тобі не можна."
+  },
+  "Тебя ожида%1$Iет|ют|ют %1$d нов%1$Iая|ые|ых заяв%1$Iка|ки|ок на подтверждение персонажа ({y{hcconfirm list new{x).": {
+   "en": "%1$d new character confirmation request%1$I|s|s await%1$Is|| you ({y{hcconfirm list new{x).",
+   "ua": "Тебе на підтвердження персонажа очіку%1$Iє|ють|ють %1$d нов%1$Iа|і|их заяв%1$Iка|ки|ок ({y{hcconfirm list new{x)."
+  },
+  "Чью заявку удалить?": {
+   "en": "Whose petition do you want to delete?",
+   "ua": "Чию заявку видалити?"
+  },
+  "Этот игрок не посылал заявки на подтверждение.": {
+   "en": "This player hasn't sent a confirmation request.",
+   "ua": "Цей гравець не надсилав заявку на підтвердження."
+  }
+ },
+ "plug-ins/admin/cplugin.cpp": {
+  "Использование: \r\nplugin list - список всех загруженных модулей.\r\nplugin reload [all|changed|<name>] \r\n            - перегрузка модулей (всех, измененных или по имени)": {
+   "en": "Usage: \r\nplugin list - list of all loaded modules.\r\nplugin reload [all|changed|<name>] \r\n            - reload modules (all, changed, or by name)",
+   "ua": "Використання: \r\nplugin list - список усіх завантажених модулів.\r\nplugin reload [all|changed|<name>] \r\n            - перезавантаження модулів (усіх, змінених або за іменем)"
+  },
+  "Мир неуловимо изменился...": {
+   "en": "The world has subtly changed...",
+   "ua": "Світ невловимо змінився..."
+  }
+ },
+ "plug-ins/admin/cprofile.cpp": {
+  "profile buildplot <player_name> -- скопировать профайлы с основного мира на стройплощадку, выдав права на OLC и феню\r\n": {
+   "en": "profile buildplot <player_name> -- copy profiles from the main world to the build site, granting OLC and Fenia rights\r\n",
+   "ua": "profile buildplot <player_name> -- скопіювати профайли з основного світу на будмайданчик, видавши права на OLC та феню\r\n"
+  },
+  "Копия профайла сохранена в var/db/backup и /tmp.": {
+   "en": "A copy of the profile has been saved to var/db/backup and /tmp.",
+   "ua": "Копію профайлу збережено в var/db/backup та /tmp."
+  },
+  "Не могу восстановить профайл. Возможно, забыли убрать случайное расширение в конце имени файла.": {
+   "en": "Can't restore the profile. Maybe you forgot to remove the random extension at the end of the file name.",
+   "ua": "Не можу відновити профайл. Можливо, забули прибрати випадкове розширення в кінці імені файлу."
+  },
+  "Неправильная подкоманда, см. {y{hcprofile{x для списка.": {
+   "en": "Invalid subcommand, see {y{hcprofile{x for the list.",
+   "ua": "Неправильна підкоманда, див. {y{hcprofile{x для списку."
+  },
+  "Номер реморта должен быть числом.": {
+   "en": "The remort number must be a number.",
+   "ua": "Номер реморту має бути числом."
+  },
+  "Персонаж %s не найден.": {
+   "en": "Character %s not found.",
+   "ua": "Персонажа %s не знайдено."
+  },
+  "Персонаж в мире, сохраняю.": {
+   "en": "Character is in the world, saving.",
+   "ua": "Персонаж у світі, зберігаю."
+  },
+  "Персонаж восстановлен из резервной копии в каталоге /tmp.": {
+   "en": "Character restored from a backup in the /tmp directory.",
+   "ua": "Персонажа відновлено з резервної копії в каталозі /tmp."
+  },
+  "Персонаж восстановлен из резервной копии.": {
+   "en": "Character restored from backup.",
+   "ua": "Персонажа відновлено з резервної копії."
+  },
+  "Персонаж восстановлен после реморта.": {
+   "en": "Character restored after remort.",
+   "ua": "Персонажа відновлено після реморту."
+  },
+  "Персонаж восстановлен после удаления.": {
+   "en": "The character has been restored after deletion.",
+   "ua": "Персонажа відновлено після видалення."
+  },
+  "Персонаж сейчас в мире, не могу перезаписать профайлы.": {
+   "en": "The character is currently in the world, can't overwrite the profiles.",
+   "ua": "Персонаж зараз у світі, не можу перезаписати профайли."
+  },
+  "Упс, не могу восстановить профайл. Сперва выполните profile backup на основном мире.": {
+   "en": "Oops, can't restore the profile. First run profile backup on the main world.",
+   "ua": "Упс, не можу відновити профайл. Спершу виконай profile backup на основному світі."
+  },
+  "Упс, ошибка при сохранении копии профайла.": {
+   "en": "Oops, an error occurred while saving the profile copy.",
+   "ua": "Упс, помилка при збереженні копії профайлу."
+  },
+  "Установлены права на феню и OLC.": {
+   "en": "Fenia and OLC permissions granted.",
+   "ua": "Встановлено права на феню та OLC."
+  },
+  "Эта команда не для тебя.": {
+   "en": "This command isn't for you.",
+   "ua": "Ця команда не для тебе."
+  },
+  "Эту команду разумнее использовать на стройплощадке.": {
+   "en": "It's wiser to use this command on a construction site.",
+   "ua": "Цю команду розумніше використовувати на будмайданчику."
+  },
+  "Упс, не могу восстановить профайл, неверное имя?": {
+   "en": "Oops, can't restore the profile, wrong name maybe?",
+   "ua": "Упс, не можу відновити профайл, невірне ім'я?"
+  }
+ },
+ "plug-ins/admin/finger.cpp": {
+  "Использование:\r\nfinger имя   - поиск игрока по полному имени\r\nfinger имя ip - просмотр всех IP адресов игрока\r\nfinger адрес - список игроков, использовавших этот IP адрес": {
+   "en": "Usage:\r\nfinger name    - search for a player by full name\r\nfinger name ip - view all IP addresses of a player\r\nfinger address - list players who used this IP address",
+   "ua": "Використання:\r\nfinger ім'я    - пошук гравця за повним іменем\r\nfinger ім'я ip - перегляд усіх IP-адрес гравця\r\nfinger адреса - список гравців, які використовували цю IP-адресу"
+  },
+  "Не найдено никого с таким IP адресом.": {
+   "en": "No one found with that IP address.",
+   "ua": "Нікого не знайдено з такою IP-адресою."
+  },
+  "Не найдено никого с таким именем.": {
+   "en": "No one found with that name.",
+   "ua": "Нікого з таким ім'ям не знайдено."
+  },
+  "Список всех игроков, заходивших с этого или похожего адреса:": {
+   "en": "List of all players who have logged in from this or a similar address:",
+   "ua": "Список усіх гравців, які заходили з цієї або схожої адреси:"
+  }
+ },
+ "plug-ins/admin/idelete.cpp": {
+  "Захешированы пароли %d персонажей из %d.": {
+   "en": "Hashed passwords for %d characters out of %d.",
+   "ua": "Захешовано паролі %d персонажів з %d."
+  },
+  "Использование: ipassword <player name> <new password>.": {
+   "en": "Usage: ipassword <player name> <new password>.",
+   "ua": "Використання: ipassword <player name> <new password>."
+  },
+  "Новый пароль установлен и сохранен.": {
+   "en": "New password set and saved.",
+   "ua": "Новий пароль встановлено та збережено."
+  },
+  "Ошибка при удалении профайла!": {
+   "en": "Error deleting the profile!",
+   "ua": "Помилка під час видалення профайлу!"
+  },
+  "Персонаж присутствует в мире, удаление невозможно.": {
+   "en": "The character is present in the world; deletion is not possible.",
+   "ua": "Персонаж присутній у світі, видалення неможливе."
+  },
+  "Персонаж с таким именем не найден.": {
+   "en": "No character with that name was found.",
+   "ua": "Персонажа з таким ім'ям не знайдено."
+  },
+  "Удалить чей профайл?": {
+   "en": "Delete whose profile?",
+   "ua": "Видалити чий профайл?"
+  },
+  "Установить пароль кому?": {
+   "en": "Set password for whom?",
+   "ua": "Кому встановити пароль?"
+  }
+ },
+ "plug-ins/admin/nochannel.cpp": {
+  "NOCHANNEL снят.": {
+   "en": "NOCHANNEL lifted.",
+   "ua": "NOCHANNEL знято."
+  },
+  "NOCHANNEL установлен.": {
+   "en": "NOCHANNEL set.",
+   "ua": "NOCHANNEL встановлено."
+  },
+  "Nochannel кому?": {
+   "en": "Nochannel whom?",
+   "ua": "Nochannel кому?"
+  },
+  "Боги вернули тебе возможность общаться.": {
+   "en": "The gods have restored your ability to communicate.",
+   "ua": "Боги повернули тобі можливість спілкуватися."
+  },
+  "Жертва не найдена. Укажите имя правильно и полностью.": {
+   "en": "Victim not found. Specify the name correctly and in full.",
+   "ua": "Жертву не знайдено. Вкажи ім'я правильно і повністю."
+  },
+  "Не получилось.": {
+   "en": "Didn't work.",
+   "ua": "Не вийшло."
+  }
+ },
+ "plug-ins/admin/nopost.cpp": {
+  "NOPOST снят.": {
+   "en": "NOPOST lifted.",
+   "ua": "NOPOST знято."
+  },
+  "NOPOST установлен.": {
+   "en": "NOPOST is set.",
+   "ua": "NOPOST встановлено."
+  },
+  "Боги вернули тебе привилегию писать письма.": {
+   "en": "The Gods have restored your privilege to write letters.",
+   "ua": "Боги повернули тобі привілей писати листи."
+  },
+  "Жертва не найдена. Укажите имя правильно и полностью.": {
+   "en": "Victim not found. Specify the name correctly and in full.",
+   "ua": "Жертву не знайдено. Вкажи ім'я правильно і повністю."
+  },
+  "Не получилось.": {
+   "en": "Didn't work.",
+   "ua": "Не вийшло."
+  }
+ },
+ "plug-ins/admin/reboot.cpp": {
+  "Мир Мечты будет ПЕРЕЗАГРУЖЕН через %d тиков!": {
+   "en": "The World of Dreams will be REBOOTED in %d ticks!",
+   "ua": "Світ Мрії буде ПЕРЕЗАВАНТАЖЕНО через %d тіків!"
+  }
+ },
+ "plug-ins/admin/reward.cpp": {
+  "{Y%1$d{x квестов%1$Iую|ые|ых единиц%1$Iу|ы|": {
+   "en": "{Y%1$d{x quest point%1$I|s|s",
+   "ua": "{Y%1$d{x квестов%1$Iу|і|их одиниц%1$Iю|і|ь"
+  },
+  "Вознаградить кого?": {
+   "en": "Reward whom?",
+   "ua": "Винагородити кого?"
+  },
+  "Наград не найдено.": {
+   "en": "No rewards found.",
+   "ua": "Нагород не знайдено."
+  },
+  "Персонаж с таким именем не найден.": {
+   "en": "No character with that name was found.",
+   "ua": "Персонажа з таким ім'ям не знайдено."
+  },
+  "Удалены все награды.": {
+   "en": "All rewards removed.",
+   "ua": "Усі нагороди видалено."
+  },
+  "Укажите кол-во квестовых единиц.\r\n": {
+   "en": "Specify the number of quest points.\r\n",
+   "ua": "Вкажи кількість квестових одиниць.\r\n"
+  },
+  "Установлена награда в %d qp, причина: %s.": {
+   "en": "Reward set at %d qp, reason: %s.",
+   "ua": "Встановлено нагороду в %d qp, причина: %s."
+  }
+ },
+ "plug-ins/ai/assist.cpp": {
+  "$c1 вступи$gло|л|ла в битву на стороне $C2.": {
+   "en": "$c1 has entered the battle on the side of $C2.",
+   "ua": "$c1 вступи$gло|в|ла в битву на боці $C2."
+  },
+  "$c1 пристально смотрит на $C4.": {
+   "en": "$c1 stares intently at $C4.",
+   "ua": "$c1 пильно дивиться на $C4."
+  },
+  "$c1 пристально смотрит на тебя.": {
+   "en": "$c1 stares intently at you.",
+   "ua": "$c1 пильно дивиться на тебе."
+  },
+  "$c1 вскрикивает и атакует!": {
+   "en": "$c1 shrieks and attacks!",
+   "ua": "$c1 скрикує і атакує!"
+  }
+ },
+ "plug-ins/ai/basicmobilebehavior.cpp": {
+  "$c1 ищет свой дом.": {
+   "en": "$c1 looks for home.",
+   "ua": "$c1 шукає свій дім."
+  },
+  "%1$^C1, подл%1$Gое|ый|ая трус%1$Gло||иха, я еще до тебя доберусь!": {
+   "en": "%1$^C1, you vile coward, I'll still get you!",
+   "ua": "%1$^C1, підл%1$Gе|ий|а боягуз%1$Gло||ка, я ще до тебе доберуся!"
+  }
+ },
+ "plug-ins/ai/specials.cpp": {
+  "$c1 осушает $o4.": {
+   "en": "$c1 drains $o4.",
+   "ua": "$c1 осушує $o4."
+  },
+  "Ты осушаешь $o4.": {
+   "en": "You drain $o4.",
+   "ua": "Ти висушуєш $o4."
+  },
+  "Ты пытаешься двигаться незаметно.": {
+   "en": "You try to move unnoticed.",
+   "ua": "Ти намагаєшся рухатися непомітно."
+  },
+  "$c1 оценивающе рассматривает $o4.": {
+   "en": "$c1 looks $o4 over appraisingly.",
+   "ua": "$c1 оцінювально розглядає $o4."
+  }
+ },
+ "plug-ins/ai/tracking.cpp": {
+  "$c1 всматривается в землю в поисках следов.": {
+   "en": "$c1 peers at the ground, searching for tracks.",
+   "ua": "$c1 вдивляється в землю в пошуках слідів."
+  },
+  "Следы $C2 ведут $t.": {
+   "en": "The tracks of $C2 lead $t.",
+   "ua": "Сліди $C2 ведуть $t."
+  },
+  "Ты не видишь здесь следов $C2.": {
+   "en": "You don't see any tracks of $C2 here.",
+   "ua": "Ти не бачиш тут слідів $C2."
+  }
+ },
+ "plug-ins/cards/cardskill.cpp": {
+  "%^C1 не разбирается в картах.": {
+   "en": "%^C1 doesn't know a thing about cards.",
+   "ua": "%^C1 не розбирається в картах."
+  },
+  "Поищи кого-то, кто разбирается в картах.": {
+   "en": "Look for someone who knows their way around cards.",
+   "ua": "Пошукай когось, хто розуміється на картах."
+  }
+ },
+ "plug-ins/cards/ccard.cpp": {
+  "%C1 - это %s из Колоды.": {
+   "en": "%C1 is a %s from the Deck.",
+   "ua": "%C1 -- це %s з Колоди."
+  },
+  "%C1 не состоит в Колоде.": {
+   "en": "%C1 isn't a member of the Deck.",
+   "ua": "%C1 не є членом Колоди."
+  },
+  "%C1 становится %s.": {
+   "en": "%C1 becomes %s.",
+   "ua": "%C1 стає %s."
+  },
+  "%s из комнаты [%d] стал(о) шестеркой.": {
+   "en": "%s from room [%d] turned into a six.",
+   "ua": "%s з кімнати [%d] перетворилося на шістку."
+  },
+  "<card level> должен быть числом от 0 до 8.": {
+   "en": "<card level> must be a number from 0 to 8.",
+   "ua": "<card level> має бути числом від 0 до 8."
+  },
+  "Жертва не найдена.": {
+   "en": "Victim not found.",
+   "ua": "Жертву не знайдено."
+  },
+  "Итого: %d тел": {
+   "en": "Total: %d bodies",
+   "ua": "Всього: %d тіл"
+  },
+  "Он(а) выбывает из Колоды.": {
+   "en": "They drop out of the Deck.",
+   "ua": "Він(вона) вибуває з Колоди."
+  },
+  "Список всех карт из Колоды: \r\nИгроки: ": {
+   "en": "List of all cards from the Deck: \r\nPlayers: ",
+   "ua": "Список усіх карт з Колоди: \r\nГравці: "
+  },
+  "Это не для тебя.": {
+   "en": "This isn't for you.",
+   "ua": "Це не для тебе."
+  },
+  "Кого ты хочешь сделать шестеркой?": {
+   "en": "Who do you want to make your flunky?",
+   "ua": "Кого ти хочеш зробити своєю шісткою?"
+  }
+ },
+ "plug-ins/cards/mobiles.cpp": {
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $o4 $C3."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "$c1 ухмыляется.": {
+   "en": "$c1 smirks.",
+   "ua": "$c1 посміхається."
+  },
+  "$c1 перетасовывает карты, хитро поглядывая на тебя.": {
+   "en": "$c1 shuffles the cards, glancing at you slyly.",
+   "ua": "$c1 тасує карти, хитро поглядаючи на тебе."
+  },
+  "$c1 произносит '{gИзвини, у меня закончились карты.{x'": {
+   "en": "$c1 says, '{gSorry, I'm out of cards.{x'",
+   "ua": "$c1 каже: '{gВибач, у мене закінчилися карти.{x'"
+  },
+  "$c1 произносит '{gУ тебя недостаточно дурной славы (qp), чтобы пользоваться моими картами.{x'": {
+   "en": "$c1 says '{gYou don't have enough infamy (qp) to use my cards.{x'",
+   "ua": "$c1 каже '{gУ тебе недостатньо лихої слави (qp), щоб користуватися моїми картами.{x'"
+  },
+  "{cТеперь ТЫ займешь её место.{x": {
+   "en": "{cNow YOU will take her place.{x",
+   "ua": "{cТепер ТИ займеш її місце.{x"
+  },
+  "{cТы уби$gло|л|ла шестерку $n2 из Колоды.{x": {
+   "en": "{cYou killed the Six of $n2 from the Deck.{x",
+   "ua": "{cТи вби$gло|в|ла шістку $n2 з Колоди.{x"
+  }
+ },
+ "plug-ins/cards/objects.cpp": {
+  "$C1 не сможет затащить тебя к себе через карту.": {
+   "en": "$C1 won't be able to pull you to them through the card.",
+   "ua": "$C1 не зможе затягнути тебе до себе через карту."
+  },
+  "$c1 дотрагивается до $o2.": {
+   "en": "$c1 touches $o2.",
+   "ua": "$c1 торкається $o2."
+  },
+  "$c1 не смо$gгло|г|гла пожать твою руку.": {
+   "en": "$c1 couldn't shake your hand.",
+   "ua": "$c1 не потисн$gуло|ув|ула твою руку."
+  },
+  "$c1 перетасовывает $o4.": {
+   "en": "$c1 shuffles $o4.",
+   "ua": "$c1 перетасовує $o4."
+  },
+  "$o1 выглядит мертвой.": {
+   "en": "$o1 looks dead.",
+   "ua": "$o1 виглядає мертвою."
+  },
+  "$o1 падают на землю.": {
+   "en": "$o1 fall to the ground.",
+   "ua": "$o1 падають на землю."
+  },
+  "Какую именно карту ты хочешь вытащить из колоды?": {
+   "en": "Which card exactly do you want to draw from the deck?",
+   "ua": "Яку саме карту ти хочеш витягти з колоди?"
+  },
+  "Колода содержит: ": {
+   "en": "The deck contains: ",
+   "ua": "Колода містить: "
+  },
+  "Похоже, сейчас твоя колода пуста.": {
+   "en": "Looks like your deck is empty right now.",
+   "ua": "Схоже, зараз твоя колода порожня."
+  },
+  "Сегодня козырь %s.": {
+   "en": "Today's trump is %s.",
+   "ua": "Сьогодні козир %s."
+  },
+  "Твоя попытка затащить $C4 к себе провалилась.": {
+   "en": "Your attempt to drag $C4 toward you has failed.",
+   "ua": "Твоя спроба затягнути $C4 до себе провалилася."
+  },
+  "Ты не можешь полностью сосредоточиться на карте.": {
+   "en": "You can't fully concentrate on the card.",
+   "ua": "Ти не можеш повністю зосередитися на карті."
+  },
+  "Ты перетасовываешь $o4 и сдаешь $O4.": {
+   "en": "You shuffle $o4 and deal $O4.",
+   "ua": "Ти перетасовуєш $o4 і роздаєш $O4."
+  },
+  "Ты пожимаешь протянутую тебе руку.": {
+   "en": "You shake the hand offered to you.",
+   "ua": "Ти тиснеш простягнуту тобі руку."
+  },
+  "Ты пытаешься вытащить из колоды карту, но она выпадает у тебя из рук.": {
+   "en": "You try to pull a card out of the deck, but it slips from your hands.",
+   "ua": "Ти намагаєшся витягнути з колоди карту, але вона випадає тобі з рук."
+  },
+  "Ты сейчас не видишь в колоде такой карты.": {
+   "en": "You don't see such a card in the deck right now.",
+   "ua": "Ти зараз не бачиш такої карти в колоді."
+  },
+  "У тебя недостаточно энергии для этого.": {
+   "en": "You don't have enough energy for that.",
+   "ua": "У тебе недостатньо енергії для цього."
+  },
+  "Эта карта пуста.": {
+   "en": "This card is empty.",
+   "ua": "Ця карта порожня."
+  },
+  "Это была последняя карта в $o6.": {
+   "en": "That was the last card in $o6.",
+   "ua": "Це була остання карта в $o6."
+  },
+  "$c1 пожимает чью-то руку.": {
+   "en": "$c1 shakes someone's hand.",
+   "ua": "$c1 тисне комусь руку."
+  },
+  "$c1 хватает кого-то за руку и тащит к себе.. упс..": {
+   "en": "$c1 grabs someone by the hand and pulls them close.. oops..",
+   "ua": "$c1 хапає когось за руку і тягне до себе.. ой.."
+  },
+  "$o1 выглядит живой, но тебе не удается понять, как сквозь нее пройти.": {
+   "en": "$o1 looks alive, but you can't figure out how to get through it.",
+   "ua": "$o1 виглядає живою, але ти не можеш зрозуміти, як крізь неї пройти."
+  },
+  "$o1 выглядит живой, но ты не можешь сосредоточиться на мелких деталях.": {
+   "en": "$o1 looks alive, but you can't focus on the finer details.",
+   "ua": "$o1 виглядає живим, але ти не можеш зосередитися на дрібних деталях."
+  },
+  "{c$o1 оживает. $C1 пожимает твою руку.\r\n{x": {
+   "en": "{c$o1 comes to life. $C1 shakes your hand.\r\n{x",
+   "ua": "{c$o1 оживає. $C1 тисне твою руку.\r\n{x"
+  },
+  "{cИз $o2 $c2 выпадает туз! Шулер!{x": {
+   "en": "{cAn ace falls out of $c2's $o2! Cheater!{x",
+   "ua": "{cІз $o2 $c2 випадає туз! Шулер!{x"
+  },
+  "{cИзображение $C2 на карте оживает и протягивает тебе руку.{x": {
+   "en": "{cThe image of $C2 on the card comes to life and reaches out its hand to you.{x",
+   "ua": "{cЗображення $C2 на карті оживає і простягає тобі руку.{x"
+  },
+  "{cТы достаешь из $o2 припрятанного туза.{x": {
+   "en": "{cYou pull a hidden ace out of $o2.{x",
+   "ua": "{cТи дістаєш із $o2 захований туз.{x"
+  },
+  "{cТы пытаешься вынуть туза из $o2, но роняешь его! Упс..{x": {
+   "en": "{cYou try to pull an ace out of $o2, but drop it! Oops...{x",
+   "ua": "{cТи намагаєшся дістати туза з $o2, але впускаєш його! Ой..{x"
+  },
+  "{cТы пытаешься затащить $C4 к себе через карту, но вместо этого тащишь кого-то другого!{x": {
+   "en": "{cYou try to drag $C4 to yourself through the card, but instead you drag someone else!{x",
+   "ua": "{cТи намагаєшся затягти $C4 до себе через карту, але замість цього тягнеш когось іншого!{x"
+  },
+  "По деталям заднего плана ты начинаешь узнавать место. Кажется, это '%s'.": {
+   "en": "From the details in the background you start to recognize the place. Looks like it's '%s'.",
+   "ua": "За деталями заднього плану ти починаєш впізнавати місце. Здається, це '%s'."
+  },
+  "Так сильно по себе скучаешь?": {
+   "en": "Miss yourself that much?",
+   "ua": "Так сильно за собою сумуєш?"
+  },
+  "Тебе показалось, что картинка на $o6 пошевелилась.": {
+   "en": "You could swear the picture on $o6 just moved.",
+   "ua": "Тобі здалося, що картинка на $o6 ворухнулася."
+  },
+  "Ты пытаешься напялить $o4, но шулер из тебя никакущий..": {
+   "en": "You try to put on $o4, but you make a lousy cardsharp...",
+   "ua": "Ти намагаєшся натягнути $o4, але шулер із тебе ніякий..."
+  },
+  "Ты хватаешь себя за руку.": {
+   "en": "You grab your own hand.",
+   "ua": "Ти хапаєш себе за руку."
+  }
+ },
+ "plug-ins/cards/skills.cpp": {
+  "$c1 создает $o4!": {
+   "en": "$c1 creates $o4!",
+   "ua": "$c1 створює $o4!"
+  },
+  "Здесь таких нет.": {
+   "en": "There's none like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Подожди пока закончится сражение.": {
+   "en": "Wait until the fight is over.",
+   "ua": "Зачекай, поки закінчиться бій."
+  },
+  "Подожди, пока закончится сражение.": {
+   "en": "Wait until the fight is over.",
+   "ua": "Зачекай, поки закінчиться бій."
+  },
+  "Пошутить над кем?": {
+   "en": "Play a joke on whom?",
+   "ua": "Пожартувати над ким?"
+  },
+  "Твоя шутка не удалась..": {
+   "en": "Your joke falls flat..",
+   "ua": "Твій жарт не вдався.."
+  },
+  "Только не верхом!": {
+   "en": "Not while mounted!",
+   "ua": "Тільки не верхи!"
+  },
+  "Ты создаешь $o4!": {
+   "en": "You create $o4!",
+   "ua": "Ти створюєш $o4!"
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$c1 лупит $C4 по голове канделябром.": {
+   "en": "$c1 whacks $C4 over the head with a candelabra.",
+   "ua": "$c1 лупить $C4 по голові канделябром."
+  },
+  "$c1 ударяет тебя канделябром по голове! Ты отключаешься.": {
+   "en": "$c1 hits you over the head with a candelabra! You black out.",
+   "ua": "$c1 б'є тебе канделябром по голові! Ти відключаєшся."
+  },
+  "$c1 удачно {R+++ПОШУТИ$gЛО|Л|ЛА+++{x!": {
+   "en": "$c1 successfully {R+++CRACKED A JOKE+++{x!",
+   "ua": "$c1 вдало {R+++ПОЖАРТУВА$gЛО|В|ЛА+++{x!"
+  },
+  "А вот эта шутка окончится для тебя плачевно.": {
+   "en": "But this joke is going to end badly for you.",
+   "ua": "А от цей жарт закінчиться для тебе сумно."
+  },
+  "Не надо.. можешь потерять сознание.": {
+   "en": "Don't.. you might pass out.",
+   "ua": "Не треба.. можеш знепритомніти."
+  },
+  "Нехорошо шутить над больными!": {
+   "en": "It's not nice to joke about the sick!",
+   "ua": "Негарно жартувати з хворих!"
+  },
+  "Нехорошо шутить над сво%1$Gим|им|ей хозя%1$Gином|ином|йкой.": {
+   "en": "It's not nice to mock your own master.",
+   "ua": "Не гоже жартувати над сво%1$Gїм|їм|єю хазя%1$Gїном|їном|йкою."
+  },
+  "Сам пошутил - сам посмеялся.": {
+   "en": "You cracked the joke yourself -- and laughed at it yourself.",
+   "ua": "Сам пожартував -- сам і посміявся."
+  },
+  "Твоя {Rшутка{x над $C5 удалась!": {
+   "en": "Your {Rjoke{x on $C5 worked!",
+   "ua": "Твій {Rжарт{x над $C5 вдався!"
+  },
+  "Ты же не хочешь ударить по голове сво%1$Gего|его|ю любим%1$Gого|ого|ую хозя%1$Gина|ина|йку?": {
+   "en": "You don't really want to bash your beloved owner over the head, do you?",
+   "ua": "Ти ж не хочеш вдарити по голові сво%1$Gго|го|ю улюблен%1$Gого|ого|у хазя%1$Gїна|їна|йку?"
+  },
+  "Ты со всей силы бьешь $C4 канделябром по голове!": {
+   "en": "You smash $C4 over the head with a candelabrum with all your strength!",
+   "ua": "Ти щосили б'єш $C4 канделябром по голові!"
+  }
+ },
+ "plug-ins/cards/xmlattributecards.cpp": {
+  "{cТеперь ты $t!{x": {
+   "en": "{cNow you are $t!{x",
+   "ua": "{cТепер ти $t!{x"
+  },
+  "{cТы становишься %s.{x": {
+   "en": "{cYou become %s.{x",
+   "ua": "{cТи стаєш %s.{x"
+  },
+  "{cТы уби$gло|л|ла $t из Колоды.{x": {
+   "en": "{cYou killed $t from the Deck.{x",
+   "ua": "{cТи вби$gло|в|ла $t з Колоди.{x"
+  },
+  "{cТы выбываешь из колоды!{x": {
+   "en": "{cYou're out of the deck!{x",
+   "ua": "{cТи вибуваєш з колоди!{x"
+  }
+ },
+ "plug-ins/clan/behavior/clanmobiles.cpp": {
+  "$C1 дает $o4 $c3.": {
+   "en": "$C1 gives $o4 to $c3.",
+   "ua": "$C1 дає $o4 $c3."
+  },
+  "$C1 дает тебе $o4.": {
+   "en": "$C1 gives you $o4.",
+   "ua": "$C1 дає тобі $o4."
+  },
+  "$c1 пишет на $o6.": {
+   "en": "$c1 writes on $o6.",
+   "ua": "$c1 пише на $o6."
+  },
+  "$c1 снимает с шеи $o4.": {
+   "en": "$c1 takes $o4 off their neck.",
+   "ua": "$c1 знімає з шиї $o4."
+  },
+  "Ты пишешь на $o6.": {
+   "en": "You write on $o6.",
+   "ua": "Ти пишеш на $o6."
+  },
+  "Ты снимаешь с шеи $o4.": {
+   "en": "You take $o4 off your neck.",
+   "ua": "Ти знімаєш з шиї $o4."
+  }
+ },
+ "plug-ins/clan/behavior/clanobjects.cpp": {
+  "$o1 загадочным образом исчезает.": {
+   "en": "$o1 mysteriously disappears.",
+   "ua": "$o1 загадковим чином зникає."
+  },
+  "$o1 растворяется и исчезает!": {
+   "en": "$o1 dissolves and disappears!",
+   "ua": "$o1 розчиняється і зникає!"
+  },
+  "%2$^C1 не может владеть %1$O5 и бросает %1$P2.": {
+   "en": "%2$^C1 can't own %1$O5 and drops it.",
+   "ua": "%2$^C1 не може володіти %1$O5 і кидає %1$O4."
+  },
+  "{WКлан %N1 утратил свою святыню.{x": {
+   "en": "{WClan %N1 has lost its shrine.{x",
+   "ua": "{WКлан %N1 втратив свою святиню.{x"
+  },
+  "Ты видишь, как медленно появляется $o1.": {
+   "en": "You see $o1 slowly appear.",
+   "ua": "Ти бачиш, як повільно з'являється $o1."
+  },
+  "Ты не можешь владеть %1$O5 и бросаешь %1$P2.": {
+   "en": "You can't own %1$O5, so you throw it away.",
+   "ua": "Ти не можеш володіти %1$O5 і кидаєш %1$O2."
+  },
+  "{RБОГИ В ГНЕВЕ!{x": {
+   "en": "{RTHE GODS ARE ENRAGED!{x",
+   "ua": "{RБОГИ У ГНІВІ!{x"
+  },
+  "{gТы вздрагиваешь от осознания Силы своего Клана!{x": {
+   "en": "{gYou shudder at the realization of your Clan's Power!{x",
+   "ua": "{gТи здригаєшся, усвідомивши Силу свого Клану!{x"
+  }
+ },
+ "plug-ins/clan/behavior/clanrooms.cpp": {
+  "Тебя здесь обслуживать не будут.": {
+   "en": "You won't be served here.",
+   "ua": "Тебе тут обслуговувати не будуть."
+  }
+ },
+ "plug-ins/clan/command/cclan.cpp": {
+  "\n\r{BИмя         раса        класс         уровень{x": {
+   "en": "\n\r{BName         race        class         level{x",
+   "ua": "\n\r{BІм'я         раса        клас         рівень{x"
+  },
+  "\n\rНет ни одной заявки.": {
+   "en": "\n\rThere isn't a single application.",
+   "ua": "\n\rНемає жодної заявки."
+  },
+  "\n\rПодробнее смотри команду клан ?{x.": {
+   "en": "\n\rFor more details see the command clan ?{x.",
+   "ua": "\n\rДетальніше дивись команду клан ?{x."
+  },
+  "%s имеет ранг [{%s%s{x].": {
+   "en": "%s has the rank [{%s%s{x].",
+   "ua": "%s має ранг [{%s%s{x]."
+  },
+  "%s не в твоем клане.": {
+   "en": "%s is not in your clan.",
+   "ua": "%s не в твоєму клані."
+  },
+  "%s не собирается вступать в твой клан.": {
+   "en": "%s isn't going to join your clan.",
+   "ua": "%s не збирається вступати до твого клану."
+  },
+  "(сейчас в мире нет никого из руководства этого клана)": {
+   "en": "(no one from this clan's leadership is currently in the world)",
+   "ua": "(зараз у світі немає нікого з керівництва цього клану)"
+  },
+  "{W%1$^C1 подал%1$Gо||а петицию в %s.{x": {
+   "en": "{W%1$^C1 filed a petition to %s.{x",
+   "ua": "{W%1$^C1 пода%1$Gло|в|ла петицію до %s.{x"
+  },
+  "{W%s вступает в %s.{x": {
+   "en": "{W%s joins %s.{x",
+   "ua": "{W%s вступає до %s.{x"
+  },
+  "{W%s становится %s %s.{x": {
+   "en": "{W%s becomes %s %s.{x",
+   "ua": "{W%s стає %s %s.{x"
+  },
+  "{g\t\t  Состояние банка твоего клана{x.\n\r": {
+   "en": "{g\t\t  Your clan's bank balance{x.\n\r",
+   "ua": "{g\t\t  Стан банку твого клану{x.\n\r"
+  },
+  "В банке твоего клана столько нету.": {
+   "en": "Your clan bank doesn't have that much.",
+   "ua": "У банку твого клану стільки немає."
+  },
+  "В его/ее клане нет клановых рангов.": {
+   "en": "There are no clan ranks in his/her clan.",
+   "ua": "У його/її клані немає кланових рангів."
+  },
+  "В мире есть такие кланы:": {
+   "en": "These are the clans that exist in the world:",
+   "ua": "У світі є такі клани:"
+  },
+  "В этом клане нет клановых рангов.": {
+   "en": "This clan has no clan ranks.",
+   "ua": "У цьому клані немає кланових рангів."
+  },
+  "В этот клан можно вступить только с %d-го уровня.": {
+   "en": "You can only join this clan starting at level %d.",
+   "ua": "До цього клану можна вступити лише з %d-го рівня."
+  },
+  "В этот клан нельзя попасть, написав петицию.": {
+   "en": "You can't join this clan by writing a petition.",
+   "ua": "До цього клану не можна потрапити, написавши петицію."
+  },
+  "Взаиморасчеты между кланами (или игроками) осуществляются в квестовых очках.": {
+   "en": "Settlements between clans (or players) are carried out in quest points.",
+   "ua": "Взаєморозрахунки між кланами (або гравцями) здійснюються у квестових очках."
+  },
+  "Выгонять руководство кланов можно только при очной ставке -- дождись, когда они зайдут в мир.": {
+   "en": "You can only kick clan leadership in person -- wait until they log into the world.",
+   "ua": "Виганяти керівництво кланів можна тільки при особистій зустрічі -- зачекай, поки вони зайдуть у світ."
+  },
+  "Для %1$#^C2 переведено: %2$d квестов%2$Iая|ые|ых едини%2$Iца|цы|ц со счета твоего клана.": {
+   "en": "Transferred %2$d quest point%2$I|s|s from your clan's account for %1$#^C2.",
+   "ua": "Для %1$#^C2 переведено: %2$d квестов%2$Iа|і|их одиниц%2$Iя|і|ь з рахунку твого клану."
+  },
+  "Для твоего клана не существует понятия дипломатии.": {
+   "en": "Your clan has no concept of diplomacy.",
+   "ua": "Для твого клану не існує поняття дипломатії."
+  },
+  "Для этого клана не существует понятия дипломатии.": {
+   "en": "This clan has no concept of diplomacy.",
+   "ua": "Для цього клану не існує поняття дипломатії."
+  },
+  "Есть желающие в клан.": {
+   "en": "There are applicants wanting to join the clan.",
+   "ua": "Є охочі вступити в клан."
+  },
+  "Игрок с таким именем не найден.": {
+   "en": "No player with that name found.",
+   "ua": "Гравця з таким ім'ям не знайдено."
+  },
+  "Игрока-получателя нет в мире.": {
+   "en": "The recipient player is not in the world.",
+   "ua": "Гравця-отримувача немає у світі."
+  },
+  "Из твоего клана невозможно никого выгнать.": {
+   "en": "You can't expel anyone from your clan.",
+   "ua": "З твого клану неможливо нікого вигнати."
+  },
+  "Из твоего клана невозможно уйти по собственной воле.": {
+   "en": "You cannot leave your clan of your own free will.",
+   "ua": "З твого клану неможливо піти за власним бажанням."
+  },
+  "Клан            |{BКвестовых единиц{x|{YЗолотых монет{x|{WСеребряных монет{x|{CБриллиантов{x|": {
+   "en": "Clan            |{BQuest Points{x|{YGold Coins{x|{WSilver Coins{x|{CDiamonds{x|",
+   "ua": "Клан            |{BОдиниць квесту{x|{YЗолотих монет{x|{WСрібних монет{x|{CДіамантів{x|"
+  },
+  "Клан      Рейтинг": {
+   "en": "Clan      Rating",
+   "ua": "Клан      Рейтинг"
+  },
+  "Клан, в который ты желаешь вступить, временно недоступен.": {
+   "en": "The clan you wish to join is temporarily unavailable.",
+   "ua": "Клан, до якого ти бажаєш вступити, тимчасово недоступний."
+  },
+  "Клан-получатель указан неверно.": {
+   "en": "The recipient clan is specified incorrectly.",
+   "ua": "Клан-отримувач вказано неправильно."
+  },
+  "Кланбанк оперирует только с кп, золото, серебро, бриллианты.": {
+   "en": "The clan bank only deals in qp, gold, silver, and diamonds.",
+   "ua": "Кланбанк оперує лише кп, золотом, сріблом, діамантами."
+  },
+  "Клановая дипломатия :": {
+   "en": "Clan diplomacy:",
+   "ua": "Кланова дипломатія:"
+  },
+  "Клановых званий в твоем клане не обнаружено.": {
+   "en": "No clan ranks found in your clan.",
+   "ua": "У твоєму клані не знайдено кланових звань."
+  },
+  "Клановых рангов в твоем клане не обнаружено.": {
+   "en": "No clan ranks were found in your clan.",
+   "ua": "Кланових рангів у твоєму клані не виявлено."
+  },
+  "Можно использовать только цифры от 0 до %d": {
+   "en": "You can only use digits from 0 to %d",
+   "ua": "Можна використовувати тільки цифри від 0 до %d"
+  },
+  "Неверная политика (см. clan diplomacy list).": {
+   "en": "Invalid policy (see clan diplomacy list).",
+   "ua": "Невірна політика (див. clan diplomacy list)."
+  },
+  "Неверная политика.": {
+   "en": "Invalid policy.",
+   "ua": "Неправильна політика."
+  },
+  "Неверный клановый ранг.": {
+   "en": "Invalid clan rank.",
+   "ua": "Невірний клановий ранг."
+  },
+  "Непонятно, чего ты хочешь?": {
+   "en": "Not sure what you want?",
+   "ua": "Незрозуміло, чого ти хочеш?"
+  },
+  "Но %s и так состоит в твоем клане.": {
+   "en": "But %s is already in your clan.",
+   "ua": "Але %s і так у твоєму клані."
+  },
+  "О таком клане ничего не известно.": {
+   "en": "Nothing is known about such a clan.",
+   "ua": "Про такий клан нічого не відомо."
+  },
+  "Петиция на вступление в клан подана.": {
+   "en": "Your petition to join the clan has been submitted.",
+   "ua": "Петицію на вступ до клану подано."
+  },
+  "Смещать руководство кланов можно только при очной ставке -- дождись, когда они зайдут в мир.": {
+   "en": "You can only depose clan leadership face to face -- wait until they log into the world.",
+   "ua": "Змістити керівництво клану можна лише за очної ставки -- почекай, поки вони зайдуть у світ."
+  },
+  "Сначала присоединись к одному из кланов.": {
+   "en": "First join one of the clans.",
+   "ua": "Спершу приєднайся до одного з кланів."
+  },
+  "Сумма должна быть больше нуля.": {
+   "en": "The amount must be greater than zero.",
+   "ua": "Сума має бути більшою за нуль."
+  },
+  "Сумма перевода задана неправильно!": {
+   "en": "The transfer amount is set incorrectly!",
+   "ua": "Сума переказу вказана неправильно!"
+  },
+  "Такого клана не существует.": {
+   "en": "No such clan exists.",
+   "ua": "Такого клану не існує."
+  },
+  "Такого клана пока не существует.": {
+   "en": "No such clan exists yet.",
+   "ua": "Такого клану поки не існує."
+  },
+  "Твой персонаж еще не подтвержден Богами.": {
+   "en": "Your character has not yet been confirmed by the Gods.",
+   "ua": "Твій персонаж ще не підтверджений Богами."
+  },
+  "Твой ранг [{%s%s{x].": {
+   "en": "Your rank is [{%s%s{x].",
+   "ua": "Твій ранг [{%s%s{x]."
+  },
+  "Тебя пытаются принудить выдать тайны своего клана, но ты не поддаешься.": {
+   "en": "Someone tries to force you to reveal your clan's secrets, but you don't give in.",
+   "ua": "Тебе намагаються примусити видати таємниці свого клану, але ти не піддаєшся."
+  },
+  "Только руководство кланов может менять политику.": {
+   "en": "Only clan leadership can change policy.",
+   "ua": "Тільки керівництво кланів може змінювати політику."
+  },
+  "Ты можешь отдать квестовые очки или какому-либо клану, или своему соклановику.": {
+   "en": "You can give quest points either to a clan, or to a fellow clan member.",
+   "ua": "Ти можеш віддати квестові очки або якомусь клану, або своєму соклановику."
+  },
+  "Ты не можешь вступить в этот клан.": {
+   "en": "You cannot join this clan.",
+   "ua": "Ти не можеш вступити до цього клану."
+  },
+  "Ты не можешь увидеть список своих соклановиков.": {
+   "en": "You can't see the list of your clanmates.",
+   "ua": "Ти не можеш побачити список своїх соклановців."
+  },
+  "У клана-получателя нет банка!": {
+   "en": "The receiving clan has no bank!",
+   "ua": "У клану-отримувача немає банку!"
+  },
+  "У тебя нет кланового банка!": {
+   "en": "You don't have a clan bank!",
+   "ua": "У тебе немає кланового банку!"
+  },
+  "У тебя нет таких полномочий.": {
+   "en": "You don't have that authority.",
+   "ua": "У тебе немає таких повноважень."
+  },
+  "У этого клана нет банка!": {
+   "en": "This clan has no bank!",
+   "ua": "У цього клану немає банку!"
+  },
+  "УХУДШЕНИЕ": {
+   "en": "WORSENING",
+   "ua": "ПОГІРШЕННЯ"
+  },
+  "Укажи единицу расчета (кп, золото, серебро, бриллианты).": {
+   "en": "Specify a unit (qp, gold, silver, diamonds).",
+   "ua": "Вкажи одиницю розрахунку (кп, золото, срібло, діаманти)."
+  },
+  "Укажи название клана.": {
+   "en": "Specify the clan name.",
+   "ua": "Вкажи назву клану."
+  },
+  "Укажи сумму перевода.": {
+   "en": "Specify the transfer amount.",
+   "ua": "Вкажи суму переказу."
+  },
+  "Установка политики": {
+   "en": "Policy setup",
+   "ua": "Встановлення політики"
+  },
+  "Это больше, чем ты имеешь.": {
+   "en": "That's more than you have.",
+   "ua": "Це більше, ніж ти маєш."
+  },
+  "Это могут сделать только руководители кланов.": {
+   "en": "Only clan leaders can do that.",
+   "ua": "Це можуть зробити тільки керівники кланів."
+  },
+  "Это ничего не меняет.": {
+   "en": "This changes nothing.",
+   "ua": "Це нічого не змінює."
+  },
+  "улучшение": {
+   "en": "upgrade",
+   "ua": "покращення"
+  },
+  "А откуда еще тебе хотелось бы уйти?": {
+   "en": "And where else would you like to leave from?",
+   "ua": "А звідки ще тобі хотілося б піти?"
+  },
+  "Если ты очень хочешь, то заставь лидера выгнать тебя из клана!": {
+   "en": "If you really want out, make the leader kick you out of the clan!",
+   "ua": "Якщо тобі так кортить, змусь лідера вигнати тебе з клану!"
+  },
+  "Если ты очень хочешь, то просто покинь свой клан!": {
+   "en": "If you really want to, just leave your clan!",
+   "ua": "Якщо тобі так приспічило, просто покинь свій клан!"
+  },
+  "И кто же тебе это позволит?": {
+   "en": "And who exactly is going to allow you that?",
+   "ua": "І хто ж тобі це дозволить?"
+  },
+  "И не лень тебе в свой клан пытаться еще раз вступить?": {
+   "en": "Aren't you tired of trying to join your own clan again?",
+   "ua": "І не ліньки тобі знову намагатися вступити у власний клан?"
+  },
+  "Не лезь в чужой клан.": {
+   "en": "Stay out of someone else's clan.",
+   "ua": "Не лізь у чужий клан."
+  },
+  "Нельзя проникнуть в тайны чужого клана с помощью колдовства.": {
+   "en": "You cannot pry into another clan's secrets with sorcery.",
+   "ua": "Не можна проникнути в таємниці чужого клану за допомогою чаклунства."
+  },
+  "Твой клан развалится и без твоей помощи": {
+   "en": "Your clan will fall apart just fine without your help",
+   "ua": "Твій клан розвалиться і без твоєї допомоги"
+  },
+  "Тихий голосок в сознании шепчет:\n\rЕсть и более глупые, чем ты...\r\nНо много ли таких?": {
+   "en": "A quiet little voice in your mind whispers:\n\rThere are those stupider than you...\r\nBut how many of them are there?",
+   "ua": "Тихий голосок у свідомості шепоче:\n\rЄ й дурніші за тебе...\r\nАле чи багато таких?"
+  },
+  "Это насовсем...": {
+   "en": "This is permanent...",
+   "ua": "Це назавжди..."
+  }
+ },
+ "plug-ins/clan/command/cclantalk.cpp": {
+  "С этого момента ты не слышишь клановые разговоры.": {
+   "en": "From now on you won't hear clan conversations.",
+   "ua": "Відтепер ти не чуєш кланові розмови."
+  },
+  "Ты не принадлежишь ни к одному Клану.": {
+   "en": "You don't belong to any Clan.",
+   "ua": "Ти не належиш до жодного Клану."
+  },
+  "Ты снова слышишь клановые разговоры.": {
+   "en": "You can hear clan chat again.",
+   "ua": "Ти знову чуєш кланові розмови."
+  },
+  "До тебя никому нет дела.": {
+   "en": "Nobody gives a damn about you.",
+   "ua": "До тебе нікому немає діла."
+  }
+ },
+ "plug-ins/clan/command/xmlattributeinduct.cpp": {
+  "%1$d петиц%1$Iия|ии|ии ожида%1$Iет|ют|ют твоего рассмотрения.\n": {
+   "en": "%1$d petition%1$I|s|s await%1$Is|| your review.\n",
+   "ua": "%1$d петиц%1$Iія|ії|ій очіку%1$Iє|ють|ють твого розгляду.\n"
+  }
+ },
+ "plug-ins/clan/core/clanorg.cpp": {
+  "%1$^O1 указа%1$Gно|н|на неверно.": {
+   "en": "%1$^O1 was specified incorrectly.",
+   "ua": "%1$^O1 вказан%1$Gо|ий|а|і неправильно."
+  },
+  "%1$^O1 указан%1$Gо||а неверно.": {
+   "en": "%1$^O1 was specified incorrectly.",
+   "ua": "%1$^O1 вказан%1$Go|ий|а|і неправильно."
+  },
+  "%1$s и так состоит в эт%2$Gом|ом|ой %2$O6.": {
+   "en": "%1$s already belongs to this %2$O6.",
+   "ua": "%1$s і так перебуває в ц%2$Gьому|ьому|ій %2$O6."
+  },
+  "%1$s не состоит в эт%2$Gом|ом|ой %2$O6!": {
+   "en": "%1$s isn't part of that %2$O6!",
+   "ua": "%1$s не перебуває у ц%2$Gьому|ьому|ій %2$O6!"
+  },
+  "%1$s покидает %2$O4.": {
+   "en": "%1$s leaves %2$O4.",
+   "ua": "%1$s покидає %2$O4."
+  },
+  "%1$s уже состоит в друг%2$Gом|ом|ой %2$O6.": {
+   "en": "%1$s is already a member of another %2$O6.",
+   "ua": "%1$s вже перебуває в інш%2$Gому|ому|ій %2$O6."
+  },
+  "%s не может вступить в %s.": {
+   "en": "%s cannot join %s.",
+   "ua": "%s не може вступити до %s."
+  },
+  "%s принимает тебя в %s!": {
+   "en": "%s accepts you into %s!",
+   "ua": "%s приймає тебе до %s!"
+  },
+  "Никого нет с таким именем. Укажи имя полностью.": {
+   "en": "There's no one with that name. Specify the full name.",
+   "ua": "Немає нікого з таким ім'ям. Вкажи ім'я повністю."
+  },
+  "Но %s не принадлежит к твоем клану!": {
+   "en": "But %s doesn't belong to your clan!",
+   "ua": "Але %s не належить до твого клану!"
+  },
+  "Но %s не принадлежит к твоему клану!": {
+   "en": "But %s does not belong to your clan!",
+   "ua": "Але %s не належить до твого клану!"
+  },
+  "Принять себя в %O4 может только рекрутер или лидер.": {
+   "en": "Only a recruiter or leader can accept themselves into %O4.",
+   "ua": "Прийняти себе до %O4 може лише рекрутер або лідер."
+  },
+  "Твоих полномочий недостаточно.": {
+   "en": "You don't have enough authority.",
+   "ua": "Твоїх повноважень недостатньо."
+  },
+  "Ты вступаешь в %s.": {
+   "en": "You join %s.",
+   "ua": "Ти вступаєш до %s."
+  },
+  "Ты и так нигде не состоишь.": {
+   "en": "You're not a member of anything anyway.",
+   "ua": "Ти й так ніде не перебуваєш."
+  },
+  "Ты не состоишь в %O6.": {
+   "en": "You are not a member of %O6.",
+   "ua": "Ти не перебуваєш у %O6."
+  },
+  "Ты не состоишь в эт%1$Gом|ом|ой %1$O6.": {
+   "en": "You are not a member of that %1$O6.",
+   "ua": "Ти не перебуваєш у ц%1$Gьому|ьому|ій|их %1$O6."
+  },
+  "Ты покидаешь сво%1$Gй|й|ю %1$^O4.": {
+   "en": "You leave your %1$^O4.",
+   "ua": "Ти покидаєш сво%1$Gє|й|ю|ї %1$^O4."
+  },
+  "Ты принимаешь %s в %s!": {
+   "en": "You accept %s into %s!",
+   "ua": "Ти приймаєш %s до %s!"
+  },
+  "Укажи правильное название %O2.": {
+   "en": "Specify the correct name of %O2.",
+   "ua": "Вкажи правильну назву %O2."
+  },
+  "%s исключает тебя из %^O2!": {
+   "en": "%s expels you from %^O2!",
+   "ua": "%s виключає тебе з %^O2!"
+  }
+ },
+ "plug-ins/clan/impl/battlerager.cpp": {
+  "$C1 выпивает лечебное зелье, данное тобой.": {
+   "en": "$C1 drinks the healing potion you gave.",
+   "ua": "$C1 випиває лікувальне зілля, дане тобою."
+  },
+  "$c1 дает лечебное зелье $C3.": {
+   "en": "$c1 gives a healing potion to $C3.",
+   "ua": "$c1 дає лікувальне зілля $C3."
+  },
+  "$c1 дает тебе лечебное зелье, предлагая выпить его.": {
+   "en": "$c1 hands you a healing potion, offering you a drink.",
+   "ua": "$c1 дає тобі лікувальне зілля, пропонуючи випити його."
+  },
+  "$c1 перевязывает свои раны.": {
+   "en": "$c1 bandages their wounds.",
+   "ua": "$c1 перев'язує свої рани."
+  },
+  "$c1 смотрит более зорко.": {
+   "en": "$c1 looks more keen-eyed.",
+   "ua": "$c1 дивиться уважніше."
+  },
+  "Твои глаза настолько зорки, насколько это возможно.": {
+   "en": "Your eyes are as sharp as they can possibly be.",
+   "ua": "Твої очі настільки гострі, наскільки це можливо."
+  },
+  "Тебе становится лучше!": {
+   "en": "You start feeling better!",
+   "ua": "Тобі стає краще!"
+  },
+  "Ты выпиваешь лечебное зелье.": {
+   "en": "You drink the healing potion.",
+   "ua": "Ти випиваєш цілюще зілля."
+  },
+  "Ты зорко смотришь вокруг, но не видишь ничего нового.": {
+   "en": "You look sharply around, but see nothing new.",
+   "ua": "Ти пильно оглядаєшся, але не бачиш нічого нового."
+  },
+  "Ты накладываешь повязку на свою рану!": {
+   "en": "You bandage your wound!",
+   "ua": "Ти накладаєш пов'язку на свою рану!"
+  },
+  "Ты передаешь лечебное зелье $C3.": {
+   "en": "You hand the healing potion to $C3.",
+   "ua": "Ти передаєш лікувальне зілля $C3."
+  },
+  "Ты пытаешься перевязать свои раны, но пальцы не слушаются тебя.": {
+   "en": "You try to bandage your wounds, but your fingers won't obey you.",
+   "ua": "Ти намагаєшся перев'язати свої рани, але пальці тебе не слухаються."
+  },
+  "Ты уже отражаешь заклинания.": {
+   "en": "You are already reflecting spells.",
+   "ua": "Ти вже відбиваєш заклинання."
+  },
+  "Ты уже перевяза$gло|л|ла свои раны!": {
+   "en": "You've already bandaged your wounds!",
+   "ua": "Ти вже перев'яза$gло|в|ла свої рани!"
+  },
+  "Ты уже сопротивляешься физическим атакам.": {
+   "en": "You are already resisting physical attacks.",
+   "ua": "Ти вже опираєшся фізичним атакам."
+  },
+  "Ты чувствуешь себя крепче!": {
+   "en": "You feel tougher!",
+   "ua": "Ти відчуваєш себе міцнішим!"
+  },
+  "Это умение сработает только в бою.": {
+   "en": "This skill only works in combat.",
+   "ua": "Це вміння спрацює лише в бою."
+  },
+  "$C1 отвешивает $c3 подзатыльник...\n\r$c1 -- как ветром сдуло.": {
+   "en": "$C1 smacks $c3 upside the head...\n\r$c1 -- gone like the wind.",
+   "ua": "$C1 відвішує $c3 потиличника...\n\r$c1 -- як вітром здуло."
+  },
+  "$C1 отвешивает тебе нехилый подзатыльник...": {
+   "en": "$C1 gives you a solid smack upside the head...",
+   "ua": "$C1 відважує тобі неабиякого потиличника..."
+  },
+  "$c1 выглядит покрепче.": {
+   "en": "$c1 looks tougher.",
+   "ua": "$c1 виглядає міцніше."
+  },
+  "$c1 зорко смотрит вокруг, но ничего нового не замечает.": {
+   "en": "$c1 looks around keenly, but notices nothing new.",
+   "ua": "$c1 пильно озирається довкола, але не помічає нічого нового."
+  },
+  "$c1 играет мускулами, пытаясь выглядеть крепче.": {
+   "en": "$c1 flexes their muscles, trying to look tougher.",
+   "ua": "$c1 грає м'язами, намагаючись виглядати міцніше."
+  },
+  "$c1 наносит тройной удар смертоносной силы!": {
+   "en": "$c1 delivers a triple strike of deadly force!",
+   "ua": "$c1 завдає потрійного удару смертоносної сили!"
+  },
+  "$c1 пытается забинтовать свою собственную тень\n\r...похоже кому-то нужен доктор.": {
+   "en": "$c1 tries to bandage its own shadow\n\r...looks like someone needs a doctor.",
+   "ua": "$c1 намагається забинтувати власну тінь\n\r...схоже, комусь потрібен лікар."
+  },
+  "$c1 распространяет вокруг себя ненависть к магии.": {
+   "en": "$c1 spreads a hatred of magic all around.",
+   "ua": "$c1 поширює навколо себе ненависть до магії."
+  },
+  "{RМолниеносный удар $c2 в одно мгновение лишает $C4 жизни!{x": {
+   "en": "{RA lightning-fast strike from $c2 snuffs $C4's life out in an instant!{x",
+   "ua": "{RБлискавичний удар $c2 миттєво позбавляє $C4 життя!{x"
+  },
+  "{RМолниеносный удар $c2 в одно мгновение лишает тебя жизни!{x": {
+   "en": "{RA lightning-fast strike from $c2 ends your life in an instant!{x",
+   "ua": "{RБлискавичний удар $c2 миттю позбавляє тебе життя!{x"
+  },
+  "{RТвой молниеносный удар в одно мгновение лишает $C4 жизни!{x": {
+   "en": "{RYour lightning strike ends $C4's life in an instant!{x",
+   "ua": "{RТвій блискавичний удар за одну мить позбавляє $C4 життя!{x"
+  },
+  "Глаза $c2 загораются кровожадным огнем.": {
+   "en": "$c2's eyes blaze with bloodthirsty fire.",
+   "ua": "Очі $c2 спалахують кровожерним вогнем."
+  },
+  "Как это наверное интересно смотрится со стороны -- бинтовать собственную тень.": {
+   "en": "That must look real interesting from the outside -- bandaging your own shadow.",
+   "ua": "Як це, мабуть, цікаво виглядає збоку -- бинтувати власну тінь."
+  },
+  "На миг ты чувствуешь себя кровожадно, но это быстро проходит.": {
+   "en": "For a moment you feel bloodthirsty, but it quickly passes.",
+   "ua": "На мить ти відчуваєш кровожерливість, але це швидко минає."
+  },
+  "Ненависть к магии окружает тебя.": {
+   "en": "Hatred of magic surrounds you.",
+   "ua": "Ненависть до магії оточує тебе."
+  },
+  "Ты жаждешь {rкрови!{x": {
+   "en": "You thirst for {rblood!{x",
+   "ua": "Ти жадаєш {rкрові!{x"
+  },
+  "Ты зорко смотришь вокруг!": {
+   "en": "You look sharply around!",
+   "ua": "Ти пильно озираєшся навколо!"
+  },
+  "Ты наносишь тройной удар смертоносной силы!": {
+   "en": "You deliver a triple strike of deadly force!",
+   "ua": "Ти завдаєш потрійного удару смертоносної сили!"
+  },
+  "Ты напрягаешь свои мускулы, но это все впустую.": {
+   "en": "You flex your muscles, but it's all for nothing.",
+   "ua": "Ти напружуєш свої мускули, але все марно."
+  },
+  "Ты слишком миролюбив{Sfа{Sx, чтоб жаждать крови.": {
+   "en": "You're too peace-loving to crave blood.",
+   "ua": "Ти надто миролюбив{Sfа{Sx, щоб жадати крові."
+  },
+  "Ты уже жаждешь крови.": {
+   "en": "You already thirst for blood.",
+   "ua": "Ти вже жадаєш крові."
+  }
+ },
+ "plug-ins/clan/impl/chaos.cpp": {
+  "$C1 и так уже не может ничего внятно произнести.": {
+   "en": "$C1 already can't utter anything coherent.",
+   "ua": "$C1 і так вже не може нічого до пуття вимовити."
+  },
+  "$c1 выглядит очень сконфуженно.": {
+   "en": "$c1 looks very embarrassed.",
+   "ua": "$c1 виглядає дуже збентежено."
+  },
+  "Зеркальные отражения могут иметь только персонажи.": {
+   "en": "Only characters can have mirror images.",
+   "ua": "Дзеркальні відображення можуть мати лише персонажі."
+  },
+  "Зеркальных отражений $C2 уже слишком много.": {
+   "en": "There are already too many mirror images of $C2.",
+   "ua": "Дзеркальних відображень $C2 вже занадто багато."
+  },
+  "Зеркальных отражений уже слишком много.": {
+   "en": "There are already too many mirror images.",
+   "ua": "Дзеркальних відображень вже занадто багато."
+  },
+  "Использование Магических Сил Хаоса опустошает тебя.": {
+   "en": "Using the Magical Powers of Chaos drains you.",
+   "ua": "Використання Магічних Сил Хаосу спустошує тебе."
+  },
+  "Не получилось.": {
+   "en": "Didn't work.",
+   "ua": "Не вийшло."
+  },
+  "Отсюда ты никого не сможешь вышвырнуть.": {
+   "en": "You can't throw anyone out from here.",
+   "ua": "Звідси ти нікого не зможеш викинути."
+  },
+  "Подходящей жертвы не нашлось.": {
+   "en": "No suitable victim was found.",
+   "ua": "Придатної жертви не знайшлося."
+  },
+  "Твоя попытка закончилась неудачей.": {
+   "en": "Your attempt has failed.",
+   "ua": "Твоя спроба закінчилася невдачею."
+  },
+  "Тебе не дано здесь чего-нибудь добиться.": {
+   "en": "You are not meant to achieve anything here.",
+   "ua": "Тобі не судилося тут чогось досягти."
+  },
+  "Тебя сконфузили!": {
+   "en": "You've been confused!",
+   "ua": "Тебе спантеличили!"
+  },
+  "Ты меняешь свой облик, подражая $C3.": {
+   "en": "You change your appearance, mimicking $C3.",
+   "ua": "Ти змінюєш свій вигляд, наслідуючи $C3."
+  },
+  "Ты не можешь подражать $C3.": {
+   "en": "You can't imitate $C3.",
+   "ua": "Ти не можеш наслідувати $C3."
+  },
+  "Ты пытаешься сотворить зеркальные отражения, но безуспешно.": {
+   "en": "You try to create mirror images, but fail.",
+   "ua": "Ти намагаєшся створити дзеркальні відображення, але безуспішно."
+  },
+  "Ты чувствуешь себя гораздо менее уверенно!": {
+   "en": "You feel much less confident!",
+   "ua": "Ти почуваєшся набагато менш впевнено!"
+  },
+  "У тебя не хватает сил разогнать эту группу.": {
+   "en": "You don't have enough strength to disperse this group.",
+   "ua": "Тобі бракує сил розігнати цю групу."
+  },
+  "Это заклинание использовалось совсем недавно.": {
+   "en": "This spell was used quite recently.",
+   "ua": "Це заклинання використовувалося зовсім недавно."
+  },
+  "$C1 выпускает частицу ХАОСА в $c2\n\r...и $c1 растворяется в нем...": {
+   "en": "$C1 releases a particle of CHAOS into $c2\n\r...and $c1 dissolves into it...",
+   "ua": "$C1 випускає частку ХАОСУ в $c2\n\r...і $c1 розчиняється в ньому..."
+  },
+  "$c1 выглядит гораздо менее уверенн$gым|ым|ой в себе!": {
+   "en": "$c1 looks much less confident!",
+   "ua": "$c1 виглядає значно менш впевнен$gим|им|ою в собі!"
+  },
+  "$c1 меняет свой облик, подражая $C3!": {
+   "en": "$c1 changes shape, mimicking $C3!",
+   "ua": "$c1 змінює свій вигляд, наслідуючи $C3!"
+  },
+  "$c1 меняет свой облик, подражая ТЕБЕ!": {
+   "en": "$c1 shifts shape, mimicking YOU!",
+   "ua": "$c1 змінює свій вигляд, наслідуючи ТЕБЕ!"
+  },
+  "Кто-то совсем недавно уже ввел в заблуждение $C4.": {
+   "en": "Someone has already misled $C4 quite recently.",
+   "ua": "Хтось зовсім нещодавно вже ввів в оману $C4."
+  },
+  "Магические Силы Хаоса изменяют окружающий мир.": {
+   "en": "The Magical Forces of Chaos reshape the world around you.",
+   "ua": "Магічні Сили Хаосу змінюють навколишній світ."
+  },
+  "Магические Силы Хаоса уже изменили окружающий мир.": {
+   "en": "The magical Forces of Chaos have already reshaped the world around you.",
+   "ua": "Магічні Сили Хаосу вже змінили навколишній світ."
+  },
+  "На мгновенье ты теряешь представление о реальности...": {
+   "en": "For a moment you lose your grip on reality...",
+   "ua": "На мить ти втрачаєш уявлення про реальність..."
+  },
+  "Несмотря на твои усилия, окружающий мир противостоит Хаосу.": {
+   "en": "Despite your efforts, the world around you resists Chaos.",
+   "ua": "Попри твої зусилля, навколишній світ протистоїть Хаосу."
+  },
+  "Ну..Ну...": {
+   "en": "Well... well...",
+   "ua": "Ну..ну..."
+  },
+  "Около тебя появляется твое зеркальное отражение!": {
+   "en": "Your mirror reflection appears next to you!",
+   "ua": "Поруч з тобою з'являється твоє дзеркальне відображення!"
+  },
+  "Окружающее тебя пространство теперь находится под властью Хаоса!": {
+   "en": "The space around you now falls under the dominion of Chaos!",
+   "ua": "Простір навколо тебе тепер під владою Хаосу!"
+  },
+  "Рядом с тобой появляется твое зеркальное отражение!": {
+   "en": "Your mirror image appears next to you!",
+   "ua": "Поруч з тобою з'являється твоє дзеркальне відображення!"
+  },
+  "Такое впечатление, что твой язык завязали узлом.": {
+   "en": "It feels like your tongue's been tied in a knot.",
+   "ua": "Таке враження, що твій язик зав'язали вузлом."
+  },
+  "Ты поделил$gось|ся|ась частицей хаоса с языком $C2.": {
+   "en": "You shared a particle of chaos with the language of $C2.",
+   "ua": "Ти поділ$gилося|ився|илася часткою хаосу з мовою $C2."
+  },
+  "Хаос остался в тебе.": {
+   "en": "Chaos remains within you.",
+   "ua": "Хаос залишився в тобі."
+  },
+  "Это просто глупо.": {
+   "en": "That's just plain stupid.",
+   "ua": "Це просто по-дурному."
+  }
+ },
+ "plug-ins/clan/impl/hunter.cpp": {
+  "$c1 втыкает $o4 в почву, но натыкается на камень.": {
+   "en": "$c1 sticks $o4 into the ground, but hits a rock.",
+   "ua": "$c1 встромляє $o4 у землю, але натрапляє на камінь."
+  },
+  "$c1 начинает копать $o4.": {
+   "en": "$c1 starts digging $o4.",
+   "ua": "$c1 починає копати $o4."
+  },
+  "$c1 орудует $O5, углубляя $o4.": {
+   "en": "$c1 wields $O5, deepening $o4.",
+   "ua": "$c1 орудує $O5, поглиблюючи $o4."
+  },
+  "$c1 отравле$gно|н|на ядом от $o2.": {
+   "en": "$c1 is poisoned by $o2.",
+   "ua": "$c1 отруєн$gо|ий|а ядом від $o2."
+  },
+  "$c1 передает $o4 $C3.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 передає $o4 $C3."
+  },
+  "$c1 передает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 передає тобі $o4."
+  },
+  "$c1 своим неумелым обращением уничтожает $o4.": {
+   "en": "$c1's clumsy handling destroys $o4.",
+   "ua": "$c1 своїм невмілим поводженням знищує $o4."
+  },
+  "$c1 сосредоточенно осматривает местность и следы на земле.": {
+   "en": "$c1 studies the terrain and tracks on the ground intently.",
+   "ua": "$c1 зосереджено оглядає місцевість і сліди на землі."
+  },
+  "$c1 теряет сознание.": {
+   "en": "$c1 loses consciousness.",
+   "ua": "$c1 втрачає свідомість."
+  },
+  "$c1 угоди$gло|л|ла в $o4!": {
+   "en": "$c1 lands right in $o4!",
+   "ua": "$c1 влучи$gло|в|ла в $o4!"
+  },
+  "$c1 устанавливает и маскирует $o4.": {
+   "en": "$c1 sets up and camouflages $o4.",
+   "ua": "$c1 встановлює і маскує $o4."
+  },
+  "$c1 устанавливает и настраивает $o4.": {
+   "en": "$c1 sets up and adjusts $o4.",
+   "ua": "$c1 встановлює і налаштовує $o4."
+  },
+  "$o1 оглушает $C4.": {
+   "en": "$o1 stuns $C4.",
+   "ua": "$o1 оглушує $C4."
+  },
+  "$o1 оглушает тебя.": {
+   "en": "$o1 stuns you.",
+   "ua": "$o1 оглушує тебе."
+  },
+  "$o1 уничтожает  оружие $C2.": {
+   "en": "$o1 destroys $C2's weapon.",
+   "ua": "$o1 знищує зброю $C2."
+  },
+  "$o1 уничтожает оружие $C2.": {
+   "en": "$o1 destroys $C2's weapon.",
+   "ua": "$o1 знищує зброю $C2."
+  },
+  "$o1 уничтожает твое оружие.": {
+   "en": "$o1 destroys your weapon.",
+   "ua": "$o1 знищує твою зброю."
+  },
+  "%1$^O1 слегка туп%1$nится|ятся.": {
+   "en": "%1$^O1 %1$ngrows|grow slightly dull.",
+   "ua": "%1$^O1 злегка туп%1$nиться|ляться."
+  },
+  "%1$^O1 слишком затупил%1$Gось|ся|ась|ись.": {
+   "en": "%1$^O1 got too dull.",
+   "ua": "%1$^O1 занадто затупи%1$Gлося|вся|лася|лися."
+  },
+  "%2$^C1 не может владеть %1$O5 и бросает %1$P2.": {
+   "en": "%2$^C1 cannot wield %1$O5 and drops it.",
+   "ua": "%2$^C1 не може володіти %1$O5 і кидає %1$O4."
+  },
+  "{C%1$^O1 начина%1$nет|ют светиться.{x": {
+   "en": "{C%1$^O1 start%1$ns| to glow.{x",
+   "ua": "{C%1$^O1 почина%1$nє|ють світитися.{x"
+  },
+  "В земле вырыта яма %s размера.": {
+   "en": "A pit of %s size has been dug in the ground.",
+   "ua": "У землі викопана яма %s розміру."
+  },
+  "В этом капкане уже кто-то побывал.": {
+   "en": "Someone has already been caught in this trap.",
+   "ua": "У цьому капкані вже хтось побував."
+  },
+  "Внимание! Сработал маяк, установленный в '%s' и настроенный на появление %s.": {
+   "en": "Attention! A beacon set up in '%s' and tuned to detect %s has triggered.",
+   "ua": "Увага! Спрацював маяк, встановлений у '%s' і налаштований на появу %s."
+  },
+  "Жертва не находится в твоем ПК.": {
+   "en": "The target isn't on your PK list.",
+   "ua": "Жертва не перебуває в твоєму ПК-списку."
+  },
+  "Жертва с таким именем не найдена.": {
+   "en": "No victim found with that name.",
+   "ua": "Жертву з таким ім'ям не знайдено."
+  },
+  "Здесь невозможно установить и замаскировать капкан.": {
+   "en": "You can't set and camouflage a trap here.",
+   "ua": "Тут неможливо встановити і замаскувати капкан."
+  },
+  "Здесь некуда засунуть $o4.": {
+   "en": "There's nowhere here to stick $o4.",
+   "ua": "Тут нема куди запхати $o4."
+  },
+  "Здесь нельзя устанавливать маяки.": {
+   "en": "You can't place beacons here.",
+   "ua": "Тут не можна встановлювати маяки."
+  },
+  "Здешняя почва непригодна для копания ямы.": {
+   "en": "The soil here is unsuitable for digging a pit.",
+   "ua": "Тутешній грунт непридатний для копання ями."
+  },
+  "Из-за неумелого обращения ты уничтожаешь $o4.": {
+   "en": "Due to clumsy handling, you destroy $o4.",
+   "ua": "Через невміле поводження ти знищуєш $o4."
+  },
+  "Извини, но тебе не удается добраться туда.": {
+   "en": "Sorry, but you can't get there.",
+   "ua": "Вибач, але тобі не вдається туди дістатися."
+  },
+  "Кого выслеживаем?": {
+   "en": "Who are we tracking?",
+   "ua": "Кого вистежуємо?"
+  },
+  "Львы защитили эту местность от ловушек Охотников.": {
+   "en": "The Lions have protected this area from the Hunters' traps.",
+   "ua": "Леви захистили цю місцевість від пасток Мисливців."
+  },
+  "На кого именно должен реагировать маяк?": {
+   "en": "Exactly who should the beacon react to?",
+   "ua": "На кого саме має реагувати маяк?"
+  },
+  "Нет никого здесь с таким именем.": {
+   "en": "There's no one here by that name.",
+   "ua": "Тут немає нікого з таким ім'ям."
+  },
+  "Подними это с земли.": {
+   "en": "Pick that up off the ground.",
+   "ua": "Підніми це з землі."
+  },
+  "Попрактикуйся сначала.": {
+   "en": "Practice first.",
+   "ua": "Спочатку потренуйся."
+  },
+  "Предыдущий капкан был установлен тобой совсем недавно.": {
+   "en": "You set your previous trap only moments ago.",
+   "ua": "Попередній капкан було встановлено тобою зовсім нещодавно."
+  },
+  "Разломанный %s лежит тут.": {
+   "en": "A broken %s lies here.",
+   "ua": "Зламаний %s лежить тут."
+  },
+  "С момента установки предыдущего маяка прошло слишком мало времени.": {
+   "en": "Not enough time has passed since the previous beacon was set.",
+   "ua": "Відтоді як встановлено попередній маяк, минуло замало часу."
+  },
+  "Сила клана защищает $c4 от ловушек Охотников.": {
+   "en": "The power of the clan protects $c4 from the Hunters' traps.",
+   "ua": "Сила клану захищає $c4 від пасток Мисливців."
+  },
+  "Сила твоего клана защищает тебя от ловушек Охотников.": {
+   "en": "Your clan's strength protects you from the Hunters' traps.",
+   "ua": "Сила твого клану захищає тебе від пасток Мисливців."
+  },
+  "Твои силы истощились и ты не можешь охотиться!": {
+   "en": "Your strength is spent and you can't hunt anymore!",
+   "ua": "Твої сили вичерпались і ти не можеш полювати!"
+  },
+  "Твоих знаний недостаточно, чтобы искать по всему миру!": {
+   "en": "Your knowledge isn't enough to search the whole world!",
+   "ua": "Твоїх знань не досить, щоб шукати по всьому світу!"
+  },
+  "Твоя попытка установить $o4 окончилась неудачей.": {
+   "en": "Your attempt to set $o4 failed.",
+   "ua": "Твоя спроба встановити $o4 закінчилася невдачею."
+  },
+  "Тебе не удается понять, как пройти к $C3.": {
+   "en": "You can't figure out how to get to $C3.",
+   "ua": "Тобі не вдається зрозуміти, як пройти до $C3."
+  },
+  "Теперь ты будешь замечать чужие ловушки.": {
+   "en": "Now you'll notice other people's traps.",
+   "ua": "Тепер ти будеш помічати чужі пастки."
+  },
+  "Ты втыкаешь $o4 в почву, но натыкаешься на камень.": {
+   "en": "You stick $o4 into the ground, but hit a rock.",
+   "ua": "Ти встромляєш $o4 у землю, але натрапляєш на камінь."
+  },
+  "Ты начинаешь копать $o4.": {
+   "en": "You start digging $o4.",
+   "ua": "Ти починаєш копати $o4."
+  },
+  "Ты не держишь $o4 в руках.": {
+   "en": "You're not holding $o4.",
+   "ua": "Ти не тримаєш $o4 в руках."
+  },
+  "Ты не можешь владеть %1$O5 и бросаешь %1$P2.": {
+   "en": "You can't wield %1$O5, so you drop it.",
+   "ua": "Ти не можеш володіти %1$O5 і кидаєш %1$O4."
+  },
+  "Ты не можешь точно определить, где находится цель.": {
+   "en": "You can't pinpoint exactly where the target is.",
+   "ua": "Ти не можеш точно визначити, де перебуває ціль."
+  },
+  "Ты недостаточно опыт$gно|ен|на, чтобы использовать $o4.": {
+   "en": "You're not experienced enough to use $o4.",
+   "ua": "Ти недостатньо досвідчен$gе|ий|а, щоб використати $o4."
+  },
+  "Ты орудуешь $O5, еще больше углубляя $o4.": {
+   "en": "You work $O5, digging $o4 even deeper.",
+   "ua": "Ти орудуєш $O5, ще більше поглиблюючи $o4."
+  },
+  "Ты передаешь $o4 $C3.": {
+   "en": "You hand $o4 to $C3.",
+   "ua": "Ти передаєш $o4 $C3."
+  },
+  "Ты пытаешься установить %1$O4, но только ломаешь %1$P2.": {
+   "en": "You try to set %1$O4, but only end up breaking it.",
+   "ua": "Ти намагаєшся встановити %1$O4, але лише ламаєш %1$O4."
+  },
+  "Ты слишком уста$gло|л|ла.": {
+   "en": "You are too tired.",
+   "ua": "Ти надто втомлен$gе|ий|а."
+  },
+  "Ты теряешь сознание.": {
+   "en": "You lose consciousness.",
+   "ua": "Ти втрачаєш свідомість."
+  },
+  "Ты устанавливаешь $o4 и настраиваешь реакцию на появление $C2.": {
+   "en": "You set up $o4 and configure it to trigger on $C2's appearance.",
+   "ua": "Ти встановлюєш $o4 і налаштовуєш реакцію на появу $C2."
+  },
+  "Ты устанавливаешь и маскируешь $o4.": {
+   "en": "You set up and disguise $o4.",
+   "ua": "Ти встановлюєш і маскуєш $o4."
+  },
+  "Ты устанавливаешь на дне $O2 $o4 и тщательно маскируешь яму.": {
+   "en": "You set $o4 at the bottom of $O2 and carefully camouflage the pit.",
+   "ua": "Ти встановлюєш на дні $O2 $o4 і ретельно маскуєш яму."
+  },
+  "У тебя недостаточно энергии для этого.": {
+   "en": "You don't have enough energy for that.",
+   "ua": "У тебе недостатньо енергії для цього."
+  },
+  "Что-то не так..": {
+   "en": "Something's not right..",
+   "ua": "Щось не так.."
+  },
+  "Это гораздо удобней делать стоя.": {
+   "en": "It's much more convenient to do this standing up.",
+   "ua": "Це набагато зручніше робити стоячи."
+  },
+  "Эту яму выкопал другой Охотник.": {
+   "en": "Another Hunter dug this pit.",
+   "ua": "Цю яму викопав інший Мисливець."
+  },
+  "имеется у %s\n\r": {
+   "en": "is held by %s\n\r",
+   "ua": "є у %s\n\r"
+  },
+  "находится в %s\n\r": {
+   "en": "is located in %s\n\r",
+   "ua": "знаходиться в %s\n\r"
+  },
+  "находится в %s [Комната %d]\n\r": {
+   "en": "is in %s [Room %d]\n\r",
+   "ua": "перебуває в %s [Кімната %d]\n\r"
+  },
+  "$C1 вытягивает такой страшненький ножичек и слегка щекочет $c4\n\r... $c1 с диким воплем уносится не видя ничего перед собой.": {
+   "en": "$C1 pulls out a nasty little knife and gives $c4 a light tickle...\n\r... $c1 dashes off with a wild shriek, seeing nothing ahead.",
+   "ua": "$C1 витягує такий страшненький ножичок і злегка лоскоче $c4...\n\r... $c1 з диким вереском мчить, не бачачи нічого перед собою."
+  },
+  "$C1 вытягивает такой страшненький ножичек и слегка щекочет тебя.\n\r...Ты с диким воплем подпрыгиваешь и уносишься не видя ничего перед собой.": {
+   "en": "$C1 pulls out a nasty little knife and gives you a light tickle.\n\r...You leap up with a wild scream and bolt off blindly, seeing nothing ahead.",
+   "ua": "$C1 витягує такий страшненький ножичок і злегка лоскоче тебе.\n\r...Ти з диким вереском підстрибуєш і мчиш геть, нічого не бачачи перед собою."
+  },
+  "$C1 прямо здесь!": {
+   "en": "$C1 is right here!",
+   "ua": "$C1 прямо тут!"
+  },
+  "$c1 проваливается в $o4 и падает прямо на $O4!": {
+   "en": "$c1 falls through $o4 and lands right on $O4!",
+   "ua": "$c1 провалюється в $o4 і падає прямо на $O4!"
+  },
+  "$c1 тычет повсюду $o5, ища, куда бы это засунуть.": {
+   "en": "$c1 pokes $o5 everywhere, looking for somewhere to shove it.",
+   "ua": "$c1 тика $o5 всюди, шукаючи, куди б це запхати."
+  },
+  "$c1 устанавливает на дне $O2 $o4 и тщательно маскирует яму.": {
+   "en": "$c1 sets $o4 at the bottom of $O2 and carefully camouflages the pit.",
+   "ua": "$c1 встановлює на дні $O2 $o4 і ретельно маскує яму."
+  },
+  "$o1 раскалывает пополам твой щит.": {
+   "en": "$o1 splits your shield clean in half.",
+   "ua": "$o1 розколює навпіл твій щит."
+  },
+  "$o1 раскалывает пополам щит $C2.": {
+   "en": "$o1 splits $C2's shield in half.",
+   "ua": "$o1 розколює навпіл щит $C2."
+  },
+  "$o1 с грохотом отскакивает от твоего щита.": {
+   "en": "$o1 bounces off your shield with a clang.",
+   "ua": "$o1 з гуркотом відскакує від твого щита."
+  },
+  "$o1 с грохотом отскакивает от щита $C2.": {
+   "en": "$o1 bounces off $C2's shield with a clatter.",
+   "ua": "$o1 з гуркотом відскакує від щита $C2."
+  },
+  "$o1 со звоном отскакивает от оружия $C2.": {
+   "en": "$o1 bounces off $C2's weapon with a clang.",
+   "ua": "$o1 з дзвоном відскакує від зброї $C2."
+  },
+  "$o1 со звоном отскакивает от твоего оружия.": {
+   "en": "$o1 bounces off your weapon with a clang.",
+   "ua": "$o1 з дзвоном відскакує від твоєї зброї."
+  },
+  "%2$^C1 пытается зарядить %1$O4, но зажимает в %1$P4 собственную руку.": {
+   "en": "%2$^C1 tries to load %1$O4, but jams their own hand in it.",
+   "ua": "%2$^C1 намагається зарядити %1$O4, але затискає в %1$O4 власну руку."
+  },
+  "%2$^C1 пытается установить %1$O4, но только ломает %1$P2.": {
+   "en": "%2$^C1 tries to set up %1$O4, but only breaks it.",
+   "ua": "%2$^C1 намагається встановити %1$O4, але тільки ламає %1$O2."
+  },
+  "В Мире Мечты нет ничего похожего на это.": {
+   "en": "There is nothing like this in the World of Dreams.",
+   "ua": "У Світі Мрій немає нічого подібного до цього."
+  },
+  "Взгляд $c2 становится более внимательным.": {
+   "en": "$c2's gaze grows more attentive.",
+   "ua": "Погляд $c2 стає уважнішим."
+  },
+  "Другой Охотник уже начал копать здесь яму, не стоит ему мешать.": {
+   "en": "Another Hunter has already started digging a pit here, better not get in his way.",
+   "ua": "Інший Мисливець вже почав копати тут яму, не варто йому заважати."
+  },
+  "С этой ямой что-то не так..": {
+   "en": "Something's off about this pit..",
+   "ua": "З цією ямою щось не так.."
+  },
+  "Слишком поздно мстить в твоем положении.": {
+   "en": "It's too late for revenge in your condition.",
+   "ua": "Занадто пізно мститися в твоєму стані."
+  },
+  "Твоя нога попала в $o4!": {
+   "en": "Your foot got caught in $o4!",
+   "ua": "Твоя нога потрапила в $o4!"
+  },
+  "Ты и так в состоянии отличить бревно от капкана.": {
+   "en": "You can already tell a log from a trap just fine.",
+   "ua": "Ти й так можеш відрізнити колоду від капкана."
+  },
+  "Ты проваливаешься в $o4 и падаешь прямо на $O4!": {
+   "en": "You fall through $o4 and land right on $O4!",
+   "ua": "Ти провалюєшся в $o4 і падаєш прямісінько на $O4!"
+  },
+  "Ты чувствуешь, как яд распространяется по твоим венам.": {
+   "en": "You feel the poison spreading through your veins.",
+   "ua": "Ти відчуваєш, як отрута розповсюджується по твоїх венах."
+  },
+  "Увы, похоже твой труп разделали на мясо.": {
+   "en": "Alas, looks like your corpse got butchered for meat.",
+   "ua": "На жаль, схоже твій труп розібрали на м'ясо."
+  },
+  "Устройство этого капкана слишком сложно для твоего понимания.": {
+   "en": "This trap's mechanism is too complex for you to understand.",
+   "ua": "Пристрій цього капкана надто складний для твого розуміння."
+  },
+  "Эта яма уже замаскирована и ждет гостей.": {
+   "en": "This pit is already camouflaged and waiting for guests.",
+   "ua": "Ця яма вже замаскована і чекає на гостей."
+  }
+ },
+ "plug-ins/clan/impl/invader.cpp": {
+  "Попробуй позже.": {
+   "en": "Try again later.",
+   "ua": "Спробуй пізніше."
+  },
+  "Твое заклинание не может пробиться через защиту от заклинаний противника.": {
+   "en": "Your spell can't break through your opponent's spell defense.",
+   "ua": "Твоє закляття не може пробитися крізь захист від заклять супротивника."
+  },
+  "Твоих полномочий хватает только посмотреть список организаций.": {
+   "en": "Your authority is only enough to view the list of organizations.",
+   "ua": "Твоїх повноважень вистачає лише переглянути список організацій."
+  },
+  "Ты не можешь спрятаться в тенях, когда в седле.": {
+   "en": "You can't hide in the shadows while in the saddle.",
+   "ua": "Ти не можеш сховатися в тінях, коли в сідлі."
+  },
+  "Ты не можешь спрятаться в тенях, когда светишься.": {
+   "en": "You can't hide in the shadows while you're glowing.",
+   "ua": "Ти не можеш сховатися в тінях, коли світишся."
+  },
+  "Ты не можешь спрятаться в тенях, когда ты оседлан%Gо||а.": {
+   "en": "You can't hide in the shadows while you're mounted.",
+   "ua": "Ти не можеш сховатися в тінях, коли ти осідлан%Gо|ий|а|і."
+  },
+  "Ты не принадлежишь к Кабалу Захватчиков.": {
+   "en": "You don't belong to the Cabal of Invaders.",
+   "ua": "Ти не належиш до Кабалу Загарбників."
+  },
+  "Ты прячешься в тенях.": {
+   "en": "You hide in the shadows.",
+   "ua": "Ти ховаєшся в тінях."
+  },
+  "Ты пытаешься спрятаться в тенях, но безуспешно.": {
+   "en": "You try to hide in the shadows, but fail.",
+   "ua": "Ти намагаєшся сховатися в тінях, але марно."
+  },
+  "Тьма не может обнаружить это существо.": {
+   "en": "The Darkness cannot detect this creature.",
+   "ua": "Темрява не може виявити цю істоту."
+  },
+  "У тебя недостаточно энергии, чтобы создать тень.": {
+   "en": "You don't have enough energy to create a shadow.",
+   "ua": "У тебе недостатньо енергії, щоб створити тінь."
+  },
+  "Это заклинание ты можешь произнести только на члена твоего клана.": {
+   "en": "You can only cast this spell on a member of your clan.",
+   "ua": "Це заклинання ти можеш накласти лише на члена свого клану."
+  },
+  "Это заклинание ты можешь произнести только на члена твоей организации.": {
+   "en": "You can only cast this spell on a member of your organization.",
+   "ua": "Це закляття ти можеш накласти лише на члена своєї організації."
+  },
+  "Это существо защищено от твоего взора.": {
+   "en": "This creature is protected from your sight.",
+   "ua": "Ця істота захищена від твого погляду."
+  },
+  "$C1 зверски ухмыляется тебе...\n\rТы теряешь рассудок от страха и куда-то несешься.": {
+   "en": "$C1 grins at you savagely...\n\rYou lose your mind with fear and bolt off somewhere.",
+   "ua": "$C1 звірячи шкіриться до тебе...\n\rТи втрачаєш розум від страху і кудись мчиш."
+  },
+  "$C1 сверлит глазами $c4, и $c1 с испугу куда-то уносится.": {
+   "en": "$C1 drills $c4 with their eyes, and $c1 bolts off somewhere in fright.",
+   "ua": "$C1 свердлить очима $c4, і $c1 з переляку кудись мчить."
+  },
+  "$c1 дает жизнь твоей тени!": {
+   "en": "$c1 breathes life into your shadow!",
+   "ua": "$c1 дає життя твоїй тіні!"
+  },
+  "$c1 дает жизнь тени $C2!": {
+   "en": "$c1 breathes life into $C2's shadow!",
+   "ua": "$c1 дає життя тіні $C2!"
+  },
+  "Бесполезная трата сил и энергии...": {
+   "en": "A pointless waste of strength and energy...",
+   "ua": "Марна трата сил та енергії..."
+  },
+  "Злые духи воцарились здесь на {W%1$d{x ча%1$Iс|са|сов.": {
+   "en": "Evil spirits have taken hold here for {W%1$d{x hour%1$I|s|s.",
+   "ua": "Злі духи запанували тут на {W%1$d{x годин%1$Iа|и|."
+  },
+  "Злые духи овладевают $c1.": {
+   "en": "Evil spirits take hold of $c1.",
+   "ua": "Злі духи оволодівають $c1."
+  },
+  "Злые духи овладевают тобой.": {
+   "en": "Evil spirits take hold of you.",
+   "ua": "Злі духи оволодівають тобою."
+  },
+  "На миг тебя окружает темнота, из которой на тебя смотрит огромный глаз.\n\r...И тихий звон {Yзолотой ауры{x рождает имя -- {D%#^C1{x.": {
+   "en": "For a moment darkness surrounds you, and a huge eye stares out at you from within it.\n\r...And the quiet chime of a {Ygolden aura{x gives birth to a name -- {D%#^C1{x.",
+   "ua": "На мить тебе оточує темрява, з якої на тебе дивиться величезне око.\n\r...І тихий дзвін {Yзолотої аури{x народжує ім'я -- {D%#^C1{x."
+  },
+  "Твоя золотая аура препятствует подлой попытке оживить твою тень!": {
+   "en": "Your golden aura foils the vile attempt to revive your shadow!",
+   "ua": "Твоя золота аура заважає підлій спробі оживити твою тінь!"
+  },
+  "Ты даешь жизнь тени $C2!": {
+   "en": "You bring the shadow of $C2 to life!",
+   "ua": "Ти даєш життя тіні $C2!"
+  },
+  "Тьма не может проникнуть туда, где скрывается это существо.": {
+   "en": "Darkness cannot reach where this creature hides.",
+   "ua": "Темрява не може проникнути туди, де ховається ця істота."
+  },
+  "У тебя не хватает силы приказать темноте.": {
+   "en": "You don't have the strength to command the darkness.",
+   "ua": "Тобі бракує сили наказати темряві."
+  }
+ },
+ "plug-ins/clan/impl/knight.cpp": {
+  "$C1 не нуждается в твоей помощи!": {
+   "en": "$C1 doesn't need your help!",
+   "ua": "$C1 не потребує твоєї допомоги!"
+  },
+  "$C1 уже окруже$Gно|н|на {YЗолотой аурой{x.": {
+   "en": "$C1 is already surrounded by the {YGolden Aura{x.",
+   "ua": "$C1 вже оточен$Gо|ий|а {YЗолотою аурою{x."
+  },
+  "$C4 уже кто-то охраняет.": {
+   "en": "Someone is already guarding $C4.",
+   "ua": "$C4 вже хтось охороняє."
+  },
+  "$c1 прыгает перед $C5!": {
+   "en": "$c1 jumps in front of $C5!",
+   "ua": "$c1 стрибає перед $C5!"
+  },
+  "$c1 прыгает перед тобой!": {
+   "en": "$c1 jumps in front of you!",
+   "ua": "$c1 стрибає перед тобою!"
+  },
+  "$c1 ставит Королевскую печать на $o6.": {
+   "en": "$c1 places the Royal Seal on $o6.",
+   "ua": "$c1 ставить Королівську печатку на $o6."
+  },
+  "$c1 теперь охраняет $C4.": {
+   "en": "$c1 now guards $C4.",
+   "ua": "$c1 тепер охороняє $C4."
+  },
+  "$o1 исчезает в серой дымке.": {
+   "en": "$o1 vanishes in a gray haze.",
+   "ua": "$o1 зникає в сірій імлі."
+  },
+  "{YЗолотая аура{x окружает $C4.": {
+   "en": "{YA golden aura{x surrounds $C4.",
+   "ua": "{YЗолота аура{x оточує $C4."
+  },
+  "Но ты не состоишь в той же группе, что и $C1.": {
+   "en": "But you're not in the same group as $C1.",
+   "ua": "Але ти не в тій самій групі, що й $C1."
+  },
+  "Но ты охраняешь кого-то другого!": {
+   "en": "But you're guarding someone else!",
+   "ua": "Але ти охороняєш когось іншого!"
+  },
+  "Ордена сейчас недоступны.": {
+   "en": "Orders are currently unavailable.",
+   "ua": "Ордени зараз недоступні."
+  },
+  "Охранять кого?": {
+   "en": "Guard whom?",
+   "ua": "Охороняти кого?"
+  },
+  "Сперва закончи свое сражение, а потом беспокойся о защите кого-либо еще.": {
+   "en": "Finish your own fight first, then worry about protecting someone else.",
+   "ua": "Спершу закінчи свій бій, а тоді вже турбуйся про захист когось іншого."
+  },
+  "Теперь тебя охраняет $c4.": {
+   "en": "Now $c4 guards you.",
+   "ua": "Тепер тебе охороняє $c4."
+  },
+  "Теперь ты охраняешь $C4.": {
+   "en": "Now you are guarding $C4.",
+   "ua": "Тепер ти охороняєш $C4."
+  },
+  "Ты не можешь охранять себя же!": {
+   "en": "You can't guard yourself!",
+   "ua": "Ти не можеш охороняти сам себе!"
+  },
+  "Ты не принадлежишь к клану Рыцарей.": {
+   "en": "You don't belong to the Knights' clan.",
+   "ua": "Ти не належиш до клану Лицарів."
+  },
+  "Ты уже окруже$gно|н|на {YЗолотой аурой{x.": {
+   "en": "You are already surrounded by a {YGolden Aura{x.",
+   "ua": "Ти вже оточен$gо|ий|а {YЗолотою аурою{x."
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$C1 кивает $c3, слегка нахмурившись, взмахивает рукой.\n\r... и $c1 с диким восторгом в глазах улетает.": {
+   "en": "$C1 nods to $c3, frowning slightly, and waves a hand.\n\r...and $c1 flies off with wild delight in their eyes.",
+   "ua": "$C1 киває $c3, злегка спохмурнівши, змахує рукою.\n\r...і $c1 з диким захватом в очах відлітає."
+  },
+  "$C1 кивает тебе, слегка хмурясь, взмахивает рукой.\n\r...и вот уже ты неторопливо несешься в воздухе.": {
+   "en": "$C1 nods at you, frowning slightly, and waves a hand.\n\r...and now you're already drifting unhurriedly through the air.",
+   "ua": "$C1 киває тобі, злегка хмурячись, змахує рукою.\n\r...і ось ти вже неквапом линеш у повітрі."
+  },
+  "$c1 внимательно сверяется со списком.": {
+   "en": "$c1 carefully checks the list.",
+   "ua": "$c1 уважно звіряється зі списком."
+  },
+  "%d рыцар%s, поставленных стык-в-стык, представляют собой потрясающее зрелище!": {
+   "en": "%d knight%s lined up shoulder to shoulder make an awesome sight!",
+   "ua": "%d лицар%s, вишикувані пліч-о-пліч, являють собою приголомшливе видовище!"
+  },
+  "{WЛучи света пронизывают комнату и в центре материализуется $o1.{x": {
+   "en": "{WBeams of light pierce the room, and $o1 materializes in the center.{x",
+   "ua": "{WПромені світла пронизують кімнату, і в центрі матеріалізується $o1.{x"
+  },
+  "{WСвет $o2 исчезает и он растворяется в воздухе!{x": {
+   "en": "{WThe light of $o2 fades and it dissolves into the air!{x",
+   "ua": "{WСвітло $o2 зникає, і воно розчиняється в повітрі!{x"
+  },
+  "{WХрамовый алтарь вашего замка был осквернен безбожниками!{x": {
+   "en": "{WThe Temple altar of your castle has been desecrated by the godless!{x",
+   "ua": "{WХрамовий вівтар вашого замку осквернили безбожники!{x"
+  },
+  "{YЗолотая аура{x окружает тебя.": {
+   "en": "{YA golden aura{x surrounds you.",
+   "ua": "{YЗолота аура{x огортає тебе."
+  },
+  "Почему бы тебе не позволить им сперва закончить сражение?": {
+   "en": "Why don't you let them finish the fight first?",
+   "ua": "Чому б тобі не дозволити їм спершу закінчити бійку?"
+  },
+  "Ты любишь сво%1$Gего|его|ю хозя%1$Gина|ина|йку так сильно, что не можешь охранять %2$C4!": {
+   "en": "You love your master so much that you can't guard %2$C4!",
+   "ua": "Ти любиш сво%1$Gго|го|ю хазя%1$Gїна|їна|йку так сильно, що не можеш охороняти %2$C4!"
+  },
+  "Ты прыгаешь перед $C5!": {
+   "en": "You jump in front of $C5!",
+   "ua": "Ти стрибаєш перед $C5!"
+  }
+ },
+ "plug-ins/clan/impl/lion.cpp": {
+  "$c1 защищает местность от ловушек Охотников и от их мести.": {
+   "en": "$c1 protects the area from the Hunters' traps and their revenge.",
+   "ua": "$c1 захищає місцевість від пасток Мисливців та їхньої помсти."
+  },
+  "Кожа $c2 становится серой!": {
+   "en": "$c2's skin turns gray!",
+   "ua": "Шкіра $c2 стає сірою!"
+  },
+  "Местность на {W%1$d{x ча%1$Iс|са|сов защищена от ловушек и мести Охотников.": {
+   "en": "The area is protected from traps and the Hunters' vengeance for {W%1$d{x hour%1$I|s|s.",
+   "ua": "Місцевість на {W%1$d{x годин%1$Iу|и| захищена від пасток і помсти Мисливців."
+  },
+  "Ты защищаешь местность от ловушек Охотников и от их мести.": {
+   "en": "You protect the area from the Hunters' traps and from their vengeance.",
+   "ua": "Ти захищаєш місцевість від пасток Мисливців і від їхньої помсти."
+  },
+  "Ты защищаешь себя от ловушек Охотников.": {
+   "en": "You guard yourself against the Hunters' traps.",
+   "ua": "Ти захищаєш себе від пасток Мисливців."
+  },
+  "Ты можешь следить только за Охотниками!": {
+   "en": "You can only track Hunters!",
+   "ua": "Ти можеш стежити тільки за Мисливцями!"
+  },
+  "Ты уже защище$gно|н|на от ловушек Охотников.": {
+   "en": "You are already protected from Hunter traps.",
+   "ua": "Ти вже захищен$gо|ий|а від пасток Мисливців."
+  },
+  "Ты уже трансформирова{Smлся{Sfлась{Sx во льва.": {
+   "en": "You have already transformed into a lion.",
+   "ua": "Ти вже трансформува{Smвся{Sfлася{Sx у лева."
+  },
+  "Это место уже защищено от мести и ловушек Охотников.": {
+   "en": "This place is already protected from the Hunters' revenge and traps.",
+   "ua": "Це місце вже захищене від помсти і пасток Мисливців."
+  },
+  "$C1 выпускает когти.\n\rИ ты быстренько убираешься из этой местности.": {
+   "en": "$C1 bares its claws.\n\rAnd you scamper away from this place real quick.",
+   "ua": "$C1 випускає кігті.\n\rІ ти хутенько забираєшся з цієї місцини."
+  },
+  "$C1, глядя на $c4, выпускает когти, и $c1 сматывает удочки.": {
+   "en": "$C1, glaring at $c4, bares its claws, and $c1 beats a hasty retreat.",
+   "ua": "$C1, дивлячись на $c4, випускає кігті, і $c1 змотує вудки."
+  },
+  "Твой львиный глаз не может найти такого.": {
+   "en": "Your lion's eye can't spot anything like that.",
+   "ua": "Твоє левине око не може знайти такого."
+  },
+  "Твой львиный глаз не смог найти такого.": {
+   "en": "Your lion's eye couldn't find such a thing.",
+   "ua": "Твоє лев'яче око не змогло знайти такого."
+  },
+  "Ты чувствуешь себя немного неповоротлив$gым|ым|ой, но зато намного более сильн$gым|ым|ой.": {
+   "en": "You feel a bit clumsier, but much stronger.",
+   "ua": "Ти відчуваєш себе трохи незграбн$gим|им|ою, але натомість значно сильніш$gим|им|ою."
+  }
+ },
+ "plug-ins/clan/impl/ruler.cpp": {
+  "$C1 аннулирует повестку $c3 в Суд.": {
+   "en": "$C1 revokes $c3's summons to Court.",
+   "ua": "$C1 анулює повістку $c3 до Суду."
+  },
+  "$C1 в тюряге менее чем на %d час%s.": {
+   "en": "$C1 has been in the clink for less than %d hour%s.",
+   "ua": "$C1 у буцегарні менше ніж на %d годин%s."
+  },
+  "$C1 лише$Gно|н|на своих привилегий Правителя менее чем на %d час%s.": {
+   "en": "$C1 is stripped of the Ruler's privileges for less than %d hour%s.",
+   "ua": "$C1 позбавлен$Gо|ий|а своїх привілеїв Правителя менш ніж на %d годин%s."
+  },
+  "$C1 может обитать в одном из следующих мест:": {
+   "en": "$C1 can reside in one of the following places:",
+   "ua": "$C1 може мешкати в одному з таких місць:"
+  },
+  "$C1 не отбывает наказания.": {
+   "en": "$C1 isn't serving a sentence.",
+   "ua": "$C1 не відбуває покарання."
+  },
+  "$C1 не разыскивается.": {
+   "en": "$C1 is not wanted.",
+   "ua": "$C1 не розшукується."
+  },
+  "$C1 обладает полными привилегиями Правителя.": {
+   "en": "$C1 has the full privileges of the Ruler.",
+   "ua": "$C1 має повні привілеї Правителя."
+  },
+  "$C1 посылает $c3 повестку в Суд.": {
+   "en": "$C1 sends $c3 a summons to Court.",
+   "ua": "$C1 надсилає $c3 повістку до Суду."
+  },
+  "$C1 свободен от оков.": {
+   "en": "$C1 is free of their chains.",
+   "ua": "$C1 вільний від кайданів."
+  },
+  "$C1 уже разыскивается.": {
+   "en": "$C1 is already wanted.",
+   "ua": "$C1 вже розшукується."
+  },
+  "$c1 аккуратно кладет $o4 на пол.": {
+   "en": "$c1 carefully puts $o4 on the floor.",
+   "ua": "$c1 акуратно кладе $o4 на підлогу."
+  },
+  "$c1 аннулирует повестку $C3 в Суд.": {
+   "en": "$c1 annuls $C3's summons to Court.",
+   "ua": "$c1 анулює повістку $C3 до Суду."
+  },
+  "$c1 аннулирует твою повестку в Суд.": {
+   "en": "$c1 cancels your summons to Court.",
+   "ua": "$c1 анулює твою повістку до Суду."
+  },
+  "$c1 больше не разыскивается.": {
+   "en": "$c1 is no longer wanted.",
+   "ua": "$c1 більше не розшукується."
+  },
+  "$c1 бросает быстрый взгляд на руки $C4.": {
+   "en": "$c1 glances quickly at $C4's hands.",
+   "ua": "$c1 кидає швидкий погляд на руки $C4."
+  },
+  "$c1 возвращает $C3 право вершить суд.": {
+   "en": "$c1 returns to $C3 the right to pass judgment.",
+   "ua": "$c1 повертає $C3 право вершити суд."
+  },
+  "$c1 забирает у $C4 несколько золотых монет в качестве штрафа.": {
+   "en": "$c1 takes a few gold coins from $C4 as a fine.",
+   "ua": "$c1 забирає у $C4 кілька золотих монет як штраф."
+  },
+  "$c1 забирает у тебя несколько золотых монет в качестве штрафа.": {
+   "en": "$c1 takes a few gold coins from you as a fine.",
+   "ua": "$c1 забирає в тебе кілька золотих монет як штраф."
+  },
+  "$c1 забирает у тебя со счета несколько золотых монет в качестве штрафа.": {
+   "en": "$c1 takes several gold coins from your account as a fine.",
+   "ua": "$c1 знімає з твого рахунку кілька золотих монет як штраф."
+  },
+  "$c1 искупи$gло|л|ла свою провинность и освобождается из-под стражи.": {
+   "en": "$c1 has atoned for their offense and is released from custody.",
+   "ua": "$c1 спокут$gувало|ував|увала свою провину і звільняється з-під варти."
+  },
+  "$c1 конфискует $o4 у $C4.": {
+   "en": "$c1 confiscates $o4 from $C4.",
+   "ua": "$c1 конфіскує $o4 у $C4."
+  },
+  "$c1 конфискует у тебя $o4.": {
+   "en": "$c1 confiscates $o4 from you.",
+   "ua": "$c1 конфіскує в тебе $o4."
+  },
+  "$c1 лишает $C4 права вершить суд.": {
+   "en": "$c1 strips $C4 of the right to pass judgment.",
+   "ua": "$c1 позбавляє $C4 права чинити суд."
+  },
+  "$c1 переводит на свой счет несколько золотых монет.": {
+   "en": "$c1 transfers a few gold coins to their account.",
+   "ua": "$c1 переказує на свій рахунок декілька золотих монет."
+  },
+  "$c1 переводит на счет $C4 несколько золотых монет.": {
+   "en": "$c1 transfers a few gold coins to $C4's account.",
+   "ua": "$c1 переказує на рахунок $C4 кілька золотих монет."
+  },
+  "$c1 переводит на твой счет несколько золотых монет.": {
+   "en": "$c1 transfers a few gold coins to your account.",
+   "ua": "$c1 переказує на твій рахунок кілька золотих монет."
+  },
+  "$c1 посылает тебе повестку в Суд.": {
+   "en": "$c1 sends you a summons to Court.",
+   "ua": "$c1 надсилає тобі повістку до Суду."
+  },
+  "$c1 приговаривает $C4 к тюремному заключению.": {
+   "en": "$c1 sentences $C4 to imprisonment.",
+   "ua": "$c1 засуджує $C4 до тюремного ув'язнення."
+  },
+  "$c1 приговаривает тебя к тюремному заключению.": {
+   "en": "$c1 sentences you to imprisonment.",
+   "ua": "$c1 засуджує тебе до тюремного ув'язнення."
+  },
+  "$c1 пристально смотрит на $C4.": {
+   "en": "$c1 stares intently at $C4.",
+   "ua": "$c1 пильно дивиться на $C4."
+  },
+  "$c1 пытается заковать $C4 в кандалы, но терпит неудачу.": {
+   "en": "$c1 tries to put $C4 in shackles, but fails.",
+   "ua": "$c1 намагається закувати $C4 в кайдани, але зазнає невдачі."
+  },
+  "$c1 снимает кандалы с рук $C4.": {
+   "en": "$c1 removes the shackles from $C4's hands.",
+   "ua": "$c1 знімає кайдани з рук $C4."
+  },
+  "$c1 снимает кандалы с твоих рук.": {
+   "en": "$c1 removes the shackles from your hands.",
+   "ua": "$c1 знімає кайдани з твоїх рук."
+  },
+  "$c1 снимает у $C4 со счета несколько золотых монет в качестве штрафа.": {
+   "en": "$c1 withdraws a few gold coins from $C4's account as a fine.",
+   "ua": "$c1 знімає з рахунку $C4 кілька золотих монет як штраф."
+  },
+  "%s выйдет на свободу через %d час%s": {
+   "en": "%s will be released in %d hour%s",
+   "ua": "%s вийде на свободу через %d годин%s"
+  },
+  "%s обитает в местности под названием %s (%s).": {
+   "en": "%s lives in the area called %s (%s).",
+   "ua": "%s мешкає в місцевості під назвою %s (%s)."
+  },
+  "Здесь нет таких.": {
+   "en": "There's no one like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Используй: wanted <player> <Y|N>": {
+   "en": "Usage: wanted <player> <Y|N>",
+   "ua": "Використовуй: wanted <player> <Y|N>"
+  },
+  "Кандалы -- только для игроков.": {
+   "en": "Shackles are for players only.",
+   "ua": "Кайдани -- лише для гравців."
+  },
+  "Кого будем осуждать?": {
+   "en": "Whom shall we sentence?",
+   "ua": "Кого будемо засуджувати?"
+  },
+  "Кому выдаем повестку в Суд?": {
+   "en": "Who gets the summons to Court?",
+   "ua": "Кому видаємо повістку до Суду?"
+  },
+  "Лишить привилегий можно только других Правителей.": {
+   "en": "You can only strip privileges from other Rulers.",
+   "ua": "Позбавити привілеїв можна тільки інших Правителів."
+  },
+  "Недопустимое значение процента.": {
+   "en": "Invalid percentage value.",
+   "ua": "Неприпустиме значення відсотка."
+  },
+  "Нельзя играть с такой вещью!": {
+   "en": "You can't play around with a thing like that!",
+   "ua": "Не можна гратися з такою річчю!"
+  },
+  "Неправильное число": {
+   "en": "Invalid number",
+   "ua": "Неправильне число"
+  },
+  "Неправильное число.": {
+   "en": "Invalid number.",
+   "ua": "Неправильне число."
+  },
+  "Неправильный процент.": {
+   "en": "Invalid percentage.",
+   "ua": "Невірний відсоток."
+  },
+  "Нет этого тут.": {
+   "en": "There's nothing like that here.",
+   "ua": "Тут такого немає."
+  },
+  "Но ведь $C3 не выдавалась повестка в Суд!": {
+   "en": "But $C3 was never summoned to Court!",
+   "ua": "Але ж $C3 не видавали повістку до Суду!"
+  },
+  "Но у тебя уже что-то надето на шею.": {
+   "en": "But you already have something worn on your neck.",
+   "ua": "Але в тебе вже щось надіто на шию."
+  },
+  "Охотник за головами послан по заданию.": {
+   "en": "The bounty hunter has been sent on assignment.",
+   "ua": "Мисливець за головами відправлений на завдання."
+  },
+  "Повестка $C2 действительна менее %d час%s.": {
+   "en": "$C2's summons is valid for less than %d hour%s.",
+   "ua": "Повістка $C2 дійсна менше ніж %d годин%s."
+  },
+  "Повестка в суд для %s истекла!": {
+   "en": "The court summons for %s has expired!",
+   "ua": "Повістка до суду для %s минула!"
+  },
+  "Повестки -- только для игроков.": {
+   "en": "Summons are for players only.",
+   "ua": "Повістки -- лише для гравців."
+  },
+  "Руки $C4 закованы в кандалы!": {
+   "en": "$C4's hands are shackled in chains!",
+   "ua": "Руки $C4 закуті в кайдани!"
+  },
+  "С %s спадут кандалы через %d час%s": {
+   "en": "%s's shackles fall off in %d hour%s",
+   "ua": "З %s спадуть кайдани через %d годин%s"
+  },
+  "Синтаксис: confiscate <наказуемый> <% от кол-ва вещей>": {
+   "en": "Syntax: confiscate <target> <% of items>",
+   "ua": "Синтаксис: confiscate <покараний> <% від кількості речей>"
+  },
+  "Сначала необходимо отменить предыдущую повестку.": {
+   "en": "You must cancel the previous summons first.",
+   "ua": "Спершу потрібно скасувати попередню повістку."
+  },
+  "Среди зеркал нет оригинала.": {
+   "en": "There is no original among the mirrors.",
+   "ua": "Серед дзеркал немає оригіналу."
+  },
+  "Твоих полномочий (кланового ранга) тут явно недостаточно.": {
+   "en": "Your authority (clan rank) clearly isn't enough here.",
+   "ua": "Твоїх повноважень (кланового рангу) тут явно недостатньо."
+  },
+  "Твой $o1 исчезает.": {
+   "en": "Your $o1 disappears.",
+   "ua": "Твій $o1 зникає."
+  },
+  "Твоя попытка закончилась неудачей.": {
+   "en": "Your attempt has failed.",
+   "ua": "Твоя спроба закінчилася невдачею."
+  },
+  "Тебе лучше использовать охранников для этой цели.": {
+   "en": "You'd better use the guards for that purpose.",
+   "ua": "Тобі краще використати охоронців для цієї мети."
+  },
+  "Тебе не удалось заглянуть под личину $C2.": {
+   "en": "You failed to see through $C2's disguise.",
+   "ua": "Тобі не вдалося зазирнути під личину $C2."
+  },
+  "Тебе незачем судить это подневольное создание.": {
+   "en": "There's no need for you to judge this bound creature.",
+   "ua": "Тобі нема чого судити цю підневільну істоту."
+  },
+  "Тебя больше не разыскивают.": {
+   "en": "You are no longer wanted.",
+   "ua": "Тебе більше не розшукують."
+  },
+  "Только для игроков.": {
+   "en": "Players only.",
+   "ua": "Лише для гравців."
+  },
+  "Ты аккуратно кладешь $o4 на пол.": {
+   "en": "You carefully place $o4 on the floor.",
+   "ua": "Ти акуратно кладеш $o4 на підлогу."
+  },
+  "Ты аннулируешь повестку $C4.": {
+   "en": "You cancel the summons for $C4.",
+   "ua": "Ти анулюєш повістку $C4."
+  },
+  "Ты возвращаешь $C3 право вершить суд.": {
+   "en": "You restore to $C3 the right to hold court.",
+   "ua": "Ти повертаєш $C3 право вершити суд."
+  },
+  "Ты забираешь у $C4 несколько золотых монет в качестве штрафа.": {
+   "en": "You take a few gold coins from $C4 as a fine.",
+   "ua": "Ти забираєш у $C4 кілька золотих монет як штраф."
+  },
+  "Ты конфискуешь $o4 у $C4.": {
+   "en": "You confiscate $o4 from $C4.",
+   "ua": "Ти конфіскуєш $o4 у $C4."
+  },
+  "Ты надеваешь символ Хранителя Закона!": {
+   "en": "You put on the Keeper of the Law's symbol!",
+   "ua": "Ти вдягаєш символ Хранителя Закону!"
+  },
+  "Ты не в силах применить обычные законы к Бессмертным.": {
+   "en": "You have no power to apply ordinary laws to the Immortals.",
+   "ua": "Ти не в змозі застосувати звичайні закони до Безсмертних."
+  },
+  "Ты не замечаешь во внешности $C2 ничего необычного.": {
+   "en": "You notice nothing unusual about $C2's appearance.",
+   "ua": "Ти не помічаєш у зовнішності $C2 нічого незвичайного."
+  },
+  "Ты не можешь забрать столько золотых монет у $C4.": {
+   "en": "You can't take that many gold coins from $C4.",
+   "ua": "Ти не можеш забрати стільки золотих монет у $C4."
+  },
+  "Ты не можешь заковывать в кандалы Бессмертных.": {
+   "en": "You cannot put Immortals in shackles.",
+   "ua": "Ти не можеш заковувати в кайдани Безсмертних."
+  },
+  "Ты не можешь лишать Бессмертных их прав.": {
+   "en": "You can't strip Immortals of their rights.",
+   "ua": "Ти не можеш позбавляти Безсмертних їхніх прав."
+  },
+  "Ты не можешь этого сделать.": {
+   "en": "You can't do that.",
+   "ua": "Ти не можеш цього зробити."
+  },
+  "Ты не находишь того, кому собирался отдать собранный штраф.": {
+   "en": "You can't find the one you meant to hand the collected fine to.",
+   "ua": "Ти не знаходиш того, кому збирався віддати зібраний штраф."
+  },
+  "Ты освобождаешь руки $C4 от оков.": {
+   "en": "You free $C4's hands from the shackles.",
+   "ua": "Ти звільняєш руки $C4 від кайданів."
+  },
+  "Ты переводишь на свой счет несколько золотых монет.": {
+   "en": "You transfer a few gold coins to your account.",
+   "ua": "Ти переводиш на свій рахунок кілька золотих монет."
+  },
+  "Ты переводишь на счет $C4 несколько золотых монет.": {
+   "en": "You transfer several gold coins to $C4's account.",
+   "ua": "Ти переказуєш на рахунок $C4 кілька золотих монет."
+  },
+  "Ты посылаешь повестку $C4.": {
+   "en": "You send a summons to $C4.",
+   "ua": "Ти надсилаєш повістку $C4."
+  },
+  "Ты приговариваешь $C4 к тюремному заключению!": {
+   "en": "You sentence $C4 to imprisonment!",
+   "ua": "Ти засуджуєш $C4 до тюремного ув'язнення!"
+  },
+  "Ты пытаешься заковать $C4 в кандалы, но что-то идет не так...": {
+   "en": "You try to put $C4 in shackles, but something goes wrong...",
+   "ua": "Ти намагаєшся закувати $C4 в кайдани, але щось йде не так..."
+  },
+  "Ты пытаешься освободить руки $C4 от оков, но они уже свободны.": {
+   "en": "You try to free $C4's hands from the shackles, but they're already free.",
+   "ua": "Ти намагаєшся звільнити руки $C4 від кайданів, але вони вже вільні."
+  },
+  "Ты снимаешь у $C4 со счета несколько золотых монет в качестве штрафа.": {
+   "en": "You withdraw a few gold coins from $C4's account as a fine.",
+   "ua": "Ти знімаєш з рахунку $C4 кілька золотих монет як штраф."
+  },
+  "Ты точно этого хочешь?": {
+   "en": "Are you sure you want this?",
+   "ua": "Ти точно цього хочеш?"
+  },
+  "Ты успешно заковываешь $C4 в кандалы!": {
+   "en": "You successfully shackle $C4!",
+   "ua": "Ти успішно заковуєш $C4 у кайдани!"
+  },
+  "У $c2 исчезает $o1.": {
+   "en": "$o1 disappears from $c2.",
+   "ua": "У $c2 зникає $o1."
+  },
+  "У тебя не получается найти преступника с таким именем.": {
+   "en": "You can't find a criminal by that name.",
+   "ua": "Тобі не вдається знайти злочинця з таким ім'ям."
+  },
+  "У тебя не хватает сил объявить $C4 в розыск.": {
+   "en": "You don't have enough strength to put $C4 on the wanted list.",
+   "ua": "Тобі бракує сил оголосити $C4 у розшук."
+  },
+  "У тебя отобрали привилегии Правителя!": {
+   "en": "Your Ruler privileges have been revoked!",
+   "ua": "У тебе відібрали привілеї Правителя!"
+  },
+  "Установлено в %d.": {
+   "en": "Set to %d.",
+   "ua": "Встановлено на %d."
+  },
+  "Это заклинание использовалось совсем недавно.": {
+   "en": "This spell was used quite recently.",
+   "ua": "Це закляття використовувалося зовсім нещодавно."
+  },
+  "$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон.": {
+   "en": "$C1 glances at you fleetingly.\n\rAnd at once you feel some magical force hurl you out.",
+   "ua": "$C1 кидає на тебе побіжний погляд.\n\rІ вмить ти відчуваєш, як якась магічна сила викидає тебе геть."
+  },
+  "$C1 взмахивает перед тобой кандалами... слегка задевает...\n\r... и ты летишь...": {
+   "en": "$C1 swings shackles in front of you... grazes you slightly...\n\r...and you go flying...",
+   "ua": "$C1 змахує перед тобою кайданами... злегка зачіпає...\n\r...і ти летиш..."
+  },
+  "$C1 задевает кандалами $c4 и $c1 с воплем улетает...": {
+   "en": "$C1 catches $c4 with the shackles and $c1 flies off with a scream...",
+   "ua": "$C1 зачіпає кайданами $c4 і $c1 з криком відлітає..."
+  },
+  "$c1 бросает быстрый взгляд на твои руки.": {
+   "en": "$c1 flicks a quick glance at your hands.",
+   "ua": "$c1 кидає швидкий погляд на твої руки."
+  },
+  "$c1 взмахивает руками и создает $o4!": {
+   "en": "$c1 waves their hands and creates $o4!",
+   "ua": "$c1 змахує руками і створює $o4!"
+  },
+  "$c1 возвращает тебе право вершить суд.": {
+   "en": "$c1 returns to you the right to pass judgment.",
+   "ua": "$c1 повертає тобі право чинити суд."
+  },
+  "$c1 возится вокруг рук $C4... Наверное, хочет чего-то..": {
+   "en": "$c1 fusses around $C4's hands... Must want something...",
+   "ua": "$c1 длубається біля рук $C4... Мабуть, чогось хоче..."
+  },
+  "$c1 делает вид, что снимает кандалы с твоих рук. К чему бы это...": {
+   "en": "$c1 pretends to remove the shackles from your hands. Now what could that mean...",
+   "ua": "$c1 вдає, що знімає кайдани з твоїх рук. І що б це могло означати..."
+  },
+  "$c1 заковывает $C4 в кандалы!": {
+   "en": "$c1 shackles $C4 in chains!",
+   "ua": "$c1 заковує $C4 в кайдани!"
+  },
+  "$c1 заковывает тебя в кандалы!": {
+   "en": "$c1 shackles you in chains!",
+   "ua": "$c1 заковує тебе в кайдани!"
+  },
+  "$c1 кричит ' ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!": {
+   "en": "$c1 shouts ' PROTECT THE INNOCENT!! DEATH TO CRIMINALS!!",
+   "ua": "$c1 кричить ' ЗАХИЩАЙ НЕВИННИХ!! СМЕРТЬ ЗЛОЧИНЦЯМ!!"
+  },
+  "$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'": {
+   "en": "$c1 shouts '%s! YOU WILL STILL ANSWER FOR YOUR CRIMES!'",
+   "ua": "$c1 кричить '%s! ТИ ЩЕ ВІДПОВІСИШ ЗА СВОЇ ЗЛОЧИНИ!'"
+  },
+  "$c1 лишает тебя права вершить суд.": {
+   "en": "$c1 strips you of the right to pass judgment.",
+   "ua": "$c1 позбавляє тебе права вершити суд."
+  },
+  "$c1 надевает символ Хранителя Закона!": {
+   "en": "$c1 dons the emblem of the Keeper of the Law!",
+   "ua": "$c1 одягає символ Хранителя Закону!"
+  },
+  "$c1 напыщенно что то говорит $C4... $C1 хихикает...": {
+   "en": "$c1 says something pompous to $C4... $C1 giggles...",
+   "ua": "$c1 пихато щось каже $C4... $C1 хихоче..."
+  },
+  "$c1 освобождает $C4 из каталажки.": {
+   "en": "$c1 releases $C4 from the clink.",
+   "ua": "$c1 звільняє $C4 з буцегарні."
+  },
+  "$c1 освобождает тебя из каталажки.": {
+   "en": "$c1 lets you out of the clink.",
+   "ua": "$c1 випускає тебе з буцегарні."
+  },
+  "$c1 посылает $C3 повестку в Суд.": {
+   "en": "$c1 sends $C3 a summons to Court.",
+   "ua": "$c1 надсилає $C3 повістку до Суду."
+  },
+  "$c1 пристально смотрит на ТЕБЯ.": {
+   "en": "$c1 stares intently at YOU.",
+   "ua": "$c1 пильно дивиться на ТЕБЕ."
+  },
+  "$c1 пытается призвать себе на помощь охотника за головами.": {
+   "en": "$c1 tries to summon a bounty hunter to help.",
+   "ua": "$c1 намагається покликати собі на допомогу мисливця за головами."
+  },
+  "$c1 пытается сковать твои руки! ОН НЕ ПРАВ!": {
+   "en": "$c1 tries to shackle your hands! HE'S WRONG!",
+   "ua": "$c1 намагається скувати твої руки! ВІН НЕ ПРАВИЙ!"
+  },
+  "$c1 пытается тебя освободить из тюрьмы. К чему бы это...": {
+   "en": "$c1 tries to free you from prison. Now what's that about...",
+   "ua": "$c1 намагається звільнити тебе з тюрми. І це ще навіщо..."
+  },
+  "$c1 роется в личном деле $C4.": {
+   "en": "$c1 rummages through $C4's personal file.",
+   "ua": "$c1 порпається в особовій справі $C4."
+  },
+  "$c1 роется в твоем личном деле.": {
+   "en": "$c1 rummages through your personal file.",
+   "ua": "$c1 длубається в твоїй особовій справі."
+  },
+  "$c1 теперь в РОЗЫСКЕ!!!": {
+   "en": "$c1 is now WANTED!!!",
+   "ua": "$c1 тепер у РОЗШУКУ!!!"
+  },
+  "%s %s! ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!": {
+   "en": "%s %s! PROTECT THE INNOCENT!! DEATH TO CRIMINALS!!",
+   "ua": "%s %s! ЗАХИЩАЙ НЕВИННИХ!! СМЕРТЬ ЗЛОЧИНЦЯМ!!"
+  },
+  "%s БАНДИТ! ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!": {
+   "en": "%s IS A BANDIT! DEFEND THE INNOCENT!! DEATH TO CRIMINALS!!",
+   "ua": "%s БАНДИТ! ЗАХИЩАЙ НЕВИННИХ!! СМЕРТЬ ЗЛОЧИНЦЯМ!!"
+  },
+  "{xНет, с {MХаосом {xтебе придется бороться другими средствами!": {
+   "en": "{xNo, you'll have to fight {MChaos{x by other means!",
+   "ua": "{xНі, з {MХаосом {xтобі доведеться боротися іншими засобами!"
+  },
+  "А тебе не кажется, можно сделать это и добровольно?": {
+   "en": "Don't you think you could do this voluntarily?",
+   "ua": "А тобі не здається, що це можна зробити і добровільно?"
+  },
+  "Ась?": {
+   "en": "Eh?",
+   "ua": "Га?"
+  },
+  "ЗАПОМНИ: Нельзя выдавать повестки задним числом.": {
+   "en": "REMEMBER: You can't backdate summonses.",
+   "ua": "ЗАПАМ'ЯТАЙ: Не можна видавати повістки заднім числом."
+  },
+  "И кого мы хотим заковать в кандалы?": {
+   "en": "And who do we want to put in chains?",
+   "ua": "І кого ми хочемо закувати в кайдани?"
+  },
+  "И кого мы хотим лишить прав?": {
+   "en": "And who do we want to strip of their rights?",
+   "ua": "І кого ж ми хочемо позбавити прав?"
+  },
+  "И кого мы хотим посадить в кутузку?": {
+   "en": "So who do we want to toss in the clink?",
+   "ua": "І кого ж ми хочемо запроторити до буцегарні?"
+  },
+  "И ты думаешь, что $C1 так просто отдаст тебе свои вещи? Сначала закуй в кандалы.": {
+   "en": "And you think $C1 will just hand over their things to you? Put them in shackles first.",
+   "ua": "І ти думаєш, що $C1 так просто віддасть тобі свої речі? Спершу закуй у кайдани."
+  },
+  "Идея неплоха, но не стоит этого делать.": {
+   "en": "Not a bad idea, but you shouldn't do that.",
+   "ua": "Ідея непогана, але не варто цього робити."
+  },
+  "Луч света, посланный $c5, отражается от зеркала и поражает $C4!": {
+   "en": "A beam of light sent by $c5 bounces off the mirror and strikes $C4!",
+   "ua": "Промінь світла, посланий $c5, відбивається від дзеркала і вражає $C4!"
+  },
+  "Луч света, посланный $c5, отражается от зеркала и поражает ТЕБЯ!": {
+   "en": "A beam of light sent by $c5 bounces off the mirror and strikes YOU!",
+   "ua": "Промінь світла, посланий $c5, відбивається від дзеркала і вражає ТЕБЕ!"
+  },
+  "Луч света, посланный тобой, отражается от зеркала и поражает $C4!": {
+   "en": "The beam of light you sent bounces off the mirror and strikes $C4!",
+   "ua": "Промінь світла, надісланий тобою, відбивається від дзеркала і вражає $C4!"
+  },
+  "Мда... Освобождать-то тебя - некуда.": {
+   "en": "Well... there's nowhere to release you TO.",
+   "ua": "Ну... звільняти тебе -- нікуди."
+  },
+  "Охотник за головами послан за тобой!": {
+   "en": "A bounty hunter has been sent after you!",
+   "ua": "Мисливець за головами надісланий за тобою!"
+  },
+  "Охотник за головами прибывает, чтобы искать $c4!": {
+   "en": "A bounty hunter arrives to search for $c4!",
+   "ua": "Мисливець за головами прибуває, щоб шукати $c4!"
+  },
+  "Похоже, что твои золотые запасы в банке уменьшились.": {
+   "en": "Looks like your gold reserves at the bank have decreased.",
+   "ua": "Схоже, твої золоті запаси в банку зменшилися."
+  },
+  "Расслабься. Все на своих местах и пашут как кони!": {
+   "en": "Relax. Everyone's at their post, working like horses!",
+   "ua": "Розслабся. Усі на своїх місцях і орють як коні!"
+  },
+  "С %s спали кандалы!": {
+   "en": "The shackles fell off %s!",
+   "ua": "З %s спали кайдани!"
+  },
+  "С этого момента %s снова на свободе!": {
+   "en": "From this moment on, %s is free again!",
+   "ua": "Відтепер %s знову на волі!"
+  },
+  "Сковывать кандалами мертвых -- какая низость.": {
+   "en": "Shackling the dead in chains -- how low can you get.",
+   "ua": "Заковувати мертвих у кайдани -- яка ницість."
+  },
+  "Смешно требовать чего-то от Бессмертных.": {
+   "en": "It's laughable to demand anything from the Immortals.",
+   "ua": "Смішно вимагати щось від Безсмертних."
+  },
+  "Странные какие-то у тебя штрафы.": {
+   "en": "Your fines are kind of odd.",
+   "ua": "Якісь дивні в тебе штрафи."
+  },
+  "ТЫ СНОВА НА СВОБОДЕ!": {
+   "en": "YOU'RE FREE AGAIN!",
+   "ua": "ТИ ЗНОВУ НА ВОЛІ!"
+  },
+  "Твоя повестка в Суд горит синим пламенем!": {
+   "en": "Your Court summons is burning with blue flame!",
+   "ua": "Твоя повістка до Суду горить синім полум'ям!"
+  },
+  "Тебе не кажется, что ты занимаешься мышиной возней?": {
+   "en": "Don't you think you're just fussing over nothing?",
+   "ua": "Тобі не здається, що ти займаєшся мишачою метушнею?"
+  },
+  "Ты взмахиваешь руками и создаешь $o4!": {
+   "en": "You wave your hands and create $o4!",
+   "ua": "Ти змахуєш руками і створюєш $o4!"
+  },
+  "Ты замечаешь, что под обликом %1$^C2 скрывается %1$#^C1!": {
+   "en": "You notice that hiding under %1$^C2's guise is %1$#^C1!",
+   "ua": "Ти помічаєш, що під виглядом %1$^C2 ховається %1$#^C1!"
+  },
+  "Ты лишаешь $C4 права вершить суд!": {
+   "en": "You strip $C4 of the right to pass judgment!",
+   "ua": "Ти позбавляєш $C4 права вершити суд!"
+  },
+  "Ты не можешь упечь за решетку Бессмертных.": {
+   "en": "You can't lock up the Immortals.",
+   "ua": "Ти не можеш запроторити за грати Безсмертних."
+  },
+  "Ты освобождаешь $C4 из каталажки.": {
+   "en": "You free $C4 from the clink.",
+   "ua": "Ти звільняєш $C4 з каталажки."
+  },
+  "Ты пытаешься освободить $C4 из тюрьмы, но ведь о$gно|н|на НЕ СИДИТ.": {
+   "en": "You try to free $C4 from prison, but they're NOT EVEN IN IT.",
+   "ua": "Ти намагаєшся звільнити $C4 з тюрми, але ж $gвоно|він|вона НЕ СИДИТЬ."
+  },
+  "Ты пытаешься призвать себе в помощь охотника за головами.": {
+   "en": "You try to summon a bounty hunter to help you.",
+   "ua": "Ти намагаєшся закликати собі на допомогу мисливця за головами."
+  },
+  "Ты теперь в РОЗЫСКЕ!!!": {
+   "en": "You are now WANTED!!!",
+   "ua": "Ти тепер У РОЗШУКУ!!!"
+  },
+  "Ты чувствуешь - тебя ждут в Суде.": {
+   "en": "You feel that you are awaited in Court.",
+   "ua": "Ти відчуваєш -- тебе чекають у Суді."
+  }
+ },
+ "plug-ins/clan/impl/shalafi.cpp": {
+  "$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает.": {
+   "en": "$C1 casts a fleeting glance at $c4, and $c1 instantly vanishes.",
+   "ua": "$C1 кидає на $c4 швидкоплинний погляд, і $c1 миттєво зникає."
+  },
+  "Ты поступаешь на {b%N4{x.": {
+   "en": "You enroll as {b%N4{x.",
+   "ua": "Ти вступаєш на {b%N4{x."
+  },
+  "Ты уже переполне$gно|н|на жизненной энергией.": {
+   "en": "You're already overflowing with life energy.",
+   "ua": "Ти вже переповн$gене|ений|ена життєвою енергією."
+  },
+  "$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон.": {
+   "en": "$C1 casts a fleeting glance at you.\n\rAnd at once you feel some magical force hurl you out.",
+   "ua": "$C1 кидає на тебе побіжний погляд.\n\rІ одразу ж ти відчуваєш, як якась магічна сила викидає тебе геть."
+  },
+  "Ментальный удар $c2 повреждает разум $C2!": {
+   "en": "$c2's mental strike damages $C2's mind!",
+   "ua": "Ментальний удар $c2 ушкоджує розум $C2!"
+  },
+  "Ментальный удар $c2 повреждает твой разум!": {
+   "en": "$c2's mental strike damages your mind!",
+   "ua": "Ментальний удар $c2 ушкоджує твій розум!"
+  },
+  "Ментальный удар повреждает твой разум!": {
+   "en": "A mental blow damages your mind!",
+   "ua": "Ментальний удар ушкоджує твій розум!"
+  },
+  "Прилив жизненной силы затмевает твой разум.": {
+   "en": "A surge of vital force clouds your mind.",
+   "ua": "Приплив життєвої сили затьмарює твій розум."
+  },
+  "Твой ментальный удар повреждает разум $C2!": {
+   "en": "Your mental strike damages $C2's mind!",
+   "ua": "Твій ментальний удар пошкоджує розум $C2!"
+  }
+ },
+ "plug-ins/clan/skill/clanskill.cpp": {
+  "%^C1 не служит твоему клану.": {
+   "en": "%^C1 doesn't serve your clan.",
+   "ua": "%^C1 не служить твоєму клану."
+  },
+  "Клан не может сейчас придать тебе сил.": {
+   "en": "The clan can't lend you strength right now.",
+   "ua": "Клан наразі не може додати тобі сил."
+  },
+  "Клановые умения практикуют у служителей клана, например, у лекаря или охранника.": {
+   "en": "Clan skills are practiced with clan servants, such as the healer or the guard.",
+   "ua": "Кланові вміння практикують у служителів клану, наприклад, у лікаря чи охоронця."
+  }
+ },
+ "plug-ins/comm/account.cpp": {
+  "Неверный пароль. Подожди 10 секунд.": {
+   "en": "Wrong password. Wait 10 seconds.",
+   "ua": "Невірний пароль. Зачекай 10 секунд."
+  },
+  "Новый пароль должен содержать более пяти символов.": {
+   "en": "The new password must contain more than five characters.",
+   "ua": "Новий пароль повинен містити більше п'яти символів."
+  },
+  "Попытка суицида отменена -- неверный пароль.": {
+   "en": "Suicide attempt cancelled -- wrong password.",
+   "ua": "Спробу самогубства скасовано -- неправильний пароль."
+  },
+  "Синтаксис: пароль <старый> <новый>.": {
+   "en": "Syntax: password <old> <new>.",
+   "ua": "Синтаксис: пароль <старий> <новий>."
+  },
+  "Твой персонаж могут удалить только Боги.": {
+   "en": "Only the Gods can delete your character.",
+   "ua": "Твого персонажа можуть видалити лише Боги."
+  },
+  "{1{C%1$^C1 идет по пути Арханта и совершает суицид, навсегда покидая этот мир.": {
+   "en": "{1{C%1$^C1 walks the path of the Archant and commits suicide, leaving this world forever.",
+   "ua": "{1{C%1$^C1 йде шляхом Арханта і кінчає життя самогубством, назавжди покидаючи цей світ."
+  },
+  "{RВНИМАНИЕ: {WЭТО НЕОБРАТИМОЕ ДЕЙСТВИЕ, ТВОЙ ПЕРСОНАЖ БУДЕТ УДАЛЕН НАСОВСЕМ!{x": {
+   "en": "{RWARNING: {WTHIS ACTION CANNOT BE UNDONE, YOUR CHARACTER WILL BE DELETED FOREVER!{x",
+   "ua": "{RУВАГА: {WЦЕ НЕЗВОРОТНА ДІЯ, ТВІЙ ПЕРСОНАЖ БУДЕ ВИДАЛЕНИЙ НАЗАВЖДИ!{x"
+  }
+ },
+ "plug-ins/comm/affects.cpp": {
+  "$C1 находится под действием следующих аффектов:": {
+   "en": "$C1 is under the effect of the following affects:",
+   "ua": "$C1 перебуває під дією таких афектів:"
+  },
+  "$C1 не находится под действием каких-либо аффектов.": {
+   "en": "$C1 isn't under the effect of any affects.",
+   "ua": "$C1 не перебуває під дією жодних афектів."
+  },
+  "Твоя мана восстанавливается на {%s%d%%{x %s.": {
+   "en": "Your mana is regenerating at {%s%d%%{x %s.",
+   "ua": "Твоя мана відновлюється на {%s%d%%{x %s."
+  },
+  "Твоя мана не восстанавливается!": {
+   "en": "Your mana isn't regenerating!",
+   "ua": "Твоя мана не відновлюється!"
+  },
+  "Твоё здоровье и шаги восстанавливаются на {%s%d%%{x %s.": {
+   "en": "Your health and moves are regenerating at {%s%d%%{x %s.",
+   "ua": "Твоє здоров'я та кроки відновлюються на {%s%d%%{x %s."
+  },
+  "Твоё здоровье и шаги не восстанавливаются!": {
+   "en": "Your health and moves aren't regenerating!",
+   "ua": "Твоє здоров'я і кроки не відновлюються!"
+  },
+  "Ты находишься под действием следующих аффектов:": {
+   "en": "You are under the effect of the following affects:",
+   "ua": "Ти перебуваєш під дією таких ефектів:"
+  },
+  "Ты не находишься под действием каких-либо аффектов.": {
+   "en": "You are not under the effect of any affects.",
+   "ua": "Ти не перебуваєш під дією жодних ефектів."
+  },
+  "У тебя {rштраф{x на все молитвы, пока ты не выберешь себе {hh1религию{x.": {
+   "en": "You have a {rpenalty{x on all prayers until you choose yourself a {hh1religion{x.",
+   "ua": "У тебе {rштраф{x на всі молитви, поки ти не обереш собі {hh1релігію{x."
+  },
+  "улучшает {m%1$s{y на {m%2$d%%{y": {
+   "en": "improves {m%1$s{y by {m%2$d%%{y",
+   "ua": "покращує {m%1$s{y на {m%2$d%%{y"
+  }
+ },
+ "plug-ins/comm/alias.cpp": {
+  "%s меняет свое значение на '%s{x'.": {
+   "en": "%s changes its value to '%s{x'.",
+   "ua": "%s змінює своє значення на '%s{x'."
+  },
+  "%s означает '%s{x'.": {
+   "en": "%s means '%s{x'.",
+   "ua": "%s означає '%s{x'."
+  },
+  "%s теперь будет означать '%s{x'.": {
+   "en": "%s will now mean '%s{x'.",
+   "ua": "%s тепер означатиме '%s{x'."
+  },
+  "Все синонимы удалены.": {
+   "en": "All aliases deleted.",
+   "ua": "Усі синоніми видалено."
+  },
+  "Какой синоним удалить?": {
+   "en": "Which alias do you want to delete?",
+   "ua": "Який синонім видалити?"
+  },
+  "Лимит синонимов (%d) уже превышен.": {
+   "en": "The alias limit (%d) has already been exceeded.",
+   "ua": "Ліміт синонімів (%d) вже перевищено."
+  },
+  "Не определен ни один синоним.": {
+   "en": "No alias is defined.",
+   "ua": "Жодного синоніма не визначено."
+  },
+  "Подстановка синонимов слишком удлинила строку, строка будет обрезана.": {
+   "en": "Alias substitution made the line too long, it will be truncated.",
+   "ua": "Підстановка синонімів занадто подовжила рядок, рядок буде обрізано."
+  },
+  "Синоним с таким именем не задан.": {
+   "en": "No alias with that name has been set.",
+   "ua": "Синонім з такою назвою не задано."
+  },
+  "Синоним удален.": {
+   "en": "Alias deleted.",
+   "ua": "Синонім видалено."
+  },
+  "Этот синоним не задан.": {
+   "en": "This alias is not set.",
+   "ua": "Цей синонім не задано."
+  }
+ },
+ "plug-ins/comm/areas.cpp": {
+  "Уровень зоны указан неверно.": {
+   "en": "The zone level is specified incorrectly.",
+   "ua": "Рівень зони вказано неправильно."
+  }
+ },
+ "plug-ins/comm/auction.cpp": {
+  "$c1 получает вырученные деньги от прибывшего аукционера.": {
+   "en": "$c1 receives the proceeds from the arriving auctioneer.",
+   "ua": "$c1 отримує виручені гроші від прибулого аукціонера."
+  },
+  "$c1 получает от прибывшего аукционера $o4.": {
+   "en": "$c1 receives $o4 from the arriving auctioneer.",
+   "ua": "$c1 отримує від аукціонера, що прибув, $o4."
+  },
+  "%1$O1{Y: буд%1$nет|ут прода%1$Gно|н|на|ны за %2$d золот%2$Iую|ых|ых монет%2$Iу|ы| -- %3$s{x.": {
+   "en": "%1$O1{Y will be sold for %2$d gold coin%2$I|s|s -- %3$s{x.",
+   "ua": "%1$O1{Y: буд%1$nе|уть продан%1$Gо|ий|а|і за %2$d золот%2$Iу|их|их монет%2$Iу|и| -- %3$s{x."
+  },
+  "%s{Y: ставок не получено -- %s{x.": {
+   "en": "%s{Y: no bids received -- %s{x.",
+   "ua": "%s{Y: ставок не отримано -- %s{x."
+  },
+  "{1{C%1$^C1 {Yпокупает {2%2$O4{1 за %3$d золот%3$Iую|ых|ых монет%3$Iу|ы|{2.": {
+   "en": "{1{C%1$^C1 {Ybuys {2%2$O4{1 for %3$d gold coin%3$I|s|s{2.",
+   "ua": "{1{C%1$^C1 {Yкупує {2%2$O4{1 за %3$d золот%3$Iу|і|их монет%3$Iу|и|{2."
+  },
+  "{WЭтот предмет исчезнет через %1$d мину%1$Iту|ты|т после продажи.{x": {
+   "en": "{WThis item will disappear %1$d minute%1$I|s|s after being sold.{x",
+   "ua": "{WЦей предмет зникне через %1$d хвилин%1$Iу|и| після продажу.{x"
+  },
+  "В данный момент на аукцион ничего не выставлено.": {
+   "en": "There's nothing up for auction right now.",
+   "ua": "Наразі на аукціон нічого не виставлено."
+  },
+  "Для получения информации по этому каналу включи его.": {
+   "en": "To get information about this channel, turn it on.",
+   "ua": "Щоб отримувати інформацію з цього каналу, увімкни його."
+  },
+  "Как ты хочешь разрекламировать товар?": {
+   "en": "How do you want to advertise the goods?",
+   "ua": "Як ти хочеш розрекламувати товар?"
+  },
+  "Какую ставку ты хочешь сделать на этот лот?": {
+   "en": "What bid do you want to place on this lot?",
+   "ua": "Яку ставку ти хочеш зробити на цей лот?"
+  },
+  "Канал Аукциона теперь {Rвключен{x.": {
+   "en": "The Auction channel is now {Ron{x.",
+   "ua": "Канал Аукціону тепер {Rувімкнений{x."
+  },
+  "Канал Аукциона теперь {Rвыключен{x.": {
+   "en": "The Auction channel is now {Roff{x.",
+   "ua": "Канал Аукціону тепер {Rвимкнений{x."
+  },
+  "На %s{Y получена новая ставка: %d золот%s{x.\n\r": {
+   "en": "A new bid has been placed on %s{Y: %d gold%s{x.\n\r",
+   "ua": "На %s{Y отримано нову ставку: %d золот%s{x.\n\r"
+  },
+  "Начальная цена -- %d золот%s{x.": {
+   "en": "Starting price -- %d gold%s{x.",
+   "ua": "Початкова ціна -- %d золот%s{x."
+  },
+  "Начальная цена: %d золот%s{x.": {
+   "en": "Starting price: %d gold%s{x.",
+   "ua": "Початкова ціна: %d золот%s{x."
+  },
+  "Попробуй позже! Кто-то другой уже выставил на аукцион $o4!": {
+   "en": "Try again later! Someone else has already put $o4 up for auction!",
+   "ua": "Спробуй пізніше! Хтось інший вже виставив на аукціон $o4!"
+  },
+  "Продавец -- %s, текущая ставка -- %s": {
+   "en": "Seller -- %s, current bid -- %s",
+   "ua": "Продавець -- %s, поточна ставка -- %s"
+  },
+  "С этого предмета нужно снять проклятие перед продажей.": {
+   "en": "This item's curse needs to be removed before selling it.",
+   "ua": "З цього предмета треба зняти прокляття перед продажем."
+  },
+  "Ставок на выставленный лот не получено{x.": {
+   "en": "No bids were received for the listed lot{x.",
+   "ua": "На виставлений лот не надійшло жодної ставки{x."
+  },
+  "Ставок не получено -- %1$#O1{Y снят%1$Gо||а|ы с аукциона{x.": {
+   "en": "No bids received -- %1$#O1{Y has been withdrawn from the auction{x.",
+   "ua": "Ставок не отримано -- %1$#O1{Y знят%1$Gо|ий|а|і з аукціону{x."
+  },
+  "Твои деньги возвращены.": {
+   "en": "Your money has been returned.",
+   "ua": "Твої гроші повернено."
+  },
+  "Твоя натура не позволит тебе владеть этим предметом.": {
+   "en": "Your nature won't let you own this item.",
+   "ua": "Твоя природа не дозволить тобі володіти цим предметом."
+  },
+  "Тебе необходимо повысить ставку хотя бы на один золотой выше начальной цены.": {
+   "en": "You need to raise the bid by at least one gold above the starting price.",
+   "ua": "Тобі потрібно підняти ставку щонайменше на одну золоту монету вище початкової ціни."
+  },
+  "Тебе необходимо повысить ставку хотя бы на один золотой выше текущей ставки.": {
+   "en": "You need to raise your bid by at least one gold above the current bid.",
+   "ua": "Тобі потрібно підняти ставку щонайменше на одне золото вище поточної ставки."
+  },
+  "Текущая ставка на выставленный лот -- %d золот%s{x.": {
+   "en": "Current bid on the listed lot -- %d gold%s{x.",
+   "ua": "Поточна ставка на виставлений лот -- %d золот%s{x."
+  },
+  "Тип оружия: %s (%s), среднее повреждение %d.": {
+   "en": "Weapon type: %s (%s), average damage %d.",
+   "ua": "Тип зброї: %s (%s), середнє пошкодження %d."
+  },
+  "Ты не можешь выставить на аукцион $T.": {
+   "en": "You can't put $T up for auction.",
+   "ua": "Ти не можеш виставити на аукціон $T."
+  },
+  "Ты не можешь купить свой же лот.": {
+   "en": "You can't buy your own lot.",
+   "ua": "Ти не можеш купити свій же лот."
+  },
+  "Ты не можешь ничего выставлять на аукцион.": {
+   "en": "You can't put anything up for auction.",
+   "ua": "Ти не можеш нічого виставляти на аукціон."
+  },
+  "Ты ничего не выставлял%Gо||а на аукцион -- рекламировать тебе нечего.": {
+   "en": "You haven't put anything up for auction -- you have nothing to advertise.",
+   "ua": "Ти нічого не виставля%Gло|в|ла на аукціон -- рекламувати тобі нічого."
+  },
+  "У тебя нет необходимой суммы!": {
+   "en": "You don't have the required amount!",
+   "ua": "У тебе немає потрібної суми!"
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  },
+  "Что ты хочешь выставить на аукцион?": {
+   "en": "What do you want to put up for auction?",
+   "ua": "Що ти хочеш виставити на аукціон?"
+  },
+  "Этот предмет не подлежит продаже.": {
+   "en": "This item cannot be sold.",
+   "ua": "Цей предмет не підлягає продажу."
+  },
+  "Этот предмет нельзя выставить на аукцион -- он исчезнет всего через %1$d минут%1$Iу|ы|.": {
+   "en": "This item can't be put up for auction -- it will disappear in just %1$d minute%1$I|s|s.",
+   "ua": "Цей предмет не можна виставити на аукціон -- він зникне вже через %1$d хвилин%1$Iу|и|."
+  },
+  "{1{YНа аукцион выставлен новый лот -- {2%O1!": {
+   "en": "{1{YA new lot has been put up for auction -- {2%O1!",
+   "ua": "{1{YНа аукціон виставлено новий лот -- {2%O1!"
+  },
+  "Из дымки перед тобой появляется аукционер и возвращает тебе {W$o4{w.": {
+   "en": "An auctioneer materializes out of the haze before you and returns {W$o4{w to you.",
+   "ua": "З туману перед тобою з'являється аукціоніст і повертає тобі {W$o4{w."
+  },
+  "Из дымки появляется аукционер и передает тебе $o4.": {
+   "en": "An auctioneer appears out of the haze and hands you $o4.",
+   "ua": "З туману з'являється аукціонер і передає тобі $o4."
+  },
+  "Из дымки появляется аукционер и передает тебе вырученные деньги.": {
+   "en": "An auctioneer appears out of the haze and hands you the proceeds.",
+   "ua": "З туману з'являється аукціоніст і передає тобі виручені гроші."
+  },
+  "На аукцион ничего не выставлено. Будь внимательней!": {
+   "en": "Nothing has been put up for auction. Pay closer attention!",
+   "ua": "На аукціон нічого не виставлено. Будь уважніший!"
+  },
+  "Продажа остановлена Богами. Лот '%s{Y' конфискован{x.": {
+   "en": "The sale has been halted by the Gods. Lot '%s{Y' has been confiscated{x.",
+   "ua": "Продаж зупинено Богами. Лот '%s{Y' конфісковано{x."
+  }
+ },
+ "plug-ins/comm/bodyposition.cpp": {
+  "$C1 уже не спит.": {
+   "en": "$C1 is no longer asleep.",
+   "ua": "$C1 вже не спить."
+  },
+  "$c1 будит $C4.": {
+   "en": "$c1 wakes $C4 up.",
+   "ua": "$c1 будить $C4."
+  },
+  "$c1 будит тебя.": {
+   "en": "$c1 wakes you up.",
+   "ua": "$c1 будить тебе."
+  },
+  "$c1 встает.": {
+   "en": "$c1 stands up.",
+   "ua": "$c1 встає."
+  },
+  "$c1 отдыхает в $o6.": {
+   "en": "$c1 rests in $o6.",
+   "ua": "$c1 відпочиває в $o6."
+  },
+  "$c1 отдыхает возле $o2.": {
+   "en": "$c1 rests near $o2.",
+   "ua": "$c1 відпочиває біля $o2."
+  },
+  "$c1 отдыхает на $o6.": {
+   "en": "$c1 rests on $o6.",
+   "ua": "$c1 відпочиває на $o6."
+  },
+  "$c1 отдыхает.": {
+   "en": "$c1 is resting.",
+   "ua": "$c1 відпочиває."
+  },
+  "$c1 пересаживается возле $o2 и отдыхает.": {
+   "en": "$c1 moves next to $o2 and rests.",
+   "ua": "$c1 пересідає біля $o2 і відпочиває."
+  },
+  "$c1 пересаживается возле $o2.": {
+   "en": "$c1 moves to sit near $o2.",
+   "ua": "$c1 пересідає біля $o2."
+  },
+  "$c1 пересаживается на $o4 и отдыхает.": {
+   "en": "$c1 moves onto $o4 and rests.",
+   "ua": "$c1 пересідає на $o4 і відпочиває."
+  },
+  "$c1 пересаживается на $o4.": {
+   "en": "$c1 moves over onto $o4.",
+   "ua": "$c1 пересідає на $o4."
+  },
+  "$c1 пересаживается отдыхать в $o4.": {
+   "en": "$c1 moves to rest in $o4.",
+   "ua": "$c1 пересідає відпочивати в $o4."
+  },
+  "$c1 просыпается и встает.": {
+   "en": "$c1 wakes up and stands up.",
+   "ua": "$c1 прокидається і встає."
+  },
+  "$c1 просыпается и садится в $o4.": {
+   "en": "$c1 wakes up and sits down in $o4.",
+   "ua": "$c1 прокидається і сідає в $o4."
+  },
+  "$c1 просыпается и садится возле $o2.": {
+   "en": "$c1 wakes up and sits down next to $o2.",
+   "ua": "$c1 прокидається і сідає біля $o2."
+  },
+  "$c1 просыпается и садится на $o4.": {
+   "en": "$c1 wakes up and sits on $o4.",
+   "ua": "$c1 прокидається і сідає на $o4."
+  },
+  "$c1 просыпается и садится отдыхать в $o4.": {
+   "en": "$c1 wakes up and sits down to rest in $o4.",
+   "ua": "$c1 прокидається і сідає відпочивати в $o4."
+  },
+  "$c1 просыпается и садится отдыхать возле $o2.": {
+   "en": "$c1 wakes up and sits down to rest next to $o2.",
+   "ua": "$c1 прокидається і сідає відпочити біля $o2."
+  },
+  "$c1 просыпается и садится отдыхать на $o4.": {
+   "en": "$c1 wakes up and sits down to rest on $o4.",
+   "ua": "$c1 прокидається і сідає відпочивати на $o4."
+  },
+  "$c1 просыпается и садится отдыхать.": {
+   "en": "$c1 wakes up and sits down to rest.",
+   "ua": "$c1 прокидається і сідає відпочивати."
+  },
+  "$c1 просыпается и садится.": {
+   "en": "$c1 wakes up and sits up.",
+   "ua": "$c1 прокидається і сідає."
+  },
+  "$c1 просыпается и становится в $o4.": {
+   "en": "$c1 wakes up and takes position in $o4.",
+   "ua": "$c1 прокидається і стає в $o4."
+  },
+  "$c1 просыпается и становится возле $o2.": {
+   "en": "$c1 wakes up and stands next to $o2.",
+   "ua": "$c1 прокидається і стає біля $o2."
+  },
+  "$c1 просыпается и становится на $o4.": {
+   "en": "$c1 wakes up and stands on $o4.",
+   "ua": "$c1 прокидається і стає на $o4."
+  },
+  "$c1 садится в $o4.": {
+   "en": "$c1 sits down in $o4.",
+   "ua": "$c1 сідає в $o4."
+  },
+  "$c1 садится возле $o2 и отдыхает.": {
+   "en": "$c1 sits down next to $o2 and rests.",
+   "ua": "$c1 сідає біля $o2 і відпочиває."
+  },
+  "$c1 садится возле $o2.": {
+   "en": "$c1 sits down next to $o2.",
+   "ua": "$c1 сідає біля $o2."
+  },
+  "$c1 садится на $o4 и отдыхает.": {
+   "en": "$c1 sits down on $o4 and rests.",
+   "ua": "$c1 сідає на $o4 і відпочиває."
+  },
+  "$c1 садится на $o4.": {
+   "en": "$c1 sits down on $o4.",
+   "ua": "$c1 сідає на $o4."
+  },
+  "$c1 садится на землю.": {
+   "en": "$c1 sits down on the ground.",
+   "ua": "$c1 сідає на землю."
+  },
+  "$c1 садится отдыхать.": {
+   "en": "$c1 sits down to rest.",
+   "ua": "$c1 сідає відпочивати."
+  },
+  "$c1 становится в $o4.": {
+   "en": "$c1 stands in $o4.",
+   "ua": "$c1 стає в $o4."
+  },
+  "$c1 становится возле $o2.": {
+   "en": "$c1 stands next to $o2.",
+   "ua": "$c1 стає біля $o2."
+  },
+  "$c1 становится на $o4.": {
+   "en": "$c1 stands on $o4.",
+   "ua": "$c1 стає на $o4."
+  },
+  "На $o6 не осталось свободного места для тебя.": {
+   "en": "There's no free space left on $o6 for you.",
+   "ua": "На $o6 не лишилося вільного місця для тебе."
+  },
+  "На $o6 нет больше свободного места.": {
+   "en": "There's no more room on $o6.",
+   "ua": "На $o6 більше немає вільного місця."
+  },
+  "На $o6 нет свободного места.": {
+   "en": "There's no free space on $o6.",
+   "ua": "На $o6 немає вільного місця."
+  },
+  "Но ты же сражаешься!": {
+   "en": "But you're fighting!",
+   "ua": "Але ж ти б'єшся!"
+  },
+  "Тебе некогда отдыхать.": {
+   "en": "You have no time to rest.",
+   "ua": "Тобі нема коли відпочивати."
+  },
+  "Ты будишь $C4.": {
+   "en": "You wake $C4.",
+   "ua": "Ти будиш $C4."
+  },
+  "Ты встаешь.": {
+   "en": "You stand up.",
+   "ua": "Ти встаєш."
+  },
+  "Ты не видишь этого здесь.": {
+   "en": "You don't see that here.",
+   "ua": "Ти не бачиш цього тут."
+  },
+  "Ты не можешь отдыхать на этом.": {
+   "en": "You can't rest on that.",
+   "ua": "Ти не можеш відпочивати на цьому."
+  },
+  "Ты не можешь отдыхать, когда ты в седле.": {
+   "en": "You can't rest while in the saddle.",
+   "ua": "Ти не можеш відпочивати, коли ти в сідлі."
+  },
+  "Ты не можешь отдыхать, когда ты оседлан%Gо||а.": {
+   "en": "You can't rest while someone's riding you.",
+   "ua": "Ти не можеш відпочивати, коли ти осідлан%Gо|ий|а|і."
+  },
+  "Ты не можешь проснуться!": {
+   "en": "You can't wake up!",
+   "ua": "Ти не можеш прокинутися!"
+  },
+  "Ты не можешь разбудить $S от нездорового сна!": {
+   "en": "You can't wake them from this unhealthy sleep!",
+   "ua": "Ти не можеш розбудити їх від цього нездорового сну!"
+  },
+  "Ты не можешь сесть на это.": {
+   "en": "You can't sit on that.",
+   "ua": "Ти не можеш сісти на це."
+  },
+  "Ты не можешь сесть, когда ты в седле.": {
+   "en": "You can't sit down while you're in the saddle.",
+   "ua": "Ти не можеш сісти, коли ти в сідлі."
+  },
+  "Ты не можешь сесть, когда ты оседлан%Gо||а.": {
+   "en": "You can't sit down while you're being ridden.",
+   "ua": "Ти не можеш сісти, коли ти осідлан%Gо||а."
+  },
+  "Ты не можешь спать на этом!": {
+   "en": "You can't sleep on that!",
+   "ua": "Ти не можеш спати на цьому!"
+  },
+  "Ты не можешь спать, когда ты в седле.": {
+   "en": "You can't sleep while in the saddle.",
+   "ua": "Ти не можеш спати, поки ти в сідлі."
+  },
+  "Ты не можешь спать, когда ты оседлан%Gо||а.": {
+   "en": "You can't sleep while you're being ridden.",
+   "ua": "Ти не можеш спати, коли ти осідлан%Gе|ий|а|і."
+  },
+  "Ты не можешь стоять на этом.": {
+   "en": "You can't stand on that.",
+   "ua": "Ти не можеш стояти на цьому."
+  },
+  "Ты отдыхаешь в $o6.": {
+   "en": "You rest in $o6.",
+   "ua": "Ти відпочиваєш у $o6."
+  },
+  "Ты отдыхаешь возле $o2.": {
+   "en": "You rest near $o2.",
+   "ua": "Ти відпочиваєш біля $o2."
+  },
+  "Ты отдыхаешь на $o6.": {
+   "en": "You rest on $o6.",
+   "ua": "Ти відпочиваєш на $o6."
+  },
+  "Ты отдыхаешь.": {
+   "en": "You rest.",
+   "ua": "Ти відпочиваєш."
+  },
+  "Ты пересаживаешься в $o4.": {
+   "en": "You move over to $o4.",
+   "ua": "Ти пересідаєш у $o4."
+  },
+  "Ты пересаживаешься возле $o2 и отдыхаешь.": {
+   "en": "You move over next to $o2 and rest.",
+   "ua": "Ти пересідаєш біля $o2 і відпочиваєш."
+  },
+  "Ты пересаживаешься возле $o2.": {
+   "en": "You move to sit near $o2.",
+   "ua": "Ти пересідаєш біля $o2."
+  },
+  "Ты пересаживаешься на $o4 и отдыхаешь.": {
+   "en": "You move over to $o4 and rest.",
+   "ua": "Ти пересідаєш на $o4 і відпочиваєш."
+  },
+  "Ты пересаживаешься на $o4.": {
+   "en": "You move over to $o4.",
+   "ua": "Ти пересідаєш на $o4."
+  },
+  "Ты пересаживаешься отдыхать в $o4.": {
+   "en": "You move to rest in $o4.",
+   "ua": "Ти пересідаєш відпочивати в $o4."
+  },
+  "Ты прекращаешь отдых.": {
+   "en": "You stop resting.",
+   "ua": "Ти припиняєш відпочинок."
+  },
+  "Ты просыпаешься и встаешь.": {
+   "en": "You wake up and stand.",
+   "ua": "Ти прокидаєшся і встаєш."
+  },
+  "Ты просыпаешься и садишься в $o4.": {
+   "en": "You wake up and sit down in $o4.",
+   "ua": "Ти прокидаєшся і сідаєш у $o4."
+  },
+  "Ты просыпаешься и садишься возле $o2.": {
+   "en": "You wake up and sit down next to $o2.",
+   "ua": "Ти прокидаєшся і сідаєш біля $o2."
+  },
+  "Ты просыпаешься и садишься на $o4.": {
+   "en": "You wake up and sit down on $o4.",
+   "ua": "Ти прокидаєшся і сідаєш на $o4."
+  },
+  "Ты просыпаешься и садишься отдыхать в $o4.": {
+   "en": "You wake up and sit down to rest in $o4.",
+   "ua": "Ти прокидаєшся і сідаєш відпочивати в $o4."
+  },
+  "Ты просыпаешься и садишься отдыхать возле $o2.": {
+   "en": "You wake up and sit down to rest near $o2.",
+   "ua": "Ти прокидаєшся і сідаєш відпочити біля $o2."
+  },
+  "Ты просыпаешься и садишься отдыхать на $o4.": {
+   "en": "You wake up and sit down to rest on $o4.",
+   "ua": "Ти прокидаєшся і сідаєш відпочивати на $o4."
+  },
+  "Ты просыпаешься и садишься отдыхать.": {
+   "en": "You wake up and sit down to rest.",
+   "ua": "Ти прокидаєшся і сідаєш відпочивати."
+  },
+  "Ты просыпаешься и садишься.": {
+   "en": "You wake up and sit up.",
+   "ua": "Ти прокидаєшся і сідаєш."
+  },
+  "Ты просыпаешься и становишься в $o4.": {
+   "en": "You wake up and stand in $o4.",
+   "ua": "Ти прокидаєшся і встаєш у $o4."
+  },
+  "Ты просыпаешься и становишься возле $o2.": {
+   "en": "You wake up and stand near $o2.",
+   "ua": "Ти прокидаєшся і стаєш біля $o2."
+  },
+  "Ты просыпаешься и становишься на $o4.": {
+   "en": "You wake up and stand on $o4.",
+   "ua": "Ти прокидаєшся і стаєш на $o4."
+  },
+  "Ты просыпаешься.": {
+   "en": "You wake up.",
+   "ua": "Ти прокидаєшся."
+  },
+  "Ты садишься в $o4.": {
+   "en": "You sit down in $o4.",
+   "ua": "Ти сідаєш у $o4."
+  },
+  "Ты садишься возле $o2 и отдыхаешь.": {
+   "en": "You sit down near $o2 and rest.",
+   "ua": "Ти сідаєш біля $o2 і відпочиваєш."
+  },
+  "Ты садишься возле $o2.": {
+   "en": "You sit down next to $o2.",
+   "ua": "Ти сідаєш біля $o2."
+  },
+  "Ты садишься на $o4 и отдыхаешь.": {
+   "en": "You sit down on $o4 and rest.",
+   "ua": "Ти сідаєш на $o4 і відпочиваєш."
+  },
+  "Ты садишься на $o4.": {
+   "en": "You sit on $o4.",
+   "ua": "Ти сідаєш на $o4."
+  },
+  "Ты садишься отдыхать в $o4.": {
+   "en": "You sit down to rest in $o4.",
+   "ua": "Ти сідаєш відпочивати в $o4."
+  },
+  "Ты садишься отдыхать.": {
+   "en": "You sit down to rest.",
+   "ua": "Ти сідаєш відпочити."
+  },
+  "Ты садишься.": {
+   "en": "You sit down.",
+   "ua": "Ти сідаєш."
+  },
+  "Ты спишь и не можешь проснуться.": {
+   "en": "You are asleep and cannot wake up.",
+   "ua": "Ти спиш і не можеш прокинутися."
+  },
+  "Ты становишься в $o4.": {
+   "en": "You stand in $o4.",
+   "ua": "Ти стаєш у $o4."
+  },
+  "Ты становишься возле $o2.": {
+   "en": "You take position next to $o2.",
+   "ua": "Ти стаєш біля $o2."
+  },
+  "Ты становишься на $o4.": {
+   "en": "You stand on $o4.",
+   "ua": "Ти стаєш на $o4."
+  },
+  "Ты уже отдыхаешь.": {
+   "en": "You're already resting.",
+   "ua": "Ти вже відпочиваєш."
+  },
+  "Ты уже сидишь.": {
+   "en": "You're already sitting.",
+   "ua": "Ти вже сидиш."
+  },
+  "Ты уже спишь.": {
+   "en": "You are already asleep.",
+   "ua": "Ти вже спиш."
+  },
+  "Ты уже сражаешься!": {
+   "en": "You're already fighting!",
+   "ua": "Ти вже б'єшся!"
+  },
+  "Ты уже стоишь.": {
+   "en": "You're already standing.",
+   "ua": "Ти вже стоїш."
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$c1 пересаживается в $o4.": {
+   "en": "$c1 moves over into $o4.",
+   "ua": "$c1 пересідає в $o4."
+  },
+  "$c1 садится отдыхать в $o4.": {
+   "en": "$c1 sits down to rest in $o4.",
+   "ua": "$c1 сідає відпочити в $o4."
+  },
+  "Во время сражения есть дела поважнее.": {
+   "en": "There are more important things to do during a fight.",
+   "ua": "Під час бою є важливіші справи."
+  },
+  "Тебе не до отдыха!": {
+   "en": "You're in no mood to rest!",
+   "ua": "Тобі не до відпочинку!"
+  },
+  "Тебе не до сна!": {
+   "en": "You're in no state to sleep!",
+   "ua": "Тобі не до сну!"
+  },
+  "Ты не можешь разбудить сам{Sfа{Sx себя!": {
+   "en": "You can't wake yourself up!",
+   "ua": "Ти не можеш розбудити сам{Sfа{Sx себе!"
+  },
+  "Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает.": {
+   "en": "You feel your harakiri wound closing up as your body heals.",
+   "ua": "Ти відчуваєш, як рана від харакірі затягується, і твоє тіло гоїться."
+  }
+ },
+ "plug-ins/comm/bugs.cpp": {
+  "Записано.": {
+   "en": "Recorded.",
+   "ua": "Записано."
+  },
+  "О какой именно опечатке ты хочешь сообщить?": {
+   "en": "Which typo exactly do you want to report?",
+   "ua": "Про яку саме опечатку ти хочеш повідомити?"
+  },
+  "О какой именно ошибке ты хочешь сообщить?": {
+   "en": "Which specific bug do you want to report?",
+   "ua": "Про яку саме помилку ти хочеш повідомити?"
+  },
+  "Об отсутствии какого раздела справки ты хочешь сообщить?": {
+   "en": "Which missing help section do you want to report?",
+   "ua": "Про відсутність якого розділу довідки ти хочеш повідомити?"
+  },
+  "Опечатка записана.": {
+   "en": "Typo recorded.",
+   "ua": "Опечатку записано."
+  },
+  "Ошибка записана.": {
+   "en": "Bug logged.",
+   "ua": "Помилку записано."
+  },
+  "Идейка записана.": {
+   "en": "Idea noted.",
+   "ua": "Ідейку записано."
+  },
+  "Идейка слишком коротка -- опиши ее подробнее (хотя бы %d символов).": {
+   "en": "That idea's too short -- describe it in more detail (at least %d characters).",
+   "ua": "Ідейка закоротка -- опиши її детальніше (хоча б %d символів)."
+  },
+  "Какой именно идейкой ты хочешь поделиться?": {
+   "en": "What little idea exactly do you want to share?",
+   "ua": "Якою саме ідейкою ти хочеш поділитися?"
+  }
+ },
+ "plug-ins/comm/close.cpp": {
+  "$O4 невозможно закрыть или закупорить.": {
+   "en": "$O4 cannot be closed or corked.",
+   "ua": "$O4 неможливо закрити або закоркувати."
+  },
+  "$O4 уже закрыли.": {
+   "en": "$O4 has already been closed.",
+   "ua": "$O4 вже закрили."
+  },
+  "$c1 закрывает $N4.": {
+   "en": "$c1 closes $N4.",
+   "ua": "$c1 закриває $N4."
+  },
+  "$c1 закрывает $O4 крышкой.": {
+   "en": "$c1 closes $O4 with a lid.",
+   "ua": "$c1 закриває $O4 кришкою."
+  },
+  "$c1 закрывает $O4.": {
+   "en": "$c1 closes $O4.",
+   "ua": "$c1 закриває $O4."
+  },
+  "$c1 закрывает $o4.": {
+   "en": "$c1 closes $o4.",
+   "ua": "$c1 закриває $o4."
+  },
+  "$c1 закупоривает $O4 пробкой.": {
+   "en": "$c1 corks $O4 shut.",
+   "ua": "$c1 закорковує $O4."
+  },
+  "%^N1 закрывается.": {
+   "en": "%^N1 closes.",
+   "ua": "%^N1 зачиняється."
+  },
+  "Закрыть что?": {
+   "en": "Close what?",
+   "ua": "Закрити що?"
+  },
+  "Здесь уже закрыто.": {
+   "en": "It's already closed here.",
+   "ua": "Тут вже зачинено."
+  },
+  "Ты закрываешь $N4.": {
+   "en": "You close $N4.",
+   "ua": "Ти закриваєш $N4."
+  },
+  "Ты закрываешь $O4 крышкой.": {
+   "en": "You close $O4 with its lid.",
+   "ua": "Ти закриваєш $O4 кришкою."
+  },
+  "Ты закрываешь $O4.": {
+   "en": "You close $O4.",
+   "ua": "Ти закриваєш $O4."
+  },
+  "Ты закрываешь $o4.": {
+   "en": "You close $o4.",
+   "ua": "Ти зачиняєш $o4."
+  },
+  "Ты закупориваешь $O4 пробкой.": {
+   "en": "You cork $O4 with a stopper.",
+   "ua": "Ти закупорюєш $O4 корком."
+  },
+  "Ты не можешь сделать этого.": {
+   "en": "You can't do that.",
+   "ua": "Ти не можеш цього зробити."
+  },
+  "У тебя нет пробки от $O2.": {
+   "en": "You don't have a stopper for $O2.",
+   "ua": "У тебе немає корка від $O2."
+  },
+  "Это не дверь!": {
+   "en": "That's not a door!",
+   "ua": "Це не двері!"
+  },
+  "Это не контейнер.": {
+   "en": "That's not a container.",
+   "ua": "Це не контейнер."
+  },
+  "$c1 шарит по карманам в поисках пробки.": {
+   "en": "$c1 rummages through pockets looking for a cork.",
+   "ua": "$c1 нишпорить по кишенях у пошуках корка."
+  }
+ },
+ "plug-ins/comm/communication.cpp": {
+  "Вдали от чего?!": {
+   "en": "Away from what?!",
+   "ua": "Подалі від чого?!"
+  },
+  "Все запомненные сообщения в хронологическом порядке:": {
+   "en": "All remembered messages in chronological order:",
+   "ua": "Усі запам'ятовані повідомлення у хронологічному порядку:"
+  },
+  "Все сообщения, полученные за время отсутствия, уже прочитаны.": {
+   "en": "All messages received during your absence have already been read.",
+   "ua": "Усі повідомлення, отримані за час відсутності, вже прочитані."
+  },
+  "За последнее время никто ничего не говорил в общих каналах.": {
+   "en": "No one has said anything on the public channels recently.",
+   "ua": "Останнім часом ніхто нічого не казав у загальних каналах."
+  },
+  "За последнее время никто ничего не говорил.": {
+   "en": "No one has said anything recently.",
+   "ua": "Останнім часом ніхто нічого не казав."
+  },
+  "За последнее время тебе никто ничего не говорил.": {
+   "en": "Nobody has said anything to you recently.",
+   "ua": "За останній час тобі ніхто нічого не казав."
+  },
+  "Запомненные личные сообщения:": {
+   "en": "Remembered personal messages:",
+   "ua": "Запам'ятовані особисті повідомлення:"
+  },
+  "Запомненные сообщения в общих каналах:": {
+   "en": "Remembered messages in common channels:",
+   "ua": "Запам'ятовані повідомлення в загальних каналах:"
+  },
+  "Запомненные сообщения рядом с тобой:": {
+   "en": "Remembered messages near you:",
+   "ua": "Запам'ятовані повідомлення поряд з тобою:"
+  },
+  "Неправильный параметр.": {
+   "en": "Invalid parameter.",
+   "ua": "Неправильний параметр."
+  },
+  "Режим AFK включен.": {
+   "en": "AFK mode enabled.",
+   "ua": "Режим AFK увімкнено."
+  },
+  "Режим AFK выключен.": {
+   "en": "AFK mode is off.",
+   "ua": "Режим AFK вимкнено."
+  },
+  "Режим полного молчания выключен.": {
+   "en": "Full silence mode is off.",
+   "ua": "Режим повного мовчання вимкнено."
+  },
+  "Рядом с тобой ничего не происходило.": {
+   "en": "Nothing has happened near you.",
+   "ua": "Поруч з тобою нічого не відбувалося."
+  },
+  "С этого момента ты будешь слышать только то, что произносят в комнате.": {
+   "en": "From now on you'll only hear what's said in the room.",
+   "ua": "Відтепер ти чутимеш лише те, що промовляють у кімнаті."
+  },
+  "С этого момента ты не хочешь ни с кем говорить.": {
+   "en": "From this moment on, you don't want to talk to anyone.",
+   "ua": "Відтепер ти не хочеш ні з ким говорити."
+  },
+  "Сообщения, полученные за время твоего отсутствия или боя:": {
+   "en": "Messages received while you were away or in combat:",
+   "ua": "Повідомлення, отримані за час твоєї відсутності або бою:"
+  },
+  "Ты в режиме AFK: {c%s.{x": {
+   "en": "You are in AFK mode: {c%s.{x",
+   "ua": "Ти в режимі AFK: {c%s.{x"
+  },
+  "Ты не можешь использовать команду replay.": {
+   "en": "You can't use the replay command.",
+   "ua": "Ти не можеш використати команду replay."
+  },
+  "Ты опять можешь говорить с кем-либо.": {
+   "en": "You can talk to others again.",
+   "ua": "Ти знову можеш говорити з будь-ким."
+  }
+ },
+ "plug-ins/comm/compare.cpp": {
+  "На тебе нет ничего, с чем можно было бы сравнить.": {
+   "en": "You're not wearing anything to compare it to.",
+   "ua": "На тобі немає нічого, з чим можна було б порівняти."
+  },
+  "Сравнить что и с чем.?": {
+   "en": "Compare what with what?",
+   "ua": "Порівняти що і з чим?"
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  }
+ },
+ "plug-ins/comm/configs.cpp": {
+  "Буферизация вывода отключена.": {
+   "en": "Output buffering is disabled.",
+   "ua": "Буферизацію виводу вимкнено."
+  },
+  "Введи значение между 10 и 200.": {
+   "en": "Enter a value between 10 and 200.",
+   "ua": "Введи значення між 10 і 200."
+  },
+  "Задай имя пользователя начиная с @.": {
+   "en": "Set a username starting with @.",
+   "ua": "Задай ім'я користувача, що починається з @."
+  },
+  "Неправильное число.": {
+   "en": "Invalid number.",
+   "ua": "Неправильне число."
+  },
+  "Неправильный переключатель. См. {W? режим{x.": {
+   "en": "Invalid switch. See {W? mode{x.",
+   "ua": "Неправильний перемикач. Див. {W? режим{x."
+  },
+  "Нечего очищать.": {
+   "en": "Nothing to clear.",
+   "ua": "Нічого очищати."
+  },
+  "Новое секретное слово: {W%s{x.": {
+   "en": "New secret word: {W%s{x.",
+   "ua": "Нове секретне слово: {W%s{x."
+  },
+  "Ок.": {
+   "en": "OK.",
+   "ua": "Гаразд."
+  },
+  "Пользователь Telegram {C%s{x.": {
+   "en": "Telegram user {C%s{x.",
+   "ua": "Користувач Telegram {C%s{x."
+  },
+  "Связь с пользователем Discord очищена. ": {
+   "en": "Discord user link cleared. ",
+   "ua": "Зв'язок з користувачем Discord очищено. "
+  },
+  "Связь с пользователем {C%s{x очищена.": {
+   "en": "Connection with user {C%s{x cleared.",
+   "ua": "З'єднання з користувачем {C%s{x очищено."
+  },
+  "Теперь {C%s{x привязан к твоему персонажу.": {
+   "en": "Now {C%s{x is bound to your character.",
+   "ua": "Тепер {C%s{x прив'язаний до твого персонажа."
+  },
+  "Ты должен ввести количество линий.": {
+   "en": "You must enter the number of lines.",
+   "ua": "Ти маєш ввести кількість рядків."
+  },
+  "Укажи язык: англ, укр или рус.": {
+   "en": "Specify a language: eng, ukr, or rus.",
+   "ua": "Вкажи мову: англ, укр або рос."
+  }
+ },
+ "plug-ins/comm/corder.cpp": {
+  "%1$^C1 не сможет выполнить эту команду, находясь в режиме AFK ('отошел').": {
+   "en": "%1$^C1 won't be able to run this command while in AFK mode ('away').",
+   "ua": "%1$^C1 не зможе виконати цю команду, перебуваючи в режимі AFK ('відійшов')."
+  },
+  "%1$^C1 оглушен%1$Gо||а и ни на что не реагирует, подожди немного.": {
+   "en": "%1$^C1 is stunned and not reacting to anything, wait a bit.",
+   "ua": "%1$^C1 оглушен%1$Gо|ий|а і ні на що не реагує, зачекай трохи."
+  },
+  "%1$^C1 следу%1$nет|ют за тобой, но не подчиня%1$nется|ются твоим приказам.": {
+   "en": "%1$^C1 follow%1$ns| you, but ignore%1$ns| your orders.",
+   "ua": "%1$^C1 слідку%1$nє|ють за тобою, але не підкоря%1$nється|ються твоїм наказам."
+  },
+  "%^C1 все еще призрак и не сможет выполнить эту команду.": {
+   "en": "%^C1 is still a ghost and cannot execute this command.",
+   "ua": "%^C1 досі привид і не зможе виконати цю команду."
+  },
+  "%^C1 приказывает тебе '%s'.": {
+   "en": "%^C1 orders you '%s'.",
+   "ua": "%^C1 наказує тобі '%s'."
+  },
+  "Похоже, такой команды не существует.": {
+   "en": "Looks like no such command exists.",
+   "ua": "Схоже, такої команди не існує."
+  },
+  "Приказать кому и что?": {
+   "en": "Order whom and what?",
+   "ua": "Наказати кому і що?"
+  },
+  "Среди твоих последователей такого нет.": {
+   "en": "There's no such person among your followers.",
+   "ua": "Серед твоїх послідовників такого немає."
+  },
+  "Твой последователь должен быть рядом с тобой.": {
+   "en": "Your follower must be near you.",
+   "ua": "Твій послідовник має бути поруч із тобою."
+  },
+  "Ты можешь только принимать приказы, а не отдавать их.": {
+   "en": "You can only take orders, not give them.",
+   "ua": "Ти можеш тільки отримувати накази, а не віддавати їх."
+  },
+  "Ты не можешь отдать приказ всем сразу.": {
+   "en": "You can't give an order to everyone at once.",
+   "ua": "Ти не можеш віддати наказ усім одразу."
+  },
+  "Эта команда не для тебя.": {
+   "en": "This command isn't for you.",
+   "ua": "Ця команда не для тебе."
+  },
+  "Эта команда недоступна здесь и сейчас.": {
+   "en": "This command isn't available here and now.",
+   "ua": "Ця команда недоступна тут і зараз."
+  },
+  "Эту команду можно приказать только в бою.": {
+   "en": "This command can only be ordered during combat.",
+   "ua": "Цю команду можна наказати лише в бою."
+  },
+  "Эту команду можно приказать только ворам.": {
+   "en": "This command can only be ordered to thieves.",
+   "ua": "Цю команду можна наказати тільки крадіям."
+  },
+  "Эту команду можно приказать только игрокам.": {
+   "en": "This command can only be given as an order to players.",
+   "ua": "Цю команду можна наказати виконати лише гравцям."
+  },
+  "Эту команду невозможно приказать.": {
+   "en": "This command can't be ordered.",
+   "ua": "Цю команду неможливо наказати."
+  },
+  "Эту команду необходимо указывать полностью.": {
+   "en": "This command must be typed in full.",
+   "ua": "Цю команду потрібно вказувати повністю."
+  },
+  "%1$^C1 наказан%1$Gо||а богами и не может выполнить эту команду.": {
+   "en": "%1$^C1 has been punished by the gods and cannot perform this command.",
+   "ua": "%1$^C1 покаран%1$Gо||а богами і не може виконати цю команду."
+  }
+ },
+ "plug-ins/comm/demand.cpp": {
+  "$C1 не в состоянии выполнить твою просьбу.": {
+   "en": "$C1 isn't able to fulfill your request.",
+   "ua": "$C1 не в змозі виконати твоє прохання."
+  },
+  "$C1 не в состоянии исполнить твой приказ.": {
+   "en": "$C1 is unable to carry out your order.",
+   "ua": "$C1 не в змозі виконати твій наказ."
+  },
+  "$C1 не подчинится твоему требованию.": {
+   "en": "$C1 will not submit to your demand.",
+   "ua": "$C1 не підкориться твоїй вимозі."
+  },
+  "$c1 просит $o4 у $C2.": {
+   "en": "$c1 asks $C2 for $o4.",
+   "ua": "$c1 просить $o4 у $C2."
+  },
+  "$c1 просит $o4 у тебя.": {
+   "en": "$c1 asks you for $o4.",
+   "ua": "$c1 просить у тебе $o4."
+  },
+  "$c1 требует $o4 у $C2.": {
+   "en": "$c1 demands $o4 from $C2.",
+   "ua": "$c1 вимагає $o4 у $C2."
+  },
+  "$c1 требует у тебя $o4.": {
+   "en": "$c1 demands $o4 from you.",
+   "ua": "$c1 вимагає у тебе $o4."
+  },
+  "%2$^s не позволяют тебе завладеть %1$O5.": {
+   "en": "%2$^s won't let you take hold of %1$O5.",
+   "ua": "%2$^s не дозволяють тобі заволодіти %1$O5."
+  },
+  "Здесь таких нет.": {
+   "en": "There's no one like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Подожди немного.": {
+   "en": "Wait a bit.",
+   "ua": "Зачекай трохи."
+  },
+  "Потребовать что и у кого?": {
+   "en": "Demand what and from whom?",
+   "ua": "Зажадати що і в кого?"
+  },
+  "Таких тут нет.": {
+   "en": "There's no one like that here.",
+   "ua": "Таких тут немає."
+  },
+  "Твои руки полны.": {
+   "en": "Your hands are full.",
+   "ua": "Твої руки повні."
+  },
+  "Ты не видишь этого.": {
+   "en": "You don't see that.",
+   "ua": "Ти не бачиш цього."
+  },
+  "Ты не можешь нести такой вес.": {
+   "en": "You can't carry that much weight.",
+   "ua": "Ти не можеш нести таку вагу."
+  },
+  "Ты не сможешь нести такую тяжесть.": {
+   "en": "You won't be able to carry that much weight.",
+   "ua": "Ти не зможеш нести таку вагу."
+  },
+  "Ты никого не запугаешь своим видом.": {
+   "en": "You won't scare anyone with your looks.",
+   "ua": "Ти нікого не налякаєш своїм виглядом."
+  },
+  "Ты просишь $o4 у $C2.": {
+   "en": "You request $o4 from $C2.",
+   "ua": "Ти просиш $o4 у $C2."
+  },
+  "Ты чувствуешь благодарность за доверие $C2.": {
+   "en": "You feel grateful for $C2's trust.",
+   "ua": "Ти відчуваєш вдячність за довіру $C2."
+  },
+  "Что и у кого ты хочешь попросить?": {
+   "en": "What do you want to ask for, and from whom?",
+   "ua": "Що і в кого ти хочеш попросити?"
+  },
+  "Извини, он не отдаст тебе это.": {
+   "en": "Sorry, he won't give that to you.",
+   "ua": "Вибач, він не віддасть тобі це."
+  },
+  "На игроков такие штучки не пройдут. Просто поговори с ними!": {
+   "en": "That kind of trick won't work on players. Just talk to them!",
+   "ua": "На гравців такі штучки не пройдуть. Просто поговори з ними!"
+  },
+  "Просто убей и отбери.": {
+   "en": "Just kill and take it.",
+   "ua": "Просто вбий і забери."
+  },
+  "Твое могущество повергает всех в трепет.": {
+   "en": "Your might strikes everyone with awe.",
+   "ua": "Твоя могутність вражає всіх трепетом."
+  },
+  "Ты требуешь $o4 у $C2.": {
+   "en": "You demand $o4 from $C2.",
+   "ua": "Ти вимагаєш $o4 у $C2."
+  },
+  "Хочешь -- купи!": {
+   "en": "Want it? Buy it!",
+   "ua": "Хочеш -- купуй!"
+  }
+ },
+ "plug-ins/comm/description.cpp": {
+  "\r\nПодробности читай в {W? описание{x.": {
+   "en": "\r\nFor details, see {W? description{x.",
+   "ua": "\r\nПодробиці читай у {W? опис{x."
+  },
+  "Буфер редактора пуст!": {
+   "en": "The editor buffer is empty!",
+   "ua": "Буфер редактора порожній!"
+  },
+  "Нет ничего для удаления.": {
+   "en": "There's nothing to delete.",
+   "ua": "Немає нічого для видалення."
+  },
+  "Новое описание вставлено из буфера редактора.": {
+   "en": "New description inserted from the editor buffer.",
+   "ua": "Новий опис вставлено з буфера редактора."
+  },
+  "Описание скопировано в буфер редактора, однако пользоваться редактором можно только изнутри веб-клиента.": {
+   "en": "The description has been copied to the editor buffer, but the editor can only be used from within the web client.",
+   "ua": "Опис скопійовано до буфера редактора, однак користуватися редактором можна лише з веб-клієнта."
+  },
+  "Слишком длинное описание.": {
+   "en": "The description is too long.",
+   "ua": "Занадто довгий опис."
+  },
+  "Слишком длиное описание.": {
+   "en": "Description is too long.",
+   "ua": "Опис задовгий."
+  },
+  "Твое описание:": {
+   "en": "Your description:",
+   "ua": "Твій опис:"
+  }
+ },
+ "plug-ins/comm/drop.cpp": {
+  "$c1 бросает $o4.": {
+   "en": "$c1 drops $o4.",
+   "ua": "$c1 кидає $o4."
+  },
+  "$c1 бросает монетку.": {
+   "en": "$c1 tosses a coin.",
+   "ua": "$c1 кидає монетку."
+  },
+  "$c1 бросает несколько монет.": {
+   "en": "$c1 drops a few coins.",
+   "ua": "$c1 кидає кілька монет."
+  },
+  "%1$^O1 пада%1$nет|ют и разбива%1$nется|ются на мелкие осколки.": {
+   "en": "%1$^O1 fall%1$ns| and shatter%1$ns| into tiny fragments.",
+   "ua": "%1$^O1 пада%1$nє|ють і розбива%1$nється|ються на дрібні скалки."
+  },
+  "%1$^O1 превраща%1$nется|ются в ничто и исчеза%1$nет|ют.": {
+   "en": "%1$^O1 turn%1$ns| into nothing and vanish%1$nes|.",
+   "ua": "%1$^O1 перетворю%1$nється|ються на ніщо і зника%1$nє|ють."
+  },
+  "%1$^O1 тон%1$nет|ут в %2$N6.": {
+   "en": "%1$^O1 sink%1$ns| in %2$N6.",
+   "ua": "%1$^O1 тон%1$nе|уть в %2$N6."
+  },
+  "Бросить что?": {
+   "en": "Drop what?",
+   "ua": "Кинути що?"
+  },
+  "Монеты падают и тонут в $n6.": {
+   "en": "The coins fall and sink into $n6.",
+   "ua": "Монети падають і тонуть у $n6."
+  },
+  "Ты бросаешь %1$O4.": {
+   "en": "You drop %1$O4.",
+   "ua": "Ти кидаєш %1$O4."
+  },
+  "Ты бросаешь монетку.": {
+   "en": "You flip a coin.",
+   "ua": "Ти кидаєш монетку."
+  },
+  "Ты бросаешь несколько монет.": {
+   "en": "You drop a few coins.",
+   "ua": "Ти кидаєш кілька монет."
+  },
+  "У тебя нет $T.": {
+   "en": "You don't have $T.",
+   "ua": "У тебе немає $T."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе немає цього."
+  },
+  "У тебя ничего нет.": {
+   "en": "You have nothing.",
+   "ua": "У тебе нічого немає."
+  }
+ },
+ "plug-ins/comm/eating.cpp": {
+  "$C1 с ужасом смотрит на $c4.": {
+   "en": "$C1 stares at $c4 in horror.",
+   "ua": "$C1 з жахом дивиться на $c4."
+  },
+  "$c1 ест $C4.": {
+   "en": "$c1 eats $C4.",
+   "ua": "$c1 їсть $C4."
+  },
+  "$c1 ест $o4.": {
+   "en": "$c1 eats $o4.",
+   "ua": "$c1 їсть $o4."
+  },
+  "$c1 осушает $o4.": {
+   "en": "$c1 drains $o4.",
+   "ua": "$c1 осушує $o4."
+  },
+  "Осушать можно только снадобья.": {
+   "en": "You can only drain potions dry.",
+   "ua": "Осушувати можна тільки зілля."
+  },
+  "Осушить что?": {
+   "en": "Drain what?",
+   "ua": "Осушити що?"
+  },
+  "Сейчас ты сражаешься -- тебе не до охоты!": {
+   "en": "You're fighting right now -- no time to hunt!",
+   "ua": "Зараз ти б'єшся -- тобі не до полювання!"
+  },
+  "Съесть что?": {
+   "en": "Eat what?",
+   "ua": "З'їсти що?"
+  },
+  "Ты ешь $C4.": {
+   "en": "You eat $C4.",
+   "ua": "Ти їси $C4."
+  },
+  "Ты ешь $o4.": {
+   "en": "You eat $o4.",
+   "ua": "Ти їси $o4."
+  },
+  "Ты не можешь принимать снадобья в кандалах.": {
+   "en": "You can't take potions while in shackles.",
+   "ua": "Ти не можеш приймати зілля в кайданах."
+  },
+  "Ты осушаешь $o4.": {
+   "en": "You drain $o4.",
+   "ua": "Ти осушуєш $o4."
+  },
+  "У тебя нет такого снадобья.": {
+   "en": "You don't have such a potion.",
+   "ua": "У тебе немає такого зілля."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  },
+  "Эта смесь чересчур сильна, чтобы ты мог%1$Gло||ла выпить её.": {
+   "en": "This mixture is too strong for you to drink.",
+   "ua": "Ця суміш надто міцна, щоб ти спроможн%1$Gе|ий|а|і випити її."
+  },
+  "Это несъедобно.": {
+   "en": "That's not edible.",
+   "ua": "Це неїстівне."
+  },
+  "$C1 вжимается в пол, закрыв глаза лапами.": {
+   "en": "$C1 presses itself into the floor, covering its eyes with its paws.",
+   "ua": "$C1 втискається в підлогу, затуляючи очі лапами."
+  },
+  "$C1 с ужасом смотрит на тебя.": {
+   "en": "$C1 looks at you in horror.",
+   "ua": "$C1 з жахом дивиться на тебе."
+  },
+  "$C1 шустро прячется за спину хозя$gина|ина|йки!": {
+   "en": "$C1 quickly ducks behind their owner's back!",
+   "ua": "$C1 моторно ховається за спину господар$gя|я|ки!"
+  },
+  "$C1 шустро прячется за твою спину!": {
+   "en": "$C1 nimbly ducks behind your back!",
+   "ua": "$C1 моторно ховається за твою спину!"
+  },
+  "$c1 с аппетитом клацает зубами при виде $C2.": {
+   "en": "$c1 snaps their teeth hungrily at the sight of $C2.",
+   "ua": "$c1 апетитно клацає зубами, побачивши $C2."
+  },
+  "$c1 с громким мяуканьем вцепляется зубами и когтями в $C4!": {
+   "en": "$c1 sinks its teeth and claws into $C4 with a loud meow!",
+   "ua": "$c1 з голосним нявканням впивається зубами і кігтями в $C4!"
+  },
+  "$c1, похоже, приня$gло|л|ла $C4 за маааленького грызунчика.": {
+   "en": "$c1, it seems, mistook $C4 for a tiiiny little rodent.",
+   "ua": "$c1, схоже, прийня$gло|в|ла $C4 за маааленького гризунчика."
+  },
+  "%1$^C1 засовыва%1$nет|ют пальцы в рот и начина%1$nет|ют блевать.": {
+   "en": "%1$^C1 shove%1$ns| fingers down their throat and start%1$ns| retching.",
+   "ua": "%1$^C1 запиха%1$nє|ють пальці до рота і почина%1$nє|ють блювати."
+  },
+  "%1$^C4 начинает тошнить, когда яд проникает в %1$Gего|его|ее|их тел%1$nо|а.": {
+   "en": "%1$^C4 starts to feel sick as the poison seeps into their bod%1$ny|ies.",
+   "ua": "%1$^C4 починає нудити, коли отрута проникає в %1$Gйого|його|її|їхнє тіл%1$nо|а."
+  },
+  "Вампирам это, увы, недоступно.": {
+   "en": "Alas, vampires can't do that.",
+   "ua": "Вампірам це, на жаль, недоступно."
+  },
+  "Воинам клана Ярости это ни к чему!": {
+   "en": "Warriors of the Rage clan have no need for that!",
+   "ua": "Воїнам клану Люті це ні до чого!"
+  },
+  "Вообразив себя ко$gтом|том|шкой, $c1 пытается изловить и сожрать $C4, но опыта явно не хватает.": {
+   "en": "Picturing itself as a cat, $c1 tries to catch and devour $C4, but clearly lacks the experience.",
+   "ua": "Уявивши себе к$gотом|отом|ішкою, $c1 намагається впіймати і зжерти $C4, але досвіду явно не вистачає."
+  },
+  "На миг вообразив себя ко$gтом|том|шкой, ты пытаешься изловить и сожрать $C4, но опыта явно не хватает.": {
+   "en": "For a moment imagining yourself a cat, you try to catch and devour $C4, but you clearly lack the experience.",
+   "ua": "На мить уявивши себе $gкотом|котом|кішкою, ти намагаєшся впіймати і зжерти $C4, але досвіду явно бракує."
+  },
+  "Тебе надо подрасти, чтобы заглотить это.": {
+   "en": "You need to grow up a bit before you can swallow that.",
+   "ua": "Тобі треба підрости, щоб заковтнути це."
+  },
+  "Тебя начинает тошнить, когда яд проникает в твое тело.": {
+   "en": "You start feeling sick as the poison seeps into your body.",
+   "ua": "Тебе починає нудити, коли отрута проникає в твоє тіло."
+  },
+  "Ты же воин клана Ярости, а не презренный МАГ!": {
+   "en": "You're a warrior of the Rage clan, not some despicable MAGE!",
+   "ua": "Ти ж воїн клану Люті, а не якийсь жалюгідний МАГ!"
+  },
+  "Ты не хочешь осквернять свое тело синтетикой.": {
+   "en": "You don't want to defile your body with synthetics.",
+   "ua": "Ти не хочеш опоганювати своє тіло синтетикою."
+  },
+  "Ты прочищаешь свой желудок двухпальцевым методом.": {
+   "en": "You clear your stomach using the two-finger method.",
+   "ua": "Ти прочищаєш свій шлунок двопальцевим методом."
+  },
+  "Ты с аппетитом клацаешь зубами при виде $C2.": {
+   "en": "You snap your teeth hungrily at the sight of $C2.",
+   "ua": "Ти апетитно клацаєш зубами, побачивши $C2."
+  },
+  "Ты с громким мяуканьем вцепляешься зубами и когтями в $C4!": {
+   "en": "With a loud meow you sink your teeth and claws into $C4!",
+   "ua": "Ти з гучним нявканням впинаєшся зубами й кігтями в $C4!"
+  },
+  "Это животное не сделало тебе ничего плохого!": {
+   "en": "This animal hasn't done anything bad to you!",
+   "ua": "Ця тварина не зробила тобі нічого поганого!"
+  }
+ },
+ "plug-ins/comm/equipment.cpp": {
+  "Ты используешь:": {
+   "en": "You are using:",
+   "ua": "Ти використовуєш:"
+  },
+  "На тебе совсем ничего нет -- не мешало бы одеться!": {
+   "en": "You're not wearing a stitch -- might want to get dressed!",
+   "ua": "На тобі геть нічого немає -- не завадило б одягнутися!"
+  }
+ },
+ "plug-ins/comm/examine.cpp": {
+  "$c1 бросает взгляд на $C4.": {
+   "en": "$c1 glances at $C4.",
+   "ua": "$c1 кидає погляд на $C4."
+  },
+  "$c1 бросает взгляд на тебя.": {
+   "en": "$c1 glances at you.",
+   "ua": "$c1 кидає погляд на тебе."
+  },
+  "$c1 осматривает себя.": {
+   "en": "$c1 examines themselves.",
+   "ua": "$c1 оглядає себе."
+  },
+  "%1$^O1 %2s содерж%1$nит|ат:": {
+   "en": "%1$^O1 %2s contain%1$ns|:",
+   "ua": "%1$^O1 %2s міст%1$nить|ять:"
+  },
+  "%1$^O1 закрыт%1$Gо||а|ы, сперва открой.": {
+   "en": "%1$^O1 is closed, open it first.",
+   "ua": "%1$^O1 закрит%1$Gо|ий|а|і, спершу відкрий."
+  },
+  "%1$^O1 заперт%1$Gо||а|ы на ключ, сперва отопри.": {
+   "en": "%1$^O1 is locked, unlock it first.",
+   "ua": "%1$^O1 замкнен%1$Gо|ий|а|і на ключ, спершу відімкни."
+  },
+  "%^O1 -- чья-то личная собственность, отпереть сможет только хозяин или хозяйка.": {
+   "en": "%^O1 is someone's private property -- only the owner can unlock it.",
+   "ua": "%^O1 -- чиясь особиста власність, відімкнути зможе тільки хазяїн або хазяйка."
+  },
+  "В кармане %1$O2 с надписью '%2$s' ты видишь:": {
+   "en": "In the pocket of %1$O2 labeled '%2$s' you see:",
+   "ua": "У кишені %1$O2 з написом '%2$s' ти бачиш:"
+  },
+  "Внутрь %O2 невозможно заглянуть.": {
+   "en": "It's impossible to look inside %O2.",
+   "ua": "Всередину %O2 неможливо зазирнути."
+  },
+  "Здесь %d золот%s и %d серебрян%s.": {
+   "en": "There are %d gold%s and %d silver%s here.",
+   "ua": "Тут %d золот%s і %d срібн%s."
+  },
+  "Здесь %d золот%s.": {
+   "en": "There's %d gold%s here.",
+   "ua": "Тут %d золот%s."
+  },
+  "Здесь %d серебрян%s.": {
+   "en": "There are %d silver%s here.",
+   "ua": "Тут %d срібн%s."
+  },
+  "Изучить что?": {
+   "en": "Examine what?",
+   "ua": "Вивчити що?"
+  },
+  "На $o4 нанизано:": {
+   "en": "Threaded onto $o4:",
+   "ua": "На $o4 нанизано:"
+  },
+  "На $o6 ты видишь:": {
+   "en": "On $o6 you see:",
+   "ua": "На $o6 ти бачиш:"
+  },
+  "На %1$O6 ты видишь:": {
+   "en": "On %1$O6 you see:",
+   "ua": "На %1$O6 ти бачиш:"
+  },
+  "На полке %1$O2 с надписью '%2$s' ты видишь:": {
+   "en": "On the shelf of %1$O2 labeled '%2$s' you see:",
+   "ua": "На полиці %1$O2 з написом '%2$s' ти бачиш:"
+  },
+  "Отделение '%2$s' %1$O2 содержит:": {
+   "en": "Compartment '%2$s' of %1$O2 contains:",
+   "ua": "Відділення '%2$s' %1$O2 містить:"
+  },
+  "Посмотреть на что?": {
+   "en": "Look at what?",
+   "ua": "Подивитися на що?"
+  },
+  "Ты не видишь здесь ни одного кармана.": {
+   "en": "You don't see a single pocket here.",
+   "ua": "Ти не бачиш тут жодної кишені."
+  },
+  "Ты не видишь этого тут.": {
+   "en": "You don't see that here.",
+   "ua": "Ти не бачиш цього тут."
+  },
+  "Жаль, но здесь нет золота.": {
+   "en": "Too bad, there's no gold here.",
+   "ua": "Шкода, але тут немає золота."
+  },
+  "Ух ты! Одна золотая монетка!": {
+   "en": "Whoa! One gold coin!",
+   "ua": "Ого! Одна золота монетка!"
+  },
+  "Ух ты! Одна серебряная монетка.": {
+   "en": "Whoa! A single silver coin.",
+   "ua": "Ого! Одна срібна монетка."
+  }
+ },
+ "plug-ins/comm/following.cpp": {
+  "$C1 не желает ходить с кем-либо.\n\r": {
+   "en": "$C1 doesn't want to follow anyone.\n\r",
+   "ua": "$C1 не бажає ходити з ким-небудь.\n\r"
+  },
+  "$C1 не может присоединиться к группе $c2.": {
+   "en": "$C1 can't join $c2's group.",
+   "ua": "$C1 не може приєднатися до групи $c2."
+  },
+  "$C1 не может присоединиться к твоей группе.": {
+   "en": "$C1 can't join your group.",
+   "ua": "$C1 не може приєднатися до твоєї групи."
+  },
+  "$C1 не следует за тобой.": {
+   "en": "$C1 isn't following you.",
+   "ua": "$C1 не йде за тобою."
+  },
+  "$C1 не сможет вступить в твою группу.": {
+   "en": "$C1 won't be able to join your group.",
+   "ua": "$C1 не зможе вступити до твоєї групи."
+  },
+  "$C1 присоединил$Gось|ся|ась к группе $c2.": {
+   "en": "$C1 has joined $c2's group.",
+   "ua": "$C1 приєдна$Gлося|вся|лася до групи $c2."
+  },
+  "$C1 присоединил$Gось|ся|ась к твоей группе.": {
+   "en": "$C1 has joined your group.",
+   "ua": "$C1 приєдна$Gлося|вся|лася|лися до твоєї групи."
+  },
+  "$C1 слишком пло$Gхое|хой|хая для твоей группы!": {
+   "en": "$C1 is too weak for your group!",
+   "ua": "$C1 занадто пога$Gне|ний|на для твоєї групи!"
+  },
+  "$c1 делит %d золот%s. Ты получаешь %d золота.": {
+   "en": "$c1 splits %d gold%s. You receive %d gold.",
+   "ua": "$c1 ділить %d золот%s. Ти отримуєш %d золота."
+  },
+  "$c1 делит %d серебра и %d золота, дает тебе %d серебра и %d золота.": {
+   "en": "$c1 splits %d silver and %d gold, giving you %d silver and %d gold.",
+   "ua": "$c1 ділить %d срібла і %d золота, дає тобі %d срібла і %d золота."
+  },
+  "$c1 делит %d серебрянн%s. Ты получаешь %d серебра.": {
+   "en": "$c1 splits %d silver%s. You get %d silver.",
+   "ua": "$c1 ділить %d срібн%s. Ти отримуєш %d срібла."
+  },
+  "$c1 исключает тебя из $s группы.": {
+   "en": "$c1 kicks you out of their group.",
+   "ua": "$c1 виключає тебе зі своєї групи."
+  },
+  "$c1 исключает тебя из числа $s последователей.": {
+   "en": "$c1 excludes you from their followers.",
+   "ua": "$c1 виключає тебе зі своїх послідовників."
+  },
+  "Группа %s:": {
+   "en": "Group %s:",
+   "ua": "Група %s:"
+  },
+  "Можешь забрать себе все.": {
+   "en": "You can take it all for yourself.",
+   "ua": "Можеш забрати собі все."
+  },
+  "Находясь в чужом теле, ты не можешь ни за кем следовать.": {
+   "en": "While in someone else's body, you can't follow anyone.",
+   "ua": "Перебуваючи в чужому тілі, ти не можеш ні за ким слідувати."
+  },
+  "Находясь в чужом теле, ты не можешь распоряжаться группой.": {
+   "en": "While in another's body, you can't command the group.",
+   "ua": "Перебуваючи в чужому тілі, ти не можеш керувати групою."
+  },
+  "Но тебе хочется следовать за $C5!": {
+   "en": "But you want to follow $C5!",
+   "ua": "Але тобі хочеться слідувати за $C5!"
+  },
+  "Но ты следуешь за кем-то еще!": {
+   "en": "But you're already following someone else!",
+   "ua": "Але ти вже йдеш за кимось іншим!"
+  },
+  "Разделить? Сколько?": {
+   "en": "Split? How much?",
+   "ua": "Розділити? Скільки?"
+  },
+  "Следовать за кем?": {
+   "en": "Follow whom?",
+   "ua": "Слідувати за ким?"
+  },
+  "Среди твоих последователей нет никого с таким именем.": {
+   "en": "None of your followers has that name.",
+   "ua": "Серед твоїх послідовників немає нікого з таким ім'ям."
+  },
+  "Твоей группе это не понравится.": {
+   "en": "Your group won't like that.",
+   "ua": "Твоїй групі це не сподобається."
+  },
+  "Теперь ты не разрешаешь следовать за собой.": {
+   "en": "Now you don't allow others to follow you.",
+   "ua": "Тепер ти не дозволяєш слідувати за собою."
+  },
+  "Теперь ты разрешаешь следовать за собой.": {
+   "en": "Now you allow others to follow you.",
+   "ua": "Тепер ти дозволяєш іти за собою."
+  },
+  "Ты делишь %d золот%s. Ты получаешь %d золота.": {
+   "en": "You split %d gold%s. You get %d gold.",
+   "ua": "Ти ділиш %d золот%s. Ти отримуєш %d золота."
+  },
+  "Ты делишь %d серебрянн%s. Ты получаешь %d серебра.": {
+   "en": "You split %d silver%s. You receive %d silver.",
+   "ua": "Ти ділиш %d срібн%s. Ти отримуєш %d срібла."
+  },
+  "Ты исключаешь $C4 из своей группы.": {
+   "en": "You kick $C4 out of your group.",
+   "ua": "Ти виключаєш $C4 зі своєї групи."
+  },
+  "Ты исключаешь $C4 из числа твоих последователей.": {
+   "en": "You remove $C4 from among your followers.",
+   "ua": "Ти виключаєш $C4 з числа своїх послідовників."
+  },
+  "Ты не можешь исключить очарованных монстров из своей группы.": {
+   "en": "You can't remove charmed monsters from your group.",
+   "ua": "Ти не можеш виключити зачарованих монстрів зі своєї групи."
+  },
+  "Ты не можешь покинуть своего повелителя.": {
+   "en": "You cannot leave your master.",
+   "ua": "Ти не можеш покинути свого повелителя."
+  },
+  "Ты не можешь присоединиться к группе $c2.": {
+   "en": "You cannot join $c2's group.",
+   "ua": "Ти не можеш приєднатися до групи $c2."
+  },
+  "Ты не находишь этого здесь.": {
+   "en": "You can't find that here.",
+   "ua": "Ти не знаходиш цього тут."
+  },
+  "Ты не сможешь вступить в группу $C2.": {
+   "en": "You won't be able to join $C2's group.",
+   "ua": "Ти не зможеш вступити в групу $C2."
+  },
+  "Ты не сможешь следовать за $C5.": {
+   "en": "You won't be able to follow $C5.",
+   "ua": "Ти не зможеш слідувати за $C5."
+  },
+  "Ты присоединил$Gось|ся|ась к группе $c2.": {
+   "en": "You joined $c2's group.",
+   "ua": "Ти приєдна$Gлося|вся|лася до групи $c2."
+  },
+  "Ты слишком пло$Gхое|хой|хая для группы $c2.": {
+   "en": "You're not good enough for $c2's group.",
+   "ua": "Ти занадто пога$Gне|ний|на|ні для групи $c2."
+  },
+  "У тебя нет столько, чтоб поделиться.": {
+   "en": "You don't have that much to share.",
+   "ua": "У тебе немає стільки, щоб поділитися."
+  },
+  "Чье следование за тобой ты хочешь прекратить?": {
+   "en": "Whose following do you want to stop?",
+   "ua": "Чиє слідування за тобою ти хочеш припинити?"
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$C1 слишком хоро$Gшее|ший|шая для твоей группы!": {
+   "en": "$C1 is too good for your group!",
+   "ua": "$C1 занадто добр$Gе|ий|а|і для твоєї групи!"
+  },
+  "%^O1 укоризненно вздрагивает, когда ты пытаешься поделиться прибылью с согруппниками.": {
+   "en": "%^O1 flinches reproachfully as you try to share the profit with your group members.",
+   "ua": "%^O1 докірливо здригається, коли ти намагаєшся поділитися прибутком зі своєю групою."
+  },
+  "А смысл?": {
+   "en": "What's the point?",
+   "ua": "А який сенс?"
+  },
+  "От себя не убежишь.": {
+   "en": "You can't run from yourself.",
+   "ua": "Від себе не втечеш."
+  },
+  "Очень мудро.": {
+   "en": "Very wise.",
+   "ua": "Дуже мудро."
+  },
+  "Ты же ненавидишь клан $C2, как ты можешь предлагать $M присоединиться к твоей группе?!": {
+   "en": "You hate $C2's clan, how can you invite them to join your group?!",
+   "ua": "Ти ж ненавидиш клан $C2, як ти можеш пропонувати їм приєднатися до твоєї групи?!"
+  },
+  "Ты же ненавидишь клан $c2, как ты можешь присоединиться к $s группе?!": {
+   "en": "You hate clan $c2 -- how can you join that group?!",
+   "ua": "Ти ж ненавидиш клан $c2, як ти можеш приєднатися до тієї групи?!"
+  },
+  "Ты любишь своего мастера так сильно, что не можешь покинуть $s!": {
+   "en": "You love your master so much that you can't leave them!",
+   "ua": "Ти так сильно любиш свого господаря, що не можеш його покинути!"
+  },
+  "Ты не взял ни одной монеты, но никому об этом не сказал.": {
+   "en": "You didn't take a single coin, but you didn't tell anyone either.",
+   "ua": "Ти не взяв жодної монети, але нікому про це не сказав."
+  },
+  "Ты слишком хоро$Gшее|ший|шая для группы $c2!": {
+   "en": "You're too good for $c2's group!",
+   "ua": "Ти занадто хоро$Gше|ший|ша для групи $c2!"
+  },
+  "Ты уже следуешь за собой.": {
+   "en": "You're already following yourself.",
+   "ua": "Ти вже слідуєш за собою."
+  }
+ },
+ "plug-ins/comm/get.cpp": {
+  "$c1 берет $C4 за $o4.": {
+   "en": "$c1 grabs $C4 by $o4.",
+   "ua": "$c1 бере $C4 за $o4."
+  },
+  "$c1 берет $o4.": {
+   "en": "$c1 takes $o4.",
+   "ua": "$c1 бере $o4."
+  },
+  "$c1 берет тебя за $o4.": {
+   "en": "$c1 takes you by the $o4.",
+   "ua": "$c1 бере тебе за $o4."
+  },
+  "%1$^C1 обжигается о %2$O4.": {
+   "en": "%1$^C1 burns themselves on %2$O4.",
+   "ua": "%1$^C1 обпікається об %2$O4."
+  },
+  "%1$^O1 не контейнер, ты не можешь ничего оттуда взять.": {
+   "en": "%1$^O1 is not a container, you can't take anything from it.",
+   "ua": "%1$^O1 не контейнер, ти не можеш нічого звідти взяти."
+  },
+  "%1$^O4 нужно сперва открыть.": {
+   "en": "%1$^O4 needs to be opened first.",
+   "ua": "%1$^O4 спершу треба відкрити."
+  },
+  "Больше взять ничего не получится.": {
+   "en": "You can't take anything else.",
+   "ua": "Більше нічого взяти не вийде."
+  },
+  "Взять что?": {
+   "en": "Take what?",
+   "ua": "Взяти що?"
+  },
+  "Кто-то использует $o4.": {
+   "en": "Someone is using $o4.",
+   "ua": "Хтось використовує $o4."
+  },
+  "Осторожно, ты не смог%1$Gло||ла бы владеть этой вещью, будучи смертн%1$Gым|ым|ой.": {
+   "en": "Careful, you wouldn't be able to wield this item as a mortal.",
+   "ua": "Обережно, ти не ма%1$Gло|в|ла права володіти цією річчю, будучи смертн%1$Gим|им|ою."
+  },
+  "Осторожно, ты уже несешь слишком много вещей.": {
+   "en": "Careful, you're already carrying too many things.",
+   "ua": "Обережно, ти вже несеш забагато речей."
+  },
+  "Ты берешь $C4 за $o4.": {
+   "en": "You take $C4 by $o4.",
+   "ua": "Ти береш $C4 за $o4."
+  },
+  "Ты берешь $o4.": {
+   "en": "You take $o4.",
+   "ua": "Ти береш $o4."
+  },
+  "Ты не видишь здесь $T.": {
+   "en": "You don't see $T here.",
+   "ua": "Ти не бачиш тут $T."
+  },
+  "Ты не видишь ничего в $o6.": {
+   "en": "You don't see anything in $o6.",
+   "ua": "Ти не бачиш нічого в $o6."
+  },
+  "Ты не видишь ничего подобного в $o6.": {
+   "en": "You don't see anything like that in $o6.",
+   "ua": "Ти не бачиш нічого подібного в $o6."
+  },
+  "Ты не видишь ничего подобного здесь.": {
+   "en": "You don't see anything like that here.",
+   "ua": "Ти не бачиш тут нічого подібного."
+  },
+  "Ты не можешь взять %1$O4.": {
+   "en": "You can't pick up %1$O4.",
+   "ua": "Ти не можеш взяти %1$O4."
+  },
+  "Ты не можешь нести вес больше %d фунтов и поэтому не сможешь поднять %O4.": {
+   "en": "You can't carry more than %d pounds, so you won't be able to pick up %O4.",
+   "ua": "Ти не можеш нести вагу більше %d фунтів, тому не зможеш підняти %O4."
+  },
+  "Ты не можешь сделать этого.": {
+   "en": "You can't do that.",
+   "ua": "Ти не можеш зробити цього."
+  },
+  "Ты не можешь снять %O4 с трупа противника, это не добыча.": {
+   "en": "You can't take %O4 off the enemy's corpse -- it's not loot.",
+   "ua": "Ти не можеш зняти %O4 з трупа ворога, це не здобич."
+  },
+  "Ты не можешь унести больше %d вещей и поэтому не сможешь поднять %O4.": {
+   "en": "You can't carry more than %d items, so you won't be able to pick up %O4.",
+   "ua": "Ти не можеш нести більше %d речей, тому не зможеш підняти %O4."
+  },
+  "Ты не умеешь обшаривать чужие трупы.": {
+   "en": "You don't know how to search other people's corpses.",
+   "ua": "Ти не вмієш обшукувати чужі трупи."
+  },
+  "Ты ничего не видишь здесь.": {
+   "en": "You don't see anything here.",
+   "ua": "Ти нічого тут не бачиш."
+  },
+  "У $C2 нет ничего похожего на $t.": {
+   "en": "$C2 doesn't have anything like $t.",
+   "ua": "У $C2 немає нічого схожого на $t."
+  },
+  "Это не твоя добыча.": {
+   "en": "That's not your loot.",
+   "ua": "Це не твоя здобич."
+  },
+  "И, кстати, не забудь, что продать вещи из ямы для пожертвований все равно не получится.": {
+   "en": "And by the way, don't forget you still can't sell stuff from the donation pit.",
+   "ua": "І, до речі, не забудь, що продати речі з ями для пожертвувань все одно не вийде."
+  },
+  "Не жадничай, пожертвования могут понадобиться кому-то еще.": {
+   "en": "Don't be greedy, someone else might need this donation.",
+   "ua": "Не жадібнич, пожертви можуть знадобитися комусь іншому."
+  },
+  "Похоже, $o4 от земли не оторвать.": {
+   "en": "Looks like $o4 won't budge from the ground.",
+   "ua": "Схоже, $o4 від землі не відірвати."
+  },
+  "Тебе не удалось нашарить ни одного кармана у $o2.": {
+   "en": "You failed to feel out a single pocket on $o2.",
+   "ua": "Тобі не вдалося намацати жодної кишені у $o2."
+  }
+ },
+ "plug-ins/comm/give.cpp": {
+  "$c1 дает $C3 несколько монет.": {
+   "en": "$c1 gives $C3 a few coins.",
+   "ua": "$c1 дає $C3 кілька монет."
+  },
+  "$c1 дает $o4 $C3.": {
+   "en": "$c1 gives $o4 to $C3.",
+   "ua": "$c1 дає $o4 $C3."
+  },
+  "$c1 дает тебе $o4.": {
+   "en": "$c1 gives you $o4.",
+   "ua": "$c1 дає тобі $o4."
+  },
+  "$c1 дает тебе $t золота.": {
+   "en": "$c1 gives you $t gold.",
+   "ua": "$c1 дає тобі $t золота."
+  },
+  "$c1 дает тебе $t серебра.": {
+   "en": "$c1 gives you $t silver.",
+   "ua": "$c1 дає тобі $t срібла."
+  },
+  "$c1 дарит $C3 несколько монет.": {
+   "en": "$c1 gives $C3 a few coins.",
+   "ua": "$c1 дарує $C3 кілька монет."
+  },
+  "$c1 дарит $o4 $C3.": {
+   "en": "$c1 gives $o4 to $C3.",
+   "ua": "$c1 дарує $o4 $C3."
+  },
+  "$c1 дарит тебе $o4.": {
+   "en": "$c1 gives you $o4 as a gift.",
+   "ua": "$c1 дарує тобі $o4."
+  },
+  "$c1 дарит тебе $t золота.": {
+   "en": "$c1 gives you $t gold.",
+   "ua": "$c1 дарує тобі $t золота."
+  },
+  "$c1 дарит тебе $t серебра.": {
+   "en": "$c1 gives you $t silver.",
+   "ua": "$c1 дарує тобі $t срібла."
+  },
+  "%1$^C1 не вид%1$nит|ят этого.": {
+   "en": "%1$^C1 %1$ndoesn't|don't see that.",
+   "ua": "%1$^C1 не бач%1$nить|ать цього."
+  },
+  "%1$^C1 не мо%1$nжет|гут нести столько вещей.": {
+   "en": "%1$^C1 %1$nis|are unable to carry that many things.",
+   "ua": "%1$^C1 не мож%1$nе|уть нести стільки речей."
+  },
+  "%1$^C1 не мо%1$nжет|гут нести такую тяжесть.": {
+   "en": "%1$^C1 %1$nis|are unable to carry that much weight.",
+   "ua": "%1$^C1 не мож%1$nе|уть нести таку вагу."
+  },
+  "%1$^C1 не смо%1$nжет|гут владеть этой вещью.": {
+   "en": "%1$^C1 %1$nisn't|aren't able to wield this item.",
+   "ua": "%1$^C1 не змож%1$nе|уть володіти цією річчю."
+  },
+  "%s себе?": {
+   "en": "%s to yourself?",
+   "ua": "%s собі?"
+  },
+  "Дать себе?": {
+   "en": "Give to yourself?",
+   "ua": "Дати собі?"
+  },
+  "Дать что и кому?": {
+   "en": "Give what to whom?",
+   "ua": "Дати що і кому?"
+  },
+  "Здесь таких нет.": {
+   "en": "There's none like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Разве можно что-то %s призраку?": {
+   "en": "Can you really %s something to a ghost?",
+   "ua": "Хіба можна щось %s привиду?"
+  },
+  "Ты даешь $C3 $t золота.": {
+   "en": "You give $C3 $t gold.",
+   "ua": "Ти даєш $C3 $t золота."
+  },
+  "Ты даешь $C3 $t серебра.": {
+   "en": "You give $C3 $t silver.",
+   "ua": "Ти даєш $C3 $t срібла."
+  },
+  "Ты даешь $o4 $C3.": {
+   "en": "You give $o4 to $C3.",
+   "ua": "Ти даєш $o4 $C3."
+  },
+  "Ты даришь $C3 $t золота.": {
+   "en": "You give $C3 $t gold.",
+   "ua": "Ти даруєш $C3 $t золота."
+  },
+  "Ты даришь $C3 $t серебра.": {
+   "en": "You give $C3 $t silver.",
+   "ua": "Ти даруєш $C3 $t срібла."
+  },
+  "Ты даришь $o4 $C3.": {
+   "en": "You give $o4 to $C3.",
+   "ua": "Ти даруєш $o4 $C3."
+  },
+  "Ты не можешь избавиться от этого.": {
+   "en": "You can't get rid of that.",
+   "ua": "Ти не можеш позбутися цього."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе немає цього."
+  },
+  "Что и кому ты хочешь подарить?": {
+   "en": "What do you want to give, and to whom?",
+   "ua": "Що і кому ти хочеш подарувати?"
+  },
+  "Они ушли, не дождавшись подарков.": {
+   "en": "They left without waiting for gifts.",
+   "ua": "Вони пішли, так і не дочекавшись подарунків."
+  },
+  "Разве можно что-то дать призраку?": {
+   "en": "Can you even give something to a ghost?",
+   "ua": "Хіба можна щось дати привиду?"
+  }
+ },
+ "plug-ins/comm/groupchannel.cpp": {
+  "Здесь никто не откликнется на твой вопрос.": {
+   "en": "No one here will respond to your question.",
+   "ua": "Тут ніхто не відгукнеться на твоє питання."
+  },
+  "На твой вопрос отвечать некому, у тебя нет {hh15питомца{x.": {
+   "en": "There's no one to answer your question -- you don't have a {hh15pet{x.",
+   "ua": "На твоє запитання відповідати нікому, у тебе немає {hh15улюбленця{x."
+  },
+  "Твое сообщение не получено!": {
+   "en": "Your message wasn't received!",
+   "ua": "Твоє повідомлення не отримано!"
+  },
+  "Твой питомец не в состоянии ответить на твой вопрос.": {
+   "en": "Your pet isn't able to answer your question.",
+   "ua": "Твій улюбленець не в змозі відповісти на твоє запитання."
+  }
+ },
+ "plug-ins/comm/help.cpp": {
+  "Нет подсказки по данному слову.": {
+   "en": "There's no help entry for that word.",
+   "ua": "Немає довідки за цим словом."
+  }
+ },
+ "plug-ins/comm/inventory.cpp": {
+  "Ты несешь:": {
+   "en": "You are carrying:",
+   "ua": "Ти несеш:"
+  }
+ },
+ "plug-ins/comm/lock.cpp": {
+  "%1$^O1 и так закры%1$Gто|т|то|ты крышкой и заколоче%1$Gно|н|но|ны.": {
+   "en": "%1$^O1 is already closed with a lid and nailed shut.",
+   "ua": "%1$^O1 і так закрит%1$Gе|ий|а|і кришкою і прибит%1$Gе|ий|а|і цвяхами."
+  },
+  "%1$^O1 и так крепко запер%1$Gто|т|то|ты.": {
+   "en": "%1$^O1 is already locked tight.",
+   "ua": "%1$^O1 і так міцно замкнут%1$Gо|ий|а|і."
+  },
+  "%1$^O1 и так плотно закупоре%1$Gно|н|но|ны пробкой.": {
+   "en": "%1$^O1 is already tightly sealed with a cork.",
+   "ua": "%1$^O1 і так щільно закоркован%1$Gо|ий|а|і корком."
+  },
+  "%1$^O1 уже заперт%1$Gо||а.": {
+   "en": "%1$^O1 is already locked.",
+   "ua": "%1$^O1 вже замкнен%1$Gо||а."
+  },
+  "%1$^O1 уже невозможно закупорить или заколотить намертво.": {
+   "en": "%1$^O1 can no longer be corked or nailed shut.",
+   "ua": "%1$^O1 вже неможливо закупорити або забити наглухо."
+  },
+  "%^C1 закрывает %N4 и запирает %O5.": {
+   "en": "%^C1 closes %N4 and locks %O5.",
+   "ua": "%^C1 закриває %N4 і замикає %O5."
+  },
+  "%^C1 закрывает %O4 и запирает %O5.": {
+   "en": "%^C1 closes %O4 and locks %O5.",
+   "ua": "%^C1 зачиняє %O4 і замикає %O5."
+  },
+  "%^C1 закрывает %O4 и запирает на ключ.": {
+   "en": "%^C1 closes %O4 and locks it with a key.",
+   "ua": "%^C1 зачиняє %O4 і замикає на ключ."
+  },
+  "%^C1 запирает %O4 %O5.": {
+   "en": "%^C1 locks %O4 with %O5.",
+   "ua": "%^C1 замикає %O4 %O5."
+  },
+  "%^C1 запирает %O4 на ключ.": {
+   "en": "%^C1 locks %O4 with a key.",
+   "ua": "%^C1 замикає %O4 на ключ."
+  },
+  "%^N1 защелкивается.": {
+   "en": "%^N1 clicks shut.",
+   "ua": "%^N1 закривається зі клацанням."
+  },
+  "%^O4 невозможно запереть.": {
+   "en": "%^O4 can't be locked.",
+   "ua": "%^O4 неможливо замкнути."
+  },
+  "В %O6 нет замочной скважины -- просто закрой.": {
+   "en": "There's no keyhole in %O6 -- just close it.",
+   "ua": "У %O6 немає замкової щілини -- просто закрий."
+  },
+  "Запереть что?": {
+   "en": "Lock what?",
+   "ua": "Замкнути що?"
+  },
+  "Здесь нет замочной скважины -- просто закрой дверь.": {
+   "en": "There's no keyhole here -- just close the door.",
+   "ua": "Тут немає замкової щілини -- просто зачини двері."
+  },
+  "Здесь нет замочной скважины -- просто закрой.": {
+   "en": "There's no keyhole here -- just close it.",
+   "ua": "Тут немає замкової щілини -- просто зачини."
+  },
+  "Здесь уже заперто.": {
+   "en": "This is already locked.",
+   "ua": "Тут уже замкнено."
+  },
+  "Ты закрываешь %N4 и запираешь %O5.": {
+   "en": "You close %N4 and lock %O5.",
+   "ua": "Ти закриваєш %N4 і замикаєш %O5."
+  },
+  "Ты закрываешь %O4 и запираешь %O5.": {
+   "en": "You close %O4 and lock %O5.",
+   "ua": "Ти закриваєш %O4 і замикаєш %O5."
+  },
+  "Ты закрываешь %O4 и запираешь на ключ.": {
+   "en": "You close %O4 and lock it with a key.",
+   "ua": "Ти закриваєш %O4 і замикаєш на ключ."
+  },
+  "Ты запираешь %N4 %O5.": {
+   "en": "You lock %N4 %O5.",
+   "ua": "Ти замикаєш %N4 %O5."
+  },
+  "Ты запираешь %O4 %O5.": {
+   "en": "You lock %O4 %O5.",
+   "ua": "Ти замикаєш %O4 %O5."
+  },
+  "Ты запираешь %O4 на ключ.": {
+   "en": "You lock %O4 with a key.",
+   "ua": "Ти замикаєш %O4 на ключ."
+  },
+  "У тебя нет ключа.": {
+   "en": "You don't have a key.",
+   "ua": "У тебе немає ключа."
+  },
+  "Это не дверь!": {
+   "en": "That's not a door!",
+   "ua": "Це не двері!"
+  },
+  "Это не контейнер.": {
+   "en": "That's not a container.",
+   "ua": "Це не контейнер."
+  },
+  "Это невозможно запереть.": {
+   "en": "This can't be locked.",
+   "ua": "Це неможливо замкнути."
+  }
+ },
+ "plug-ins/comm/look.cpp": {
+  "\n\rТы заглядываешь в инвентарь: ": {
+   "en": "\n\rYou peek into the inventory: ",
+   "ua": "\n\rТи заглядаєш в інвентар: "
+  },
+  "\r\n$C1 использует: ": {
+   "en": "\r\n$C1 is using: ",
+   "ua": "\r\n$C1 використовує: "
+  },
+  "\r\nБоевая трансформация скрывает экипировку от твоего взора.": {
+   "en": "\r\nYour battle transformation hides your equipment from view.",
+   "ua": "\r\nБойова трансформація приховує спорядження від твого погляду."
+  },
+  "$N1: тут закрыто.": {
+   "en": "$N1: it's locked here.",
+   "ua": "$N1: тут зачинено."
+  },
+  "$N1: тут открыто.": {
+   "en": "$N1: it's open here.",
+   "ua": "$N1: тут відчинено."
+  },
+  "$c1 смотрит на $C4.": {
+   "en": "$c1 looks at $C4.",
+   "ua": "$c1 дивиться на $C4."
+  },
+  "$c1 смотрит на себя.": {
+   "en": "$c1 looks at themselves.",
+   "ua": "$c1 дивиться на себе."
+  },
+  "$c1 смотрит на тебя.": {
+   "en": "$c1 looks at you.",
+   "ua": "$c1 дивиться на тебе."
+  },
+  "%1$N1: тут закрыто.": {
+   "en": "%1$N1: it's closed here.",
+   "ua": "%1$N1: тут зачинено."
+  },
+  "%1$N1: тут открыто.": {
+   "en": "%1$N1: it's open here.",
+   "ua": "%1$N1: тут відчинено."
+  },
+  "({1{DНевидим%Gо||а{2)": {
+   "en": "({1{DInvisible{2)",
+   "ua": "({1{DНевидим%Gе|ий|а|і{2)"
+  },
+  "({1{DСпрятан%Gо||а{2)": {
+   "en": "({1{Dhidden{2)",
+   "ua": "({1{DСхован%Gо|ий|а{2)"
+  },
+  "({1{GЗамаскирован%Gо||а{2)": {
+   "en": "({1{GDisguised{2)",
+   "ua": "({1{GЗамаскован%Gе|ий|а|і{2)"
+  },
+  "({1{bОчень невидим%Gо||а{2)": {
+   "en": "({1{bVery invisible{2)",
+   "ua": "({1{bДуже невидим%Gе|ий|а|і{2)"
+  },
+  "({1{gОседлан%Gо||а{2)": {
+   "en": "({1{gRidden{2)",
+   "ua": "({1{gОсідлан%Gо|ий|а{2)"
+  },
+  "({1{mОчарован%Gо||а{2)": {
+   "en": "({1{mCharmed{2)",
+   "ua": "({1{mЗачаров%Gано|аний|ана|ані{2)"
+  },
+  "{B име%1$nет|ют несколько маленьких ран и синяков": {
+   "en": "{B ha%1$ns|ve a few small wounds and bruises",
+   "ua": "{B ма%1$nє|ють кілька невеликих ран і синців"
+  },
+  "{G име%1$nет|ют довольно много ран": {
+   "en": "{G ha%1$ns|ve quite a few wounds",
+   "ua": "{G ма%1$nє|ють досить багато ран"
+  },
+  "Здесь нет ничего особенного.": {
+   "en": "There's nothing special here.",
+   "ua": "Тут немає нічого особливого."
+  },
+  "Здесь слишком темно... ": {
+   "en": "It's too dark here... ",
+   "ua": "Тут занадто темно... "
+  },
+  "Ничего особенного тут.": {
+   "en": "Nothing special here.",
+   "ua": "Нічого особливого тут."
+  },
+  "Тебе не удается ничего разглядеть в кромешной темноте.": {
+   "en": "You can't make out anything in the pitch darkness.",
+   "ua": "Тобі не вдається нічого розгледіти в непроглядній темряві."
+  },
+  "Ты выглядишь как обычн$Gое|ый|ая $n1.": {
+   "en": "You look like an ordinary $n1.",
+   "ua": "Ти виглядаєш як звичайн$Gе|ий|а $n1."
+  },
+  "Ты не видишь этого тут.": {
+   "en": "You don't see that here.",
+   "ua": "Ти не бачиш цього тут."
+  },
+  "Ты не можешь видеть вещи!": {
+   "en": "You can't see things!",
+   "ua": "Ти не можеш бачити речі!"
+  },
+  "Ты ничего не видишь, ты спишь!": {
+   "en": "You don't see anything, you're asleep!",
+   "ua": "Ти нічого не бачиш, ти спиш!"
+  },
+  "{R истека%1$nет|ют кровью": {
+   "en": "{R bleed%1$ns| out",
+   "ua": "{R стіка%1$nє|ють кров'ю"
+  },
+  "{WТы видишь взгляд {Rпылающих красных глаз{W, следящих за ТОБОЙ!{x": {
+   "en": "{WYou see the gaze of {Rblazing red eyes{W, watching YOU!{x",
+   "ua": "{WТи бачиш погляд {Rпалаючих червоних очей{W, що стежать за ТОБОЮ!{x"
+  },
+  "Огромное и мускулистое тело ночно%1$Gго|го|й хищни%1$Gка|ка|цы, обрамленное крыльями, какие есть у летучих мышей, замерло в ожидании.\n\r": {
+   "en": "The huge, muscular body of the night predator, framed by wings like a bat's, has frozen in anticipation.\n\r",
+   "ua": "Величезне й мускулисте тіло ніч%1$Gного|ного|ної хижа%1$Gка|ка|чки, облямоване крилами, які є в кажанів, завмерло в очікуванні.\n\r"
+  },
+  "Ты не видишь ничего, кроме звезд!": {
+   "en": "You see nothing but stars!",
+   "ua": "Ти не бачиш нічого, окрім зірок!"
+  }
+ },
+ "plug-ins/comm/move.cpp": {
+  "Куда ты хочешь войти?": {
+   "en": "Where do you want to enter?",
+   "ua": "Куди ти хочеш увійти?"
+  },
+  "Ты не видишь здесь такого портала или дополнительного выхода.": {
+   "en": "You don't see such a portal or extra exit here.",
+   "ua": "Ти не бачиш тут такого порталу чи додаткового виходу."
+  },
+  "Ты не находишь пути внутрь %O2, это не портал.": {
+   "en": "You can't find a way inside %O2, it's not a portal.",
+   "ua": "Ти не знаходиш шляху всередину %O2, це не портал."
+  }
+ },
+ "plug-ins/comm/open.cpp": {
+  "$c1 вынимает пробку из $O2.": {
+   "en": "$c1 pulls the stopper out of $O2.",
+   "ua": "$c1 виймає корок з $O2."
+  },
+  "$c1 открывает $O4.": {
+   "en": "$c1 opens $O4.",
+   "ua": "$c1 відкриває $O4."
+  },
+  "$c1 открывает $o4.": {
+   "en": "$c1 opens $o4.",
+   "ua": "$c1 відкриває $o4."
+  },
+  "$c1 открывает крышку $O2.": {
+   "en": "$c1 opens the lid of $O2.",
+   "ua": "$c1 відкриває кришку $O2."
+  },
+  "%1$^O1 закры%1$Gто|т|та|ты крышкой и заколоче%1$Gн|но|на|ны.": {
+   "en": "%1$^O1 is closed with a lid and boarded up.",
+   "ua": "%1$^O1 закрит%1$Gо|ий|а|і кришкою і забит%1$Gо|ий|а|і цвяхами."
+  },
+  "%1$^O1 запер%1$Gто|т|та|ты.": {
+   "en": "%1$^O1 is locked.",
+   "ua": "%1$^O1 замкнен%1$Gе|ий|а|і."
+  },
+  "%1$^O1 и так не запер%1$Gто|т|та|ты.": {
+   "en": "%1$^O1 wasn't locked anyway.",
+   "ua": "%1$^O1 і так не замкнен%1$Gо|ий|а|і."
+  },
+  "%1$^O1 крепко запер%1$Gто|т|та|ты.": {
+   "en": "%1$^O1 is securely locked.",
+   "ua": "%1$^O1 міцно замкнен%1$Gе|ий|а|і."
+  },
+  "%1$^O1 плотно закупоре%1$Gно|н|на|ны пробкой, поищи штопор.": {
+   "en": "%1$^O1 is tightly corked with a stopper -- look for a corkscrew.",
+   "ua": "%1$^O1 щільно закупорен%1$Gе|ий|а|і корком, пошукай штопор."
+  },
+  "%^O4 невозможно открыть.": {
+   "en": "%^O4 cannot be opened.",
+   "ua": "%^O4 неможливо відкрити."
+  },
+  "Здесь заперто.": {
+   "en": "It's locked here.",
+   "ua": "Тут замкнено."
+  },
+  "Открыть что?": {
+   "en": "Open what?",
+   "ua": "Відкрити що?"
+  },
+  "Ты вынимаешь пробку из $O2.": {
+   "en": "You pull the cork out of $O2.",
+   "ua": "Ти виймаєш корок з $O2."
+  },
+  "Ты не можешь сделать этого.": {
+   "en": "You can't do that.",
+   "ua": "Ти не можеш це зробити."
+  },
+  "Ты открываешь $O4.": {
+   "en": "You open $O4.",
+   "ua": "Ти відкриваєш $O4."
+  },
+  "Ты открываешь $o4.": {
+   "en": "You open $o4.",
+   "ua": "Ти відкриваєш $o4."
+  },
+  "Ты открываешь крышку $O2.": {
+   "en": "You open the lid of $O2.",
+   "ua": "Ти відкриваєш кришку $O2."
+  },
+  "Это уже открыто.": {
+   "en": "That's already open.",
+   "ua": "Це вже відкрито."
+  }
+ },
+ "plug-ins/comm/prompt.cpp": {
+  "Вывод строки состояния включен.": {
+   "en": "Status line output is enabled.",
+   "ua": "Виведення рядка стану увімкнено."
+  },
+  "Вывод строки состояния выключен.": {
+   "en": "Status line output is disabled.",
+   "ua": "Виведення рядка стану вимкнено."
+  },
+  "Новая строка состояния в бою: %s": {
+   "en": "New combat status line: %s",
+   "ua": "Новий рядок стану в бою: %s"
+  },
+  "Новая строка состояния: %s": {
+   "en": "New status line: %s",
+   "ua": "Новий рядок стану: %s"
+  },
+  "Текущая строка состояния в бою:": {
+   "en": "Current combat status line:",
+   "ua": "Поточний рядок стану в бою:"
+  },
+  "Текущая строка состояния:": {
+   "en": "Current status line:",
+   "ua": "Поточний рядок стану:"
+  }
+ },
+ "plug-ins/comm/put.cpp": {
+  "%1$^O1 закрыт%1$Gо||а|ы, попробуй открыть.": {
+   "en": "%1$^O1 is closed, try opening it.",
+   "ua": "%1$^O1 закрит%1$Gо|ий|а|і, спробуй відкрити."
+  },
+  "%1$^O1 закрыт%1$Gо||а|ы.": {
+   "en": "%1$^O1 is closed.",
+   "ua": "%1$^O1 закрит%1$Gо|ий|а|і."
+  },
+  "%1$^O1 заперт%1$Gо||а|ы на ключ, попробуй отпереть.": {
+   "en": "%1$^O1 is locked, try to unlock it.",
+   "ua": "%1$^O1 замкнен%1$Gо||а|і на ключ, спробуй відімкнути."
+  },
+  "%1$^O1 не сможет вместить в себя %2$O4.": {
+   "en": "%1$^O1 won't be able to hold %2$O4.",
+   "ua": "%1$^O1 не зможе вмістити в себе %2$O4."
+  },
+  "%^O1 не контейнер, туда ничего нельзя положить.": {
+   "en": "%^O1 is not a container, you can't put anything in there.",
+   "ua": "%^O1 не контейнер, туди нічого не можна покласти."
+  },
+  "На $o4 ты можешь нанизать только ключи или отмычки.": {
+   "en": "You can only string keys or lockpicks onto $o4.",
+   "ua": "На $o4 ти можеш нанизати лише ключі або відмички."
+  },
+  "На $o6 не осталось свободного места.": {
+   "en": "There's no free space left on $o6.",
+   "ua": "На $o6 не лишилося вільного місця."
+  },
+  "Небезопасно далее складывать снадобья в $o4.": {
+   "en": "It's not safe to keep stacking potions in $o4.",
+   "ua": "Небезпечно й далі складати зілля в $o4."
+  },
+  "Положить что и куда?": {
+   "en": "Put what where?",
+   "ua": "Покласти що і куди?"
+  },
+  "Ты кладешь %s %s %O4.": {
+   "en": "You put %s %s %O4.",
+   "ua": "Ти кладеш %s %s %O4."
+  },
+  "Ты можешь положить деньги только в стационарные контейнеры: ямы для пожертвований, алтари.": {
+   "en": "You can only put money into fixed containers: donation pits, altars.",
+   "ua": "Ти можеш покласти гроші тільки у стаціонарні контейнери: ями для пожертв, вівтарі."
+  },
+  "Ты можешь положить только стрелы в $o4.": {
+   "en": "You can only put arrows in $o4.",
+   "ua": "Ти можеш покласти лише стріли в $o4."
+  },
+  "Ты не видишь здесь $T.": {
+   "en": "You don't see $T here.",
+   "ua": "Ти не бачиш тут $T."
+  },
+  "Ты не можешь избавиться от $o2.": {
+   "en": "You can't get rid of $o2.",
+   "ua": "Ти не можеш позбутися $o2."
+  },
+  "Ты не можешь положить %O4 в другой контейнер.": {
+   "en": "You can't put %O4 into another container.",
+   "ua": "Ти не можеш покласти %O4 в інший контейнер."
+  },
+  "Ты не можешь сделать этого.": {
+   "en": "You can't do that.",
+   "ua": "Ти не можеш зробити цього."
+  },
+  "Ты не наш$gло|ел|ла ничего, что можно нанизать на $o4.": {
+   "en": "You didn't find anything you could thread onto $o4.",
+   "ua": "Ти не знайш$gло|ов|ла|ли нічого, що можна нанизати на $o4."
+  },
+  "Ты не наш$gло|ел|ла ничего, что можно положить в $o4.": {
+   "en": "You didn't find anything you could put in $o4.",
+   "ua": "Ти не знайш$gло|ов|ла нічого, що можна покласти в $o4."
+  },
+  "Ты пытаешься положить деньги в %O4, но это не контейнер.": {
+   "en": "You try to put money into %O4, but it's not a container.",
+   "ua": "Ти намагаєшся покласти гроші в %O4, але це не контейнер."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе немає цього."
+  },
+  "$o4 нельзя хранить в такой дребедени.": {
+   "en": "$o4 can't be stored in such junk.",
+   "ua": "$o4 не можна зберігати в такому мотлоху."
+  },
+  "Опасно запихивать столько вещей в $o4!": {
+   "en": "It's dangerous to stuff that many things into $o4!",
+   "ua": "Небезпечно запихати стільки речей у $o4!"
+  },
+  "Сколько-сколько монет?": {
+   "en": "How many-how many coins?",
+   "ua": "Скільки-скільки монет?"
+  },
+  "Тебе не удалось нашарить ни одного кармана на %O6.": {
+   "en": "You couldn't feel out a single pocket on %O6.",
+   "ua": "Тобі не вдалося намацати жодної кишені на %O6."
+  },
+  "Ты не можешь положить что-то в себя же.": {
+   "en": "You can't put something inside yourself.",
+   "ua": "Ти не можеш покласти щось у самого себе."
+  }
+ },
+ "plug-ins/comm/quit.cpp": {
+  "$c1 покину$gло|л|ла этот мир.": {
+   "en": "$c1 has left this world.",
+   "ua": "$c1 покину$gло|в|ла цей світ."
+  },
+  "%1$#C1 покинул%1$#Gо||а Мир Мечты.": {
+   "en": "%1$#C1 has left the World of Dreams.",
+   "ua": "%1$#C1 покину%1$#Gло|в|ла|ли Світ Мрій."
+  },
+  "Здесь нет ренты. Просто покинь мир.": {
+   "en": "There's no rent here. Just leave the world.",
+   "ua": "Тут немає ренти. Просто покинь світ."
+  },
+  "Не сейчас! Тебе необходимо закончить сражение!": {
+   "en": "Not now! You need to finish the fight first!",
+   "ua": "Не зараз! Тобі треба закінчити бій!"
+  },
+  "Подожди пока вещь, выставленная на аукцион, будет продана или возвращена.": {
+   "en": "Wait until the item put up for auction is sold or returned.",
+   "ua": "Зачекай, поки річ, виставлену на аукціон, буде продано або повернено."
+  },
+  "Ты не можешь покинуть сво%1$Gего|его|ю хозя%1$Gина|ина|йку.": {
+   "en": "You can't leave your owner.",
+   "ua": "Ти не можеш покинути сво%1$Gго|го|ю хазя%1$Gїна|їна|йку."
+  },
+  "Архивариус {CМира Мечты{x заносит сведения о тебе в свои манускрипты.": {
+   "en": "The Archivist of {CDreamland{x records your deeds in the manuscripts.",
+   "ua": "Архіваріус {CСвіту Мрії{x заносить відомості про тебе у свої манускрипти."
+  },
+  "Боги еще помнят убийство, совершенное тобой.": {
+   "en": "The gods still remember the murder you committed.",
+   "ua": "Боги ще пам'ятають вбивство, вчинене тобою."
+  },
+  "Жаль, но все хорошее когда-нибудь заканчивается.": {
+   "en": "Too bad, but all good things come to an end eventually.",
+   "ua": "Шкода, але все хороше колись закінчується."
+  },
+  "Злые духи в этой зоне не отпускают тебя.": {
+   "en": "Evil spirits in this zone won't let you go.",
+   "ua": "Злі духи в цій зоні не відпускають тебе."
+  },
+  "Злые духи, овладевшие тобой, не позволяют тебе покинуть этот мир.": {
+   "en": "The evil spirits possessing you won't let you leave this world.",
+   "ua": "Злі духи, що заволоділи тобою, не дозволяють тобі покинути цей світ."
+  },
+  "Правда о твоем поражении еще не забыта.": {
+   "en": "The truth about your defeat is not yet forgotten.",
+   "ua": "Правда про твою поразку ще не забута."
+  },
+  "Сначала выберись из ловушки, а потом можно и покинуть этот мир.": {
+   "en": "Get out of the trap first, then you can leave this world.",
+   "ua": "Спершу вибирайся з пастки, а потім вже можна й покинути цей світ."
+  },
+  "Ты еще не УМЕ%GРЛО|Р|РЛА.": {
+   "en": "You haven't DIED yet.",
+   "ua": "Ти ще не ПОМЕ%GРЛО|Р|РЛА."
+  },
+  "Ты не можешь покинуть этот мир! Твой дух во власти противника.": {
+   "en": "You cannot leave this world! Your spirit is in your enemy's grip.",
+   "ua": "Ти не можеш покинути цей світ! Твій дух у владі супротивника."
+  },
+  "Ты не можешь этого сделать -- здесь не твоя территория!": {
+   "en": "You can't do that -- this isn't your territory!",
+   "ua": "Ти не можеш цього зробити -- тут не твоя територія!"
+  },
+  "Ты не можешь этого сделать -- тебя ждет Суд!": {
+   "en": "You can't do that -- the Court awaits you!",
+   "ua": "Ти не можеш цього зробити -- на тебе чекає Суд!"
+  },
+  "У тебя слишком много адреналина в крови.": {
+   "en": "You've got too much adrenaline in your blood.",
+   "ua": "У тебе занадто багато адреналіну в крові."
+  }
+ },
+ "plug-ins/comm/read.cpp": {
+  "Ты не видишь этого тут.": {
+   "en": "You don't see that here.",
+   "ua": "Ти не бачиш цього тут."
+  }
+ },
+ "plug-ins/comm/report.cpp": {
+  "%1$^C1 говорит тебе '{G%N2, я %d уровня, у меня %d/%d жизни и %d/%d маны.{x'": {
+   "en": "%1$^C1 tells you '{G%N2, I'm level %d, I have %d/%d health and %d/%d mana.{x'",
+   "ua": "%1$^C1 каже тобі '{G%N2, я %d рівня, у мене %d/%d здоров'я і %d/%d мани.{x'"
+  }
+ },
+ "plug-ins/comm/run.cpp": {
+  "До упора в одну сторону можно побежать только один раз.": {
+   "en": "You can only run all the way in one direction once.",
+   "ua": "До упору в один бік можна побігти тільки один раз."
+  },
+  "Исходное положение для бега -- стоя!": {
+   "en": "The starting position for running is standing!",
+   "ua": "Вихідне положення для бігу -- стоячи!"
+  },
+  "Маршрут не может оканчиваться на цифру.": {
+   "en": "A route can't end with a digit.",
+   "ua": "Маршрут не може закінчуватися на цифру."
+  },
+  "Непонятное направление для бега: '%c'.": {
+   "en": "Unrecognized direction to run: '%c'.",
+   "ua": "Незрозумілий напрямок для бігу: '%c'."
+  },
+  "По какому маршруту ты хочешь бежать?": {
+   "en": "Which route do you want to run?",
+   "ua": "Яким маршрутом ти хочеш бігти?"
+  },
+  "Развернутый маршрут: %s": {
+   "en": "Expanded route: %s",
+   "ua": "Розгорнутий маршрут: %s"
+  },
+  "Слишком далеко бежать.": {
+   "en": "Too far to run.",
+   "ua": "Занадто далеко бігти."
+  },
+  "Тебе оставалось бежать: {hs{c%s{x": {
+   "en": "You still have left to run: {hs{c%s{x",
+   "ua": "Тобі залишалося бігти: {hs{c%s{x"
+  },
+  "Тебе доступно только передвижение пешком, увы.": {
+   "en": "Alas, all that's available to you is moving on foot.",
+   "ua": "На жаль, тобі доступне лише пересування пішки."
+  }
+ },
+ "plug-ins/comm/scan.cpp": {
+  "$c1 осматривает все вокруг.": {
+   "en": "$c1 looks around at everything.",
+   "ua": "$c1 оглядає все навкруги."
+  },
+  "$c1 пристально смотрит $T.": {
+   "en": "$c1 stares intently $T.",
+   "ua": "$c1 пильно дивиться $T."
+  },
+  "В какую сторону?": {
+   "en": "Which direction?",
+   "ua": "У який бік?"
+  },
+  "Ты видишь:": {
+   "en": "You see:",
+   "ua": "Ти бачиш:"
+  },
+  "Ты пристально смотришь $T.": {
+   "en": "You stare intently at $T.",
+   "ua": "Ти пильно дивишся $T."
+  },
+  "Ты спишь и можешь видеть только сны.": {
+   "en": "You're asleep and can only see dreams.",
+   "ua": "Ти спиш і можеш бачити тільки сни."
+  },
+  "Ты ничего не видишь, кроме звезд...": {
+   "en": "You see nothing but stars...",
+   "ua": "Ти нічого не бачиш, окрім зірок..."
+  }
+ },
+ "plug-ins/comm/score.cpp": {
+  "     %1$s| {xТы призрак и обретёшь плоть через {Y%2$3d {xсекунд%2$-1Iу|ы|.                  %1$s|": {
+   "en": "     %1$s| {xYou are a ghost and will regain flesh in {Y%2$3d {xsecond%2$-1I|s|s.                  %1$s|",
+   "ua": "     %1$s| {xТи привид і відновиш плоть через {Y%2$3d {xсекунд%2$-1Iу|и|.                  %1$s|"
+  },
+  "%^N1 %d (%d), максимум %d.": {
+   "en": "%^N1 %d (%d), max %d.",
+   "ua": "%^N1 %d (%d), максимум %d."
+  },
+  ", тебе %1$d %1$Iгод|года|лет (%2$d ча%2$Iс|са|сов).": {
+   "en": ", you are %1$d year%1$I|s|s old (%2$d hour%2$I|s|s).",
+   "ua": ", тобі %1$d %1$Iрік|роки|років (%2$d %2$Iгодина|години|годин)."
+  },
+  "{xТы призрак и обретёшь плоть через {Y%1$d {xсекун%1$Iду|ды|д.": {
+   "en": "{xYou are a ghost and will regain flesh in {Y%1$d {xsecond%1$I|s|s.",
+   "ua": "{xТи привид і обретеш плоть через {Y%1$d {xсекун%1$Iду|ди|д."
+  },
+  "Божественный взор %s. Невидимость %d уровня, инкогнито %d уровня.": {
+   "en": "Divine sight %s. Invisibility level %d, incognito level %d.",
+   "ua": "Божественний зір %s. Невидимість %d рівня, інкогніто %d рівня."
+  },
+  "Вес %d из %d.": {
+   "en": "Weight %d of %d.",
+   "ua": "Вага %d з %d."
+  },
+  "Вещи %d из %d.": {
+   "en": "Items %d of %d.",
+   "ua": "Речі %d з %d."
+  },
+  "Возраст %d.": {
+   "en": "Age %d.",
+   "ua": "Вік %d."
+  },
+  "До %1$s квеста осталось {Y%2$d{x ти%2$Iк|ка|ков.": {
+   "en": "{Y%2$d{x tick%2$I|s|s left until %1$s quest.",
+   "ua": "До %1$s лишилося {Y%2$d{x ти%2$Iк|ки|ків."
+  },
+  "Защита от заклинаний %d.": {
+   "en": "Saves versus spells %d.",
+   "ua": "Захист від заклять %d."
+  },
+  "Защита от укола {W%d{x, от удара {W%d{x, от разрезания {W%d{x, от экзотики {W%d{x.\n\r": {
+   "en": "Protection from piercing {W%d{x, from blunt {W%d{x, from slashing {W%d{x, from exotic {W%d{x.\n\r",
+   "ua": "Захист від колючої {W%d{x, від тупої {W%d{x, від ріжучої {W%d{x, від екзотичної {W%d{x.\n\r"
+  },
+  "Защита от уколов %d, ударов %d, разрезов %d, экзотики %d.": {
+   "en": "Protection from pierce %d, blunt %d, slash %d, exotic %d.",
+   "ua": "Захист від колючих %d, тупих %d, ріжучих %d, екзотичних %d."
+  },
+  "Здоровье %d из %d.": {
+   "en": "Health %d out of %d.",
+   "ua": "Здоров'я %d з %d."
+  },
+  "Золота %d.": {
+   "en": "Gold: %d.",
+   "ua": "Золота: %d."
+  },
+  "Мана %d из %d.": {
+   "en": "Mana %d of %d.",
+   "ua": "Мана %d з %d."
+  },
+  "Опыта до уровня %d.": {
+   "en": "Experience to next level: %d.",
+   "ua": "Досвіду до рівня: %d."
+  },
+  "Пол %s.": {
+   "en": "Gender: %s.",
+   "ua": "Стать: %s."
+  },
+  "Практик %d.": {
+   "en": "Practices: %d.",
+   "ua": "Практик: %d."
+  },
+  "Религия %s.": {
+   "en": "Religion: %s.",
+   "ua": "Релігія %s."
+  },
+  "Серебра %d.": {
+   "en": "Silver: %d.",
+   "ua": "Срібла %d."
+  },
+  "Смертей %d.": {
+   "en": "Deaths: %d.",
+   "ua": "Смертей: %d."
+  },
+  "Такого параметра не существует или он скрыт от тебя, попробуй что-то еще.": {
+   "en": "No such parameter exists, or it's hidden from you -- try something else.",
+   "ua": "Такого параметра не існує, або він прихований від тебе, спробуй щось інше."
+  },
+  "Твои заслуги перед законом:  %d.\n\r": {
+   "en": "Your merits before the law:  %d.\n\r",
+   "ua": "Твої заслуги перед законом:  %d.\n\r"
+  },
+  "Твои параметры: исходные, (текущие)\n\r      Сила : %d(%d)    Интеллект : %d(%d)\n\r  Мудрость : %d(%d)     Ловкость : %d(%d)\n\r  Сложение : %d(%d)      Обаяние : %d(%d)\n\r": {
+   "en": "Your stats: base, (current)\n\r      Str : %d(%d)    Int : %d(%d)\n\r  Wis : %d(%d)     Dex : %d(%d)\n\r  Con : %d(%d)      Cha : %d(%d)\n\r",
+   "ua": "Твої параметри: базові, (поточні)\n\r      Сила : %d(%d)    Інтелект : %d(%d)\n\r  Мудрість : %d(%d)     Спритність : %d(%d)\n\r  Тілобудова : %d(%d)      Харизма : %d(%d)\n\r"
+  },
+  "Твой дом - %s.": {
+   "en": "Your home is %s.",
+   "ua": "Твій дім - %s."
+  },
+  "Твоя религия: {C%s{x.  ": {
+   "en": "Your religion: {C%s{x.  ",
+   "ua": "Твоя релігія: {C%s{x.  "
+  },
+  "Тебе нужно набрать {W%d{x очков опыта до следующего уровня.\n\r": {
+   "en": "You need to earn {W%d{x experience points to reach the next level.\n\r",
+   "ua": "Тобі потрібно набрати {W%d{x очок досвіду до наступного рівня.\n\r"
+  },
+  "Тебя убили уже {r%1$d{x ра%1$Iз|за|з.": {
+   "en": "You have already been killed {r%1$d{x time%1$I|s|s.",
+   "ua": "Тебе вже вбивали {r%1$d{x ра%1$Iз|зи|з."
+  },
+  "Точность %d.": {
+   "en": "Accuracy %d.",
+   "ua": "Точність %d."
+  },
+  "Точность: {C%d{x  Урон: {C%d{x  Защита от заклинаний: {C%d{x\n\r": {
+   "en": "Accuracy: {C%d{x  Damage: {C%d{x  Spell defense: {C%d{x\n\r",
+   "ua": "Точність: {C%d{x  Шкода: {C%d{x  Захист від заклять: {C%d{x\n\r"
+  },
+  "Тренировки %d.": {
+   "en": "Practices: %d.",
+   "ua": "Тренування: %d."
+  },
+  "Ты %N1.": {
+   "en": "You %N1.",
+   "ua": "Ти %N1."
+  },
+  "Ты {W%1$s%2$s{x, уровень {C%3$d{w": {
+   "en": "You are {W%1$s%2$s{x, level {C%3$d{w",
+   "ua": "Ти {W%1$s%2$s{x, рівень {C%3$d{w"
+  },
+  "Ты не определил%Gось|ся|ась с выбором религии.": {
+   "en": "You haven't settled on a religion yet.",
+   "ua": "Ти не визнач%Gилось|ився|илася з вибором релігії."
+  },
+  "Ты не определил%Gось|ся|ась с выбором религии.  ": {
+   "en": "You haven't decided on a religion yet.  ",
+   "ua": "Ти не визначи%Gлося|вся|лася з вибором релігії.  "
+  },
+  "Ты несешь {W%d/%d{x вещей с весом {W%d/%d{x фунтов.\n\r": {
+   "en": "You are carrying {W%d/%d{x items weighing {W%d/%d{x pounds.\n\r",
+   "ua": "Ти несеш {W%d/%d{x речей вагою {W%d/%d{x фунтів.\n\r"
+  },
+  "Ты охраняешь: %s. ": {
+   "en": "You are guarding: %s. ",
+   "ua": "Ти охороняєш: %s. "
+  },
+  "Ты охраняешься: %s.": {
+   "en": "You are guarded by: %s.",
+   "ua": "Тебе охороняє: %s."
+  },
+  "Ты попытаешься убежать при %d жизни.  ": {
+   "en": "You will attempt to flee at %d HP.  ",
+   "ua": "Ти спробуєш втекти при %d ХП.  "
+  },
+  "Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.": {
+   "en": "You have killed {Y%d{x %s, {W%d{x %s, and {r%d{x %s characters.",
+   "ua": "Ти вби%Gло|в|ла {Y%d{x %s, {W%d{x %s та {r%d{x %s персонажів."
+  },
+  "Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.\n\r": {
+   "en": "You have killed {Y%d{x %s, {W%d{x %s and {r%d{x %s characters.\n\r",
+   "ua": "Ти уби%Gло|в|ла {Y%d{x %s, {W%d{x %s і {r%d{x %s персонажів.\n\r"
+  },
+  "У тебя %1$d очк%1$Iо|а|ов опыта. До следующего уровня осталось %2$d очк%2$Iо|а|ов из %3$d.": {
+   "en": "You have %1$d experience point%1$I|s|s. %2$d point%2$I|s|s remain until the next level, out of %3$d.",
+   "ua": "У тебе %1$d бал%1$I|и|ів досвіду. До наступного рівня залишилося %2$d бал%2$I|и|ів із %3$d."
+  },
+  "У тебя %s натура.": {
+   "en": "You have a %s nature.",
+   "ua": "У тебе %s натура."
+  },
+  "У тебя %s натура.  ": {
+   "en": "You have a %s nature.  ",
+   "ua": "У тебе %s натура.  "
+  },
+  "У тебя %s этос.": {
+   "en": "You have %s ethos.",
+   "ua": "У тебе %s етос."
+  },
+  "У тебя {R%d{x/{r%d{x жизни, {C%d{x/{c%d{x энергии и %d/%d движения.\n\r": {
+   "en": "You have {R%d{x/{r%d{x hp, {C%d{x/{c%d{x mana and %d/%d moves.\n\r",
+   "ua": "У тебе {R%d{x/{r%d{x здоров'я, {C%d{x/{c%d{x енергії та %d/%d руху.\n\r"
+  },
+  "У тебя {W%d{x очков опыта, и %s\n\r": {
+   "en": "You have {W%d{x experience points, and %s\n\r",
+   "ua": "У тебе {W%d{x очок досвіду, і %s\n\r"
+  },
+  "У тебя {Y%1$d{x квестов%1$Iая|ые|ых едини%1$Iца|цы|ц. ": {
+   "en": "You have {Y%1$d{x quest point%1$I|s|s. ",
+   "ua": "У тебе {Y%1$d{x квестов%1$Iа|і|их одиниц%1$Iя|і|ь. "
+  },
+  "У тебя {Y%1$d{x практи%1$Iка|ки|к и {Y%2$d{x тренировочн%2$Iая|ые|ых сесси%2$Iя|и|й.": {
+   "en": "You have {Y%1$d{x practice%1$I|s|s and {Y%2$d{x training session%2$I|s|s.",
+   "ua": "У тебе {Y%1$d{x практи%1$Iка|ки|к і {Y%2$d{x тренувальн%2$Iа|і|их сесі%2$Iя|ї|й."
+  },
+  "Уровень %d.": {
+   "en": "Level %d.",
+   "ua": "Рівень %d."
+  },
+  "Урон %d.": {
+   "en": "Damage %d.",
+   "ua": "Шкода %d."
+  },
+  "Шагов %d из %d.": {
+   "en": "Steps %d of %d.",
+   "ua": "Кроків %d з %d."
+  },
+  "Трусость %d.": {
+   "en": "Cowardice %d.",
+   "ua": "Боягузтво %d."
+  }
+ },
+ "plug-ins/comm/search.cpp": {
+  "Ты можешь искать только камни.": {
+   "en": "You can only search for stones.",
+   "ua": "Ти можеш шукати лише камені."
+  }
+ },
+ "plug-ins/comm/senses.cpp": {
+  "  ... но оттуда не доносится ни звука.": {
+   "en": "  ... but not a sound comes from there.",
+   "ua": "  ... але звідти не долинає жодного звуку."
+  },
+  "$c1 нюхает $o4.": {
+   "en": "$c1 sniffs $o4.",
+   "ua": "$c1 нюхає $o4."
+  },
+  "$c1 обнюхивает $C4.": {
+   "en": "$c1 sniffs $C4.",
+   "ua": "$c1 обнюхує $C4."
+  },
+  "$c1 обнюхивает себя.": {
+   "en": "$c1 sniffs themselves.",
+   "ua": "$c1 обнюхує себе."
+  },
+  "$c1 обнюхивает тебя.": {
+   "en": "$c1 sniffs you.",
+   "ua": "$c1 обнюхує тебе."
+  },
+  "$c1 подносит к уху $o4 и прислушивается.": {
+   "en": "$c1 holds $o4 up to their ear and listens.",
+   "ua": "$c1 підносить до вуха $o4 і прислухається."
+  },
+  "$c1 прикладывает ухо к $o3 и прислушивается.": {
+   "en": "$c1 presses an ear to $o3 and listens.",
+   "ua": "$c1 прикладає вухо до $o3 і прислухається."
+  },
+  "$c1 принюхивается.": {
+   "en": "$c1 sniffs the air.",
+   "ua": "$c1 принюхується."
+  },
+  "$c1 прислушивается.": {
+   "en": "$c1 listens closely.",
+   "ua": "$c1 прислухається."
+  },
+  "Вокруг пахнет вполне обычно.": {
+   "en": "The air around smells perfectly ordinary.",
+   "ua": "Навколо пахне цілком звично."
+  },
+  "Пахнет вполне обычно.": {
+   "en": "It smells quite ordinary.",
+   "ua": "Пахне цілком звично."
+  },
+  "Теперь ты будешь пахнуть так:\n\r%s": {
+   "en": "Now you will smell like this:\n\r%s",
+   "ua": "Тепер ти будеш пахнути так:\n\r%s"
+  },
+  "Теперь ты никак не пахнешь.": {
+   "en": "Now you don't smell like anything.",
+   "ua": "Тепер ти ніяк не пахнеш."
+  },
+  "Ты не видишь здесь этого.": {
+   "en": "You don't see that here.",
+   "ua": "Ти не бачиш тут цього."
+  },
+  "Ты не слышишь ничего особенного вокруг.": {
+   "en": "You don't hear anything unusual around you.",
+   "ua": "Ти не чуєш нічого особливого навколо."
+  },
+  "Ты ничем особенным не пахнешь.": {
+   "en": "You don't smell of anything special.",
+   "ua": "Ти нічим особливим не пахнеш."
+  },
+  "Ты нюхаешь $o4.": {
+   "en": "You sniff $o4.",
+   "ua": "Ти нюхаєш $o4."
+  },
+  "Ты нюхаешь воздух.": {
+   "en": "You sniff the air.",
+   "ua": "Ти нюхаєш повітря."
+  },
+  "Ты обнюхиваешь $C4.": {
+   "en": "You sniff $C4.",
+   "ua": "Ти обнюхуєш $C4."
+  },
+  "Ты обнюхиваешь себя.": {
+   "en": "You sniff yourself.",
+   "ua": "Ти обнюхуєш себе."
+  },
+  "Ты пахнешь:\n\r%s": {
+   "en": "You smell like:\n\r%s",
+   "ua": "Ти пахнеш:\n\r%s"
+  },
+  "Ты подносишь к уху $o4 и прислушиваешься.": {
+   "en": "You hold $o4 up to your ear and listen.",
+   "ua": "Ти підносиш до вуха $o4 і прислухаєшся."
+  },
+  "Ты прикладываешь ухо к $o3 и прислушиваешься.": {
+   "en": "You press your ear to $o3 and listen closely.",
+   "ua": "Ти прикладаєш вухо до $o3 і прислухаєшся."
+  },
+  "Ты прислушиваешься.": {
+   "en": "You listen closely.",
+   "ua": "Ти прислухаєшся."
+  },
+  "Ты чувствуешь слабую вибрацию.": {
+   "en": "You feel a faint vibration.",
+   "ua": "Ти відчуваєш слабку вібрацію."
+  }
+ },
+ "plug-ins/comm/set.cpp": {
+  "Аттрибут '%s' нельзя удалить этой командой.": {
+   "en": "The '%s' attribute cannot be removed with this command.",
+   "ua": "Атрибут '%s' не можна видалити цією командою."
+  },
+  "Аттрибут '%s' удален.": {
+   "en": "Attribute '%s' removed.",
+   "ua": "Атрибут '%s' видалено."
+  },
+  "Аттрибут '%s' установлен.": {
+   "en": "Attribute '%s' set.",
+   "ua": "Атрибут '%s' встановлено."
+  },
+  "Временное умение удалено.": {
+   "en": "Temporary skill removed.",
+   "ua": "Тимчасове вміння видалено."
+  },
+  "Значение должно лежать в пределах %d...%d.": {
+   "en": "The value must be within %d...%d.",
+   "ua": "Значення повинно бути в межах %d...%d."
+  },
+  "Значение должно лежать в пределах 0...60.": {
+   "en": "The value must be between 0 and 60.",
+   "ua": "Значення має бути в межах 0...60."
+  },
+  "Значение должно лежать в пределах 2...60.": {
+   "en": "The value must be between 2 and 60.",
+   "ua": "Значення має бути в межах 2...60."
+  },
+  "Игрок не найден, укажите имя полностью.": {
+   "en": "Player not found, specify the full name.",
+   "ua": "Гравця не знайдено, вкажи повне ім'я."
+  },
+  "Игрок с таким именем не найден.": {
+   "en": "No player found with that name.",
+   "ua": "Гравця з таким ім'ям не знайдено."
+  },
+  "Извините, но данная возможность находится в стадии разработки.": {
+   "en": "Sorry, but this feature is still under development.",
+   "ua": "Вибач, але ця можливість перебуває в стадії розробки."
+  },
+  "Использование: set char questp имя_персонажа [+|-]число": {
+   "en": "Usage: set char questp character_name [+|-]number",
+   "ua": "Використання: set char questp ім'я_персонажа [+|-]число"
+  },
+  "Нет тут такого.": {
+   "en": "There's no such thing here.",
+   "ua": "Немає тут такого."
+  },
+  "Ошибочные данные.": {
+   "en": "Invalid data.",
+   "ua": "Помилкові дані."
+  },
+  "Персонаж не найден, укажите имя полностью.": {
+   "en": "Character not found, please specify the full name.",
+   "ua": "Персонажа не знайдено, вкажи ім'я повністю."
+  },
+  "Персонажу %s изменено кол-во квестовых единиц с %d на %d, разница %d.": {
+   "en": "Character %s's quest point count changed from %d to %d, difference %d.",
+   "ua": "Персонажу %s змінено кількість квестових одиниць з %d на %d, різниця %d."
+  },
+  "Персонажу %s изменено кол-во квестовых единиц с %d на %d.": {
+   "en": "Character %s's quest point count has been changed from %d to %d.",
+   "ua": "Персонажу %s змінено кількість квестових одиниць з %d на %d."
+  },
+  "Строковый аттрибут '%s' со значением '%s' установлен.": {
+   "en": "String attribute '%s' with value '%s' has been set.",
+   "ua": "Рядковий атрибут '%s' зі значенням '%s' встановлено."
+  },
+  "Текущее значение: %d": {
+   "en": "Current value: %d",
+   "ua": "Поточне значення: %d"
+  },
+  "Укажите  название аттрибута.": {
+   "en": "Specify an attribute name.",
+   "ua": "Вкажи назву атрибута."
+  },
+  "Укажите имя персонажа и кол-во qp.": {
+   "en": "Specify the character's name and qp amount.",
+   "ua": "Вкажи ім'я персонажа і кількість qp."
+  },
+  "Флаг {BVIOLENT{x выставлен.": {
+   "en": "The {BVIOLENT{x flag has been set.",
+   "ua": "Прапорець {BVIOLENT{x встановлено."
+  },
+  "Флаг {BVIOLENT{x убран.": {
+   "en": "The {BVIOLENT{x flag has been removed.",
+   "ua": "Прапорець {BVIOLENT{x знято."
+  },
+  "Флаг {DSLAIN{x выставлен.": {
+   "en": "The {DSLAIN{x flag has been set.",
+   "ua": "Прапор {DSLAIN{x встановлено."
+  },
+  "Флаг {DSLAIN{x убран.": {
+   "en": "The {DSLAIN{x flag has been removed.",
+   "ua": "Прапор {DSLAIN{x знято."
+  },
+  "Флаг {RKILLER{x выставлен.": {
+   "en": "The {RKILLER{x flag has been set.",
+   "ua": "Прапор {RKILLER{x встановлено."
+  },
+  "Флаг {RKILLER{x убран.": {
+   "en": "The {RKILLER{x flag has been removed.",
+   "ua": "Прапор {RKILLER{x знято."
+  },
+  "Численный аттрибут '%s' со значением '%s' установлен.": {
+   "en": "Numeric attribute '%s' set to value '%s'.",
+   "ua": "Числовий атрибут '%s' зі значенням '%s' встановлено."
+  },
+  "Это сейчас невозможно.": {
+   "en": "That's not possible right now.",
+   "ua": "Це зараз неможливо."
+  },
+  "Это умение не является временным для персонажа.": {
+   "en": "This skill isn't temporary for the character.",
+   "ua": "Це вміння не є тимчасовим для персонажа."
+  }
+ },
+ "plug-ins/comm/showtable.cpp": {
+  "Не найдено ни одной команды, начинающейся с '%s'.": {
+   "en": "No command found starting with '%s'.",
+   "ua": "Не знайдено жодної команди, що починається з '%s'."
+  }
+ },
+ "plug-ins/comm/title.cpp": {
+  "В начале или в конце претитула не должно быть пробелов.": {
+   "en": "There must be no spaces at the start or end of the pretitle.",
+   "ua": "На початку або в кінці претитулу не повинно бути пробілів."
+  },
+  "В претитуле разрешено использовать только буквы, пробелы и одинарные кавычки.": {
+   "en": "Only letters, spaces, and single quotes are allowed in a pretitle.",
+   "ua": "У претитулі дозволено використовувати тільки літери, пробіли та одинарні лапки."
+  },
+  "Русский и английский претитулы очищены.": {
+   "en": "Russian and English pre-titles have been cleared.",
+   "ua": "Російський і англійський претитули очищено."
+  },
+  "Русский претитул: %s": {
+   "en": "Russian pre-title: %s",
+   "ua": "Російський претитул: %s"
+  },
+  "Слишком длинный претитул!": {
+   "en": "Pretitle too long!",
+   "ua": "Занадто довгий претитул!"
+  },
+  "Слишком длинный титул.": {
+   "en": "Title too long.",
+   "ua": "Занадто довгий титул."
+  },
+  "Твой претитул: %s": {
+   "en": "Your pre-title: %s",
+   "ua": "Твій претитул: %s"
+  },
+  "Твой претитул: %s\r\nРусский претитул: %s": {
+   "en": "Your pretitle: %s\r\nRussian pretitle: %s",
+   "ua": "Твій претитул: %s\r\nРосійський претитул: %s"
+  },
+  "Теперь ты {W%C1{x%s{x": {
+   "en": "Now you {W%C1{x%s{x",
+   "ua": "Тепер ти {W%C1{x%s{x"
+  },
+  "Титул удален.": {
+   "en": "Title deleted.",
+   "ua": "Титул видалено."
+  },
+  "Ты не можешь изменить претитул.": {
+   "en": "You can't change your pretitle.",
+   "ua": "Ти не можеш змінити претитул."
+  },
+  "Ты не можешь сменить титул.": {
+   "en": "You can't change your title.",
+   "ua": "Ти не можеш змінити титул."
+  }
+ },
+ "plug-ins/comm/unlock.cpp": {
+  "$c1 открывает $o5 $O2.": {
+   "en": "$c1 unlocks $O2 with $o5.",
+   "ua": "$c1 відмикає $O2 за допомогою $o5."
+  },
+  "%1$^C1 отпирает %2$O4 %3$O5 и открывает %2$P2.": {
+   "en": "%1$^C1 unlocks %2$O4 with %3$O5 and opens it.",
+   "ua": "%1$^C1 відмикає %2$O4 %3$O5 і відкриває %2$O2."
+  },
+  "%1$^C1 отпирает ключом %2$O4 и открывает %2$P2.": {
+   "en": "%1$^C1 unlocks %2$O4 with a key and opens it.",
+   "ua": "%1$^C1 відмикає ключем %2$O4 і відкриває %2$O4."
+  },
+  "%^C1 отпирает %O5 и открывает %N4.": {
+   "en": "%^C1 unlocks %O5 and opens %N4.",
+   "ua": "%^C1 відмикає %O5 і відчиняє %N4."
+  },
+  "%^N1 щелкает.": {
+   "en": "%^N1 clicks.",
+   "ua": "%^N1 клацає."
+  },
+  "%^O1 -- чья-то личная собственность, ключ есть только у хозяина или хозяйки.": {
+   "en": "%^O1 is someone's private property -- only the owner has the key.",
+   "ua": "%^O1 -- чиясь особиста власність, ключ є лише у господаря чи господині."
+  },
+  "%^O4 невозможно отпереть.": {
+   "en": "%^O4 can't be unlocked.",
+   "ua": "%^O4 неможливо відімкнути."
+  },
+  "Здесь уже не заперто.": {
+   "en": "It's already unlocked here.",
+   "ua": "Тут вже не замкнено."
+  },
+  "К %O3 не существует ключа.": {
+   "en": "There is no key to %O3.",
+   "ua": "До %O3 не існує ключа."
+  },
+  "К этой двери не существует ключа.": {
+   "en": "There's no key to this door.",
+   "ua": "До цих дверей не існує ключа."
+  },
+  "Отпереть что?": {
+   "en": "Unlock what?",
+   "ua": "Відімкнути що?"
+  },
+  "Тут не заперто и не закупорено.": {
+   "en": "This isn't locked or sealed.",
+   "ua": "Тут не замкнено і не закупорено."
+  },
+  "Ты выдергиваешь гвозди из крышки $O2 с помощью $o4.": {
+   "en": "You pry the nails out of $O2's lid with $o4.",
+   "ua": "Ти витягуєш цвяхи з кришки $O2 за допомогою $o4."
+  },
+  "Ты отпираешь %1$O4 %2$O5 и открываешь %1$P2.": {
+   "en": "You unlock %1$O4 with %2$O5 and open it.",
+   "ua": "Ти відмикаєш %1$O4 %2$O5 і відчиняєш %1$O4."
+  },
+  "Ты отпираешь %O5 и открываешь %N4.": {
+   "en": "You unlock %O5 and open %N4.",
+   "ua": "Ти відмикаєш %O5 і відкриваєш %N4."
+  },
+  "Ты отпираешь ключом %1$O4 и открываешь %1$P2.": {
+   "en": "You unlock %1$O4 with the key and open it.",
+   "ua": "Ти відмикаєш ключем %1$O4 і відчиняєш %1$O4."
+  },
+  "Ты расшатываешь пробку в $O6 с помощью $o4.": {
+   "en": "You loosen the stopper in $O6 using $o4.",
+   "ua": "Ти розхитуєш корок у $O6 за допомогою $o4."
+  },
+  "У тебя нет ключа.": {
+   "en": "You don't have a key.",
+   "ua": "У тебе немає ключа."
+  },
+  "У тебя нечем вытащить пробку.": {
+   "en": "You have nothing to pull the cork out with.",
+   "ua": "Тобі нічим витягти корок."
+  },
+  "У тебя нечем открыть эту емкость.": {
+   "en": "You have nothing to open this container with.",
+   "ua": "Тобі нема чим відкрити цю ємність."
+  },
+  "У тебя нечем оторвать крышку.": {
+   "en": "You have nothing to pry the lid off with.",
+   "ua": "Тобі нема чим відірвати кришку."
+  },
+  "Это не дверь!": {
+   "en": "That's not a door!",
+   "ua": "Це не двері!"
+  },
+  "Это не контейнер.": {
+   "en": "That's not a container.",
+   "ua": "Це не контейнер."
+  },
+  "$c1 выдергивает гвозди из крышки $O2 с помощью $o4.": {
+   "en": "$c1 pulls the nails out of the lid of $O2 using $o4.",
+   "ua": "$c1 висмикує цвяхи з кришки $O2 за допомогою $o4."
+  },
+  "$c1 расшатывает пробку в $O6 с помощью $o4.": {
+   "en": "$c1 works the cork loose in $O6 with $o4.",
+   "ua": "$c1 розхитує корок у $O6 за допомогою $o4."
+  },
+  "Ты открываешь $o5 $O2.": {
+   "en": "With $o5, you open $O2.",
+   "ua": "За допомогою $o5 ти відкриваєш $O2."
+  }
+ },
+ "plug-ins/comm/use.cpp": {
+  "%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре.": {
+   "en": "%1$^O1 must be in your inventory.",
+   "ua": "%1$^O1 повин%1$Gно|ен|на|ні бути у твоєму інвентарі."
+  },
+  "%1$^O4 сперва необходимо зажать в руках.": {
+   "en": "%1$^O4 must first be gripped in your hands.",
+   "ua": "%1$^O4 спершу потрібно затиснути в руках."
+  },
+  "Использовать что?": {
+   "en": "Use what?",
+   "ua": "Використати що?"
+  },
+  "Ты не видишь здесь этого.": {
+   "en": "You don't see that here.",
+   "ua": "Ти не бачиш тут цього."
+  },
+  "$c1 вертит в руках $o4, не находя способа это использовать.": {
+   "en": "$c1 turns $o4 over in their hands, unable to figure out how to use it.",
+   "ua": "$c1 крутить у руках $o4, не знаходячи способу це використати."
+  },
+  "$c1 озадаченно ощупывает $o4, не находя способа это использовать.": {
+   "en": "$c1 fumbles over $o4 in confusion, unable to find a way to use it.",
+   "ua": "$c1 спантеличено обмацує $o4, не знаходячи способу це використати."
+  },
+  "Ты вертишь в руках $o4, не находя способа это использовать.": {
+   "en": "You turn $o4 over in your hands, unable to find a way to use it.",
+   "ua": "Ти вертиш у руках $o4, не знаходячи способу це використати."
+  },
+  "Ты озадаченно ощупываешь $o4, не находя способа это использовать.": {
+   "en": "You puzzledly feel around $o4, but can't find a way to use it.",
+   "ua": "Ти спантеличено обмацуєш $o4, не знаходячи способу це використати."
+  }
+ },
+ "plug-ins/comm/where.cpp": {
+  "Никого.": {
+   "en": "No one.",
+   "ua": "Нікого."
+  },
+  "Ты находишься в зоне {W{hh%s{x. Недалеко от тебя:": {
+   "en": "You are in the zone {W{hh%s{x. Not far from you:",
+   "ua": "Ти перебуваєш у зоні {W{hh%s{x. Неподалік від тебе:"
+  },
+  "Ты не можешь видеть вещи!": {
+   "en": "You can't see things!",
+   "ua": "Ти не можеш бачити речі!"
+  },
+  "Ты не находишь $T.": {
+   "en": "You don't find $T.",
+   "ua": "Ти не знаходиш $T."
+  },
+  "Ты ничего не видишь! Слишком темно!": {
+   "en": "You can't see anything! It's too dark!",
+   "ua": "Ти нічого не бачиш! Занадто темно!"
+  }
+ },
+ "plug-ins/comm/who.cpp": {
+  "Еще {W%1$d{w игрок%1$I|а|ов слыш%1$Iит|ат|ат общие каналы:": {
+   "en": "{W%1$d{w more player%1$I|s|s %1$Ihears|hear|hear the general channels:",
+   "ua": "Ще {W%1$d{w %1$Iгравець|гравці|гравців чу%1$Iє|ють|ють загальні канали:"
+  },
+  "Сейчас в мире {W%1$d{w игрок%1$I|а|ов:": {
+   "en": "There are currently {W%1$d{w player%1$I|s|s in the world:",
+   "ua": "Зараз у світі {W%1$d{w грав%1$Iець|ці|ців:"
+  }
+ },
+ "plug-ins/comm/wimpy.cpp": {
+  "Ты попытаешься убежать при %d очков жизни.": {
+   "en": "You will try to flee at %d hit points.",
+   "ua": "Ти спробуєш втекти при %d очках життя."
+  },
+  "Стыдись! Это будет слишком большим позором для самурая.": {
+   "en": "Shame on you! That would be too great a disgrace for a samurai.",
+   "ua": "Соромся! Це буде занадто великою ганьбою для самурая."
+  },
+  "Твоя отвага превосходит твою мудрость.": {
+   "en": "Your courage outstrips your wisdom.",
+   "ua": "Твоя відвага переважає твою мудрість."
+  },
+  "Это будет слишком большим позором для тебя.": {
+   "en": "That would be too great a disgrace for you.",
+   "ua": "Це буде надто великою ганьбою для тебе."
+  }
+ },
+ "plug-ins/comm/wizard.cpp": {
+  "\n\rВсего лимитов: %d из %d.": {
+   "en": "\n\rTotal limits: %d of %d.",
+   "ua": "\n\rВсього лімітів: %d з %d."
+  },
+  "  %d сейчас в игре, а еще %d в профилях игроков.": {
+   "en": "  %d currently in the game, and %d more in player profiles.",
+   "ua": "  %d зараз у грі, а ще %d у профілях гравців."
+  },
+  " в течение %1$d час%1$Iа|ов|ов": {
+   "en": " for %1$d hour%1$I|s|s",
+   "ua": " протягом %1$d годин%1$Iу|и|"
+  },
+  "$c1 {Gвосстановил$gо||а {xтвои силы!": {
+   "en": "$c1 {Grestored{x your strength!",
+   "ua": "$c1 {Gвіднови$gло|в|ла {xтвої сили!"
+  },
+  "$c1 больше не маскируется.": {
+   "en": "$c1 is no longer in disguise.",
+   "ua": "$c1 більше не маскується."
+  },
+  "$c1 внезапно проявляется в реальности.": {
+   "en": "$c1 suddenly manifests into reality.",
+   "ua": "$c1 раптово проявляється в реальності."
+  },
+  "$c1 переименова$gло|л|ла тебя в $C4!": {
+   "en": "$c1 renamed you to $C4!",
+   "ua": "$c1 перейменува$gло|в|ла тебе на $C4!"
+  },
+  "$c1 создает $C4!": {
+   "en": "$c1 creates $C4!",
+   "ua": "$c1 створює $C4!"
+  },
+  "$c1 создает $o4!": {
+   "en": "$c1 creates $o4!",
+   "ua": "$c1 створює $o4!"
+  },
+  "%-35s [%5d]  Лимит: %3d  Собрано: %3d": {
+   "en": "%-35s [%5d]  Limit: %3d  Collected: %3d",
+   "ua": "%-35s [%5d]  Ліміт: %3d  Зібрано: %3d"
+  },
+  "%3d) %N1 в руках у %s [Комната %d]\n\r": {
+   "en": "%3d) %N1 is held by %s [Room %d]\n\r",
+   "ua": "%3d) %N1 в руках у %s [Кімната %d]\n\r"
+  },
+  "%3d) %N1 на полу в %s [Комната %d]\n\r": {
+   "en": "%3d) %N1 on the floor in %s [Room %d]\n\r",
+   "ua": "%3d) %N1 на підлозі в %s [Кімната %d]\n\r"
+  },
+  "%3d) %s (в теле %s) находится в %s [%d]\n\r": {
+   "en": "%3d) %s (in the body of %s) is in %s [%d]\n\r",
+   "ua": "%3d) %s (у тілі %s) перебуває в %s [%d]\n\r"
+  },
+  "%3d) %s находится в %s [%d]\n\r": {
+   "en": "%3d) %s is located in %s [%d]\n\r",
+   "ua": "%3d) %s перебуває в %s [%d]\n\r"
+  },
+  "%s проходит через дверь %d.\r\n": {
+   "en": "%s goes through door %d.\r\n",
+   "ua": "%s проходить крізь двері %d.\r\n"
+  },
+  "%s с именем %s не найден.": {
+   "en": "%s named %s not found.",
+   "ua": "%s з ім'ям %s не знайдено."
+  },
+  "Stat чему?": {
+   "en": "Stat what?",
+   "ua": "Stat що?"
+  },
+  "Vnum: %d  Лимит: %d  Тип: %s  Ресеты: %d\n\r": {
+   "en": "Vnum: %d  Limit: %d  Type: %s  Resets: %d\n\r",
+   "ua": "Vnum: %d  Ліміт: %d  Тип: %s  Ресети: %d\n\r"
+  },
+  "[%3d] %-33^N1 [%5d]  Лимит: %3d  Собрано: %3d В игре : %3d": {
+   "en": "[%3d] %-33^N1 [%5d]  Limit: %3d  Collected: %3d In game: %3d",
+   "ua": "[%3d] %-33^N1 [%5d]  Ліміт: %3d  Зібрано: %3d У грі: %3d"
+  },
+  "{CТебя разморозили!{x Ты чувствуешь как способность двигаться возвращается.": {
+   "en": "{CYou've been unfrozen!{x You feel your ability to move returning.",
+   "ua": "{CТебе розморозили!{x Ти відчуваєш, як здатність рухатися повертається."
+  },
+  "Берется в: %s\n\rЭкстра флаги: %s\n\r": {
+   "en": "Worn on: %s\n\rExtra flags: %s\n\r",
+   "ua": "Одягається на: %s\n\rЕкстра прапорці: %s\n\r"
+  },
+  "В комнате: %d  Внутри: %s  В руках у: %s  Надето на: %s\n\r": {
+   "en": "In room: %d  Inside: %s  In hands of: %s  Worn on: %s\n\r",
+   "ua": "У кімнаті: %d  Всередині: %s  В руках у: %s  Вдягнено на: %s\n\r"
+  },
+  "Владелец: %s\n\r": {
+   "en": "Owner: %s\n\r",
+   "ua": "Власник: %s\n\r"
+  },
+  "Вместимость: %d#  Максимальный вес: %d#  Флаги: %s\n\r": {
+   "en": "Capacity: %d#  Maximum weight: %d#  Flags: %s\n\r",
+   "ua": "Місткість: %d#  Максимальна вага: %d#  Прапори: %s\n\r"
+  },
+  "Внутри %-20s [%d]": {
+   "en": "Inside %-20s [%d]",
+   "ua": "Всередині %-20s [%d]"
+  },
+  "Все активные игроки восстановлены!": {
+   "en": "All active players have been restored!",
+   "ua": "Усіх активних гравців відновлено!"
+  },
+  "Вселиться в чье тело?": {
+   "en": "Possess whose body?",
+   "ua": "Вселитися в чиє тіло?"
+  },
+  "Вселиться можно только в тело мобов.": {
+   "en": "You can only possess the body of a mob.",
+   "ua": "Вселитися можна лише в тіло мобів."
+  },
+  "Готово.": {
+   "en": "Done.",
+   "ua": "Готово."
+  },
+  "Дескриптор не найден!": {
+   "en": "Descriptor not found!",
+   "ua": "Дескриптор не знайдено!"
+  },
+  "Доступные тебе опции Визнета:": {
+   "en": "Wiznet options available to you:",
+   "ua": "Доступні тобі опції Візнету:"
+  },
+  "Заклинания %d уровня:": {
+   "en": "Level %d spells:",
+   "ua": "Заклинання %d рівня:"
+  },
+  "Заморозить кого?": {
+   "en": "Freeze whom?",
+   "ua": "Заморозити кого?"
+  },
+  "Имеет %d(%d) зарядов уровня %d": {
+   "en": "Has %d(%d) charges of level %d",
+   "ua": "Має %d(%d) зарядів рівня %d"
+  },
+  "Имена: [{W%s{x]  ": {
+   "en": "Names: [{W%s{x]  ",
+   "ua": "Імена: [{W%s{x]  "
+  },
+  "Класс брони: %d колющее, %d удар, %d режущее, %d экзотика\n\r": {
+   "en": "Armor class: %d piercing, %d blunt, %d slashing, %d exotic\n\r",
+   "ua": "Клас броні: %d колючий, %d ударний, %d ріжучий, %d екзотика\n\r"
+  },
+  "Ключ: [{W%7u{x]  ": {
+   "en": "Key: [{W%7u{x]  ",
+   "ua": "Ключ: [{W%7u{x]  "
+  },
+  "Комната восстановлена.": {
+   "en": "Room restored.",
+   "ua": "Кімнату відновлено."
+  },
+  "Комната приватная и сейчас занята.": {
+   "en": "The room is private and currently occupied.",
+   "ua": "Кімната приватна і зараз зайнята."
+  },
+  "Комната с таким именем не найдена.": {
+   "en": "No room with that name was found.",
+   "ua": "Кімнату з таким ім'ям не знайдено."
+  },
+  "Краткое: [{W%s{x]  ": {
+   "en": "Short: [{W%s{x]  ",
+   "ua": "Коротко: [{W%s{x]  "
+  },
+  "Кто-то уже следит за этим игроком.": {
+   "en": "Someone is already watching this player.",
+   "ua": "Хтось вже стежить за цим гравцем."
+  },
+  "Лимит исчезнет в %s.\r\n": {
+   "en": "The limit will disappear at %s.\r\n",
+   "ua": "Ліміт зникне о %s.\r\n"
+  },
+  "Материал: %s\n\r": {
+   "en": "Material: %s\n\r",
+   "ua": "Матеріал: %s\n\r"
+  },
+  "Моба с таким внумом не найдено.": {
+   "en": "No mob found with that vnum.",
+   "ua": "Моба з таким внумом не знайдено."
+  },
+  "Мобы с таким именем не найдены.": {
+   "en": "No mobs found with that name.",
+   "ua": "Мобів з таким ім'ям не знайдено."
+  },
+  "Мобы этого не умеют.": {
+   "en": "Mobs can't do that.",
+   "ua": "Моби цього не вміють."
+  },
+  "Найти какую комнату?": {
+   "en": "Find which room?",
+   "ua": "Знайти яку кімнату?"
+  },
+  "Найти кого?": {
+   "en": "Find whom?",
+   "ua": "Знайти кого?"
+  },
+  "Найти что?": {
+   "en": "Find what?",
+   "ua": "Знайти що?"
+  },
+  "Начинаем слежку.": {
+   "en": "Beginning surveillance.",
+   "ua": "Розпочинаємо стеження."
+  },
+  "Объект с таким внумом не найден.": {
+   "en": "No object with that vnum found.",
+   "ua": "Об'єкт з таким внумом не знайдено."
+  },
+  "Объекты с таким именем не найдены.": {
+   "en": "No objects with that name were found.",
+   "ua": "Об'єктів з такою назвою не знайдено."
+  },
+  "Отменяем всю слежку.": {
+   "en": "Canceling all surveillance.",
+   "ua": "Скасовуємо все стеження."
+  },
+  "Переместиться куда?": {
+   "en": "Move to where?",
+   "ua": "Переміститися куди?"
+  },
+  "Перенести кого и куда?": {
+   "en": "Transfer whom and where?",
+   "ua": "Перенести кого і куди?"
+  },
+  "Поведение: [%s]\r\n": {
+   "en": "Behavior: [%s]\r\n",
+   "ua": "Поведінка: [%s]\r\n"
+  },
+  "Принудить кого к чему?": {
+   "en": "Force whom to do what?",
+   "ua": "Примусити кого до чого?"
+  },
+  "Рядом с кем? Сделать что?": {
+   "en": "Next to whom? Do what?",
+   "ua": "Поряд з ким? Зробити що?"
+  },
+  "С таким именем ничего не найдено.": {
+   "en": "Nothing found with that name.",
+   "ua": "З таким ім'ям нічого не знайдено."
+  },
+  "Следить за кем?": {
+   "en": "Watch whom?",
+   "ua": "Стежити за ким?"
+  },
+  "Содержит жидкость %s цвета, %s.\n": {
+   "en": "Contains a %s-colored liquid, %s.\n",
+   "ua": "Містить рідину %s кольору, %s.\n"
+  },
+  "Состояние : %d (%s) ": {
+   "en": "Condition : %d (%s) ",
+   "ua": "Стан : %d (%s) "
+  },
+  "Статус Визнета:": {
+   "en": "Wiznet status:",
+   "ua": "Статус Візнета:"
+  },
+  "Стейков: %d, Уровень: %d, Части тела: '%s', Vnum: %d\r\n": {
+   "en": "Steaks: %d, Level: %d, Body parts: '%s', Vnum: %d\r\n",
+   "ua": "Стейків: %d, Рівень: %d, Частини тіла: '%s', Vnum: %d\r\n"
+  },
+  "Таких здесь нет.": {
+   "en": "There's none like that here.",
+   "ua": "Таких тут немає."
+  },
+  "Таких сейчас в мире нет": {
+   "en": "There are none like that in the world right now",
+   "ua": "Таких зараз у світі немає"
+  },
+  "Таких сейчас в мире нет.": {
+   "en": "There are none like that in the world right now.",
+   "ua": "Таких зараз у світі немає."
+  },
+  "Такого типа нет ни у одного объекта.": {
+   "en": "No object has that type.",
+   "ua": "Такого типу немає в жодного об'єкта."
+  },
+  "Такого типа предмета не существует.": {
+   "en": "No such item type exists.",
+   "ua": "Такого типу предмета не існує."
+  },
+  "Такой опции Визнета нет, или тебе она пока недоступна.": {
+   "en": "There's no such Wiznet option, or it's not yet available to you.",
+   "ua": "Такої опції Візнету немає, або вона тобі поки що недоступна."
+  },
+  "Твое сообщение poofin теперь: %s": {
+   "en": "Your poofin message is now: %s",
+   "ua": "Твоє повідомлення poofin тепер: %s"
+  },
+  "Твое сообщение poofin: %s": {
+   "en": "Your poofin message: %s",
+   "ua": "Твоє повідомлення poofin: %s"
+  },
+  "Твое сообщение poofout теперь %s": {
+   "en": "Your poofout message is now %s",
+   "ua": "Твоє повідомлення poofout тепер %s"
+  },
+  "Твое сообщение poofout: %s": {
+   "en": "Your poofout message: %s",
+   "ua": "Твоє повідомлення poofout: %s"
+  },
+  "Тебе не удалось найти $T.": {
+   "en": "You couldn't find $T.",
+   "ua": "Тобі не вдалося знайти $T."
+  },
+  "Тип удара: %s.\n\r": {
+   "en": "Hit type: %s.\n\r",
+   "ua": "Тип удару: %s.\n\r"
+  },
+  "Тут таких нет.": {
+   "en": "There's none like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Ты больше не маскируешься.": {
+   "en": "You are no longer disguised.",
+   "ua": "Ти більше не маскуєшся."
+  },
+  "Ты больше не следишь за %s через Визнет.": {
+   "en": "You are no longer watching %s through Wiznet.",
+   "ua": "Ти більше не стежиш за %s через Візнет."
+  },
+  "Ты в своем теле.": {
+   "en": "You're in your own body.",
+   "ua": "Ти у своєму тілі."
+  },
+  "Ты возвращаешься в своё привычное тело.": {
+   "en": "You return to your usual body.",
+   "ua": "Ти повертаєшся у своє звичне тіло."
+  },
+  "Ты вселяешься в чужое тело.": {
+   "en": "You possess another's body.",
+   "ua": "Ти вселяєшся в чуже тіло."
+  },
+  "Ты и так в своем теле.": {
+   "en": "You're already in your own body.",
+   "ua": "Ти й так у своєму тілі."
+  },
+  "Ты наполняешь комнату миром и спокойствием.": {
+   "en": "You fill the room with peace and tranquility.",
+   "ua": "Ти наповнюєш кімнату миром і спокоєм."
+  },
+  "Ты не видишь здесь моба или предмет с таким именем.": {
+   "en": "You don't see a mob or item with that name here.",
+   "ua": "Ти не бачиш тут моба чи предмет з таким ім'ям."
+  },
+  "Ты скрываешь свое присутствие.": {
+   "en": "You conceal your presence.",
+   "ua": "Ти приховуєш свою присутність."
+  },
+  "Ты создаешь $C4!": {
+   "en": "You create $C4!",
+   "ua": "Ти створюєш $C4!"
+  },
+  "Ты создаешь $o4!": {
+   "en": "You create $o4!",
+   "ua": "Ти створюєш $o4!"
+  },
+  "Ты теперь отслеживаешь %s через Визнет.": {
+   "en": "You are now tracking %s through Visnet.",
+   "ua": "Ти тепер відстежуєш %s через Візнет."
+  },
+  "Ты уже в чужом теле.": {
+   "en": "You're already in someone else's body.",
+   "ua": "Ти вже в чужому тілі."
+  },
+  "У тебя пока не хватает прав для этого.": {
+   "en": "You don't have enough privileges for that yet.",
+   "ua": "Тобі поки бракує прав для цього."
+  },
+  "У тебя пока не хватает прав на принуждение.": {
+   "en": "You don't have sufficient rights to force yet.",
+   "ua": "У тебе поки що не вистачає прав на примус."
+  },
+  "У тебя пока не хватает прав на слежку за игроками.": {
+   "en": "You don't have sufficient permissions to monitor players yet.",
+   "ua": "У тебе поки що не вистачає прав на стеження за гравцями."
+  },
+  "У тебя пока не хватает прав на такое принуждение.": {
+   "en": "You don't have sufficient privileges for that kind of force yet.",
+   "ua": "Тобі поки бракує прав на такий примус."
+  },
+  "Уменьшение веса: %d%%\n\r": {
+   "en": "Weight reduction: %d%%\n\r",
+   "ua": "Зменшення ваги: %d%%\n\r"
+  },
+  "Уровень не может быть ниже нуля или выше твоего.": {
+   "en": "The level cannot be lower than zero or higher than yours.",
+   "ua": "Рівень не може бути нижчим за нуль або вищим за твій."
+  },
+  "Уровень: %d  Цена: %d  Состояние: %d  Таймер: %d По счету: %d\n\r": {
+   "en": "Level: %d  Price: %d  Condition: %d  Timer: %d  Count: %d\n\r",
+   "ua": "Рівень: %d  Ціна: %d  Стан: %d  Таймер: %d  Лічильник: %d\n\r"
+  },
+  "Урон %dd%d (среднее %d)\n\r": {
+   "en": "Damage %dd%d (average %d)\n\r",
+   "ua": "Шкода %dd%d (середнє %d)\n\r"
+  },
+  "Флаги оружия: %s\n\r": {
+   "en": "Weapon flags: %s\n\r",
+   "ua": "Прапори зброї: %s\n\r"
+  },
+  "Флаги: [{W%s{x]": {
+   "en": "Flags: [{W%s{x]",
+   "ua": "Прапорці: [{W%s{x]"
+  },
+  "Формат:": {
+   "en": "Format:",
+   "ua": "Формат:"
+  },
+  "Формат: advance <char> <level>.": {
+   "en": "Format: advance <char> <level>.",
+   "ua": "Формат: advance <char> <рівень>."
+  },
+  "Формат: load mob <vnum>.": {
+   "en": "Format: load mob <vnum>.",
+   "ua": "Формат: load mob <vnum>."
+  },
+  "Формат: load obj <vnum> <level>.": {
+   "en": "Format: load obj <vnum> <level>.",
+   "ua": "Формат: load obj <vnum> <level>."
+  },
+  "Формат: oload <vnum> <level>.": {
+   "en": "Format: oload <vnum> <level>.",
+   "ua": "Формат: oload <vnum> <рівень>."
+  },
+  "Цель заморожена.": {
+   "en": "Target frozen.",
+   "ua": "Ціль заморожена."
+  },
+  "Цель не найдена.": {
+   "en": "Target not found.",
+   "ua": "Ціль не знайдено."
+  },
+  "Цель не найдена: %s.": {
+   "en": "Target not found: %s.",
+   "ua": "Ціль не знайдено: %s."
+  },
+  "Цель разморожена.": {
+   "en": "Target unfrozen.",
+   "ua": "Ціль розморожена."
+  },
+  "Число: %d/%d  Вес: %d/%d/%d (десятые доли фунта)\n\r": {
+   "en": "Count: %d/%d  Weight: %d/%d/%d (tenths of a pound)\n\r",
+   "ua": "Число: %d/%d  Вага: %d/%d/%d (десяті частки фунта)\n\r"
+  },
+  "Шорт: %s\n\rДлинное описание: %s\n\r": {
+   "en": "Short: %s\n\rLong description: %s\n\r",
+   "ua": "Короткий опис: %s\n\rДовгий опис: %s\n\r"
+  },
+  "Это не лимит.": {
+   "en": "That's not a limit.",
+   "ua": "Це не ліміт."
+  },
+  "Этого игрока тут нет.": {
+   "en": "That player isn't here.",
+   "ua": "Цього гравця тут немає."
+  },
+  "Этот игрок сейчас в приватной комнате.": {
+   "en": "This player is currently in a private room.",
+   "ua": "Цей гравець зараз у приватній кімнаті."
+  },
+  "Этот персонаж сейчас в приватной комнате.": {
+   "en": "This character is currently in a private room.",
+   "ua": "Цей персонаж зараз у приватній кімнаті."
+  },
+  "Эту цель ты пока не можешь принудить!": {
+   "en": "You can't force this target yet!",
+   "ua": "Цю ціль ти поки не можеш примусити!"
+  },
+  "$c1 внезапно появляется в столбе {Cбожественной энергии.{x": {
+   "en": "$c1 suddenly appears in a pillar of {Cdivine energy.{x",
+   "ua": "$c1 раптово з'являється у стовпі {Cбожественної енергії.{x"
+  },
+  "$c1 изничтожает $C4.": {
+   "en": "$c1 obliterates $C4.",
+   "ua": "$c1 винищує $C4."
+  },
+  "$c1 изничтожает $o4.": {
+   "en": "$c1 annihilates $o4.",
+   "ua": "$c1 знищує $o4."
+  },
+  "$c1 изничтожает все в комнате!": {
+   "en": "$c1 annihilates everything in the room!",
+   "ua": "$c1 знищує все в кімнаті!"
+  },
+  "$c1 исчезает в столбе {Cбожественной энергии.{x": {
+   "en": "$c1 vanishes in a pillar of {Cdivine energy.{x",
+   "ua": "$c1 зникає в стовпі {Cбожественної енергії.{x"
+  },
+  "$c1 подмигивает и растворяется за подкладкой реальности.": {
+   "en": "$c1 winks and dissolves behind the lining of reality.",
+   "ua": "$c1 підморгує і розчиняється за підкладкою реальності."
+  },
+  "%1$^C1 прибывает в столбе {Cбожественной энергии!{x": {
+   "en": "%1$^C1 arrives in a pillar of {Cdivine energy!{x",
+   "ua": "%1$^C1 прибуває у стовпі {Cбожественної енергії!{x"
+  },
+  "%3d) %N1 черт его знает где.\n\r": {
+   "en": "%3d) %N1 is God knows where.\n\r",
+   "ua": "%3d) %N1 хтозна де.\n\r"
+  },
+  "%^C1 жестом прекращает войны и агрессию вокруг.": {
+   "en": "%^C1 ends all wars and aggression around with a gesture.",
+   "ua": "%^C1 жестом припиняє війни та агресію навколо."
+  },
+  "**** ООООО ДАААААААААА ****": {
+   "en": "**** OHHHHH YEAAAAAAAAS ****",
+   "ua": "**** ООООО ТАААААААААК ****"
+  },
+  "**** ОООООО НЕЕЕЕЕЕЕЕЕТ!!! ****": {
+   "en": "**** OOOOOH NOOOOOO!!! ****",
+   "ua": "**** ООООО НІІІІІІ!!! ****"
+  },
+  "{CТЕБЯ ЗАМОРОЗИЛИ!{x Ты теряешь способность двигаться и говорить.": {
+   "en": "{CYOU HAVE BEEN FROZEN!{x You lose the ability to move and speak.",
+   "ua": "{CТЕБЕ ЗАМОРОЗИЛИ!{x Ти втрачаєш здатність рухатися і говорити."
+  },
+  "В это тело уже кто-то вселился!": {
+   "en": "Someone has already possessed this body!",
+   "ua": "У це тіло вже хтось вселився!"
+  },
+  "Визнет включен, добро пожаловать в мир спама!": {
+   "en": "Wiznet is on, welcome to the world of spam!",
+   "ua": "Візнет увімкнено, ласкаво просимо у світ спаму!"
+  },
+  "Визнет отключен. Уф.": {
+   "en": "Wiznet disabled. Phew.",
+   "ua": "Візнет вимкнено. Уф."
+  },
+  "Мобов замораживать бесполезно.": {
+   "en": "Freezing mobs is pointless.",
+   "ua": "Заморожувати мобів безглуздо."
+  },
+  "Ни на земле, ни в небесах не найдено. Увы и ах.": {
+   "en": "Not found on earth, nor in the heavens. Alas and alack.",
+   "ua": "Ні на землі, ні в небесах не знайдено. Гай-гай."
+  },
+  "Плохая идея.": {
+   "en": "Bad idea.",
+   "ua": "Погана ідея."
+  },
+  "Сила воли, бессердечная ты сука.": {
+   "en": "Willpower, you heartless bitch.",
+   "ua": "Сила волі, безсердечна ти сука."
+  },
+  "Сначала научись рисовать и отрасти усики.": {
+   "en": "First learn to draw and grow yourself some whiskers.",
+   "ua": "Спершу навчися малювати і відрости вусики."
+  },
+  "Ты изничтожаешь $C4.": {
+   "en": "You annihilate $C4.",
+   "ua": "Ти знищуєш $C4."
+  },
+  "Ты изничтожаешь $o4.": {
+   "en": "You obliterate $o4.",
+   "ua": "Ти вщент знищуєш $o4."
+  },
+  "Ты растворяешься за подкладкой реальности.": {
+   "en": "You dissolve behind the lining of reality.",
+   "ua": "Ти розчиняєшся за підкладкою реальності."
+  },
+  "Ты снова проявляешься в реальности.": {
+   "en": "You materialize back into reality.",
+   "ua": "Ти знову проявляєшся у реальності."
+  },
+  "Упс, круговая слежка!": {
+   "en": "Oops, circular tracking!",
+   "ua": "Упс, кругове стеження!"
+  },
+  "Эта команда нужна для смены тел -- а ты и так в своем теле.": {
+   "en": "This command is for switching bodies -- and you're already in your own body.",
+   "ua": "Ця команда потрібна для зміни тіл -- а ти і так у своєму тілі."
+  }
+ },
+ "plug-ins/comm/writing.cpp": {
+  "$c1 выцарапывает $O5 надпись на $o6.": {
+   "en": "$c1 scratches $O5 inscription onto $o6.",
+   "ua": "$c1 видряпує $O5 напис на $o6."
+  },
+  "$c1 скребет $o4.": {
+   "en": "$c1 scratches at $o4.",
+   "ua": "$c1 шкребе $o4."
+  },
+  "$c1 тщательно отшкрябывает все надписи с $o2.": {
+   "en": "$c1 carefully scrapes all the inscriptions off $o2.",
+   "ua": "$c1 ретельно зішкрябує всі написи з $o2."
+  },
+  "Подними $o4 с земли, а потом пиши.": {
+   "en": "Pick $o4 up off the ground before you write.",
+   "ua": "Підніми $o4 із землі, а потім пиши."
+  },
+  "Подробнее см. 'help write'.": {
+   "en": "For more info see 'help write'.",
+   "ua": "Детальніше див. 'help write'."
+  },
+  "Тебе не удастся ничего нацарапать на $o6.": {
+   "en": "You won't manage to scratch anything onto $o6.",
+   "ua": "Тобі не вдасться нічого надряпати на $o6."
+  },
+  "Ты делаешь запись на $o6 в раздел '$T'": {
+   "en": "You make an entry in $o6 under the section '$T'",
+   "ua": "Ти робиш запис на $o6 у розділ '$T'"
+  },
+  "Ты делаешь запись на $o6.": {
+   "en": "You make a note on $o6.",
+   "ua": "Ти робиш запис на $o6."
+  },
+  "Ты не держишь в руках ничего колющего или царапающего.": {
+   "en": "You're not holding anything sharp or scratchy in your hands.",
+   "ua": "Ти не тримаєш у руках нічого гострого чи дряпаючого."
+  },
+  "Ты стираешь с $o2 все, что касается '$T'.": {
+   "en": "You erase everything about '$T' from $o2.",
+   "ua": "Ти стираєш з $o2 усе, що стосується '$T'."
+  },
+  "Ты удаляешь последнюю строку с $o2 в разделе '$T'.": {
+   "en": "You delete the last line from $o2 in section '$T'.",
+   "ua": "Ти видаляєш останній рядок з $o2 в розділі '$T'."
+  },
+  "Ты удаляешь последнюю строку с $o2.": {
+   "en": "You delete the last line from $o2.",
+   "ua": "Ти видаляєш останній рядок з $o2."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе немає цього."
+  },
+  "Удалять с $o2 больше нечего.": {
+   "en": "There's nothing left to remove from $o2.",
+   "ua": "Видаляти з $o2 більше нічого."
+  },
+  "Что именно ты хочешь записать на $o4?": {
+   "en": "What exactly do you want to write on $o4?",
+   "ua": "Що саме ти хочеш записати на $o4?"
+  },
+  "Это не пергамент.": {
+   "en": "That's not parchment.",
+   "ua": "Це не пергамент."
+  },
+  "$o1 девственно чист(а) - удалять нечего.": {
+   "en": "$o1 is spotlessly clean -- nothing to erase.",
+   "ua": "$o1 незаймано чист(а) -- видаляти нічого."
+  },
+  "Ты выцарапываешь $O5 надпись на $o6.": {
+   "en": "You scratch out an inscription with $O5 on $o6.",
+   "ua": "Ти видряпуєш $O5 напис на $o6."
+  },
+  "Ты отшкрябываешь последнюю строчку с $o2.": {
+   "en": "You scrape the last line off $o2.",
+   "ua": "Ти зіскрібаєш останній рядок з $o2."
+  },
+  "Ты стираешь все надписи с лицевой стороны $o2.": {
+   "en": "You erase all the writing from the front side of $o2.",
+   "ua": "Ти стираєш усі написи з лицьової сторони $o2."
+  },
+  "Ты тщательно отшкрябываешь все надписи с $o2.": {
+   "en": "You carefully scrape off all the writing from $o2.",
+   "ua": "Ти ретельно відшкрябуєш усі написи з $o2."
+  },
+  "Что именно ты хочешь выцарапать на $o6?": {
+   "en": "What exactly do you want to scratch onto $o6?",
+   "ua": "Що саме ти хочеш видряпати на $o6?"
+  }
+ },
+ "plug-ins/command/command.cpp": {
+  "Выйди сначала из {WAFK{x": {
+   "en": "Exit {WAFK{x mode first",
+   "ua": "Спочатку вийди з {WAFK{x"
+  },
+  "Команду '%s' необходимо ввести полностью.": {
+   "en": "The command '%s' must be entered in full.",
+   "ua": "Команду '%s' потрібно ввести повністю."
+  },
+  "Ты не в состоянии сделать это.": {
+   "en": "You're not able to do that.",
+   "ua": "Ти не в змозі зробити це."
+  },
+  "Ты полностью замороже%Gно|н|на!": {
+   "en": "You are completely frozen!",
+   "ua": "Ти повністю заморож%Gено|ений|ена!"
+  },
+  "Эта команда сейчас недоступна.": {
+   "en": "This command is currently unavailable.",
+   "ua": "Ця команда зараз недоступна."
+  },
+  "Во сне? Или может сначала проснешься...": {
+   "en": "In your sleep? Maybe wake up first...",
+   "ua": "Уві сні? А може спершу прокинешся..."
+  },
+  "Даже не думай об этом! Ты в ужасном состоянии.": {
+   "en": "Don't even think about it! You're in terrible shape.",
+   "ua": "Навіть не думай про це! Ти в жахливому стані."
+  },
+  "Куда! Ты долж$gно|ен|на сражаться.": {
+   "en": "No running! You must fight.",
+   "ua": "Куди! Ти повин$gно|ен|на битися."
+  },
+  "Лежи смирно! Ты {RТРУП{x.": {
+   "en": "Lie still! You're a {RCORPSE{x.",
+   "ua": "Лежи смирно! Ти {RТРУП{x."
+  },
+  "Сидя? Или может сначала встанешь...": {
+   "en": "Sitting down? Maybe you should stand up first...",
+   "ua": "Сидячи? Чи, може, спершу встанеш..."
+  },
+  "Сперва спроси разрешения у любим%1$Gого|ого|ой хозя%1$Gина|ина|йки!": {
+   "en": "First ask permission from your owner!",
+   "ua": "Спершу запитай дозволу в улюблен%1$Gого|ого|ої хазя%1$Gїна|їна|йки!"
+  },
+  "Ты не можешь этого сделать - мешают кандалы!": {
+   "en": "You can't do that -- your shackles are in the way!",
+   "ua": "Ти не можеш цього зробити -- заважають кайдани!"
+  },
+  "У тебя нет тела... А твой немощный дух не в состоянии тебе помочь.": {
+   "en": "You have no body... And your feeble spirit is in no shape to help you.",
+   "ua": "У тебе немає тіла... А твій немічний дух не в змозі тобі допомогти."
+  },
+  "Уфф... Но ведь ты отдыхаешь...": {
+   "en": "Ugh... But you're resting...",
+   "ua": "Уфф... Але ж ти відпочиваєш..."
+  }
+ },
+ "plug-ins/communication/channels.cpp": {
+  "Ты не находишь этого персонажа.": {
+   "en": "You can't find that character.",
+   "ua": "Ти не знаходиш такого персонажа."
+  },
+  "У $C2 нет хрустального шара.": {
+   "en": "$C2 doesn't have a crystal ball.",
+   "ua": "У $C2 немає кришталевої кулі."
+  },
+  "Боги запретили тебе волноваться.": {
+   "en": "The gods have forbidden you from worrying.",
+   "ua": "Боги заборонили тобі хвилюватися."
+  },
+  "Информационное агенство не может найти данного абонента.": {
+   "en": "The information agency cannot find this subscriber.",
+   "ua": "Інформаційна агенція не може знайти даного абонента."
+  },
+  "Тебе определенно нужен хрустальный шар и то, что внутри него.": {
+   "en": "You definitely need a crystal ball and whatever's inside it.",
+   "ua": "Тобі точно потрібна кришталева куля і те, що всередині неї."
+  }
+ },
+ "plug-ins/communication/globalchannel.cpp": {
+  "Боги лишили тебя возможности общаться.": {
+   "en": "The gods have stripped you of the ability to speak.",
+   "ua": "Боги позбавили тебе можливості спілкуватися."
+  },
+  "В этом канале ты можешь только слушать, прости.": {
+   "en": "You can only listen on this channel, sorry.",
+   "ua": "У цьому каналі ти можеш тільки слухати, вибач."
+  },
+  "Канал %s теперь включен.": {
+   "en": "Channel %s is now enabled.",
+   "ua": "Канал %s тепер увімкнено."
+  },
+  "Канал %s теперь выключен.": {
+   "en": "Channel %s is now disabled.",
+   "ua": "Канал %s тепер вимкнено."
+  },
+  "Только подтвержденные богами персонажи могут общаться в этом канале.": {
+   "en": "Only characters confirmed by the gods can talk on this channel.",
+   "ua": "Тільки підтверджені богами персонажі можуть спілкуватися в цьому каналі."
+  },
+  "$c1 сдавленно хрипит, не в силах вымолвить ни слова.": {
+   "en": "$c1 wheezes strangled, unable to utter a single word.",
+   "ua": "$c1 здавлено хрипить, не в змозі вимовити ні слова."
+  },
+  "Сначала необходимо повынимать вату из ушей.": {
+   "en": "First you need to pull the cotton out of your ears.",
+   "ua": "Спочатку треба повиймати вату з вух."
+  },
+  "Стены могилы поглощают звуки.": {
+   "en": "The grave's walls swallow the sound.",
+   "ua": "Стіни могили поглинають звуки."
+  },
+  "У тебя недостаточно сил, чтобы орать на весь мир.": {
+   "en": "You don't have enough strength to shout to the whole world.",
+   "ua": "У тебе недостатньо сил, щоб репетувати на весь світ."
+  },
+  "Этот канал не для тебя, прости.": {
+   "en": "This channel isn't for you, sorry.",
+   "ua": "Цей канал не для тебе, вибач."
+  }
+ },
+ "plug-ins/communication/personalchannel.cpp": {
+  "$C1 отсутствует и не может сейчас получить твое сообщение.": {
+   "en": "$C1 is away and can't receive your message right now.",
+   "ua": "$C1 відсутній і не може зараз отримати твоє повідомлення."
+  },
+  "$E не слышит тебя, попробуй позже.": {
+   "en": "They don't hear you, try again later.",
+   "ua": "Вони не чують тебе, спробуй пізніше."
+  },
+  "Сперва выйди из режима глухоты (deaf).": {
+   "en": "First get out of deaf mode.",
+   "ua": "Спершу вийди з режиму глухоти (deaf)."
+  },
+  "Сперва выйди из режима тишины (quiet).": {
+   "en": "First exit quiet mode (quiet).",
+   "ua": "Спершу вийди з режиму тиші (quiet)."
+  },
+  "Ты не находишь этого персонажа.": {
+   "en": "You can't find that character.",
+   "ua": "Ти не знаходиш такого персонажа."
+  },
+  "Боги лишили тебя возможности личного общения.": {
+   "en": "The Gods have stripped you of the ability to communicate privately.",
+   "ua": "Боги позбавили тебе можливості особистого спілкування."
+  }
+ },
+ "plug-ins/communication/replay.cpp": {
+  "Тебя ожидает {R%1$d{x сообщен%1$Iие|ия|ий, используй команду {hc{yпрослушать{x для просмотра.": {
+   "en": "You have {R%1$d{x message%1$I|s|s waiting, use the {hc{ylisten{x command to view them.",
+   "ua": "На тебе чекає {R%1$d{x повідомлен%1$Iня|ня|ь, використай команду {hc{yпрослухати{x для перегляду."
+  }
+ },
+ "plug-ins/craft/craftskill.cpp": {
+  "%1$^C1 не может научить тебя искусству '%2$s'.\nУчителя можно найти, прочитав справку по этому умению.": {
+   "en": "%1$^C1 can't teach you the art of '%2$s'.\nYou can find a teacher by reading the help for this skill.",
+   "ua": "%1$^C1 не може навчити тебе мистецтву '%2$s'.\nВчителя можна знайти, прочитавши довідку з цього уміння."
+  },
+  "{GТы учишься на своих ошибках, и твое умение '%K1' совершенствуется.{x": {
+   "en": "{GYou learn from your mistakes, and your '%K1' skill improves.{x",
+   "ua": "{GТи вчишся на своїх помилках, і твоє вміння '%K1' вдосконалюється.{x"
+  },
+  "Тебе не с кем практиковаться здесь.": {
+   "en": "There's no one to practice with here.",
+   "ua": "Тобі немає з ким практикуватися тут."
+  },
+  "{GТеперь ты гораздо лучше владеешь искусством '%K1'!{x": {
+   "en": "{GYou now have a much better grasp of the art of '%K1'!{x",
+   "ua": "{GТепер ти набагато краще володієш мистецтвом '%K1'!{x"
+  },
+  "{WТеперь ты {Cмастерски{W владеешь искусством {C%K1{W!{x": {
+   "en": "{WNow you {Cmasterfully{W command the art of {C%K1{W!{x",
+   "ua": "{WТепер ти {Cмайстерно{W володієш мистецтвом {C%K1{W!{x"
+  }
+ },
+ "plug-ins/craft/craftwearloc.cpp": {
+  "Только специальные средства могут избавить тебя от $o2.": {
+   "en": "Only special means can rid you of $o2.",
+   "ua": "Тільки спеціальні засоби можуть позбавити тебе $o2."
+  }
+ },
+ "plug-ins/craft/impl.cpp": {
+  "%^O1 бледнеет.": {
+   "en": "%^O1 pales.",
+   "ua": "%^O1 блідне."
+  },
+  "Краски на %O6 постепенно тускнеют.": {
+   "en": "The paint on %O6 is gradually fading.",
+   "ua": "Фарби на %O6 поступово тьмяніють."
+  }
+ },
+ "plug-ins/craft/subprofession.cpp": {
+  "%1$#C1 дости%1$#Gгло|г|гла нового уровня мастерства в профессии %2$N2.": {
+   "en": "%1$#C1 reached a new level of mastery in the %2$N2 profession.",
+   "ua": "%1$#C1 дося%1$#Gгло|г|гла нового рівня майстерності в професії %2$N2."
+  },
+  "{CТы достигаешь {Y%1$dго{C уровня мастерства в профессии {Y%2$N2{C!{x": {
+   "en": "{CYou reach mastery level {Y%1$d{C in the profession {Y%2$N2{C!{x",
+   "ua": "{CТи досягаєш {Y%1$d{C рівня майстерності у професії {Y%2$N2{C!{x"
+  },
+  "Ты получаешь %1$d очк%1$Iо|а|ов опыта в профессии %2$N2.": {
+   "en": "You gain %1$d point%1$I|s|s of experience in the %2$N2 profession.",
+   "ua": "Ти отримуєш %1$d бал%1$I|и|ів досвіду в професії %2$N2."
+  }
+ },
+ "plug-ins/desire/misc_desires.cpp": {
+  "Твой желудок полон, ты больше не можешь съесть ни кусочка.": {
+   "en": "Your stomach is full, you can't eat another bite.",
+   "ua": "Твій шлунок повний, ти більше не можеш з'їсти ні шматочка."
+  },
+  "%^O1 на челе %C2 вспыхивает {rбагряным{x.": {
+   "en": "%^O1 flares up crimson on %C2's brow.",
+   "ua": "%^O1 на чолі %C2 спалахує {rбагряним{x."
+  },
+  "{rКармина{x утоляет твою жажду, предотвращая безумие.": {
+   "en": "{rCarmine{x quenches your thirst, staving off madness.",
+   "ua": "{rКарміна{x втамовує твою спрагу, запобігаючи безумству."
+  },
+  "Твой желудок полон, ты больше не можешь выпить ни капли.": {
+   "en": "Your stomach is full, you can't drink another drop.",
+   "ua": "Твій шлунок повний, ти більше не можеш випити ні краплі."
+  },
+  "Ты проносишь мимо рта... *ИК*": {
+   "en": "You carry it past your mouth... *HIC*",
+   "ua": "Ти проносиш повз рота... *ГИК*"
+  }
+ },
+ "plug-ins/feniaroot/ccodesource.cpp": {
+  "Неверная подкоманда, используйте {Wcodesource help{x для справки.": {
+   "en": "Invalid subcommand, use {Wcodesource help{x for help.",
+   "ua": "Невірна підкоманда, використовуй {Wcodesource help{x для довідки."
+  },
+  "Синтаксис: cs search <строка>": {
+   "en": "Syntax: cs search <string>",
+   "ua": "Синтаксис: cs search <рядок>"
+  },
+  "Сценарий %d скопирован в буфер редактора.": {
+   "en": "Script %d copied to the editor buffer.",
+   "ua": "Сценарій %d скопійовано в буфер редактора."
+  },
+  "Сценарий под номером %d не найден.": {
+   "en": "Script number %d not found.",
+   "ua": "Сценарій під номером %d не знайдено."
+  },
+  "Сценарий с темой '%s' не найден.": {
+   "en": "Script with topic '%s' not found.",
+   "ua": "Сценарій з темою '%s' не знайдено."
+  },
+  "Ты не редактируешь сценарий.": {
+   "en": "You are not editing a script.",
+   "ua": "Ти не редагуєш сценарій."
+  },
+  "Ты не ботаешь по фене.": {
+   "en": "You don't speak thieves' cant.",
+   "ua": "Ти не ботаєш по фені."
+  }
+ },
+ "plug-ins/feniaroot/ceval.cpp": {
+  "Синтаксис: {Weval {x<expression>": {
+   "en": "Syntax: {Weval {x<expression>",
+   "ua": "Синтаксис: {Weval {x<expression>"
+  },
+  "Ты не ботаешь по фене.": {
+   "en": "You don't speak the underworld lingo.",
+   "ua": "Ти не ботаєш по фені."
+  }
+ },
+ "plug-ins/feniaroot/cfindref.cpp": {
+  "Сценарий с таким номером не найден.": {
+   "en": "No script with that number was found.",
+   "ua": "Сценарій з таким номером не знайдено."
+  },
+  "Укажи номер сценария.": {
+   "en": "Specify a scenario number.",
+   "ua": "Вкажи номер сценарію."
+  },
+  "Ты не ботаешь по фене.": {
+   "en": "You don't speak the criminals' cant.",
+   "ua": "Ти не ботаєш по фені."
+  }
+ },
+ "plug-ins/feniaroot/characterwrapper.cpp": {
+  "%1$^C1 переста%1$nет|ют летать.": {
+   "en": "%1$^C1 stop%1$ns| flying.",
+   "ua": "%1$^C1 переста%1$nє|ють літати."
+  },
+  "%^C1 возвращает тебе %O4.": {
+   "en": "%^C1 returns %O4 to you.",
+   "ua": "%^C1 повертає тобі %O4."
+  },
+  "%^C1 дает %C3 %O4.": {
+   "en": "%^C1 gives %C3 %O4.",
+   "ua": "%^C1 дає %C3 %O4."
+  },
+  "%^C1 дает тебе %O4.": {
+   "en": "%^C1 gives you %O4.",
+   "ua": "%^C1 дає тобі %O4."
+  },
+  "%^C1 произносит '{g%s{x'": {
+   "en": "%^C1 says '{g%s{x'",
+   "ua": "%^C1 промовляє '{g%s{x'"
+  },
+  "Ты перестаешь летать.": {
+   "en": "You stop flying.",
+   "ua": "Ти перестаєш літати."
+  }
+ },
+ "plug-ins/fight/effects.cpp": {
+  "%^C1 теперь ничего не слышит.": {
+   "en": "%^C1 now can't hear a thing.",
+   "ua": "%^C1 тепер нічого не чує."
+  },
+  "{MТы ничего не слышишь!{x": {
+   "en": "{MYou hear nothing!{x",
+   "ua": "{MТи нічого не чуєш!{x"
+  },
+  "Твое тело парализовано.": {
+   "en": "Your body is paralyzed.",
+   "ua": "Твоє тіло паралізоване."
+  },
+  "$c1 ничего не видит из-за дыма, попавшего в глаза!": {
+   "en": "$c1 can't see a thing because of smoke in the eyes!",
+   "ua": "$c1 нічого не бачить через дим, що потрапив в очі!"
+  },
+  "%^C1 ничего не видит из-за песка, попавшего в глаза!": {
+   "en": "%^C1 can't see a thing because of sand in the eyes!",
+   "ua": "%^C1 нічого не бачить через пісок, що потрапив в очі!"
+  },
+  "%^C1 ошеломленно трясет головой.": {
+   "en": "%^C1 shakes their head, dazed.",
+   "ua": "%^C1 приголомшено трясе головою."
+  },
+  "{WТы ошеломленно трясешь головой!{x": {
+   "en": "{WYou shake your head in a daze!{x",
+   "ua": "{WТи приголомшено трясеш головою!{x"
+  },
+  "{gТебя начинает тошнить, когда яд проникает в твое тело.{x": {
+   "en": "{gYou start to feel sick as the poison spreads through your body.{x",
+   "ua": "{gТебе починає нудити, коли отрута проникає в твоє тіло.{x"
+  },
+  "Волна холода пронизывает $c4.": {
+   "en": "A wave of cold pierces $c4.",
+   "ua": "Хвиля холоду пронизує $c4."
+  },
+  "Дикий вопль заставляет %C4 отвлечься от сражения!": {
+   "en": "A wild scream forces %C4 to be distracted from the fight!",
+   "ua": "Дикий крик змушує %C4 відволіктися від бою!"
+  },
+  "Дикий вопль заставляет тебя отвлечься от сражения!": {
+   "en": "A wild scream forces you to lose focus on the fight!",
+   "ua": "Дикий крик змушує тебе відволіктися від бою!"
+  },
+  "Твои глаза слезятся от попавшего в них дыма... и ты ничего не видишь!": {
+   "en": "Your eyes water from the smoke that's gotten into them... and you can't see a thing!",
+   "ua": "Твої очі сльозяться від диму, що потрапив у них... і ти нічого не бачиш!"
+  },
+  "Твои глаза слезятся от попавшего в них песка... ты ничего не видишь!": {
+   "en": "Your eyes water from the sand that got into them... you can't see a thing!",
+   "ua": "Твої очі сльозяться від піску, що потрапив у них... ти нічого не бачиш!"
+  },
+  "Холод окутывает тебя и проникает до самых костей.": {
+   "en": "Cold wraps around you and seeps into your very bones.",
+   "ua": "Холод огортає тебе і проникає аж до кісток."
+  }
+ },
+ "plug-ins/fight/fight.cpp": {
+  "$o1 наносит повреждения $O3.": {
+   "en": "$o1 deals damage to $O3.",
+   "ua": "$o1 завдає шкоди $O3."
+  },
+  "%^C1 вступает в битву с %C5.": {
+   "en": "%^C1 joins the battle against %C5.",
+   "ua": "%^C1 вступає в бій із %C5."
+  },
+  "Оглушение постепенно проходит.": {
+   "en": "The stun is gradually wearing off.",
+   "ua": "Оглушення поступово минає."
+  },
+  "Ты вступаешь в битву с %C5.": {
+   "en": "You enter battle with %C5.",
+   "ua": "Ти вступаєш у битву з %C5."
+  },
+  "$O1 разлетается на мелкие части.": {
+   "en": "$O1 shatters into tiny pieces.",
+   "ua": "$O1 розлітається на дрібні шматки."
+  },
+  "%^C1 вступает с тобой в битву!": {
+   "en": "%^C1 engages you in battle!",
+   "ua": "%^C1 вступає з тобою в бій!"
+  },
+  "Адреналин в твоей крови улегся, и ты успокаиваешься.": {
+   "en": "The adrenaline in your blood settles, and you calm down.",
+   "ua": "Адреналін у твоїй крові вгамувався, і ти заспокоюєшся."
+  },
+  "Гул в твоей голове затихает.": {
+   "en": "The ringing in your head fades away.",
+   "ua": "Гул у твоїй голові стихає."
+  }
+ },
+ "plug-ins/fight/fight_cmds.cpp": {
+  "Таких здесь нет.": {
+   "en": "There's none like that here.",
+   "ua": "Таких тут немає."
+  },
+  "Твоя попытка безуспешна.": {
+   "en": "Your attempt fails.",
+   "ua": "Твоя спроба невдала."
+  },
+  "Ты уже сражаешься -- сначала разберись с текущим противником.": {
+   "en": "You're already fighting -- deal with your current opponent first.",
+   "ua": "Ти вже б'єшся -- спершу розберись із поточним супротивником."
+  },
+  "Убить кого?": {
+   "en": "Kill whom?",
+   "ua": "Вбити кого?"
+  },
+  "Умертвить кого?": {
+   "en": "Slay whom?",
+   "ua": "Умертвити кого?"
+  },
+  "$c1 хладнокровно умерщвляет $C4!": {
+   "en": "$c1 coldbloodedly puts $C4 to death!",
+   "ua": "$c1 холоднокровно умертвляє $C4!"
+  },
+  "$c1 хладнокровно умерщвляет тебя!": {
+   "en": "$c1 coldbloodedly puts you to death!",
+   "ua": "$c1 холоднокровно вбиває тебе!"
+  },
+  "{RТЫ ЖЕСТОКО ИЗБИВАЕШЬ САМ{SfУ{Sx СЕБЯ!{x": {
+   "en": "YOU BRUTALLY BEAT YOURSELF UP!",
+   "ua": "ТИ ЖОРСТОКО КАТУЄШ САМ{SfУ{Sx СЕБЕ!"
+  },
+  "Но $C1 -- тво$Gй|й|я любим$Gый|ый|ая хозя$Gин|ин|йка!": {
+   "en": "But $C1 is your beloved master!",
+   "ua": "Але ж $C1 -- тв$Gоє|ій|оя улюблен$Gе|ий|а хазя$Gїн|їн|йка!"
+  },
+  "Но $C1 -- тво$Gй|й|я любим$Gый|ый|ая хозя$Gин|ин|йка.": {
+   "en": "But $C1 is your beloved owner.",
+   "ua": "Але $C1 -- тв$Gій|ій|оя улюблен$Gий|ий|а хазя$Gїн|їн|йка."
+  },
+  "Порешить кого?": {
+   "en": "Off whom?",
+   "ua": "Порішити кого?"
+  },
+  "Самоубийство -- это смертельный грех.": {
+   "en": "Suicide is a mortal sin.",
+   "ua": "Самогубство -- це смертний гріх."
+  },
+  "Ты хладнокровно умерщвляешь $C4!": {
+   "en": "You coldly put $C4 to death!",
+   "ua": "Ти холоднокровно вбиваєш $C4!"
+  }
+ },
+ "plug-ins/fight/fight_death.cpp": {
+  "Ты лишаешься тела на несколько минут.": {
+   "en": "You lose your body for a few minutes.",
+   "ua": "Ти позбавляєшся тіла на кілька хвилин."
+  },
+  "Ты чувствуешь, как твое обаяние уменьшается после этой смерти.": {
+   "en": "You feel your charisma diminish after this death.",
+   "ua": "Ти відчуваєш, як твоя чарівність зменшується після цієї смерті."
+  },
+  "Ты чувствуешь, как твое телосложение уменьшается после этой смерти.": {
+   "en": "You feel your constitution shrink after this death.",
+   "ua": "Ти відчуваєш, як твоя статура зменшується після цієї смерті."
+  },
+  "$c1 УМЕ$gРЛО|Р|РЛА, и навсегда покину$gло|л|ла этот мир.\n\r": {
+   "en": "$c1 HAS DIED, and left this world forever.\n\r",
+   "ua": "$c1 ПОМЕ$gРЛО|Р|РЛА, і назавжди покин$gуло|ув|ула цей світ.\n\r"
+  },
+  "%1$^C1 превраща%1$nется|ются в прах и развеива%1$nется|ются по ветру, не оставляя после себя трупа.": {
+   "en": "%1$^C1 crumble%1$ns| to dust and scatter%1$ns| on the wind, leaving no corpse behind.",
+   "ua": "%1$^C1 перетворю%1$nється|ються на порох і розвію%1$nється|ються за вітром, не залишаючи по собі трупа."
+  },
+  "{R$c1 выпивает последние капли жизни из $C2!{x": {
+   "en": "{R$c1 drains the last drops of life from $C2!{x",
+   "ua": "{R$c1 випиває останні краплі життя з $C2!{x"
+  },
+  "{RТы выпиваешь последние капли жизни из $C2!{x": {
+   "en": "{RYou drink the last drops of life from $C2!{x",
+   "ua": "{RТи випиваєш останні краплі життя з $C2!{x"
+  },
+  "{WТебе хочется осмотреть труп, но ты ничего не видишь!{x": {
+   "en": "{WYou want to examine the corpse, but you can't see a thing!{x",
+   "ua": "{WТобі хочеться оглянути труп, але ти нічого не бачиш!{x"
+  },
+  "{WТы методично обдираешь все вещи с трупа:{x": {
+   "en": "{WYou methodically strip all the items off the corpse:{x",
+   "ua": "{WТи методично обдираєш усі речі з трупа:{x"
+  },
+  "{WТы пытаешься вслепую ограбить труп, но ничего не выходит.{x": {
+   "en": "{WYou try to blindly loot the corpse, but nothing comes of it.{x",
+   "ua": "{WТи намагаєшся навмання обшукати труп, але нічого не виходить.{x"
+  },
+  "{WТы пытаешься ограбить труп, но почему-то не находишь его.{x": {
+   "en": "{WYou try to loot the corpse, but for some reason can't find it.{x",
+   "ua": "{WТи намагаєшся пограбувати труп, але чомусь не знаходиш його.{x"
+  },
+  "{WТы пытаешься осмотреть труп, но почему-то не находишь его.{x": {
+   "en": "{WYou try to examine the corpse, but somehow can't find it.{x",
+   "ua": "{WТи намагаєшся оглянути труп, але чомусь не знаходиш його.{x"
+  },
+  "Милостивая Варда больше не сможет тебя возродить.": {
+   "en": "Merciful Varda will no longer be able to resurrect you.",
+   "ua": "Милостива Варда більше не зможе тебе воскресити."
+  },
+  "Ты превращаешься в призрак в последний раз и навсегда покидаешь этот мир.": {
+   "en": "You turn into a ghost for the last time and leave this world forever.",
+   "ua": "Ти перетворюєшся на привида востаннє і назавжди покидаєш цей світ."
+  }
+ },
+ "plug-ins/fight/fight_exp.cpp": {
+  "$c1 пытается использовать $o4, но оно $m не подходит.": {
+   "en": "$c1 tries to use $o4, but it doesn't fit.",
+   "ua": "$c1 намагається використати $o4, але воно не підходить."
+  },
+  "$c1 становится более метк$gим|им|ой!\n\r": {
+   "en": "$c1 becomes more accurate!\n\r",
+   "ua": "$c1 стає влучніш$gим|им|ою!\n\r"
+  },
+  "$c1 улучшает свои параметры!\n\r": {
+   "en": "$c1 improves their stats!\n\r",
+   "ua": "$c1 покращує свої параметри!\n\r"
+  },
+  "{cБлагодаря твоему умелому руководству группа получает больше опыта.{x": {
+   "en": "{cThanks to your skilled leadership, the group gains more experience.{x",
+   "ua": "{cЗавдяки твоєму вмілому керівництву група отримує більше досвіду.{x"
+  },
+  "Защита $c2 улучшается!\n\r": {
+   "en": "$c2's defense improves!\n\r",
+   "ua": "Захист $c2 покращується!\n\r"
+  },
+  "Здоровье $c2 растет!\n\r": {
+   "en": "$c2's health grows!\n\r",
+   "ua": "Здоров'я $c2 зростає!\n\r"
+  },
+  "На твоем счету {%2$s%1$d{x труп%1$I|а|ов {%2$s%3$s{x персонажей.": {
+   "en": "You have {%2$s%1$d{x character corpse%1$I|s|s {%2$s%3$s{x to your credit.",
+   "ua": "На твоєму рахунку {%2$s%1$d{x труп%1$I|и|ів {%2$s%3$s{x персонажів."
+  },
+  "На твоем счету {W%1$d{x труп%1$I|а|ов {W%s{x персонажей.": {
+   "en": "You have {W%1$d{x corpse%1$I|s|s of {W%s{x characters to your name.",
+   "ua": "На твоєму рахунку {W%1$d{x труп%1$I|и|ів {W%s{x персонажів."
+  },
+  "Твое обаяние повысилось на единицу.": {
+   "en": "Your charisma has increased by one.",
+   "ua": "Твоя харизма зросла на одиницю."
+  },
+  "Твое обаяние понизилось на единицу.": {
+   "en": "Your charisma has dropped by one point.",
+   "ua": "Твоя харизма знизилась на одиницю."
+  },
+  "Твои параметры улучшаются!": {
+   "en": "Your stats improve!",
+   "ua": "Твої параметри покращуються!"
+  },
+  "Теперь ты будешь наносить больше повреждений!": {
+   "en": "Now you'll deal more damage!",
+   "ua": "Тепер ти будеш завдавати більше шкоди!"
+  },
+  "Ты получаешь {C%1$d{x очк%1$Iо|а|ов опыта за убийство %2$#C2.": {
+   "en": "You gain {C%1$d{x experience point%1$I|s|s for killing %2$#C2.",
+   "ua": "Ти отримуєш {C%1$d{x очк%1$Iо|и|ів досвіду за вбивство %2$#C2."
+  },
+  "Ты получаешь уровень!": {
+   "en": "You gain a level!",
+   "ua": "Ти отримуєш рівень!"
+  },
+  "Ты пытаешься использовать $o4, но это не для тебя.": {
+   "en": "You try to use $o4, but it's not for you.",
+   "ua": "Ти намагаєшся використати $o4, але це не для тебе."
+  },
+  "Ты слишком высокого уровня для этой группы.": {
+   "en": "You're too high level for this group.",
+   "ua": "Ти надто високого рівня для цієї групи."
+  },
+  "Ты слишком низкого уровня для этой группы.": {
+   "en": "You're too low level for this group.",
+   "ua": "Ти маєш занадто низький рівень для цієї групи."
+  },
+  "$c1 выглядит более опытн$gым|ым|ой!\n\r": {
+   "en": "$c1 looks more experienced!\n\r",
+   "ua": "$c1 виглядає досвідченіш$gим|им|ою!\n\r"
+  },
+  "$c1 наполняется энергией!\n\r": {
+   "en": "$c1 fills up with energy!\n\r",
+   "ua": "$c1 наповнюється енергією!\n\r"
+  },
+  "$c1 становится более опасн$gым|ым|ой!\n\r": {
+   "en": "$c1 becomes more dangerous!\n\r",
+   "ua": "$c1 стає небезпечніш$gим|им|ою!\n\r"
+  },
+  "$c1 теперь будет больнее бить!\n\r": {
+   "en": "$c1 will now hit harder!\n\r",
+   "ua": "$c1 тепер битиме дошкульніше!\n\r"
+  },
+  "{cБлагодаря умелому руководству %C2 ты получаешь больше опыта.{x": {
+   "en": "{cThanks to %C2's skillful leadership, you gain more experience.{x",
+   "ua": "{cЗавдяки вмілому керівництву %C2 ти отримуєш більше досвіду.{x"
+  },
+  "Твоя защита улучшается!": {
+   "en": "Your defense improves!",
+   "ua": "Твій захист покращується!"
+  },
+  "Теперь ты будешь больнее бить!": {
+   "en": "Now you'll hit harder!",
+   "ua": "Тепер ти битимеш болючіше!"
+  },
+  "Теперь ты будешь попадать более метко!": {
+   "en": "Now you'll strike true more often!",
+   "ua": "Тепер ти влучатимеш точніше!"
+  },
+  "Ты здоровеешь!": {
+   "en": "You're getting healthier!",
+   "ua": "Ти здоровшаєш!"
+  },
+  "Ты уби$gло|л|ла достойного противника, и твое обаяние повысилось на единицу.": {
+   "en": "You killed a worthy opponent, and your charisma increased by one.",
+   "ua": "Ти вб$gило|ив|ила достойного супротивника, і твоя харизма підвищилася на одиницю."
+  },
+  "Ты чувствуешь прилив энергии!": {
+   "en": "You feel a rush of energy!",
+   "ua": "Ти відчуваєш приплив енергії!"
+  }
+ },
+ "plug-ins/fight/fight_subr.cpp": {
+  "{1{GПаралич %1$C2 проходит, и %1$P1 снова начина%1$nет|ют двигаться!{2": {
+   "en": "{1{GThe paralysis on %1$C2 wears off, and %1$C1 start%1$ns| moving again!{2",
+   "ua": "{1{GПараліч %1$C2 минає, і %1$C1 знову почина%1$nє|ють рухатися!{2"
+  },
+  "{1{GТвой паралич проходит, и ты снова можешь двигаться!{2": {
+   "en": "{1{GYour paralysis wears off, and you can move again!{2",
+   "ua": "{1{GТвій параліч минає, і ти знову можеш рухатися!{2"
+  },
+  "{1{MТвой паралич проходит, но ты все еще оглуше%1$Gно|н|на|ны!{2": {
+   "en": "{1{MYour paralysis fades, but you're still stunned!{2",
+   "ua": "{1{MТвій параліч минає, але ти все ще оглуше%1$Gно|н|на|ні!{2"
+  },
+  "{W%1$^C1 оглуше%1$Gно|н|на|ны и не мо%1$nжет|гут реагировать на атаки.{x": {
+   "en": "{W%1$^C1 %1$nis|are stunned and can't react to attacks.{x",
+   "ua": "{W%1$^C1 оглуш%1$Gене|ений|ена|ені і не мож%1$nе|уть реагувати на атаки.{x"
+  },
+  "{W%1$^C1 оглуше%1$Gно|н|на|ны и не мо%1$nжет|гут реагировать на твои атаки.{x": {
+   "en": "{W%1$^C1 %1$nis|are stunned and can't react to your attacks.{x",
+   "ua": "{W%1$^C1 оглуше%1$Gно|ний|на|ні і не мо%1$nже|жуть реагувати на твої атаки.{x"
+  },
+  "{W%1$^C1 парализова%1$Gно|н|на|ны и не мо%1$nжет|гут реагировать на атаки.{x": {
+   "en": "{W%1$^C1 %1$nis|are paralyzed and cannot react to attacks.{x",
+   "ua": "{W%1$^C1 паралізован%1$Gе|ий|а|і і не мо%1$nже|жуть реагувати на атаки.{x"
+  },
+  "{W%1$^C1 парализова%1$Gно|н|на|ны и не мо%1$nжет|гут реагировать на твои атаки.{x": {
+   "en": "{W%1$^C1 %1$nis|are paralyzed and cannot react to your attacks.{x",
+   "ua": "{W%1$^C1 паралізован%1$Gо|ий|а|і і не мо%1$nже|жуть реагувати на твої атаки.{x"
+  },
+  "{WТы оглуше%1$Gно|н|на|ны и не можешь реагировать на атаки %2$C2.{x": {
+   "en": "{WYou are stunned and cannot react to %2$C2's attacks.{x",
+   "ua": "{WТи оглуше%1$Gно|ний|на|ні і не можеш реагувати на атаки %2$C2.{x"
+  },
+  "{WТы парализова%1$Gно|н|на|ны и не можешь реагировать на атаки %2$C2.{x": {
+   "en": "{WYou are paralyzed and cannot react to %2$C2's attacks.{x",
+   "ua": "{WТи паралізован%1$Gо|ий|а|і і не можеш реагувати на атаки %2$C2.{x"
+  },
+  "Ты вступаешь в битву на стороне $C2.": {
+   "en": "You join the battle on the side of $C2.",
+   "ua": "Ти вступаєш у бій на боці $C2."
+  },
+  "{RБОЛЬШЕ КРОВИ! БОЛЬШЕ КРОВИ! БОЛЬШЕ КРОВИ!!!{x": {
+   "en": "{RMORE BLOOD! MORE BLOOD! MORE BLOOD!!!{x",
+   "ua": "{RБІЛЬШЕ КРОВІ! БІЛЬШЕ КРОВІ! БІЛЬШЕ КРОВІ!!!{x"
+  }
+ },
+ "plug-ins/fight/magic.cpp": {
+  "%1$^C1 пыта%1$nется|ются сотворить заклинание, но изолирующий экран блокирует %1$P2.": {
+   "en": "%1$^C1 tr%1$nies|y to cast a spell, but the isolating screen blocks them.",
+   "ua": "%1$^C1 намага%1$nється|ються сотворити заклинання, але ізолюючий екран блокує %1$C4."
+  },
+  "%^N1 {1{Gочень слабо{2 влияет на %C4.": {
+   "en": "%^N1 {1{Gvery weakly{2 affects %C4.",
+   "ua": "%^N1 {1{Gдуже слабко{2 впливає на %C4."
+  },
+  "%^N1 {1{Gочень слабо{2 влияет на тебя.": {
+   "en": "%^N1 affects you {1{Gvery weakly{2.",
+   "ua": "%^N1 {1{Gдуже слабко{2 впливає на тебе."
+  },
+  "%^N1 {1{Rособо пагубно{2 влияет на %C4.": {
+   "en": "%^N1 has an {1{Respecially harmful{2 effect on %C4.",
+   "ua": "%^N1 {1{Rособливо згубно{2 впливає на %C4."
+  },
+  "%^N1, похоже, никак не сможет навредить %C3.": {
+   "en": "%^N1, it seems, won't be able to harm %C3 at all.",
+   "ua": "%^N1, здається, ніяк не зможе нашкодити %C3."
+  },
+  "%^N1, похоже, никак не сможет навредить тебе.": {
+   "en": "%^N1 doesn't seem to be able to harm you at all.",
+   "ua": "%^N1, схоже, ніяк не зможе зашкодити тобі."
+  },
+  "Глухота мешает %1$C3 как следует произнести заклинание.": {
+   "en": "Deafness prevents %1$C3 from properly casting the spell.",
+   "ua": "Глухота заважає %1$C3 як слід вимовити заклинання."
+  },
+  "Глухота мешает тебе как следует произнести заклинание.": {
+   "en": "Deafness keeps you from casting the spell properly.",
+   "ua": "Глухота заважає тобі як слід вимовити заклинання."
+  },
+  "Ты пытаешься сотворить заклинание, но изолирующий экран блокирует тебя.": {
+   "en": "You try to cast a spell, but an isolating screen blocks you.",
+   "ua": "Ти намагаєшся сотворити заклинання, але ізолюючий екран блокує тебе."
+  },
+  "Эта местность поглощает и блокирует твое заклинание.": {
+   "en": "This terrain absorbs and blocks your spell.",
+   "ua": "Ця місцевість поглинає і блокує твоє заклинання."
+  },
+  "%^N1 {1{Rособо пагубно{2 влияет на тебя.": {
+   "en": "%^N1 has an {1{Respecially harmful{2 effect on you.",
+   "ua": "%^N1 {1{Rособливо згубно{2 впливає на тебе."
+  },
+  "Твой язык заплетается, и ты не можешь как следует произнести заклинание.": {
+   "en": "Your tongue trips over itself, and you can't properly utter the spell.",
+   "ua": "Твій язик заплітається, і ти не можеш як слід вимовити заклинання."
+  }
+ },
+ "plug-ins/fight/onehit_undef.cpp": {
+  "$c1 разбивается на мелкие осколки.": {
+   "en": "$c1 shatters into tiny fragments.",
+   "ua": "$c1 розбивається на дрібні скалки."
+  },
+  "С ослабленными нервными окончаниями оглушить противника становится легче.": {
+   "en": "With weakened nerve endings, it becomes easier to stun an opponent.",
+   "ua": "З ослабленими нервовими закінченнями оглушити противника стає легше."
+  },
+  "$o1 $c2 загорается {Cголубым светом{x.": {
+   "en": "$o1, that belongs to $c2, lights up with {Cblue light{x.",
+   "ua": "$o1 $c2 займається {Cблакитним світлом{x."
+  },
+  "$o1 в твоей $T руке загорается {Cголубым светом{x.": {
+   "en": "$o1 in your $T hand bursts into {Cblue light{x.",
+   "ua": "$o1 у твоїй $T руці спалахує {Cблакитним світлом{x."
+  },
+  "%^C1 и %C1 наводят {Rстрах и ужас{x на противников, нанося дополнительный урон!": {
+   "en": "%^C1 and %C1 strike fear and terror into their {Renemies{x, dealing bonus damage!",
+   "ua": "%^C1 і %C1 наводять {Rстрах і жах{x на супротивників, завдаючи додаткової шкоди!"
+  },
+  "%^C1 уже ТРУП!!": {
+   "en": "%^C1 is already a CORPSE!!",
+   "ua": "%^C1 вже ТРУП!!"
+  },
+  "{r$c1 оглушает $C4 мощной серией ударов в голову!{x": {
+   "en": "{r$c1 stuns $C4 with a powerful flurry of blows to the head!{x",
+   "ua": "{r$c1 оглушує $C4 потужною серією ударів у голову!{x"
+  },
+  "{r$c1 сильно оглушает тебя мощной серией ударов в голову!{x": {
+   "en": "{r$c1 stuns you hard with a powerful series of blows to the head!{x",
+   "ua": "{r$c1 сильно оглушує тебе потужною серією ударів у голову!{x"
+  },
+  "{r$c1 слегка оглушает $C4 ударом в голову!{x": {
+   "en": "{r$c1 lightly stuns $C4 with a blow to the head!{x",
+   "ua": "{r$c1 злегка оглушує $C4 ударом у голову!{x"
+  },
+  "{r$c1 слегка оглушает СЕБЯ ударом в голову!{x": {
+   "en": "{r$c1 slightly stuns THEMSELVES with a blow to the head!{x",
+   "ua": "{r$c1 злегка оглушує САМЕ СЕБЕ ударом по голові!{x"
+  },
+  "{r$c1 слегка оглушает тебя ударом в голову!{x": {
+   "en": "{r$c1 slightly stuns you with a blow to the head!{x",
+   "ua": "{r$c1 злегка оглушує тебе ударом у голову!{x"
+  },
+  "{rМощной серией ударов в голову ты сильно оглушаешь $C4!{x": {
+   "en": "{rWith a powerful series of blows to the head, you stun $C4 hard!{x",
+   "ua": "{rПотужною серією ударів у голову ти сильно оглушуєш $C4!{x"
+  },
+  "{rТвой удар в голову слегка оглушает $C4!{x": {
+   "en": "{rYour blow to the head slightly stuns $C4!{x",
+   "ua": "{rТвій удар у голову трохи оглушує $C4!{x"
+  },
+  "{rТвой удар отклонен тебе ж в голову! Ты слегка оглушаешь СЕБЯ!{x": {
+   "en": "{rYour blow bounces right back into your own head! You stun YOURSELF a little!{x",
+   "ua": "{rТвій удар відбивається тобі ж у голову! Ти трохи оглушуєш САМ СЕБЕ!{x"
+  },
+  "Руки $c2 наполняются смертоносной силой!": {
+   "en": "$c2's hands fill with deadly power!",
+   "ua": "Руки $c2 наповнюються смертоносною силою!"
+  },
+  "Твои руки наполняются смертоносной силой!": {
+   "en": "Your hands fill with deadly power!",
+   "ua": "Твої руки наповнюються смертоносною силою!"
+  },
+  "Тебя УБИЛИ!": {
+   "en": "YOU'VE BEEN KILLED!",
+   "ua": "ТЕБЕ ВБИЛИ!"
+  },
+  "Ты и %C1 наводите {Rстрах и ужас{x на противников, нанося дополнительный урон!": {
+   "en": "You and %C1 strike {Rfear and terror{x into your enemies, dealing extra damage!",
+   "ua": "Ти і %C1 наводите {Rстрах і жах{x на ворогів, завдаючи додаткової шкоди!"
+  }
+ },
+ "plug-ins/fight/onehit_weapon.cpp": {
+  "Ты парализова$gно|н|на и роняешь оружие!": {
+   "en": "You are paralyzed and drop your weapon!",
+   "ua": "Ти паралізован$gо|ий|а і впускаєш зброю!"
+  },
+  "$C1 возвращает удар $c2 обратно!": {
+   "en": "$C1 returns $c2's blow right back!",
+   "ua": "$C1 повертає удар $c2 назад!"
+  },
+  "$C1 направляет твой удар против тебя само$gго|го|й!": {
+   "en": "$C1 redirects your strike back against yourself!",
+   "ua": "$C1 спрямовує твій удар проти тебе сам$gого|ого|ої!"
+  },
+  "$o1 ярко вспыхивает!": {
+   "en": "$o1 flares up brightly!",
+   "ua": "$o1 яскраво спалахує!"
+  },
+  "{DЧерная немощь{x поражает руку $c2!": {
+   "en": "{DBlack Weakness{x strikes $c2's arm!",
+   "ua": "{DЧорна неміч{x вражає руку $c2!"
+  },
+  "{DЧерная немощь{x поражает твою руку!": {
+   "en": "{DBlack Palsy{x strikes your arm!",
+   "ua": "{DЧорна немічність{x вражає твою руку!"
+  }
+ },
+ "plug-ins/fight_core/damage.cpp": {
+  "$c1 без сознания, но возможно придет в себя.": {
+   "en": "$c1 is unconscious, but might come to.",
+   "ua": "$c1 у непритомному стані, але, можливо, ще прийде до тями."
+  },
+  "{1%1$^C1 {Wподнима%1$nется|ются и вста%1$nет|ют, готовясь атаковать.{2": {
+   "en": "{1%1$^C1 {Wget%1$ns| up and rise%1$ns|, readying to attack.{2",
+   "ua": "{1%1$^C1 {Wпідніма%1$nється|ються і вста%1$nє|ють, готуючись атакувати.{2"
+  },
+  "{1{BТы всплываешь и поворачиваешься к противнику, готовясь к атаке.{2": {
+   "en": "{1{BYou surface and turn to face your opponent, readying an attack.{2",
+   "ua": "{1{BТи спливаєш і повертаєшся до супротивника, готуючись до атаки.{2"
+  },
+  "{1{WТы поднимаешься и встаешь, готовясь атаковать.{2": {
+   "en": "{1{WYou rise to your feet, readying to attack.{2",
+   "ua": "{1{WТи піднімаєшся і встаєш, готуючись атакувати.{2"
+  },
+  "Ты без сознания, но еще можешь придти в себя.": {
+   "en": "You're unconscious, but you can still come to.",
+   "ua": "Ти без свідомості, але ще можеш прийти до тями."
+  },
+  "Ты просыпаешься от внезапной боли.": {
+   "en": "You wake up from a sudden pain.",
+   "ua": "Ти прокидаєшся від раптового болю."
+  },
+  "Ты смертельно ране$gно|н|на и скоро умрешь, если тебе не помогут.": {
+   "en": "You are mortally wounded and will die soon unless someone helps you.",
+   "ua": "Ти смертельно поранен$gо|ий|а і скоро помреш, якщо тобі не допоможуть."
+  },
+  "$c1 уже {RТРУП{x!!": {
+   "en": "$c1 is already a {RCORPSE{x!!",
+   "ua": "$c1 вже {RТРУП{x!!"
+  },
+  "{1{B%1$^C1 всплыва%1$nет|ют и поворачива%1$nется|ются к противнику, готовясь к атаке.{2": {
+   "en": "{1{B%1$^C1 surface%1$ns| and turn%1$ns| to face the enemy, readying for an attack.{2",
+   "ua": "{1{B%1$^C1 сплива%1$nє|ють і поверта%1$nється|ються до противника, готуючись до атаки.{2"
+  },
+  "{1{B%1$^C1 вста%1$nет|ют на мелководье и отряхива%1$nется|ются, готовясь атаковать.{2": {
+   "en": "{1{B%1$^C1 stand%1$ns| in the shallows and shake%1$ns| off, preparing to attack.{2",
+   "ua": "{1{B%1$^C1 вста%1$nє|ють на мілководді і обтруш%1$nується|уються, готуючись атакувати.{2"
+  },
+  "{1{BТы встаешь на мелководье и отряхиваешься, готовясь атаковать.{2": {
+   "en": "{1{BYou stand up in the shallows and shake yourself off, readying to attack.{2",
+   "ua": "{1{BТи встаєш на мілководді і обтрушуєшся, готуючись атакувати.{2"
+  },
+  "{1{C%1$^C1 кувырка%1$nется|ются в воздухе, поворачиваясь к противнику и готовясь к атаке.{2": {
+   "en": "{1{C%1$^C1 tumble%1$ns| through the air, turning to face the opponent and readying to attack.{2",
+   "ua": "{1{C%1$^C1 кувірка%1$nється|ються в повітрі, повертаючись до супротивника і готуючись до атаки.{2"
+  },
+  "{1{CТы кувыркаешься в воздухе, поворачиваясь к противнику и готовясь к атаке.{2": {
+   "en": "{1{CYou tumble through the air, turning to face your opponent and readying an attack.{2",
+   "ua": "{1{CТи перекидаєшся в повітрі, повертаючись до противника і готуючись до атаки.{2"
+  },
+  "{1{b%1$^C1 кувырка%1$nется|ются под водой, поворачиваясь к противнику и готовясь к атаке.{2": {
+   "en": "{1{b%1$^C1 tumble%1$ns| underwater, turning to face the opponent and preparing to attack.{2",
+   "ua": "{1{b%1$^C1 кувирка%1$nється|ються під водою, повертаючись до супротивника і готуючись до атаки.{2"
+  },
+  "{1{bТы кувыркаешься под водой, поворачиваясь к противнику и готовясь к атаке.{2": {
+   "en": "{1{bYou tumble underwater, turning to face your opponent and preparing to attack.{2",
+   "ua": "{1{bТи перекидаєшся під водою, повертаючись до противника і готуючись до атаки.{2"
+  },
+  "Тебя {RУБИЛИ{x!!\n\r": {
+   "en": "You've been {RKILLED{x!!\n\r",
+   "ua": "Тебе {RВБИЛИ{x!!\n\r"
+  },
+  "Ты истекаешь {RКРОВЬЮ{x!": {
+   "en": "You're bleeding {ROUT{x!",
+   "ua": "Ти стікаєш {RКРОВ'Ю{x!"
+  },
+  "Ты совершенно беспомощ$gно|ен|на и скоро умрешь, если тебе не помогут.": {
+   "en": "You are utterly helpless and will die soon unless someone helps you.",
+   "ua": "Ти цілком безпоміч$gне|ний|на і скоро помреш, якщо тобі не допоможуть."
+  },
+  "Это было действительно БОЛЬНО!": {
+   "en": "That really HURT!",
+   "ua": "Це було справді БОЛЯЧЕ!"
+  }
+ },
+ "plug-ins/fight_core/fight_extract.cpp": {
+  "Ты принимаешь свое истинное обличье.": {
+   "en": "You take on your true form.",
+   "ua": "Ти набуваєш своєї справжньої подоби."
+  }
+ },
+ "plug-ins/fight_core/fight_safe.cpp": {
+  "$C1 находится под защитой богов.": {
+   "en": "$C1 is under the protection of the gods.",
+   "ua": "$C1 перебуває під захистом богів."
+  },
+  "Боги защитили $C4 от $c2.": {
+   "en": "The gods protected $C4 from $c2.",
+   "ua": "Боги захистили $C4 від $c2."
+  },
+  "Боги защищают $c4 от заклинаний в этой местности.": {
+   "en": "The gods protect $c4 from spells in this area.",
+   "ua": "Боги захищають $c4 від заклять у цій місцевості."
+  },
+  "Боги защищают тебя от заклинаний в этой местности.": {
+   "en": "The gods protect you from spells in this area.",
+   "ua": "Боги захищають тебе від заклять у цій місцевості."
+  }
+ },
+ "plug-ins/fight_core/follow_utils.cpp": {
+  "$c1 прекращает охранять $C4.": {
+   "en": "$c1 stops guarding $C4.",
+   "ua": "$c1 припиняє охороняти $C4."
+  },
+  "$c1 прекращает охранять тебя.": {
+   "en": "$c1 stops guarding you.",
+   "ua": "$c1 припиняє охороняти тебе."
+  },
+  "%1$^C1 больше не следу%1$nет|ют за тобой.": {
+   "en": "%1$^C1 no longer follow%1$ns| you.",
+   "ua": "%1$^C1 більше не слід%1$nує|ють за тобою."
+  },
+  "%1$^C1 теперь следу%1$nет|ют за тобой.": {
+   "en": "%1$^C1 now follow%1$ns| you.",
+   "ua": "%1$^C1 тепер слідку%1$nє|ють за тобою."
+  },
+  "Ты больше не следуешь за %1$C5.": {
+   "en": "You are no longer following %1$C5.",
+   "ua": "Ти більше не слідуєш за %1$C5."
+  },
+  "Ты прекращаешь охранять $C4.": {
+   "en": "You stop guarding $C4.",
+   "ua": "Ти припиняєш охороняти $C4."
+  },
+  "Ты теперь следуешь за %1$C5.": {
+   "en": "You now follow %1$C5.",
+   "ua": "Ти тепер ідеш за %1$C5."
+  }
+ },
+ "plug-ins/fight_core/item_progs.cpp": {
+  "Твой кошелек пополнился на %s.": {
+   "en": "Your purse grew richer by %s.",
+   "ua": "Твій гаманець поповнився на %s."
+  }
+ },
+ "plug-ins/fight_core/weaponrandomizer.cpp": {
+  "%^O1 меняет свои характеристики на случайные.": {
+   "en": "%^O1 changes its stats to random ones.",
+   "ua": "%^O1 змінює свої характеристики на випадкові."
+  },
+  "%^C1 проводит инвентаризацию.": {
+   "en": "%^C1 takes inventory.",
+   "ua": "%^C1 проводить інвентаризацію."
+  }
+ },
+ "plug-ins/gquest/command/cgquest.cpp": {
+  "%sСписок глобальных квестов Мира Грез": {
+   "en": "%sList of Global Quests of the World of Dreams",
+   "ua": "%sСписок глобальних квестів Світу Мрій"
+  },
+  "Глобальный квест остановлен.": {
+   "en": "The global quest has been stopped.",
+   "ua": "Глобальний квест зупинено."
+  },
+  "Конфигурация глобального квеста обновлена.": {
+   "en": "Global quest configuration updated.",
+   "ua": "Конфігурацію глобального квесту оновлено."
+  },
+  "Неверное время, минимум %d минут.": {
+   "en": "Invalid time, minimum %d minutes.",
+   "ua": "Невірний час, мінімум %d хвилин."
+  },
+  "Неверное количество побед.": {
+   "en": "Invalid number of wins.",
+   "ua": "Невірна кількість перемог."
+  },
+  "Неправильное время.": {
+   "en": "Wrong time.",
+   "ua": "Неправильний час."
+  },
+  "Неправильный ID, либо квест не запущен.": {
+   "en": "Invalid ID, or the quest isn't running.",
+   "ua": "Неправильний ID, або квест не запущено."
+  },
+  "Неправильный ID.": {
+   "en": "Invalid ID.",
+   "ua": "Неправильний ID."
+  },
+  "Неправильный параметр: пишите вкл или выкл, да или нет.": {
+   "en": "Invalid parameter: type on or off, yes or no.",
+   "ua": "Неправильний параметр: пиши увімк або вимк, так чи ні."
+  },
+  "Новое время квеста %d минут, до конца остается %d минут.": {
+   "en": "New quest time is %d minutes, %d minutes remain until the end.",
+   "ua": "Новий час квесту %d хвилин, до кінця залишається %d хвилин."
+  },
+  "Сейчас нет ни одного глобального задания.": {
+   "en": "There are currently no global quests.",
+   "ua": "Зараз немає жодного глобального завдання."
+  },
+  "Сказать что?": {
+   "en": "Say what?",
+   "ua": "Сказати що?"
+  },
+  "Тебе нельзя.": {
+   "en": "You can't.",
+   "ua": "Тобі не можна."
+  },
+  "Ты будешь получать опыт как награду за глобальные квесты.": {
+   "en": "You will receive experience as a reward for global quests.",
+   "ua": "Ти отримуватимеш досвід як нагороду за глобальні квести."
+  },
+  "Ты не будешь получать опыт как награду за глобальные квесты.": {
+   "en": "You will not receive experience as a reward for global quests.",
+   "ua": "Ти не отримуватимеш досвід як нагороду за глобальні квести."
+  },
+  "Укажите ID глобального квеста.": {
+   "en": "Specify the global quest ID.",
+   "ua": "Вкажи ID глобального квесту."
+  },
+  "Укажите имя правильно и полностью.": {
+   "en": "Specify the name correctly and in full.",
+   "ua": "Вкажи ім'я правильно і повністю."
+  }
+ },
+ "plug-ins/gquest/command/gquestnotifyplugin.cpp": {
+  "\r\nГлобальные квесты, в которых ты можешь принять участие: ": {
+   "en": "\r\nGlobal quests you can take part in: ",
+   "ua": "\r\nГлобальні квести, у яких ти можеш взяти участь: "
+  }
+ },
+ "plug-ins/gquest/core/globalquest.cpp": {
+  "$c1 улетучивается.": {
+   "en": "$c1 vanishes into thin air.",
+   "ua": "$c1 випаровується."
+  },
+  "Ты исчезаешь отсюда.": {
+   "en": "You vanish from here.",
+   "ua": "Ти зникаєш звідси."
+  }
+ },
+ "plug-ins/gquest/core/gqobjects.cpp": {
+  "%^O1 исчезает.": {
+   "en": "%^O1 disappears.",
+   "ua": "%^O1 зникає."
+  }
+ },
+ "plug-ins/gquest/gangsters/gangmob.cpp": {
+  "$c1 что-то говорит на ухо $C3.": {
+   "en": "$c1 whispers something into $C3's ear.",
+   "ua": "$c1 щось шепоче на вухо $C3."
+  },
+  "$c1 бормочет '{gОпа, менты, менты...{x'": {
+   "en": "$c1 mutters, '{gWhoa, cops, cops...{x'",
+   "ua": "$c1 бурмоче: '{gОпа, менти, менти...{x'"
+  },
+  "$c1 вопит '{gMamma mia!{x'": {
+   "en": "$c1 screams '{gMamma mia!{x'",
+   "ua": "$c1 верещить '{gMamma mia!{x'"
+  },
+  "$c1 вопит '{gПомогите! Хулиганы зрения лишают!{x'": {
+   "en": "$c1 screams '{gHelp! Thugs are taking my eyesight!{x'",
+   "ua": "$c1 репетує '{gРятуйте! Хулігани зору позбавляють!{x'"
+  },
+  "$c1 выхватывает из кармана ключ и съедает его!": {
+   "en": "$c1 whips a key out of their pocket and eats it!",
+   "ua": "$c1 вихоплює з кишені ключ і з'їдає його!"
+  },
+  "$c1 говорит тебе '{GВход в логово я видел около $t. Но больше мне ничего не известно.{x'": {
+   "en": "$c1 tells you '{GI saw the entrance to the lair near $t. But that's all I know.{x'",
+   "ua": "$c1 каже тобі '{GВхід до лігва я бачив біля $t. Але більше мені нічого не відомо.{x'"
+  },
+  "$c1 громко вопит '{gПытаешься подкупить меня, сопля$Gк|к|чка?!{x'": {
+   "en": "$c1 screams loudly '{gTrying to bribe me, you little snot-nose?!{x'",
+   "ua": "$c1 голосно верещить: '{gНамагаєшся підкупити мене, сопля$Gк|к|чка|ки?!{x'"
+  },
+  "$c1 дрожит от страха перед $C5.": {
+   "en": "$c1 trembles with fear before $C5.",
+   "ua": "$c1 тремтить від страху перед $C5."
+  },
+  "$c1 мерзко ухмыляется.": {
+   "en": "$c1 sneers vilely.",
+   "ua": "$c1 бридко посміхається."
+  },
+  "$c1 потирает руки и удаляется в сторону ближайшей таверны.": {
+   "en": "$c1 rubs their hands together and heads off toward the nearest tavern.",
+   "ua": "$c1 потирає руки і прямує в бік найближчої таверни."
+  },
+  "$c1 предсмертной хваткой цепляется за твою одежду.": {
+   "en": "$c1 clings to your clothes with a death grip.",
+   "ua": "$c1 передсмертною хваткою чіпляється за твій одяг."
+  },
+  "$c1 произносит '{g$C1, ну че ты за мной ходишь, влюбил$Gось|ся|ась?{x'": {
+   "en": "$c1 says, '{g$C1, why do you keep following me around, you got a crush on me or something?{x'",
+   "ua": "$c1 каже: '{g$C1, ну шо ти за мною ходиш, закоха$Gлось|вся|лася?{x'"
+  },
+  "$c1 произносит '{gВарда милостивая, это опять ты?{x'": {
+   "en": "$c1 says '{gMerciful Varda, is that you again?{x'",
+   "ua": "$c1 каже '{gВардо милостива, це знову ти?{x'"
+  },
+  "$c1 произносит '{gМент поганый! Получай!{x'": {
+   "en": "$c1 says '{gDirty cop! Take this!{x'",
+   "ua": "$c1 каже '{gМент поганий! Отримуй!{x'"
+  },
+  "$c1 произносит '{gПлакали твои денежки, $C1!{x'": {
+   "en": "$c1 says '{gKiss your money goodbye, $C1!{x'",
+   "ua": "$c1 промовляє '{gПлакали твої грошики, $C1!{x'"
+  },
+  "$c1 произносит '{gУговорил$G||а, красноречив$Gый|ый|ая{x... Я открою тебе тайну!{x'": {
+   "en": "$c1 says '{gYou talked me into it, you silver-tongued so-and-so{x... I'll let you in on a secret!{x'",
+   "ua": "$c1 каже '{gУмови$Gло|в|ла, красномовн$Gе|ий|а{x... Я відкрию тобі таємницю!{x'"
+  },
+  "$c1 произносит '{gЧертов фараон! Сейчас я тебе покажу!{x'": {
+   "en": "$c1 says '{gDamn copper! I'll show you now!{x'",
+   "ua": "$c1 промовляє '{gЧортів фараон! Зараз я тобі покажу!{x'"
+  },
+  "$c1 рычит '{g$C1, как же ты меня доста$Gло|л|ла!{x'": {
+   "en": "$c1 growls '{g$C1, you've really gotten on my nerves!{x'",
+   "ua": "$c1 гарчить '{g$C1, як же ти мене дістав$Gло|в|ла!{x'"
+  },
+  "$c1 тяжко вздыхает.": {
+   "en": "$c1 sighs heavily.",
+   "ua": "$c1 важко зітхає."
+  },
+  "$c1 хрипит '{g$C1, тебе незнакомо понятие чести...{x'": {
+   "en": "$c1 rasps '{g$C1, you have no notion of honor...{x'",
+   "ua": "$c1 хрипить '{g$C1, тобі незнайоме поняття честі...{x'"
+  },
+  "$c1 хрипит '{g$GБро|Братан|Сестра, передай от меня привет шефу!{x'": {
+   "en": "$c1 rasps '{gYo, pass my regards to the boss!{x'",
+   "ua": "$c1 хрипить '{g$GБро|Братане|Сестро, передай від мене привіт шефу!{x'"
+  },
+  "$c1 хрипит '{gВход в логово найдешь неподалеку от $t...{x'": {
+   "en": "$c1 rasps '{gYou'll find the entrance to the lair not far from $t...{x'",
+   "ua": "$c1 хрипить '{gВхід у лігво знайдеш неподалік від $t...{x'"
+  },
+  "$c1 хрипит '{gКонец моим мучениям...{x'": {
+   "en": "$c1 rasps '{gAn end to my suffering...{x'",
+   "ua": "$c1 хрипить '{gКінець моїм мукам...{x'"
+  },
+  "$c1 хрипит '{gЛучше сдохнуть своей смертью, чем от руки такой собаки, как ты, $C2.{x'": {
+   "en": "$c1 rasps, '{gBetter to die my own death than by the hand of a dog like you, $C2.{x'",
+   "ua": "$c1 хрипить: '{gКраще здохнути своєю смертю, ніж від руки такого пса, як ти, $C2.{x'"
+  },
+  "$c1 хрипит '{gМне крышка...{x'": {
+   "en": "$c1 wheezes '{gI'm done for...{x'",
+   "ua": "$c1 хрипить '{gМені кінець...{x'"
+  },
+  "$c1 хрипит '{gТолько сейчас я понял, как неправильно жил. Я раскаиваюсь и перед смертью открою тебе тайну.{x'": {
+   "en": "$c1 rasps, '{gOnly now do I see how wrong I've lived. I repent, and before I die I'll tell you a secret.{x'",
+   "ua": "$c1 хрипить: '{gТільки зараз я зрозумів, як неправильно жив. Я каюся і перед смертю відкрию тобі таємницю.{x'"
+  },
+  "$c1 хрипит '{gЭта напасть доконала меня...{x'": {
+   "en": "$c1 rasps '{gThis affliction has done me in...{x'",
+   "ua": "$c1 хрипить '{gЦя напасть доконала мене...{x'"
+  },
+  "$c1 хрипит '{gЭх, все равно помирать... Так слушай же.{x'": {
+   "en": "$c1 wheezes '{gEh, I'm dying anyway... So listen up.{x'",
+   "ua": "$c1 хрипить '{gЕх, все одно помирати... То слухай же.{x'"
+  },
+  "$c1 хрипит '{gЯ не должен был умереть от твоей руки, $C1...{x'": {
+   "en": "$c1 rasps: '{gI wasn't supposed to die by your hand, $C1...{x'",
+   "ua": "$c1 хрипить: '{gЯ не мав померти від твоєї руки, $C1...{x'"
+  }
+ },
+ "plug-ins/gquest/gangsters/gangsters.cpp": {
+  "$c1 исчезает в клубе дыма.": {
+   "en": "$c1 disappears in a puff of smoke.",
+   "ua": "$c1 зникає в клубах диму."
+  }
+ },
+ "plug-ins/gquest/invasion/invasion.cpp": {
+  "$o1 исчезает.": {
+   "en": "$o1 disappears.",
+   "ua": "$o1 зникає."
+  },
+  "$c1 лопается.": {
+   "en": "$c1 bursts.",
+   "ua": "$c1 лопається."
+  }
+ },
+ "plug-ins/gquest/invasion/mobiles.cpp": {
+  "$C1 что-то говорит $c3.": {
+   "en": "$C1 says something to $c3.",
+   "ua": "$C1 щось каже $c3."
+  },
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "{YБожественные силы возвращают $c4 к жизни!{x": {
+   "en": "{YDivine powers bring $c4 back to life!{x",
+   "ua": "{YБожественні сили повертають $c4 до життя!{x"
+  },
+  "{YВ твоих услугах более никто не нуждается.{x": {
+   "en": "{YNobody needs your services anymore.{x",
+   "ua": "{YУ твоїх послугах більше ніхто не має потреби.{x"
+  }
+ },
+ "plug-ins/gquest/invasion/objects.cpp": {
+  "То, на что ты замахиваешься, не сделало тебе ничего плохого.": {
+   "en": "Whatever you're swinging at hasn't done anything wrong to you.",
+   "ua": "Те, на що ти замахуєшся, не зробило тобі нічого поганого."
+  },
+  "Цель не найдена.": {
+   "en": "Target not found.",
+   "ua": "Ціль не знайдено."
+  },
+  "$c1 с серьезным видом сжимает $o4.": {
+   "en": "$c1 clutches $o4 with a serious look.",
+   "ua": "$c1 з серйозним виглядом стискає $o4."
+  },
+  "$c1 угрожающе размахивает $o5 - берегись!": {
+   "en": "$c1 brandishes $o5 threateningly -- watch out!",
+   "ua": "$c1 загрозливо розмахує $o5 -- бережись!"
+  },
+  "Покрепче зажми $o4 в руках - глядишь, поможет..": {
+   "en": "Grip $o4 tighter in your hands -- who knows, it might help..",
+   "ua": "Стисни $o4 міцніше в руках -- хтозна, може, й допоможе.."
+  },
+  "Ты покрепче сжимаешь $o4, готовясь к грядущим подвигам.": {
+   "en": "You grip $o4 tighter, bracing for the exploits ahead.",
+   "ua": "Ти міцніше стискаєш $o4, готуючись до прийдешніх подвигів."
+  }
+ },
+ "plug-ins/gquest/rainbow/mobiles.cpp": {
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x": {
+   "en": "{RYou can no longer take part in this quest, since you've stained your hands with murder.{x",
+   "ua": "{RТи більше не зможеш брати участь у завданні, оскільки осквернив%Gло|в|ла свої руки вбивством.{x"
+  },
+  "Божественные силы возвращают $c4 к жизни!": {
+   "en": "Divine powers bring $c4 back to life!",
+   "ua": "Божественні сили повертають $c4 до життя!"
+  }
+ },
+ "plug-ins/gquest/rainbow/rainbow.cpp": {
+  "%s%-30s%s из %s%s": {
+   "en": "%s%-30s%s from %s%s",
+   "ua": "%s%-30s%s з %s%s"
+  },
+  "{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x": {
+   "en": "{RYou can no longer take part in the quest, since you've stained your hands with murder.{x",
+   "ua": "{RТи більше не зможеш брати участь у завданні, бо оскверни%Gло|в|ла свої руки вбивством.{x"
+  }
+ },
+ "plug-ins/groups/class_antipaladin.cpp": {
+  "$C1 ране$Gно|н|на и настороженно оглядывается... ты не сможешь подкрасться незаметно.": {
+   "en": "$C1 is wounded and looks around warily... you won't be able to sneak up unnoticed.",
+   "ua": "$C1 поранен$Gо|ий|а|і і насторожено озирається... ти не зможеш підкрастися непомітно."
+  },
+  "Вооружись для начала режущим или рубящим оружием.": {
+   "en": "Arm yourself with a slashing or cutting weapon first.",
+   "ua": "Озбройся спершу ріжучою або рублячою зброєю."
+  },
+  "Дождись окончания боя.": {
+   "en": "Wait for combat to end.",
+   "ua": "Зачекай на закінчення бою."
+  },
+  "Находясь в седле, трудно это сделать!": {
+   "en": "It's hard to do that while in the saddle!",
+   "ua": "Перебуваючи в сідлі, важко це зробити!"
+  },
+  "Рассечь кого?": {
+   "en": "Slash whom?",
+   "ua": "Розсікти кого?"
+  },
+  "Чтобы рассечь кого-то, нужно вооружится режущим или рубящим оружием.": {
+   "en": "To cleave someone, you need to be armed with a slashing or chopping weapon.",
+   "ua": "Щоб розсікти когось, потрібно озброїтися ріжучою або рубаючою зброєю."
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$c1 рассекает $C4 {RПОПОЛАМ{x!": {
+   "en": "$c1 cleaves $C4 {RIN HALF{x!",
+   "ua": "$c1 розсікає $C4 {RНАВПІЛ{x!"
+  },
+  "$c1 рассекает тебя {RПОПОЛАМ{x!": {
+   "en": "$c1 splits you {RIN HALF{x!",
+   "ua": "$c1 розрубує тебе {RНАВПІЛ{x!"
+  },
+  "Себя???": {
+   "en": "Yourself???",
+   "ua": "Себе???"
+  },
+  "Ты рассекаешь $C4 {RПОПОЛАМ{x!": {
+   "en": "You cleave $C4 {RIN HALF{x!",
+   "ua": "Ти розтинаєш $C4 {RНАВПІЛ{x!"
+  }
+ },
+ "plug-ins/groups/class_ninja.cpp": {
+  "$C1 имеет иммунитет к физическим воздействиям.": {
+   "en": "$C1 is immune to physical effects.",
+   "ua": "$C1 має імунітет до фізичних впливів."
+  },
+  "$C1 обладает иммунитетом к этой технике.": {
+   "en": "$C1 is immune to this technique.",
+   "ua": "$C1 має імунітет до цієї техніки."
+  },
+  "$C1 ран$Gено|ен|ена и настороженно оглядывается... ты не можешь подкрасться.": {
+   "en": "$C1 is wounded and looking around warily... you can't sneak up.",
+   "ua": "$C1 поран$Gено|ений|ена і насторожено озирається... ти не можеш підкрастися."
+  },
+  "$c1 нажимает пальцами на твои нервные окончания, но ничего не происходит.": {
+   "en": "$c1 presses their fingers into your nerve endings, but nothing happens.",
+   "ua": "$c1 натискає пальцями на твої нервові закінчення, але нічого не відбувається."
+  },
+  "$c1 ослабляет $C4.": {
+   "en": "$c1 weakens $C4.",
+   "ua": "$c1 послаблює $C4."
+  },
+  "%^C4 нельзя переместить.": {
+   "en": "%^C4 can't be moved.",
+   "ua": "%^C4 не можна перемістити."
+  },
+  "{W%^C1 не поддается воздействию вспышки!{x": {
+   "en": "{W%^C1 is unaffected by the flash!{x",
+   "ua": "{W%^C1 не піддається дії спалаху!{x"
+  },
+  "В этой зоне тебе некуда исчезать.": {
+   "en": "There's nowhere to vanish to in this zone.",
+   "ua": "У цій зоні тобі нема куди зникати."
+  },
+  "Здесь таких нет.": {
+   "en": "There's no one like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Из этого места нельзя исчезать.": {
+   "en": "You cannot vanish from this place.",
+   "ua": "З цього місця не можна зникати."
+  },
+  "На Бессмертных это не подействует.": {
+   "en": "This won't work on Immortals.",
+   "ua": "На Безсмертних це не подіє."
+  },
+  "Освободи обе руки для этого.": {
+   "en": "Free up both hands for that.",
+   "ua": "Звільни обидві руки для цього."
+  },
+  "Подожди, пока закончится сражение.": {
+   "en": "Wait until the fight is over.",
+   "ua": "Зачекай, поки закінчиться бій."
+  },
+  "Сейчас ты не сражаешься!": {
+   "en": "You're not fighting right now!",
+   "ua": "Зараз ти не б'єшся!"
+  },
+  "Твоя попытка закончилась неудачей.": {
+   "en": "Your attempt ended in failure.",
+   "ua": "Твоя спроба закінчилася невдачею."
+  },
+  "Тебе не удается активировать световую гранату.": {
+   "en": "You fail to activate the flash grenade.",
+   "ua": "Тобі не вдається активувати світлову гранату."
+  },
+  "Тебе нужна хотя бы одна рука для этой техники.": {
+   "en": "You need at least one free hand for this technique.",
+   "ua": "Тобі потрібна хоча б одна рука для цієї техніки."
+  },
+  "Ты мгновенно концентрируешься, готовясь к столкновению с магией.": {
+   "en": "You instantly focus, bracing for a clash with magic.",
+   "ua": "Ти миттєво концентруєшся, готуючись до зіткнення з магією."
+  },
+  "Ты не можешь исчезнуть, пока ты верхом или оседла%Gно|н|на!": {
+   "en": "You can't vanish while mounted or riding!",
+   "ua": "Ти не можеш зникнути, поки ти верхи або осідла%Gно|ний|на!"
+  },
+  "Ты не можешь покинуть это место без посторонней помощи!": {
+   "en": "You can't leave this place without outside help!",
+   "ua": "Ти не можеш покинути це місце без сторонньої допомоги!"
+  },
+  "Ты не можешь сделать противника еще слабее.": {
+   "en": "You cannot weaken your opponent any further.",
+   "ua": "Ти не можеш зробити супротивника ще слабшим."
+  },
+  "Ты не можешь стать еще выносливее.": {
+   "en": "You can't become any more resilient.",
+   "ua": "Ти не можеш стати ще витривалішим."
+  },
+  "Ты пытаешься скрыться, но противник бдит, и бой продолжается!": {
+   "en": "You try to slip away, but your opponent stays alert, and the fight continues!",
+   "ua": "Ти намагаєшся сховатися, але противник пильнує, і бій триває!"
+  },
+  "У тебя нет рук.": {
+   "en": "You have no hands.",
+   "ua": "У тебе немає рук."
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$C1 имеет слишком крепкую шею, чтобы ее можно было сломать.": {
+   "en": "$C1's neck is too sturdy to break.",
+   "ua": "У $C1 надто міцна шия, щоб її можна було зламати."
+  },
+  "$C1 успевает вырваться из объятий $c2!": {
+   "en": "$C1 manages to break free from $c2's embrace!",
+   "ua": "$C1 встигає вирватися з обіймів $c2!"
+  },
+  "$C1 успевает вырваться из твоих объятий!": {
+   "en": "$C1 manages to break free from your embrace!",
+   "ua": "$C1 встигає вирватися з твоїх обіймів!"
+  },
+  "$c1 {R{IS+++ {IxЛОМАЕТ ТЕБЕ ШЕЮ{IS +++{Ix{x!": {
+   "en": "$c1 {R{IS+++ {IxBREAKS YOUR NECK{IS +++{Ix{x!",
+   "ua": "$c1 {R{IS+++ {IxЛАМАЄ ТОБІ ШИЮ{IS +++{Ix{x!"
+  },
+  "$c1 {R{IS+++ {IxЛОМАЕТ ШЕЮ{IS +++{Ix{x $C3!": {
+   "en": "$c1 {R{IS+++ {IxBREAKS THE NECK{IS +++{Ix{x $C3!",
+   "ua": "$c1 {R{IS+++ {IxЛАМАЄ ШИЮ{IS +++{Ix{x $C3!"
+  },
+  "$c1 бросает на землю небольшой шар. {WЯркая вспышка{x на мгновение ослепляет тебя!": {
+   "en": "$c1 throws a small ball to the ground. {WA bright flash{x blinds you for a moment!",
+   "ua": "$c1 кидає на землю невеличку кулю. {WЯскравий спалах{x на мить сліпить тебе!"
+  },
+  "$c1 мгновенно концентрируется, готовясь к столкновению с магией.": {
+   "en": "$c1 instantly focuses, preparing to clash with magic.",
+   "ua": "$c1 миттєво концентрується, готуючись до зіткнення з магією."
+  },
+  "$c1 нажимает пальцами на нервные окончания $C2, но ничего не происходит.": {
+   "en": "$c1 presses their fingers into $C2's nerve endings, but nothing happens.",
+   "ua": "$c1 натискає пальцями на нервові закінчення $C2, але нічого не відбувається."
+  },
+  "$c1 ослабляет тебя, пережимая твои нервные окончания.": {
+   "en": "$c1 weakens you, pinching your nerve endings.",
+   "ua": "$c1 послаблює тебе, перетискаючи твої нервові закінчення."
+  },
+  "$c1 пытается взять $C4 в охапку!": {
+   "en": "$c1 tries to grab $C4 in a bear hug!",
+   "ua": "$c1 намагається схопити $C4 в оберемок!"
+  },
+  "$c1 пытается взять тебя в охапку!": {
+   "en": "$c1 tries to scoop you up in a bear hug!",
+   "ua": "$c1 намагається схопити тебе в оберемок!"
+  },
+  "$c1 пытается потрогать свою тень.": {
+   "en": "$c1 tries to touch their own shadow.",
+   "ua": "$c1 намагається торкнутися своєї тіні."
+  },
+  "$c1 пытается придушить собственную тень.": {
+   "en": "$c1 tries to strangle their own shadow.",
+   "ua": "$c1 намагається придушити власну тінь."
+  },
+  "$c1 пытается скрыться, но противник бдит, и бой продолжается!": {
+   "en": "$c1 tries to slip away, but the enemy is watching, and the fight goes on!",
+   "ua": "$c1 намагається зникнути, але супротивник пильнує, і бій триває!"
+  },
+  "$c1 пытается скрыться, но спотыкается и падает!": {
+   "en": "$c1 tries to flee, but stumbles and falls!",
+   "ua": "$c1 намагається сховатися, але спотикається і падає!"
+  },
+  "$c1 пытается сломать шею своей тени.": {
+   "en": "$c1 tries to break its own shadow's neck.",
+   "ua": "$c1 намагається зламати шию власній тіні."
+  },
+  "$c1 пытается схватить в охапку свою тень.": {
+   "en": "$c1 tries to scoop up their own shadow.",
+   "ua": "$c1 намагається згребти в оберемок власну тінь."
+  },
+  "$c1 смыкает руки на твоей шее и ты погружаешься в сон.": {
+   "en": "$c1 closes their hands around your neck and you sink into sleep.",
+   "ua": "$c1 змикає руки на твоїй шиї, і ти занурюєшся в сон."
+  },
+  "{W%^C1 сопротивляется воздействию вспышки!{x": {
+   "en": "{W%^C1 resists the flash's effect!{x",
+   "ua": "{W%^C1 опирається дії спалаху!{x"
+  },
+  "Выносливость -- не твой удел.": {
+   "en": "Endurance is not your strong suit.",
+   "ua": "Витривалість -- не твоя стихія."
+  },
+  "И кого ты хочешь придушить?": {
+   "en": "And who do you want to strangle?",
+   "ua": "І кого ти хочеш придушити?"
+  },
+  "Кого убиваем СЕГОДНЯ?": {
+   "en": "Who are we killing TODAY?",
+   "ua": "Кого вбиваємо СЬОГОДНІ?"
+  },
+  "Но $C1 твой друг!!!": {
+   "en": "But $C1 is your friend!!!",
+   "ua": "Але $C1 твій друг!!!"
+  },
+  "Облако загадочной пыли наполнило комнату.": {
+   "en": "A cloud of mysterious dust fills the room.",
+   "ua": "Хмара загадкового пилу наповнила кімнату."
+  },
+  "Облако отравленного дыма наполнило комнату.": {
+   "en": "A cloud of poisonous smoke filled the room.",
+   "ua": "Хмара отруєного диму наповнила кімнату."
+  },
+  "Твои пальцы проходят сквозь тень!": {
+   "en": "Your fingers pass right through the shadow!",
+   "ua": "Твої пальці проходять крізь тінь!"
+  },
+  "Твой путь не включает в себя суицид.": {
+   "en": "Your path doesn't include suicide.",
+   "ua": "Твій шлях не передбачає суїциду."
+  },
+  "Твоя жертва уже в отключке.": {
+   "en": "Your victim is already out cold.",
+   "ua": "Твоя жертва вже в відключці."
+  },
+  "Только не верхом!": {
+   "en": "Not while mounted!",
+   "ua": "Тільки не верхи!"
+  },
+  "Ты бросаешь на землю световую гранату. {WЯркая вспышка{x на мгновение ослепляет всех вокруг!": {
+   "en": "You throw a flashbang grenade to the ground. {WA bright flash{x blinds everyone around for a moment!",
+   "ua": "Ти кидаєш на землю світлову гранату. {WЯскравий спалах{x на мить засліплює всіх навколо!"
+  },
+  "Ты же не хочешь придушить сво%1$Gего|его|ю хозя%1$Gина|ина|йку?": {
+   "en": "You don't really want to strangle your master, do you?",
+   "ua": "Ти ж не хочеш придушити сво%1$Gго|го|ю хазя%1$Gїна|їна|йку?"
+  },
+  "Ты же не хочешь убить сво%1$Gего|его|ю любим%1$Gого|ого|ю хозя%1$Gина|ина|йку.": {
+   "en": "You don't really want to kill your beloved master, do you?",
+   "ua": "Ти ж не хочеш вбити сво%1$Gго|го|ю улюблен%1$Gого|ого|у хазя%1$Gїна|їна|йку."
+  },
+  "Ты нажимаешь не туда, куда надо.": {
+   "en": "You press the wrong spot.",
+   "ua": "Ти натискаєш не туди, куди треба."
+  },
+  "Ты ослабляешь $C4, пережимая нервные окончания.": {
+   "en": "You weaken $C4 by pinching their nerve endings.",
+   "ua": "Ти послаблюєш $C4, перетискаючи нервові закінчення."
+  },
+  "Ты пытаешься взять $C4 в охапку.": {
+   "en": "You try to scoop $C4 up in your arms.",
+   "ua": "Ти намагаєшся взяти $C4 в оберемок."
+  },
+  "Ты пытаешься скрыться, но спотыкаешься и падаешь!": {
+   "en": "You try to slip away, but trip and fall!",
+   "ua": "Ти намагаєшся втекти, але спотикаєшся і падаєш!"
+  },
+  "Ты пытаешься схватить в охапку свою тень!": {
+   "en": "You try to grab your own shadow in a bear hug!",
+   "ua": "Ти намагаєшся схопити в оберемок свою тінь!"
+  },
+  "Ты смыкаешь руки на собственной шее и удовлетворенно хрипишь.": {
+   "en": "You close your hands around your own throat and rasp with satisfaction.",
+   "ua": "Ти змикаєш руки на власній шиї і задоволено хрипиш."
+  },
+  "Ты трогаешь себя в нескольких неожиданных местах и довольно улыбаешься.": {
+   "en": "You touch yourself in a few unexpected places and smile contentedly.",
+   "ua": "Ти торкаєшся себе в кількох несподіваних місцях і задоволено посміхаєшся."
+  },
+  "Ты умудряешься вырваться из объятий $c2": {
+   "en": "You manage to break free from $c2's embrace",
+   "ua": "Тобі вдається вирватися з обіймів $c2"
+  }
+ },
+ "plug-ins/groups/class_ranger.cpp": {
+  "%1$^O1, посланн%1$Gое|ый|ая|ые %3$C5, улете%1$nла|ли %2$s.": {
+   "en": "%1$^O1, sent by %3$C5, flew %2$s.",
+   "ua": "%1$^O1, надіслан%1$Gе|ий|а|і %3$C5, полеті%1$nла|ли %2$s."
+  },
+  "Боги покровительствуют %C3.": {
+   "en": "The gods favor %C3.",
+   "ua": "Боги протегують %C3."
+  },
+  "В $o6 закончились стрелы.": {
+   "en": "$o6 is out of arrows.",
+   "ua": "У $o6 закінчилися стріли."
+  },
+  "Возьми в руки колчан.": {
+   "en": "Take the quiver in your hands.",
+   "ua": "Візьми до рук сагайдак."
+  },
+  "Выстрелить в каком направлении и в кого?": {
+   "en": "Shoot in which direction and at whom?",
+   "ua": "У якому напрямку і в кого стріляти?"
+  },
+  "Для того, чтобы стрелять тебе нужен лук!": {
+   "en": "You need a bow to shoot!",
+   "ua": "Щоб стріляти, тобі потрібен лук!"
+  },
+  "Засаду кому?": {
+   "en": "Ambush whom?",
+   "ua": "Засідку кому?"
+  },
+  "Кого ты хочешь выследить?": {
+   "en": "Whom do you want to track?",
+   "ua": "Кого ти хочеш вистежити?"
+  },
+  "Следы %N2 ведут %s.": {
+   "en": "The tracks of %N2 lead %s.",
+   "ua": "Сліди %N2 ведуть %s."
+  },
+  "Сначала тебе стоит замаскироваться.": {
+   "en": "You should disguise yourself first.",
+   "ua": "Спершу тобі варто замаскуватися."
+  },
+  "Сражаясь, ты не можешь прицелиться.": {
+   "en": "You can't take aim while fighting.",
+   "ua": "Б'ючись, ти не можеш прицілитися."
+  },
+  "Твоя вторая рука должна быть свободна!": {
+   "en": "Your other hand must be free!",
+   "ua": "Твоя друга рука має бути вільною!"
+  },
+  "Твоя жертва тебя видит.": {
+   "en": "Your target sees you.",
+   "ua": "Твоя жертва тебе бачить."
+  },
+  "Твоя попытка замаскироваться закончилась неудачей.": {
+   "en": "Your attempt to disguise yourself failed.",
+   "ua": "Твоя спроба замаскуватися закінчилася невдачею."
+  },
+  "Тебе не хватает опыта воспользоватся этой стрелой.": {
+   "en": "You don't have enough experience to use this arrow.",
+   "ua": "Тобі не вистачає досвіду, щоб скористатися цією стрілою."
+  },
+  "Ты готовишься к засаде.": {
+   "en": "You prepare for an ambush.",
+   "ua": "Ти готуєшся до засідки."
+  },
+  "Ты маскируешься на местности.": {
+   "en": "You camouflage yourself in the terrain.",
+   "ua": "Ти маскуєшся на місцевості."
+  },
+  "Ты можешь замаскироваться только в дикой местности.": {
+   "en": "You can only camouflage yourself in the wilderness.",
+   "ua": "Ти можеш замаскуватися тільки в дикій місцевості."
+  },
+  "Ты не видишь здесь следов.": {
+   "en": "You don't see any tracks here.",
+   "ua": "Ти не бачиш тут слідів."
+  },
+  "Ты не можешь быть в засаде верхом!": {
+   "en": "You can't be in ambush while mounted!",
+   "ua": "Ти не можеш бути в засідці верхи!"
+  },
+  "Ты не можешь замаскироваться, когда светишься.": {
+   "en": "You can't camouflage yourself while glowing.",
+   "ua": "Ти не можеш замаскуватися, коли світишся."
+  },
+  "Ты не можешь замаскироваться, когда ты в седле.": {
+   "en": "You can't disguise yourself while in the saddle.",
+   "ua": "Ти не можеш замаскуватися, коли ти в сідлі."
+  },
+  "Ты не можешь замаскироваться, когда ты оседлан%Gо||а.": {
+   "en": "You can't disguise yourself while you're being ridden.",
+   "ua": "Ти не можеш замаскуватися, коли ти осідлан%Gо|ий|а."
+  },
+  "Ты не можешь сделать этого.": {
+   "en": "You can't do that.",
+   "ua": "Ти не можеш цього зробити."
+  },
+  "Ты не можешь стрелять из лука в упор.": {
+   "en": "You can't shoot a bow at point-blank range.",
+   "ua": "Ти не можеш стріляти з лука впритул."
+  },
+  "Ты сидишь в засаде на '%s'.": {
+   "en": "You're lying in ambush for '%s'.",
+   "ua": "Ти сидиш у засідці на '%s'."
+  },
+  "У тебя в руках ничего нет!": {
+   "en": "You have nothing in your hands!",
+   "ua": "У тебе в руках нічого немає!"
+  },
+  "Это невозможно!": {
+   "en": "That's impossible!",
+   "ua": "Це неможливо!"
+  },
+  "$c1 всматривается в землю в поисках следов.": {
+   "en": "$c1 peers at the ground, searching for tracks.",
+   "ua": "$c1 вдивляється в землю в пошуках слідів."
+  },
+  "$c1 пытается замаскироваться, но не может найти укрытия.": {
+   "en": "$c1 tries to camouflage themselves but can't find cover.",
+   "ua": "$c1 намагається замаскуватися, але не може знайти укриття."
+  },
+  "{YТЫ ВЫСКАКИВАЕШЬ ИЗ ЗАСАДЫ!{x": {
+   "en": "{YYOU LEAP OUT OF AMBUSH!{x",
+   "ua": "{YТИ ВИСКАКУЄШ ІЗ ЗАСІДКИ!{x"
+  },
+  "Засаду себе? Это еще как?!": {
+   "en": "Ambush yourself? How's that supposed to work?!",
+   "ua": "Засідку самому собі? Це як таке?!"
+  }
+ },
+ "plug-ins/groups/class_samurai.cpp": {
+  "$c1 делает катану из $o2!": {
+   "en": "$c1 makes a katana out of $o2!",
+   "ua": "$c1 робить катану з $o2!"
+  },
+  "$c1 поджигает что-то.": {
+   "en": "$c1 sets something on fire.",
+   "ua": "$c1 підпалює щось."
+  },
+  "Здесь таких нет.": {
+   "en": "There's no one like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Подорвать кого?": {
+   "en": "Blow up whom?",
+   "ua": "Підірвати кого?"
+  },
+  "Сделать катану? Из чего?": {
+   "en": "Make a katana? Out of what?",
+   "ua": "Зробити катану? З чого?"
+  },
+  "Ты делаешь катану из $o2!": {
+   "en": "You forge a katana from $o2!",
+   "ua": "Ти робиш катану з $o2!"
+  },
+  "Ты совсем недавно уже изготавливал%Gо||а катану.": {
+   "en": "You already forged a katana quite recently.",
+   "ua": "Ти зовсім недавно вже виготовля%Gло|в|ла катану."
+  },
+  "У тебя нет нужного материала -- поищи в Королевстве Дварфов": {
+   "en": "You don't have the right material -- try looking in the Dwarven Kingdom",
+   "ua": "У тебе немає потрібного матеріалу -- пошукай у Королівстві Дворфів"
+  },
+  "$c1 вместе со своей тенью пытаются сделать катану.\n\r...глупое занятие.": {
+   "en": "$c1 and their shadow try to make a katana together.\n\r...what a foolish endeavor.",
+   "ua": "$c1 разом зі своєю тінню намагаються зробити катану.\n\r...дурне заняття."
+  },
+  "$c1 не может даже сделать себе харакири.\n...пора на пенсию.": {
+   "en": "$c1 can't even commit hara-kiri properly.\n...time to retire.",
+   "ua": "$c1 не може навіть зробити собі харакірі.\n...пора на пенсію."
+  },
+  "$c1 поджигает что-то взрывчатое под тобой!": {
+   "en": "$c1 ignites something explosive beneath you!",
+   "ua": "$c1 підпалює щось вибухове під тобою!"
+  },
+  "$c1 разрезает свое тело и ждет смерти.": {
+   "en": "$c1 cuts open their own body and waits for death.",
+   "ua": "$c1 розрізає своє тіло і чекає на смерть."
+  },
+  "Если уж реши$gло|л|ла покончить с собой -- попробуй убить Тисахна.": {
+   "en": "If you've decided to end it all -- try killing Tisahn instead.",
+   "ua": "Якщо вже наду$gмало|мав|мала покінчити з собою -- спробуй вбити Тисахна."
+  },
+  "Используй свой шанс сразиться до конца.": {
+   "en": "Use your chance to fight to the end.",
+   "ua": "Використай свій шанс битися до кінця."
+  },
+  "Пусть все сгорит!": {
+   "en": "Let it all burn!",
+   "ua": "Хай усе горить!"
+  },
+  "Твоя тень все время мелькает перед глазами.\n\rТяжеловато сделать катану в таких условиях.": {
+   "en": "Your shadow keeps flickering before your eyes.\n\rIt's tough to forge a katana under these conditions.",
+   "ua": "Твоя тінь весь час мигтить перед очима.\n\rВажкувато зробити катану в таких умовах."
+  },
+  "Ты безуспешно режешь свою тень.": {
+   "en": "You slash uselessly at your own shadow.",
+   "ua": "Ти безуспішно ріжеш свою тінь."
+  },
+  "Ты не можешь отрезать себе палец. Ведь это не так легко!.": {
+   "en": "You can't cut off your own finger. It's not that easy!",
+   "ua": "Ти не можеш відрізати собі палець. Адже це не так легко!"
+  },
+  "Ты не можешь сделать харакири, если ты верхом!": {
+   "en": "You can't commit harakiri while mounted!",
+   "ua": "Ти не можеш зробити харакірі, якщо ти верхи!"
+  },
+  "Ты отрезаешь себе палец и ждешь, когда вытечет вся кровь.": {
+   "en": "You cut off your own finger and wait for all the blood to drain out.",
+   "ua": "Ти відрізаєш собі палець і чекаєш, поки витече вся кров."
+  },
+  "Ты понапрасну изводишь $o4.": {
+   "en": "You're pestering $o4 for nothing.",
+   "ua": "Ти даремно виснажуєш $o4."
+  },
+  "Ты понапрасну изводишь брусок хорошего железа.": {
+   "en": "You're wasting a perfectly good iron bar for nothing.",
+   "ua": "Ти намарно псуєш брусок доброго заліза."
+  },
+  "У тебя нету ни куска железа.": {
+   "en": "You don't have a single scrap of iron.",
+   "ua": "У тебе нема жодного шматка заліза."
+  }
+ },
+ "plug-ins/groups/class_thief.cpp": {
+  "$c1 изготавливает $o4.": {
+   "en": "$c1 crafts $o4.",
+   "ua": "$c1 виготовляє $o4."
+  },
+  "$c1 проделывает манипуляции с $o5.": {
+   "en": "$c1 fiddles with $o5.",
+   "ua": "$c1 маніпулює з $o5."
+  },
+  "Взломать чем?": {
+   "en": "Pick with what?",
+   "ua": "Зламати чим?"
+  },
+  "Взломать что?": {
+   "en": "Pick what?",
+   "ua": "Зламати що?"
+  },
+  "Вооружись для начала.": {
+   "en": "Arm yourself first.",
+   "ua": "Озбройся для початку."
+  },
+  "Вооружись для этого кинжалом или другим колющим оружием.": {
+   "en": "Arm yourself with a dagger or other piercing weapon for this.",
+   "ua": "Озбройся для цього кинджалом або іншою колючою зброєю."
+  },
+  "Для этого тебе нужен кинжал.": {
+   "en": "You need a dagger for that.",
+   "ua": "Для цього тобі потрібен кинджал."
+  },
+  "Здесь нет замочной скважины.": {
+   "en": "There's no keyhole here.",
+   "ua": "Тут немає замкової щілини."
+  },
+  "Непонятно, что же открывает этот ключ.": {
+   "en": "It's not clear what this key opens.",
+   "ua": "Незрозуміло, що ж відкриває цей ключ."
+  },
+  "Нет таких здесь.": {
+   "en": "There's no such thing here.",
+   "ua": "Таких тут немає."
+  },
+  "Подделать что?": {
+   "en": "Forge what?",
+   "ua": "Підробити що?"
+  },
+  "Подожди, пока закончится сражение.": {
+   "en": "Wait until the fight ends.",
+   "ua": "Зачекай, поки закінчиться бій."
+  },
+  "Пырнуть ножом кого?": {
+   "en": "Stab whom with a knife?",
+   "ua": "Штрикнути ножем кого?"
+  },
+  "Сейчас ты не сражаешься.": {
+   "en": "You aren't fighting right now.",
+   "ua": "Зараз ти не б'єшся."
+  },
+  "Таких здесь нет.": {
+   "en": "There's no one like that here.",
+   "ua": "Таких тут немає."
+  },
+  "Тебе не удалось точно передать рисунок бороздок $o2.": {
+   "en": "You failed to accurately reproduce the pattern of grooves on $o2.",
+   "ua": "Тобі не вдалося точно передати малюнок борозенок $o2."
+  },
+  "Тебе понадобится заготовка, чтобы создать дубликат или отмычку.": {
+   "en": "You'll need a blank to make a duplicate or a lockpick.",
+   "ua": "Тобі знадобиться заготовка, щоб створити дублікат або відмичку."
+  },
+  "Ты долж$gно|ен|на быть вооруже$gно|н|на, чтоб ударить сзади.": {
+   "en": "You must be armed to strike from behind.",
+   "ua": "Ти повин$gно|ен|на бути озброє$gне|ний|на, щоб вдарити ззаду."
+  },
+  "Ты изготавливаешь $o4 из $O2.": {
+   "en": "You craft $o4 out of $O2.",
+   "ua": "Ти виготовляєш $o4 з $O2."
+  },
+  "Ты не видишь здесь такого замка.": {
+   "en": "You don't see such a lock here.",
+   "ua": "Ти не бачиш тут такого замка."
+  },
+  "Ты не можешь взломать что-либо, пока ты в седле.": {
+   "en": "You cannot pick a lock while you're in the saddle.",
+   "ua": "Ти не можеш зламати щось, поки ти в сідлі."
+  },
+  "Ты не можешь сделать это, защищаясь от ударов.": {
+   "en": "You can't do that while defending against blows.",
+   "ua": "Ти не можеш зробити це, захищаючись від ударів."
+  },
+  "Ты не можешь ударить сзади того, кто уже сражается.": {
+   "en": "You can't backstab someone who's already fighting.",
+   "ua": "Ти не можеш вдарити ззаду того, хто вже б'ється."
+  },
+  "Ты не можешь ударить сзади, если ты верхом!": {
+   "en": "You can't backstab while mounted!",
+   "ua": "Ти не можеш вдарити ззаду, якщо ти верхи!"
+  },
+  "У тебя нет такого ключа, и здесь нет такой замочной скважины.": {
+   "en": "You don't have such a key, and there's no such keyhole here.",
+   "ua": "У тебе немає такого ключа, і тут немає такої замкової щілини."
+  },
+  "Ударить сзади? Кого?": {
+   "en": "Backstab? Whom?",
+   "ua": "Вдарити ззаду? Кого?"
+  },
+  "Чтобы ударить сзади, нужно вооружиться кинжалом или другим колющим оружием.": {
+   "en": "To strike from behind, you need to arm yourself with a dagger or another piercing weapon.",
+   "ua": "Щоб вдарити ззаду, потрібно озброїтися кинджалом або іншою колючою зброєю."
+  },
+  "Это ключ от сломанного замка.": {
+   "en": "This is a key to a broken lock.",
+   "ua": "Це ключ від зламаного замка."
+  },
+  "Этот замок защищен от взлома.": {
+   "en": "This lock is protected against picking.",
+   "ua": "Цей замок захищений від зламу."
+  },
+  "$C1 беспокойно озирается по сторонам... ты не сможешь незаметно подкрасться.": {
+   "en": "$C1 glances around nervously... you won't be able to sneak up unnoticed.",
+   "ua": "$C1 неспокійно озирається довкола... тобі не вдасться непомітно підкрастися."
+  },
+  "$o1 в твоих умелых руках постепенно превращается в отмычку для $N2.": {
+   "en": "$o1 gradually turns into a lockpick for $N2 in your skilled hands.",
+   "ua": "$o1 у твоїх умілих руках поступово перетворюється на відмичку для $N2."
+  },
+  "Как ты можешь ударить сзади себя?": {
+   "en": "How can you hit yourself from behind?",
+   "ua": "Як ти можеш вдарити себе ззаду?"
+  },
+  "Твои попытки превратить $o4 в отмычку к этому замку ни к чему не привели.": {
+   "en": "Your attempts to turn $o4 into a pick for this lock led to nothing.",
+   "ua": "Твої спроби перетворити $o4 на відмичку до цього замка ні до чого не призвели."
+  },
+  "Тебе некогда подкрадываться к противнику -- ты сражаешься!": {
+   "en": "You have no time to sneak up on an opponent -- you're fighting!",
+   "ua": "Тобі ніколи підкрадатися до супротивника -- ти б'єшся!"
+  },
+  "Только не верхом!": {
+   "en": "Not while mounted!",
+   "ua": "Тільки не верхи!"
+  },
+  "У тебя боязнь себя?": {
+   "en": "Afraid of yourself, are you?",
+   "ua": "У тебе страх перед самим собою?"
+  },
+  "Это ключ от замка, который невозможно взломать. Увы..": {
+   "en": "This is the key to a lock that can't be picked. Alas..",
+   "ua": "Це ключ від замка, який неможливо зламати. На жаль.."
+  }
+ },
+ "plug-ins/groups/class_vampire.cpp": {
+  "$C1 имеет иммунитет к темной магии.": {
+   "en": "$C1 is immune to dark magic.",
+   "ua": "$C1 має імунітет до темної магії."
+  },
+  "Высасывать кровь можно, только превратившись в вампир%Gа|а|шу!": {
+   "en": "You can only drain blood after turning into a vampire!",
+   "ua": "Смоктати кров можна, лише перетворившись на вампір%Gа|а|ку!"
+  },
+  "Здесь неподходящее место для копания могилы.": {
+   "en": "This isn't a good place to dig a grave.",
+   "ua": "Тут непідходяще місце для копання могили."
+  },
+  "Здесь слишком твердая почва.": {
+   "en": "The ground here is too hard.",
+   "ua": "Тут занадто тверда земля."
+  },
+  "Нападать можно только из-под земли.": {
+   "en": "You can only attack from underground.",
+   "ua": "Атакувати можна тільки з-під землі."
+  },
+  "Пить кровь из кого?": {
+   "en": "Drink blood from whom?",
+   "ua": "Пити кров із кого?"
+  },
+  "Подожди, пока закончится сражение.": {
+   "en": "Wait until the fight is over.",
+   "ua": "Зачекай, поки закінчиться бій."
+  },
+  "Сначала жертва должна уснуть.": {
+   "en": "The victim must fall asleep first.",
+   "ua": "Спершу жертва повинна заснути."
+  },
+  "Сначала усыпи жертву.": {
+   "en": "Put the victim to sleep first.",
+   "ua": "Спершу приспи жертву."
+  },
+  "Таких здесь нет.": {
+   "en": "There's no one like that here.",
+   "ua": "Таких тут немає."
+  },
+  "Твое здоровье и энергия восполняются, когда ты высасываешь кровь из противника.": {
+   "en": "Your health and energy are replenished as you drain blood from your opponent.",
+   "ua": "Твоє здоров'я та енергія відновлюються, коли ти висмоктуєш кров з противника."
+  },
+  "Твоя жертва еще не отошла от прикосновения.": {
+   "en": "Your victim hasn't recovered from the touch yet.",
+   "ua": "Твоя жертва ще не відійшла від дотику."
+  },
+  "Тебе нужна хотя бы одна рука для прикосновения.": {
+   "en": "You need at least one hand to touch something.",
+   "ua": "Тобі потрібна хоча б одна рука для дотику."
+  },
+  "Тут таких нет.": {
+   "en": "There are none like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Ты прикасаешься к шее %1$C2 и %1$P1 забыва%1$nется|ются в ужасном кошмаре.": {
+   "en": "You touch %1$C2's neck, and %1$C1 sink%1$ns| into a horrible nightmare.",
+   "ua": "Ти торкаєшся шиї %1$C2, і %1$C1 занурю%1$nється|ються у жахливий кошмар."
+  },
+  "У тебя еще не зажили старые раны.": {
+   "en": "Your old wounds haven't healed yet.",
+   "ua": "У тебе ще не загоїлися старі рани."
+  },
+  "Укусить кого?": {
+   "en": "Bite whom?",
+   "ua": "Вкусити кого?"
+  },
+  "Усыпить кого?": {
+   "en": "Put whom to sleep?",
+   "ua": "Приспати кого?"
+  },
+  "Чтобы укусить, сначала необходимо превратиться в вампир%Gа|а|шу!": {
+   "en": "To bite, you first need to turn into a vampire!",
+   "ua": "Щоб укусити, спершу необхідно перетворитися на вампір%Gа|а|ку!"
+  },
+  "Чтобы усыпить, сначала необходимо превратиться в вампир%Gа|а|шу!": {
+   "en": "To put someone to sleep, you first need to turn into a vampire!",
+   "ua": "Щоб приспати, спершу потрібно перетворитися на вампір%Gа|а|ку|ів!"
+  },
+  "Чью тень ты хочешь подкараулить?": {
+   "en": "Whose shadow do you want to lie in wait for?",
+   "ua": "Чию тінь ти хочеш підстерегти?"
+  },
+  "$C1 имеет слишком крепкую шею, чтобы ее можно было прокусить.": {
+   "en": "$C1's neck is too tough to bite through.",
+   "ua": "$C1 має занадто міцну шию, щоб її можна було прокусити."
+  },
+  "$c1 выкапывает себе могилку и устраивается в ней со всеми удобствами.": {
+   "en": "$c1 digs itself a little grave and settles in comfortably.",
+   "ua": "$c1 викопує собі могилку і влаштовується в ній з усіма зручностями."
+  },
+  "$c1 высасывает {rкровь{x из шеи $C2.": {
+   "en": "$c1 sucks the {rblood{x from $C2's neck.",
+   "ua": "$c1 висмоктує {rкров{x із шиї $C2."
+  },
+  "$c1 костяным ножом промахивается мимо твоей тени!": {
+   "en": "$c1 swings a bone knife and misses your shadow!",
+   "ua": "$c1 кістяним ножем промахується повз твою тінь!"
+  },
+  "$c1 костяным ножом промахивается мимо тени $C2!": {
+   "en": "$c1 misses $C2's shadow with a bone knife!",
+   "ua": "$c1 кістяним ножем промахується повз тінь $C2!"
+  },
+  "$c1 неуловимо меняется, превращаясь в нечто ужасное!": {
+   "en": "$c1 shifts imperceptibly, turning into something horrifying!",
+   "ua": "$c1 невловимо змінюється, перетворюючись на щось жахливе!"
+  },
+  "$c1 предпринимает попытку закопать себя.": {
+   "en": "$c1 makes an attempt to bury themselves.",
+   "ua": "$c1 намагається закопати себе."
+  },
+  "$c1 приковывает твою тень костяным ножом к земле!\r\nТы не можешь сдвинуться с места!": {
+   "en": "$c1 pins your shadow to the ground with a bone knife!\r\nYou can't move an inch!",
+   "ua": "$c1 приковує твою тінь кістяним ножем до землі!\r\nТи не можеш зрушити з місця!"
+  },
+  "$c1 приковывает тень $C2 костяным ножом к земле!": {
+   "en": "$c1 pins $C2's shadow to the ground with a bone knife!",
+   "ua": "$c1 приковує тінь $C2 кістяним ножем до землі!"
+  },
+  "$c1 пытается прогрызть шею своей тени.": {
+   "en": "$c1 tries to gnaw through their shadow's neck.",
+   "ua": "$c1 намагається прогризти шию своїй тіні."
+  },
+  "$c1 пытается усыпить собственную тень.": {
+   "en": "$c1 tries to put its own shadow to sleep.",
+   "ua": "$c1 намагається приспати власну тінь."
+  },
+  "$c1 разрезает свою руку и жадно смотрит на капающую кровь.": {
+   "en": "$c1 slices their own hand and stares hungrily at the dripping blood.",
+   "ua": "$c1 розрізає свою руку і жадібно дивиться на кров, що крапає."
+  },
+  "$c1 слишком сильно ранит свою руку и не может остановить кровь.": {
+   "en": "$c1 wounds their own hand too badly and can't stop the bleeding.",
+   "ua": "$c1 занадто сильно ранить свою руку і не може зупинити кров."
+  },
+  "%1$^C1 прикасается к шее %2$C2 и %2$P1 забыва%1$nется|ются в ужасном кошмаре.": {
+   "en": "%1$^C1 touches %2$C2's neck, and %2$C1 forgets%1$ns| themselves in a terrible nightmare.",
+   "ua": "%1$^C1 торкається шиї %2$C2, і %2$C1 забува%1$nється|ються у жахливому кошмарі."
+  },
+  "%^C1 прикасается к твоей шее и ты забываешься в ужасном кошмаре.": {
+   "en": "%^C1 touches your neck and you drift into a terrible nightmare.",
+   "ua": "%^C1 торкається твоєї шиї, і ти забуваєшся в жахливому кошмарі."
+  },
+  "%^O1 на челе %C2 вспыхивает {Rярко-красным{x.": {
+   "en": "%^O1 flares up bright red on %C2's brow.",
+   "ua": "%^O1 на чолі %C2 спалахує {Rяскраво-червоним{x."
+  },
+  "{rКармина{x позволяет тебе насладиться кровью ради чистого удовольствия!": {
+   "en": "{rCarmine{x lets you savor blood for pure pleasure!",
+   "ua": "{rКарміна{x дозволяє тобі насолодитися кров'ю заради чистої втіхи!"
+  },
+  "{rКармина{x придает твоему костяному ножу особую остроту.": {
+   "en": "{rKarmina{x lends your bone knife special sharpness.",
+   "ua": "{rКарміна{x надає твоєму кістяному ножу особливої гостроти."
+  },
+  "В жертве нет необходимой дырочки.": {
+   "en": "The victim doesn't have the necessary little hole.",
+   "ua": "У жертви немає потрібної дірочки."
+  },
+  "Из шеи жертвы уже можно пить.": {
+   "en": "You can already drink from the victim's neck.",
+   "ua": "З шиї жертви вже можна пити."
+  },
+  "Копать в воздухе? И как ты себе это представляешь?": {
+   "en": "Dig in mid-air? How exactly do you picture that?",
+   "ua": "Копати в повітрі? І як ти це собі уявляєш?"
+  },
+  "Может стоит просто заснуть?": {
+   "en": "Maybe you should just fall asleep?",
+   "ua": "Може, варто просто заснути?"
+  },
+  "От безделья ты пытаешься грызануть себя за локоть, но ничего не выходит.": {
+   "en": "Out of sheer boredom you try to gnaw your own elbow, but nothing comes of it.",
+   "ua": "Від неробства ти намагаєшся вгризтися собі в лікоть, але нічого не виходить."
+  },
+  "Откуда-то сверху раздается громовой голос: \"ЛОПАТУ ВЕРНИ!\"": {
+   "en": "A thunderous voice booms from somewhere above: \"GIVE BACK THE SHOVEL!\"",
+   "ua": "Звідкись згори лунає громовий голос: \"ВЕРНИ ЛОПАТУ!\""
+  },
+  "Помни, тебе нужно остерегаться солнечных лучей!": {
+   "en": "Remember, you need to beware of sunlight!",
+   "ua": "Пам'ятай, тобі треба остерігатися сонячних променів!"
+  },
+  "Превращаясь в кровожадн%1$Gого|ого|ую вампир%1$Gа|а|шу, ты чувствуешь прилив силы.": {
+   "en": "Turning into a bloodthirsty vampire, you feel a surge of strength.",
+   "ua": "Перетворюючись на кровожерн%1$Gого|ого|у вампір%1$Gа|а|ку, ти відчуваєш приплив сили."
+  },
+  "Рана от твоих клыков на шее $C2 начинает гноиться.": {
+   "en": "The wound from your fangs on $C2's neck begins to fester.",
+   "ua": "Рана від твоїх іклів на шиї $C2 починає гноїтися."
+  },
+  "Сквозь кошмарный сон ты чувствуешь, как $c1 высасывает твою {rкровь{x.": {
+   "en": "Through a nightmare, you feel $c1 sucking out your {rblood{x.",
+   "ua": "Крізь жахливий сон ти відчуваєш, як $c1 висмоктує твою {rкров{x."
+  },
+  "Сначала детрансформируйся. Кровь упыря тебя не возбудит.": {
+   "en": "Detransform first. A ghoul's blood won't excite you.",
+   "ua": "Спершу детрансформуйся. Кров упиря тебе не збудить."
+  },
+  "Твое прикосновение проходит сквозь тень!": {
+   "en": "Your touch passes right through the shadow!",
+   "ua": "Твій дотик проходить крізь тінь!"
+  },
+  "Твои клыки проходят сквозь тень!": {
+   "en": "Your fangs pass right through the shadow!",
+   "ua": "Твої ікла проходять крізь тінь!"
+  },
+  "Твоя тень падает на могилу...": {
+   "en": "Your shadow falls across the grave...",
+   "ua": "Твоя тінь падає на могилу..."
+  },
+  "Тень $c2 падает на могилу...": {
+   "en": "$c2's shadow falls upon the grave...",
+   "ua": "Тінь $c2 падає на могилу..."
+  },
+  "Только не верхом!": {
+   "en": "Not while mounted!",
+   "ua": "Тільки не верхи!"
+  },
+  "Ты вскрикиваешь от боли, когда рана от клыков $c2 начинает гнить!": {
+   "en": "You cry out in pain as the wound from $c2's fangs starts to rot!",
+   "ua": "Ти скрикуєш від болю, коли рана від іклів $c2 починає гнити!"
+  },
+  "Ты выкапываешь себе могилку и устраиваешься в ней со всеми удобствами.": {
+   "en": "You dig yourself a little grave and settle into it in comfort.",
+   "ua": "Ти викопуєш собі могилку і влаштовуєшся в ній з усіма зручностями."
+  },
+  "Ты высасываешь {rкровь{x из шеи $C2.": {
+   "en": "You suck the {rblood{x from $C2's neck.",
+   "ua": "Ти висмоктуєш {rкров{x із шиї $C2."
+  },
+  "Ты ждешь, когда некто '{R%s{x' отбросит тень на твою могилу.": {
+   "en": "You wait for someone named '{R%s{x' to cast a shadow on your grave.",
+   "ua": "Ти чекаєш, коли хтось на ім'я '{R%s{x' кине тінь на твою могилу."
+  },
+  "Ты же не хочешь промокнуть?": {
+   "en": "You don't want to get soaked, do you?",
+   "ua": "Ти ж не хочеш промокнути?"
+  },
+  "Ты же не хочешь укусить сво%1$Gего|его|ю любим%1$Gого|ого|ю хозя%1$Gина|ина|йку.": {
+   "en": "You don't really want to bite your beloved master, do you.",
+   "ua": "Ти ж не хочеш вкусити сво%1$Gго|го|ю улюблен%1$Gого|ого|у хазя%1$Gїна|їна|йку."
+  },
+  "Ты же не хочешь усыпить сво%1$Gего|его|ю хозя%1$Gина|ина|йку?": {
+   "en": "You don't really want to put your master to sleep, do you?",
+   "ua": "Ти ж не хочеш приспати сво%1$Gго|го|ю хазя%1$Gїна|їна|йку?"
+  },
+  "Ты костяным ножом промахиваешься мимо тени $C2!": {
+   "en": "You miss the shadow of $C2 with your bone knife!",
+   "ua": "Ти кістяним ножем промахуєшся повз тінь $C2!"
+  },
+  "Ты не можешь стать еще более вампир%Gом|ом|шей!": {
+   "en": "You can't become even more of a vampire!",
+   "ua": "Ти не можеш стати ще більш вампір%Gом|ом|кою!"
+  },
+  "Ты не ощущаешь ни капли крови в этом существе. Брррр...": {
+   "en": "You don't sense a single drop of blood in this creature. Brrr...",
+   "ua": "Ти не відчуваєш жодної краплі крові в цій істоті. Бррр..."
+  },
+  "Ты перерезаешь себе вены.\r\nВид собственной {Rкрови{x возбуждает тебя!": {
+   "en": "You slit your own veins.\r\nThe sight of your own {Rblood{x arouses you!",
+   "ua": "Ти перерізаєш собі вени.\r\nВигляд власної {Rкрові{x збуджує тебе!"
+  },
+  "Ты приковываешь тень $C2 костяным ножом к земле!": {
+   "en": "You pin $C2's shadow to the ground with a bone knife!",
+   "ua": "Ти приковуєш тінь $C2 кістяним ножем до землі!"
+  },
+  "Ты просыпаешься от невыносимой боли в шее!": {
+   "en": "You wake up from unbearable pain in your neck!",
+   "ua": "Ти прокидаєшся від нестерпного болю в шиї!"
+  },
+  "Ты с отвращением высасываешь кровь, {cхолодную{x как сердца разработчиков.": {
+   "en": "You suck the blood down in disgust, {ccold{x as the developers' hearts.",
+   "ua": "Ти з відразою висмоктуєш кров, {cхолодну{x як серця розробників."
+  },
+  "Ты с отвращением глотаешь кровь $C2, {cхолодную{x как сердца разработчиков.": {
+   "en": "You swallow $C2's blood with disgust, {ccold{x as the developers' hearts.",
+   "ua": "Ти з відразою ковтаєш кров $C2, {cхолодну{x, як серця розробників."
+  },
+  "Ты слишком возбужде$gно|н|на, чтобы копать.": {
+   "en": "You're too aroused to dig.",
+   "ua": "Ти надто збуджен$gо|ий|а, щоб копати."
+  },
+  "Ты старательно ковыряешься в земле, но ничего не выходит.": {
+   "en": "You dig around diligently in the dirt, but nothing comes of it.",
+   "ua": "Ти старанно длубаєшся в землі, але нічого не виходить."
+  },
+  "Ты стонешь во сне, когда рана от клыков $c2 начинает гнить!": {
+   "en": "You moan in your sleep as the wound from $c2's fangs starts to rot!",
+   "ua": "Ти стогнеш уві сні, коли рана від іклів $c2 починає гнити!"
+  },
+  "У тебя недостаточно гибкий позвоночник.": {
+   "en": "Your spine isn't flexible enough.",
+   "ua": "У тебе недостатньо гнучкий хребет."
+  },
+  "Упс! Кажется, ты потеря$gло|л|ла СЛИШКОМ много крови!": {
+   "en": "Oops! Looks like you've lost TOO much blood!",
+   "ua": "Упс! Здається, ти втрати$gло|в|ла ЗАНАДТО багато крові!"
+  },
+  "Упс, похоже, этот участок уже занял твой коллега.": {
+   "en": "Oops, looks like your colleague already claimed this spot.",
+   "ua": "Упс, схоже, цю ділянку вже зайняв твій колега."
+  }
+ },
+ "plug-ins/groups/class_warrior.cpp": {
+  "$c1 восстанавливает $o4.": {
+   "en": "$c1 repairs $o4.",
+   "ua": "$c1 відновлює $o4."
+  },
+  "$c1 пробует восстановить $o4, но безуспешно.": {
+   "en": "$c1 tries to repair $o4, but fails.",
+   "ua": "$c1 намагається відновити $o4, але безуспішно."
+  },
+  "%1$^O1 по%1$nет|ют под твоими руками, обретая первозданный вид.": {
+   "en": "%1$^O1 yield%1$ns| under your hands, regaining its original appearance.",
+   "ua": "%1$^O1 підда%1$nється|ються під твоїми руками, повертаючи первісний вигляд."
+  },
+  "Какую вещь ты хочешь восстановить?": {
+   "en": "Which item do you want to repair?",
+   "ua": "Яку річ ти хочеш відновити?"
+  },
+  "Но это не повреждено.": {
+   "en": "But this isn't damaged.",
+   "ua": "Але це не пошкоджено."
+  },
+  "Подожди пока сражение закончится.": {
+   "en": "Wait until the fight is over.",
+   "ua": "Зачекай, поки бій закінчиться."
+  },
+  "Сначала возьми в руки кузнечный молот.": {
+   "en": "First take a smithing hammer in your hands.",
+   "ua": "Спершу візьми до рук ковальський молот."
+  },
+  "Ты восстанавливаешь $o4.\n\r": {
+   "en": "You restore $o4.\n\r",
+   "ua": "Ти відновлюєш $o4.\n\r"
+  },
+  "У тебя не получилось восстановить $o4.": {
+   "en": "You failed to repair $o4.",
+   "ua": "У тебе не вийшло відновити $o4."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  },
+  "Тебе понадобится специальный молот -- ищи его в Королевстве Дварфов.": {
+   "en": "You'll need a special hammer -- look for it in the Kingdom of the Dwarves.",
+   "ua": "Тобі знадобиться особливий молот -- шукай його в Королівстві Дварфів."
+  }
+ },
+ "plug-ins/groups/genericskill.cpp": {
+  "%1$^C1 не может научить тебя искусству '%2$s'.\nУчителя можно найти, прочитав справку по этому умению.": {
+   "en": "%1$^C1 can't teach you the art of '%2$s'.\nYou can find a teacher by reading the help for this skill.",
+   "ua": "%1$^C1 не може навчити тебе мистецтву '%2$s'.\nВчителя можна знайти, прочитавши довідку по цьому вмінню."
+  },
+  "Для этого необходимо превратиться в вампира!": {
+   "en": "You need to turn into a vampire for that!",
+   "ua": "Для цього потрібно перетворитися на вампіра!"
+  },
+  "Тебе не с кем практиковаться здесь.": {
+   "en": "There's no one here for you to practice with.",
+   "ua": "Тобі немає з ким практикуватися тут."
+  }
+ },
+ "plug-ins/groups/group_arcane.cpp": {
+  "$c1 взмахивает $o5 на $C4.": {
+   "en": "$c1 swings $o5 at $C4.",
+   "ua": "$c1 змахує $o5 на $C4."
+  },
+  "$c1 взмахивает $o5 на $O4.": {
+   "en": "$c1 swings $o5 at $O4.",
+   "ua": "$c1 змахує $o5 на $O4."
+  },
+  "$c1 взмахивает $o5.": {
+   "en": "$c1 waves $o5.",
+   "ua": "$c1 змахує $o5."
+  },
+  "%1$^O1 %2$C2 развалива%1$nется|ются на куски.": {
+   "en": "%1$^O1 of %2$C2 fall%1$ns| apart into pieces.",
+   "ua": "%1$^O1 %2$C2 розвалю%1$nється|ються на шматки."
+  },
+  "%1$^O1 %2$C2 темне%1$nет|ют и исчеза%1$nет|ют.": {
+   "en": "%1$^O1 %2$C2 darken%1$ns| and disappear%1$ns|.",
+   "ua": "%1$^O1 %2$C2 темні%1$nє|ють і зника%1$nє|ють."
+  },
+  "%^C1 зачитывает заклинание %s %O2.": {
+   "en": "%^C1 recites the spell %s at %O2.",
+   "ua": "%^C1 зачитує заклинання %s на %O2."
+  },
+  "%^O1 превращается в пыль.": {
+   "en": "%^O1 crumbles into dust.",
+   "ua": "%^O1 перетворюється на пил."
+  },
+  "...и ничего не происходит.": {
+   "en": "...and nothing happens.",
+   "ua": "...і нічого не відбувається."
+  },
+  "Взмахнуть жезлом на кого именно?": {
+   "en": "Wave the wand at whom exactly?",
+   "ua": "Змахнути жезлом саме на кого?"
+  },
+  "Взмахнуть жезлом на что?": {
+   "en": "Wave the wand at what?",
+   "ua": "Змахнути жезлом на що?"
+  },
+  "Жезл нужно сначала взять в руку.": {
+   "en": "You need to take the wand in hand first.",
+   "ua": "Жезл спершу треба взяти до руки."
+  },
+  "На таком расстоянии жертва ничего не почувствует.": {
+   "en": "At this distance, the victim won't feel a thing.",
+   "ua": "На такій відстані жертва нічого не відчує."
+  },
+  "С помощью этой команды можно зачитывать только свитки.": {
+   "en": "This command can only be used to read scrolls.",
+   "ua": "За допомогою цієї команди можна читати лише сувої."
+  },
+  "Твой жезл не дотягивается до соседней комнаты.": {
+   "en": "Your wand doesn't reach into the next room.",
+   "ua": "Твій жезл не дотягується до сусідньої кімнати."
+  },
+  "Ты взмахиваешь $o5 на $C4.": {
+   "en": "You swing $o5 at $C4.",
+   "ua": "Ти змахуєш $o5 на $C4."
+  },
+  "Ты взмахиваешь $o5 на $O4.": {
+   "en": "You swing $o5 at $O4.",
+   "ua": "Ти змахуєш $o5 на $O4."
+  },
+  "Ты взмахиваешь $o5 на себя.": {
+   "en": "You swing $o5 at yourself.",
+   "ua": "Ти змахуєш $o5 на себе."
+  },
+  "Ты взмахиваешь $o5.": {
+   "en": "You swing $o5.",
+   "ua": "Ти змахуєш $o5."
+  },
+  "Ты зачитываешь одно из заклинаний %s %O2, но оно не находит, на кого подействовать.": {
+   "en": "You read one of the %s spells from %O2, but it finds nothing to affect.",
+   "ua": "Ти зачитуєш одне із заклинань %s %O2, але воно не знаходить, на кого подіяти."
+  },
+  "Ты зачитываешь одно из заклинаний %s %O2, но оно не находит, на что подействовать.": {
+   "en": "You read out one of the spells of %s %O2, but it finds nothing to affect.",
+   "ua": "Ти зачитуєш одне із заклинань %s %O2, але воно не знаходить, на що подіяти."
+  },
+  "Ты можешь взмахнуть только волшебным жезлом!": {
+   "en": "You can only wave a magic wand!",
+   "ua": "Ти можеш махнути тільки магічним жезлом!"
+  },
+  "Ты можешь взмахнуть только посохом.": {
+   "en": "You can only wave a staff.",
+   "ua": "Ти можеш змахнути лише посохом."
+  },
+  "Ты не смо$gгло|г|гла активировать $o4.": {
+   "en": "You couldn't activate $o4.",
+   "ua": "Ти не змі$gгло|г|гла активувати $o4."
+  },
+  "Ты не совлада$gло|л|ла с произношением.": {
+   "en": "You couldn't manage the pronunciation.",
+   "ua": "Ти не впора$gлося|вся|лася з вимовою."
+  },
+  "Ты ударяешь $o5 $T.": {
+   "en": "You land a blow with $o5 on $T.",
+   "ua": "Ти завдаєш удару $o5 по $T."
+  },
+  "У тебя нет такого свитка.": {
+   "en": "You don't have that scroll.",
+   "ua": "У тебе немає такого сувою."
+  },
+  "Чтобы пользоваться посохами, их надо взять в руки.": {
+   "en": "To use staves, you must take them in hand.",
+   "ua": "Щоб користуватися посохами, їх треба взяти до рук."
+  },
+  "$c1 взмахивает $o5 на себя.": {
+   "en": "$c1 waves $o5 over themselves.",
+   "ua": "$c1 змахує $o5 на себе."
+  },
+  "$c1 взмахивает $o5 на тебя!": {
+   "en": "$c1 waves $o5 at you!",
+   "ua": "$c1 змахує $o5 на тебе!"
+  },
+  "Какие еще свитки-шмитки?! Ты же вои{Smн{Sfтельница{Sx клана Ярости, а не презренный МАГ!": {
+   "en": "What scrolls-shmolls?! You're a warrior of the Rage clan, not some despicable MAGE!",
+   "ua": "Які ще сувої-мувої?! Ти ж во{Smїн{Sfйовниця{Sx клану Люті, а не мерзенний МАГ!"
+  },
+  "Палками махать?! Ты же вои{Smн{Sfтельница{Sx клана Ярости, а не презренный МАГ!": {
+   "en": "Waving sticks around?! You're a warrior of the Rage clan, not some lowly MAGE!",
+   "ua": "Палицями махати?! Ти ж войовни{Smк{Sfця{Sx клану Люті, а не мерзенний МАГ!"
+  },
+  "Тво%1$Gе|й|я|и %1$O1 развалива%1$nется|ются на куски.": {
+   "en": "Your %1$O1 fall%1$ns| apart.",
+   "ua": "Тво%1$Gє|й|я|ї %1$O1 розвалю%1$nється|ються на шматки."
+  },
+  "Твои усиленные манипуляции с $o5 приводят лишь к дыму и искрам.": {
+   "en": "Your frantic fiddling with $o5 only produces smoke and sparks.",
+   "ua": "Твої посилені маніпуляції з $o5 призводять лише до диму та іскор."
+  },
+  "Ты долж%1$Gно|ен|на уничтожать магию, а не использовать её!": {
+   "en": "You're supposed to destroy magic, not use it!",
+   "ua": "Ти повин%1$Gно|ен|на знищувати магію, а не використовувати її!"
+  },
+  "Усиленные манипуляции $c2 с $o5 приводят лишь к дыму и искрам.": {
+   "en": "$c2's intensified fiddling with $o5 produces only smoke and sparks.",
+   "ua": "Посилені маніпуляції $c2 з $o5 призводять лише до диму та іскор."
+  },
+  "Этот свиток чересчур сложен для твоего понимания.": {
+   "en": "This scroll is too complex for you to understand.",
+   "ua": "Цей сувій занадто складний для твого розуміння."
+  }
+ },
+ "plug-ins/groups/group_beguiling.cpp": {
+  "Твоя душа возвращается к тебе.": {
+   "en": "Your soul returns to you.",
+   "ua": "Твоя душа повертається до тебе."
+  },
+  "Твоя попытка закончилась неудачей.": {
+   "en": "Your attempt ended in failure.",
+   "ua": "Твоя спроба закінчилася невдачею."
+  },
+  "Ты заполучи%gло|л|ла блудную душу.": {
+   "en": "You've acquired a wayward soul.",
+   "ua": "Ти здобу%gло|в|ла заблудлу душу."
+  },
+  "У тебя нет пустого сосуда, чтоб заточить в него дух противника.": {
+   "en": "You don't have an empty vessel to trap your opponent's spirit in.",
+   "ua": "У тебе немає порожньої посудини, щоб ув'язнити в ній дух супротивника."
+  },
+  "$c1 {Rзаточил твой дух в сосуде.{x": {
+   "en": "$c1 {Rimprisoned your spirit in a vessel.{x",
+   "ua": "$c1 {Rув'язнив твій дух у посудині.{x"
+  },
+  "Вот это удача!": {
+   "en": "Now that's luck!",
+   "ua": "Оце пощастило!"
+  },
+  "Дух $C2 теперь заточен в сосуде и находится в твоей власти.": {
+   "en": "The spirit of $C2 is now sealed in the vessel and under your control.",
+   "ua": "Дух $C2 тепер ув'язнений у посудині і перебуває під твоєю владою."
+  },
+  "Душа твоего противника где-то далеко...": {
+   "en": "Your opponent's soul is somewhere far away...",
+   "ua": "Душа твого супротивника десь далеко..."
+  },
+  "Душа этого противника неподвластна тебе!": {
+   "en": "This opponent's soul is beyond your power!",
+   "ua": "Душа цього противника непідвладна тобі!"
+  },
+  "Твоя душа всегда с тобой!": {
+   "en": "Your soul is always with you!",
+   "ua": "Твоя душа завжди з тобою!"
+  }
+ },
+ "plug-ins/groups/group_fightmaster.cpp": {
+  "$C1 не может сдержать ошеломляющую атаку $c2 и падает.": {
+   "en": "$C1 can't withstand $c2's stunning attack and falls.",
+   "ua": "$C1 не може стримати приголомшливу атаку $c2 і падає."
+  },
+  "Тебе не удается удержать равновесие!\nТы падаешь!": {
+   "en": "You fail to keep your balance!\nYou fall!",
+   "ua": "Тобі не вдається втримати рівновагу!\nТи падаєш!"
+  },
+  "$C1 не может сдержать твою атаку и падает!": {
+   "en": "$C1 can't withstand your attack and falls!",
+   "ua": "$C1 не може стримати твою атаку і падає!"
+  },
+  "$C1 не может устоять на ногах и падает вниз!": {
+   "en": "$C1 can't keep their footing and falls down!",
+   "ua": "$C1 не може встояти на ногах і падає вниз!"
+  },
+  "$C1 пытается парировать мощный удар $c1, но не может устоять на ногах.": {
+   "en": "$C1 tries to parry $c1's powerful blow, but can't stay on their feet.",
+   "ua": "$C1 намагається парирувати потужний удар $c1, але не може встояти на ногах."
+  },
+  "Ты не можешь устоять на ногах!": {
+   "en": "You can't keep your feet!",
+   "ua": "Ти не можеш встояти на ногах!"
+  },
+  "Ты падаешь вниз!": {
+   "en": "You fall down!",
+   "ua": "Ти падаєш вниз!"
+  }
+ },
+ "plug-ins/groups/group_movement.cpp": {
+  "%1$#^C1 начинает скрытно передвигаться.\n\r": {
+   "en": "%1$#^C1 starts moving stealthily.\n\r",
+   "ua": "%1$#^C1 починає скрадатися.\n\r"
+  },
+  "%1$#^C1 не удается скрытно передвигаться.\n\r": {
+   "en": "%1$#^C1 fails to move stealthily.\n\r",
+   "ua": "%1$#^C1 не вдається непомітно пересуватися.\n\r"
+  },
+  "Команда 'возврат' сейчас недоступна тебе.": {
+   "en": "The 'recall' command is currently unavailable to you.",
+   "ua": "Команда 'повернення' зараз недоступна тобі."
+  },
+  "Тебе не удается скрытно передвигаться.": {
+   "en": "You fail to move stealthily.",
+   "ua": "Тобі не вдається непомітно пересуватися."
+  },
+  "Тебе некуда возвращаться.": {
+   "en": "You have nowhere to return to.",
+   "ua": "Тобі нікуди повертатися."
+  },
+  "Ты и так двигаешься бесшумно.": {
+   "en": "You already move silently.",
+   "ua": "Ти й так рухаєшся безшумно."
+  },
+  "Ты начинаешь скрытно передвигаться.": {
+   "en": "You start moving stealthily.",
+   "ua": "Ти починаєш скрадатися."
+  },
+  "Ты не можешь двигаться бесшумно, когда ты в седле.": {
+   "en": "You can't move quietly while in the saddle.",
+   "ua": "Ти не можеш рухатися безшумно, коли ти в сідлі."
+  },
+  "Ты не можешь сбежать туда, попробуй другое место.": {
+   "en": "You can't escape there, try another spot.",
+   "ua": "Ти не можеш втекти туди, спробуй інше місце."
+  },
+  "Ты сейчас ни с кем не дерешься.": {
+   "en": "You're not fighting anyone right now.",
+   "ua": "Ти зараз ні з ким не б'єшся."
+  },
+  "Укажи направление.": {
+   "en": "Specify a direction.",
+   "ua": "Вкажи напрямок."
+  },
+  "Что-то не дает тебе сбежать в этом направлении.": {
+   "en": "Something prevents you from fleeing in that direction.",
+   "ua": "Щось не дає тобі втекти в цьому напрямку."
+  },
+  "И куда это мы намылились?": {
+   "en": "And where do you think you're sneaking off to?",
+   "ua": "І куди це ми намилилися?"
+  },
+  "На тебе сверху кто-то сидит и не дает сбежать.": {
+   "en": "Someone is sitting on top of you and won't let you escape.",
+   "ua": "На тобі згори хтось сидить і не дає втекти."
+  },
+  "Сначала слезь, а потом уже убегай.": {
+   "en": "Dismount first, then run away.",
+   "ua": "Спочатку злізь, а потім вже тікай."
+  }
+ },
+ "plug-ins/groups/group_weaponsmaster.cpp": {
+  "$C1 вооружается вторичным оружием как основным!": {
+   "en": "$C1 wields their secondary weapon as their primary!",
+   "ua": "$C1 озброюється другорядною зброєю як основною!"
+  },
+  "$c1 обезоруживает $C4!": {
+   "en": "$c1 disarms $C4!",
+   "ua": "$c1 обеззброює $C4!"
+  },
+  "$c1 пытается обезоружить $C4, но безуспешно.": {
+   "en": "$c1 tries to disarm $C4, but fails.",
+   "ua": "$c1 намагається обеззброїти $C4, але безуспішно."
+  },
+  "$c1 пытается обезоружить $C4, но не может.": {
+   "en": "$c1 tries to disarm $C4, but can't.",
+   "ua": "$c1 намагається обеззброїти $C4, але не може."
+  },
+  "$c1 пытается обезоружить $C4, но оружие не двигается с места.": {
+   "en": "$c1 tries to disarm $C4, but the weapon doesn't budge.",
+   "ua": "$c1 намагається обеззброїти $C4, але зброя не рухається з місця."
+  },
+  "$c1 пытается обезоружить тебя, но не может.": {
+   "en": "$c1 tries to disarm you, but can't.",
+   "ua": "$c1 намагається обеззброїти тебе, але не може."
+  },
+  "{DПризрачная аура{x вокруг %1$C2 мешает тебе обезоружить %1$P2.": {
+   "en": "{DA ghostly aura{x around %1$C2 stops you from disarming them.",
+   "ua": "{DПривидна аура{x навколо %1$C2 заважає тобі обеззброїти %1$C2."
+  },
+  "Возьми в руки хлыст.": {
+   "en": "Take a whip in your hands.",
+   "ua": "Візьми в руки батіг."
+  },
+  "Вооружиться чем?": {
+   "en": "Arm yourself with what?",
+   "ua": "Озброїтися чим?"
+  },
+  "Для этого навыка нужно оружие с рубящей кромкой.": {
+   "en": "This skill requires a weapon with a chopping edge.",
+   "ua": "Для цієї навички потрібна зброя з рубаючим лезом."
+  },
+  "Для этого ты долж%Gно|ен|на вооружиться топором, мечом или алебардой.": {
+   "en": "For that you must be armed with an axe, sword, or halberd.",
+   "ua": "Для цього ти пови%Gнно|нен|нна озброїтися сокирою, мечем або алебардою."
+  },
+  "Для этого умения твоему последователю потребуется вооружиться хлыстом.": {
+   "en": "For this skill, your follower will need to arm themselves with a whip.",
+   "ua": "Для цього уміння твоєму послідовнику знадобиться озброїтися батогом."
+  },
+  "Но ты ни с кем не сражаешься!": {
+   "en": "But you're not fighting anyone!",
+   "ua": "Але ти ні з ким не б'єшся!"
+  },
+  "Оружие $c2 со звоном отскакивает от щита $C2.": {
+   "en": "$c2's weapon bounces off $C2's shield with a clang.",
+   "ua": "Зброя $c2 зі дзвоном відскакує від щита $C2."
+  },
+  "Оружие твоего противника слишком прочно, его не удастся разрубить.": {
+   "en": "Your opponent's weapon is too sturdy to cleave through.",
+   "ua": "Зброя твого супротивника занадто міцна, її не вдасться розрубати."
+  },
+  "Сейчас ты не сражаешься.": {
+   "en": "You're not fighting right now.",
+   "ua": "Зараз ти не б'єшся."
+  },
+  "Твой противник не вооружен.": {
+   "en": "Your opponent isn't armed.",
+   "ua": "Твій супротивник не озброєний."
+  },
+  "Твой противник не использует щит.": {
+   "en": "Your opponent isn't using a shield.",
+   "ua": "Твій супротивник не використовує щит."
+  },
+  "Тебе не удалось обезоружить $C4.": {
+   "en": "You failed to disarm $C4.",
+   "ua": "Тобі не вдалося обеззброїти $C4."
+  },
+  "Тут таких нет.": {
+   "en": "There are none like that here.",
+   "ua": "Тут таких немає."
+  },
+  "Ты вооружаешься вторичным оружием как основным!": {
+   "en": "You wield your secondary weapon as your primary!",
+   "ua": "Ти озброюєшся вторинною зброєю як основною!"
+  },
+  "Ты лишь оцарапа$gло|л|ла $C4.": {
+   "en": "You only scratched $C4.",
+   "ua": "Ти лише подряпа$gло|в|ла $C4."
+  },
+  "Ты не можешь вооружиться этим как вторичным оружием.": {
+   "en": "You can't wield this as a secondary weapon.",
+   "ua": "Ти не можеш озброїтися цим як другорядною зброєю."
+  },
+  "Ты не сможешь обезоружить, если ты верхом!": {
+   "en": "You can't disarm while mounted!",
+   "ua": "Ти не зможеш обеззброїти, якщо ти верхи!"
+  },
+  "Ты обезоруживаешь $C4!": {
+   "en": "You disarm $C4!",
+   "ua": "Ти обеззброюєш $C4!"
+  },
+  "Ты уклоняешься от хлыста $c2.": {
+   "en": "You dodge $c2's whip.",
+   "ua": "Ти ухиляєшся від батога $c2."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  },
+  "Щит твоего противника слишком прочен, его не удастся разрубить.": {
+   "en": "Your opponent's shield is too sturdy, you won't manage to hack through it.",
+   "ua": "Щит твого супротивника надто міцний, його не вдасться розрубати."
+  },
+  "Этот навык можно использовать только с оружием в руках: топором, мечом или алебардой.": {
+   "en": "This skill can only be used with a weapon in hand: an axe, a sword, or a halberd.",
+   "ua": "Цей навик можна використовувати лише зі зброєю в руках: сокирою, мечем або алебардою."
+  },
+  "Этот навык можно применять только в бою.": {
+   "en": "This skill can only be used in combat.",
+   "ua": "Цю навичку можна застосовувати лише в бою."
+  },
+  "$C1 хватает тебя за руку и ускользает!": {
+   "en": "$C1 grabs your hand and slips away!",
+   "ua": "$C1 хапає тебе за руку і вислизає!"
+  },
+  "$c1 {1{RРАСКАЛЫВАЕТ{2 твое оружие надвое!": {
+   "en": "$c1 {1{RSPLITS{2 your weapon in two!",
+   "ua": "$c1 {1{RРОЗКОЛЮЄ{2 твою зброю навпіл!"
+  },
+  "$c1 {1{RРАСКАЛЫВАЕТ{2 твой щит надвое!": {
+   "en": "$c1 {1{RSPLITS{2 your shield in two!",
+   "ua": "$c1 {1{RРОЗКОЛЮЄ{2 твій щит навпіл!"
+  },
+  "$c1 бьет свою тень хлыстом.": {
+   "en": "$c1 whips its own shadow.",
+   "ua": "$c1 б'є свою тінь батогом."
+  },
+  "$c1 взмахом хлыста поцарапал $C4!": {
+   "en": "$c1 lashed out with a whip and scratched $C4!",
+   "ua": "$c1 замахом батога подряпав $C4!"
+  },
+  "$c1 подсекает $C4 своим хлыстом.": {
+   "en": "$c1 trips $C4 up with their whip.",
+   "ua": "$c1 підсікає $C4 своїм батогом."
+  },
+  "$c1 подсекает тебя своим хлыстом!!": {
+   "en": "$c1 trips you up with their whip!!",
+   "ua": "$c1 підсікає тебе своїм батогом!!"
+  },
+  "$c1 пытается выбить у своей тени оружие.\n...как глупо это выглядит.": {
+   "en": "$c1 tries to knock the weapon out of their own shadow's hands.\n...how stupid that looks.",
+   "ua": "$c1 намагається вибити зброю у власної тіні.\n...як же дурнувато це виглядає."
+  },
+  "$c1 пытается обезоружить тебя, но оружие не двигается с места!": {
+   "en": "$c1 tries to disarm you, but the weapon won't budge!",
+   "ua": "$c1 намагається обеззброїти тебе, але зброя не рухається з місця!"
+  },
+  "$c1 размахивается и разрубает свою тень.": {
+   "en": "$c1 swings and cleaves through their own shadow.",
+   "ua": "$c1 замахується і розрубує свою тінь."
+  },
+  "$c1 раскалывает оружие $C2 надвое.": {
+   "en": "$c1 splits $C2's weapon in two.",
+   "ua": "$c1 розколює зброю $C2 навпіл."
+  },
+  "$c1 раскалывает щит $C2 надвое.": {
+   "en": "$c1 splits $C2's shield in two.",
+   "ua": "$c1 розколює щит $C2 навпіл."
+  },
+  "$c1 старательно опутывает свои ноги хлыстом и падает на землю.": {
+   "en": "$c1 diligently tangles their own legs in the whip and falls flat on the ground.",
+   "ua": "$c1 старанно заплутує собі ноги батогом і падає на землю."
+  },
+  "%^C1 пытается обезоружить тебя, но не может пробиться сквозь {Dпризрачную ауру{x.": {
+   "en": "%^C1 tries to disarm you, but can't get through the {Dghostly aura{x.",
+   "ua": "%^C1 намагається обеззброїти тебе, але не може пробитися крізь {Dпривидну ауру{x."
+  },
+  "%^C1 размахивается и разрубает свою тень.": {
+   "en": "%^C1 winds up and cleaves their own shadow.",
+   "ua": "%^C1 розмахується і розрубує свою тінь."
+  },
+  "{R$c1 ВЫБИ$gЛО|Л|ЛА {xу тебя оружие!{x": {
+   "en": "{R$c1 KNOCKED{x your weapon out of your hands!{x",
+   "ua": "{R$c1 ВИБИ$gЛО|В|ЛА {xу тебе зброю!{x"
+  },
+  "{R$c1 ВЫБИ$gЛО|Л|ЛА {xу тебя оружие, и оно упало на землю!{x": {
+   "en": "{R$c1 KNOCKS{x the weapon from your hands, and it falls to the ground!{x",
+   "ua": "{R$c1 ВИБИ$gЛО|В|ЛА {xу тебе зброю, і вона впала на землю!{x"
+  },
+  "Вибрация от столкновения на мгновение ошеломляет тебя!": {
+   "en": "The vibration from the clash stuns you for a moment!",
+   "ua": "Вібрація від зіткнення на мить оглушує тебе!"
+  },
+  "Выбить оружие, которое ты не видишь, оказывается гораздо сложнее...": {
+   "en": "Disarming a weapon you can't see turns out to be much harder...",
+   "ua": "Вибити зброю, яку ти не бачиш, виявляється набагато складніше..."
+  },
+  "Да... Как глупо пытаться разоружить свою тень.": {
+   "en": "Yeah... How stupid, trying to disarm your own shadow.",
+   "ua": "Ага... Як же дурнувато намагатися обеззброїти власну тінь."
+  },
+  "Но $C1 твой друг!": {
+   "en": "But $C1 is your friend!",
+   "ua": "Але ж $C1 твій друг!"
+  },
+  "Но у %C2 нету ног!": {
+   "en": "But %C2 has no legs!",
+   "ua": "Але ж у %C2 немає ніг!"
+  },
+  "Оружие $c2 со звоном отскакивает от оружия $C2.": {
+   "en": "$c2's weapon rings out as it bounces off $C2's weapon.",
+   "ua": "Зброя $c2 з дзвоном відскакує від зброї $C2."
+  },
+  "Оружие $c2 со звоном отскакивает от твоего оружия!": {
+   "en": "$c2's weapon bounces off yours with a clang!",
+   "ua": "Зброя $c2 з дзвоном відскакує від твоєї зброї!"
+  },
+  "Оружие $c2 со звоном отскакивает от твоего щита!": {
+   "en": "$c2's weapon bounces off your shield with a clang!",
+   "ua": "Зброя $c2 зі дзвоном відскакує від твого щита!"
+  },
+  "Разрубить оружие, которое ты не видишь, оказывается гораздо сложнее...": {
+   "en": "Turns out it's much harder to cleave a weapon you can't see...",
+   "ua": "Розрубати зброю, яку ти не бачиш, виявляється набагато складніше..."
+  },
+  "Разрубить щит, который ты не видишь, оказывается гораздо сложнее...": {
+   "en": "Turns out it's a lot harder to cleave a shield you can't see...",
+   "ua": "Розрубати щит, якого ти не бачиш, виявляється значно складніше..."
+  },
+  "Твое оружие со звоном отскакивает от оружия $C2!": {
+   "en": "Your weapon clangs off $C2's weapon!",
+   "ua": "Твоя зброя зі дзвоном відскакує від зброї $C2!"
+  },
+  "Твое оружие со звоном отскакивает от щита $C2!": {
+   "en": "Your weapon bounces off $C2's shield with a clang!",
+   "ua": "Твоя зброя з дзвоном відскакує від щита $C2!"
+  },
+  "Ты {1{Rраскалываешь{2 оружие $C2 надвое!": {
+   "en": "You {1{Rsplit{2 $C2's weapon in two!",
+   "ua": "Ти {1{Rрозколюєш{2 зброю $C2 навпіл!"
+  },
+  "Ты {1{Rраскалываешь{2 щит $C2 надвое!": {
+   "en": "You {1{Rsplit{2 $C2's shield in two!",
+   "ua": "Ти {1{Rрозколюєш{2 щит $C2 навпіл!"
+  },
+  "Ты запутываешься в хлысте и падаешь!": {
+   "en": "You get tangled in the whip and fall!",
+   "ua": "Ти заплутуєшся в батозі і падаєш!"
+  },
+  "Ты подсекаешь $C4 своим хлыстом!": {
+   "en": "You trip $C4 up with your whip!",
+   "ua": "Ти підсікаєш $C4 своїм батогом!"
+  },
+  "Ты пытаешься огреть хлыстом собственную тень.": {
+   "en": "You try to whip your own shadow.",
+   "ua": "Ти намагаєшся вперіщити батогом власну тінь."
+  },
+  "Ты размахиваешься и разрубаешь свою тень.": {
+   "en": "You swing and hack through your own shadow.",
+   "ua": "Ти розмахуєшся і розрубуєш власну тінь."
+  }
+ },
+ "plug-ins/help/areahelp.cpp": {
+  "%1$d раз%1$I|а| за жизнь": {
+   "en": "%1$d time%1$I|s|s in a lifetime",
+   "ua": "%1$d раз%1$I|и|ів за життя"
+  }
+ },
+ "plug-ins/iomanager/interprethandler.cpp": {
+  "$c1 потеря$gло|л|ла связь с этим миром.": {
+   "en": "$c1 lost connection with this world.",
+   "ua": "$c1 втрати$gло|в|ла зв'язок з цим світом."
+  }
+ },
+ "plug-ins/languages/core/languagecommand.cpp": {
+  "%^C1 бормочет что-то неразборчивое.": {
+   "en": "%^C1 mutters something unintelligible.",
+   "ua": "%^C1 бурмоче щось нерозбірливе."
+  },
+  "%^C1 изрекает на %^N6 '{C%s{x'": {
+   "en": "%^C1 utters in %^N6 '{C%s{x'",
+   "ua": "%^C1 промовляє на %^N6 '{C%s{x'"
+  },
+  "%^C1 изрекает на %^N6, указывая в твою сторону: '{C%s{x'": {
+   "en": "%^C1 utters in %^N6, pointing in your direction: '{C%s{x'",
+   "ua": "%^C1 промовляє на %^N6, вказуючи у твій бік: '{C%s{x'"
+  },
+  "%^C1 что-то бормочет на странном языке.": {
+   "en": "%^C1 mutters something in a strange language.",
+   "ua": "%^C1 щось бурмоче дивною мовою."
+  },
+  "Выбери, на какую вещь произнести слово.": {
+   "en": "Choose which item to say the word on.",
+   "ua": "Обери, на яку річ вимовити слово."
+  },
+  "Звучание слова %s кажется тебе бессмысленным.": {
+   "en": "The sound of the word %s seems meaningless to you.",
+   "ua": "Звучання слова %s здається тобі беззмістовним."
+  },
+  "Знание языка помогает тебе приподнять завесу тайны над словом '{c%s{x':": {
+   "en": "Your knowledge of the language helps you lift the veil of mystery over the word '{c%s{x':",
+   "ua": "Знання мови допомагає тобі підняти завісу таємниці над словом '{c%s{x':"
+  },
+  "Смысл чего ты пытаешься понять?": {
+   "en": "What are you trying to understand the meaning of?",
+   "ua": "Зміст чого ти намагаєшся зрозуміти?"
+  },
+  "Твои слова, не достигнув цели, обратились на тебя сам%Gого|ого|у.": {
+   "en": "Your words, missing their mark, have turned back on you.",
+   "ua": "Твої слова, не досягнувши цілі, обернулися на тебе сам%Gого|ого|у."
+  },
+  "Тебе ни разу ничего не снилось на %N6.": {
+   "en": "You've never once dreamed in %N6.",
+   "ua": "Тобі ще ніколи нічого не снилося мовою %N6."
+  },
+  "Тебе приснились и запомнились слова на %N6: ": {
+   "en": "You dreamed and remembered words in %N6: ",
+   "ua": "Тобі наснилися і запам'яталися слова %N6: "
+  },
+  "Тебе сообщили такие слова на разных языках: ": {
+   "en": "You were told these words in various languages: ",
+   "ua": "Тобі повідомили такі слова різними мовами: "
+  },
+  "Текущий словарный запас для языка {c%N1{x: ": {
+   "en": "Current vocabulary for the {c%N1{x language: ",
+   "ua": "Поточний словниковий запас для мови {c%N1{x: "
+  },
+  "Ты забываешь слово %s.": {
+   "en": "You forget the word %s.",
+   "ua": "Ти забуваєш слово %s."
+  },
+  "Ты запоминаешь слово %s.": {
+   "en": "You memorize the word %s.",
+   "ua": "Ти запам'ятовуєш слово %s."
+  },
+  "Ты и так помнишь это слово.": {
+   "en": "You already remember that word.",
+   "ua": "Ти й так пам'ятаєш це слово."
+  },
+  "Ты изрекаешь '{C%s{x'": {
+   "en": "You utter '{C%s{x'",
+   "ua": "Ти промовляєш '{C%s{x'"
+  },
+  "Ты изрекаешь, глядя на %O4: '{C%s{x'.": {
+   "en": "You utter, looking at %O4: '{C%s{x'.",
+   "ua": "Ти промовляєш, дивлячись на %O4: '{C%s{x'."
+  },
+  "Ты не знаешь никаких слов.": {
+   "en": "You don't know any words.",
+   "ua": "Ти не знаєш жодних слів."
+  },
+  "Ты не знаешь такого слова.": {
+   "en": "You don't know that word.",
+   "ua": "Ти не знаєш такого слова."
+  },
+  "Ты не можешь вспомнить ни одного слова.": {
+   "en": "You can't remember a single word.",
+   "ua": "Ти не можеш згадати жодного слова."
+  },
+  "Ты не умеешь разговаривать на %^N6.": {
+   "en": "You don't know how to speak %^N6.",
+   "ua": "Ти не вмієш розмовляти на %^N6."
+  },
+  "Что именно ты хочешь забыть?": {
+   "en": "What exactly do you want to forget?",
+   "ua": "Що саме ти хочеш забути?"
+  },
+  "Что именно ты хочешь запомнить?": {
+   "en": "What exactly do you want to memorize?",
+   "ua": "Що саме ти хочеш запам'ятати?"
+  },
+  "Что ты хочешь произнести на %^N6?": {
+   "en": "What do you want to say in %^N6?",
+   "ua": "Що ти хочеш сказати на %^N6?"
+  },
+  "Это слово не существует.": {
+   "en": "That word doesn't exist.",
+   "ua": "Такого слова не існує."
+  },
+  "оно содержит в себе секрет {c%N2{x.": {
+   "en": "it contains the secret of {c%N2{x.",
+   "ua": "воно містить у собі секрет {c%N2{x."
+  },
+  "%^C1 что-то произносит, указывая в твою сторону.": {
+   "en": "%^C1 mutters something, pointing in your direction.",
+   "ua": "%^C1 щось промовляє, вказуючи в твій бік."
+  },
+  "{CНа мгновение все вокруг стихло.{x": {
+   "en": "{CFor a moment everything around you falls silent.{x",
+   "ua": "{CНа мить усе навколо стихло.{x"
+  },
+  "Все приснившиеся тебе слова ускользают из твоей памяти.": {
+   "en": "All the words you dreamed of slip away from your memory.",
+   "ua": "Усі слова, що тобі наснилися, вислизають з твоєї пам'яті."
+  },
+  "Муу-у-у.": {
+   "en": "Moo-o-o.",
+   "ua": "Муу-у-у."
+  },
+  "Тайный смысл слов %^N2 ускользает от тебя.": {
+   "en": "The hidden meaning of %^N2's words escapes you.",
+   "ua": "Таємний зміст слів %^N2 вислизає від тебе."
+  },
+  "Тебя подвело произношение.": {
+   "en": "Your pronunciation let you down.",
+   "ua": "Тебе підвела вимова."
+  },
+  "Ты изрекаешь, указывая на %^C4: '{C%s{x'": {
+   "en": "You proclaim, pointing at %^C4: '{C%s{x'",
+   "ua": "Ти виголошуєш, вказуючи на %^C4: '{C%s{x'"
+  },
+  "Ты проводишь рукой над %O5 и изрекаешь '{C%s{x'.": {
+   "en": "You pass your hand over %O5 and utter '{C%s{x'.",
+   "ua": "Ти проводиш рукою над %O5 і промовляєш '{C%s{x'."
+  }
+ },
+ "plug-ins/languages/core/languagemanager.cpp": {
+  "{wСлово {w%s{w утрачивает силу.{x": {
+   "en": "{wThe word {w%s{w loses its power.{x",
+   "ua": "{wСлово {w%s{w втрачає силу.{x"
+  }
+ },
+ "plug-ins/languages/core/languageskill.cpp": {
+  "Поищи бродячего монаха.": {
+   "en": "Look for a wandering monk.",
+   "ua": "Пошукай мандрівного монаха."
+  },
+  "Ты совершенствуешь свои познания в %^N6.": {
+   "en": "You improve your knowledge of %^N6.",
+   "ua": "Ти вдосконалюєш свої знання у %^N6."
+  },
+  "%^C1 отнюдь не полиглот.": {
+   "en": "%^C1 is no polyglot.",
+   "ua": "%^C1 аж ніяк не поліглот."
+  }
+ },
+ "plug-ins/languages/core/xmlattributelanguage.cpp": {
+  "{wСлово {w%s{w ускользает от тебя.{x": {
+   "en": "{wThe word {w%s{w slips away from you.{x",
+   "ua": "{wСлово {w%s{w вислизає від тебе.{x"
+  }
+ },
+ "plug-ins/languages/impl/ahenn_effects.cpp": {
+  "{C$c1 выглядит просветленн$gым|ым|ой.{x": {
+   "en": "{C$c1 looks enlightened.{x",
+   "ua": "{C$c1 виглядає просвітлен$gим|им|ою.{x"
+  },
+  "{CЖажда творить и совершенствовать переполняет тебя.{x": {
+   "en": "{CA thirst to create and perfect overflows within you.{x",
+   "ua": "{CСпрага творити і вдосконалювати переповнює тебе.{x"
+  },
+  "{CСила древних проклятий проникает в мир.{x": {
+   "en": "{CThe power of ancient curses seeps into the world.{x",
+   "ua": "{CСила стародавніх прокльонів проникає у світ.{x"
+  }
+ },
+ "plug-ins/languages/impl/arcadian_effects.cpp": {
+  "$c1 вздрагивает и просыпается.": {
+   "en": "$c1 startles and wakes up.",
+   "ua": "$c1 здригається і прокидається."
+  },
+  "$c1 ворочается во сне.": {
+   "en": "$c1 tosses and turns in sleep.",
+   "ua": "$c1 крутиться уві сні."
+  },
+  "$c1 выглядит невероятно умиротворенн$gым|ым|ой и спокойн$gым|ым|ой.": {
+   "en": "$c1 looks incredibly at peace and calm.",
+   "ua": "$c1 виглядає неймовірно умиротворен$gим|им|ою і спокійн$gим|им|ою."
+  },
+  "%1$^C1 выглядит посвежевш%1$Gим|им|ей.": {
+   "en": "%1$^C1 looks refreshed.",
+   "ua": "%1$^C1 виглядає посвіжіл%1$Gим|им|ою."
+  },
+  "%1$^O1 мало похож%1$Gе||а|и на емкость для жидкости.": {
+   "en": "%1$^O1 doesn't look much like a container for liquid.",
+   "ua": "%1$^O1 мало схож%1$Gе|ий|а|і на ємність для рідини."
+  },
+  "В $o6 налито слишком много жидкости.": {
+   "en": "Too much liquid has been poured into $o6.",
+   "ua": "У $o6 налито забагато рідини."
+  },
+  "Жидкость в $o6 уже обладает необычными свойствами.": {
+   "en": "The liquid in $o6 already has unusual properties.",
+   "ua": "Рідина в $o6 вже має незвичайні властивості."
+  },
+  "Напиток освежает тебя. {D[{G%d{D]{x": {
+   "en": "The drink refreshes you. {D[{G%d{D]{x",
+   "ua": "Напій освіжає тебе. {D[{G%d{D]{x"
+  },
+  "Напиток слегка взбадривает тебя.": {
+   "en": "The drink perks you up a little.",
+   "ua": "Напій трохи бадьорить тебе."
+  },
+  "Пивная пленка на коже $c2 становится прочнее.": {
+   "en": "The beer film on $c2's skin grows tougher.",
+   "ua": "Пивна плівка на шкірі $c2 стає міцнішою."
+  },
+  "Повлиять на эту емкость у тебя не получится.": {
+   "en": "You won't be able to affect this container.",
+   "ua": "Вплинути на цю ємність тобі не вдасться."
+  },
+  "То, что налито в $o4, мало похоже на вино.": {
+   "en": "Whatever's been poured into $o4 doesn't look much like wine.",
+   "ua": "Те, що налито в $o4, мало схоже на вино."
+  },
+  "Ты ворочаешься во сне.": {
+   "en": "You toss and turn in your sleep.",
+   "ua": "Ти крутишся уві сні."
+  },
+  "Ты чувствуешь мимолетную сонливость.": {
+   "en": "You feel a fleeting drowsiness.",
+   "ua": "Ти відчуваєш скороминучу сонливість."
+  },
+  "Ты чувствуешь терпкий привкус.": {
+   "en": "You taste a tart aftertaste.",
+   "ua": "Ти відчуваєш терпкий присмак."
+  },
+  "Это слово действует только на воду.": {
+   "en": "This word only works on water.",
+   "ua": "Це слово діє лише на воду."
+  },
+  "$c1 зевает во всю пасть и засыпает.": {
+   "en": "$c1 yawns wide and falls asleep.",
+   "ua": "$c1 позіхає на всю пащу і засинає."
+  },
+  "$c1 на мгновение кажется более умиротворенн$gым|ым|ой.": {
+   "en": "$c1 seems more at peace for a moment.",
+   "ua": "$c1 на мить здається більш умиротворен$gим|им|ою."
+  },
+  "$o1 начинает бурлить, рождая из себя $C4!": {
+   "en": "$o1 begins to bubble, birthing $C4 from within!",
+   "ua": "$o1 починає вирувати, породжуючи з себе $C4!"
+  },
+  "$o1 яростно булькает, но ничего не происходит.": {
+   "en": "$o1 gurgles furiously, but nothing happens.",
+   "ua": "$o1 люто булькає, але нічого не відбувається."
+  },
+  "Вода в %O6 начинает бурлить и пениться, постепенно окрашиваясь {1%N5{2 цветом.{x": {
+   "en": "The water in %O6 begins to bubble and froth, gradually turning {1%N5{2 in color.{x",
+   "ua": "Вода в %O6 починає вирувати й піняватися, поступово забарвлюючись у {1%N5{2 колір.{x"
+  },
+  "Вода в %O6 начинает шипеть и искриться, постепенно окрашиваясь {1%N5{2 цветом.{x": {
+   "en": "The water in %O6 begins to hiss and sparkle, gradually taking on a {1%N5{2 hue.{x",
+   "ua": "Вода в %O6 починає шипіти й іскритися, поступово забарвлюючись у {1%N5{2 колір.{x"
+  },
+  "Из пенных брызг рождается $C1!": {
+   "en": "$C1 is born from the foamy spray!",
+   "ua": "З пінних бризок народжується $C1!"
+  },
+  "Кожа $c2 покрывается защитной пивной пленкой.": {
+   "en": "$c2's skin is covered with a protective beer film.",
+   "ua": "Шкіра $c2 вкривається захисною пивною плівкою."
+  },
+  "Напиток бурлит у тебя в животе!": {
+   "en": "The drink churns in your stomach!",
+   "ua": "Напій вирує у тебе в животі!"
+  },
+  "Пивная пленка на твоей коже становится прочнее.": {
+   "en": "The beer film on your skin grows sturdier.",
+   "ua": "Пивна плівка на твоїй шкірі стає міцнішою."
+  },
+  "Радужные блики играют в пенных пузырьках %N2.": {
+   "en": "Rainbow glints play across the foam bubbles of %N2.",
+   "ua": "Райдужні відблискиграють у пінних бульбашках %N2."
+  },
+  "Разноцветные искры пробегают по поверхности %N2.": {
+   "en": "Multicolored sparks race across the surface of %N2.",
+   "ua": "Різнокольорові іскри пробігають по поверхні %N2."
+  },
+  "Слово эхом отозвалось в пустоте $o2.": {
+   "en": "The word echoed through the void of $o2.",
+   "ua": "Слово відлунило в порожнечі $o2."
+  },
+  "Сон как рукой сняло!": {
+   "en": "Sleep vanished as if wiped away!",
+   "ua": "Сон мов рукою зняло!"
+  },
+  "Твоя кожа покрывается защитной пивной пленкой.": {
+   "en": "Your skin gets covered in a protective beer film.",
+   "ua": "Твоя шкіра вкривається захисною пивною плівкою."
+  },
+  "То, что налито в $o4, мало похоже на пиво.": {
+   "en": "Whatever's poured into $o4 doesn't look much like beer.",
+   "ua": "Те, що налито в $o4, мало схоже на пиво."
+  },
+  "Ты чувствуешь внезапный неодолимый приступ сонливости.": {
+   "en": "You feel a sudden, overwhelming wave of drowsiness.",
+   "ua": "Ти відчуваєш раптовий нездоланний напад сонливості."
+  },
+  "Ты чувствуешь мимолетное умиротворение.": {
+   "en": "You feel a fleeting sense of peace.",
+   "ua": "Ти відчуваєш швидкоплинне умиротворення."
+  },
+  "Ты чувствуешь мимолетную бодрость.": {
+   "en": "You feel a fleeting burst of vigor.",
+   "ua": "Ти відчуваєш скороминущу бадьорість."
+  },
+  "Ты чувствуешь удивительное спокойствие.": {
+   "en": "You feel a remarkable sense of calm.",
+   "ua": "Ти відчуваєш дивовижний спокій."
+  }
+ },
+ "plug-ins/languages/impl/elvish_effects.cpp": {
+  "$C1 не страдает врожденной уязвимостью к железу.": {
+   "en": "$C1 doesn't suffer from an innate vulnerability to iron.",
+   "ua": "$C1 не страждає від вродженої вразливості до заліза."
+  },
+  "%1$^O1 уже благословле%1$Gно|н|на|ны.": {
+   "en": "%1$^O1 is already blessed.",
+   "ua": "%1$^O1 вже благословен%1$Gне|ний|на|ні."
+  },
+  "{CСекретное знание Сидхов теперь защищает $c4.{x": {
+   "en": "{CThe secret knowledge of the Sidhe now protects $c4.{x",
+   "ua": "{CТаємне знання Сідхів тепер захищає $c4.{x"
+  },
+  "Ты не страдаешь врожденной уязвимостью к железу.": {
+   "en": "You no longer suffer from an innate vulnerability to iron.",
+   "ua": "Ти не страждаєш від вродженої вразливості до заліза."
+  },
+  "{C$o1 на мгновение загорается огнем нездешних звёзд.{x": {
+   "en": "{C$o1 flares for a moment with the fire of otherworldly stars.{x",
+   "ua": "{C$o1 на мить займається вогнем нездешніх зірок.{x"
+  },
+  "{CСекретное знание Сидхов теперь защищает тебя.{x": {
+   "en": "{CThe secret knowledge of the Sidhe now protects you.{x",
+   "ua": "{CТаємне знання Сідхів тепер захищає тебе.{x"
+  },
+  "{CТаинственное мелодичное слово пронизывает $C4 теплом.{x": {
+   "en": "{CA mysterious melodic word pierces $C4 with warmth.{x",
+   "ua": "{CТаємниче мелодійне слово пронизує $C4 теплом.{x"
+  },
+  "{CТаинственное мелодичное слово пронизывает тебя теплом.{x": {
+   "en": "{CA mysterious melodic word fills you with warmth.{x",
+   "ua": "{CТаємниче мелодійне слово пронизує тебе теплом.{x"
+  }
+ },
+ "plug-ins/languages/impl/khuzdul_effects.cpp": {
+  "Слово не достигло цели - $C1 ничем не вооруж$Gено|ен|ена.": {
+   "en": "The word missed its target -- $C1 isn't armed with anything.",
+   "ua": "Слово не досягло цілі - $C1 нічим не озброєн$Gо|ий|а."
+  },
+  "Слово не достигло цели - ты ничем не вооруж$gено|ен|ена.": {
+   "en": "The word missed its mark -- you aren't armed with anything.",
+   "ua": "Слово не досягло цілі -- ти нічим не озброєн$gе|ий|а."
+  },
+  "Ты чувствуешь легкое покалывание ладони.": {
+   "en": "You feel a slight tingling in your palm.",
+   "ua": "Ти відчуваєш легке поколювання в долоні."
+  },
+  "{CОбмундирование на $c6 вспыхивает ослепительным блеском.{x": {
+   "en": "{CThe gear on $c6 flares with a blinding shine.{x",
+   "ua": "{CОбмундирування на $c6 спалахує сліпучим блиском.{x"
+  },
+  "{CПламя древней ярости вспыхивает в %C6!{x": {
+   "en": "{CThe flame of ancient fury flares up in %C6!{x",
+   "ua": "{CПолум'я давньої люті спалахує в %C6!{x"
+  },
+  "{CПламя древней ярости вспыхивает в тебе!{x": {
+   "en": "{CThe flame of ancient fury flares up within you!{x",
+   "ua": "{CПолум'я давньої люті спалахує в тобі!{x"
+  },
+  "{CСекреты древних кузнецов улучшают облик обмундирования $c2.{x": {
+   "en": "{CThe secrets of ancient smiths improve the look of $c2's gear.{x",
+   "ua": "{CСекрети давніх ковалів покращують вигляд обмундирування $c2.{x"
+  },
+  "{CСекреты древних кузнецов улучшают облик твоего обмундирования.{x": {
+   "en": "{CThe secrets of the ancient smiths refine the look of your gear.{x",
+   "ua": "{CСекрети давніх ковалів покращують вигляд твого спорядження.{x"
+  },
+  "{CСекреты кузнецов древности преображают $o4!{x": {
+   "en": "{CThe secrets of ancient smiths transform $o4!{x",
+   "ua": "{CТаємниці ковалів давнини перетворюють $o4!{x"
+  },
+  "{CТвое обмундирование вспыхивает ослепительным блеском.{x": {
+   "en": "{CYour gear flares with a blinding shine.{x",
+   "ua": "{CТвоє спорядження спалахує сліпучим блиском.{x"
+  },
+  "Пламя древней ярости уже горит в %C6.": {
+   "en": "The flame of ancient fury already burns in %C6.",
+   "ua": "Полум'я давньої люті вже горить у %C6."
+  },
+  "Пламя древней ярости уже горит в тебе.": {
+   "en": "The flame of ancient fury already burns within you.",
+   "ua": "Полум'я давньої люті вже горить у тобі."
+  },
+  "Ты слишком миролюбив{Sfа{Sx для древней ярости.": {
+   "en": "You are too peaceable for the ancient fury.",
+   "ua": "Ти надто миролюбн{Smий{Sfа{Sx для давньої люті."
+  }
+ },
+ "plug-ins/learn/cskills.cpp": {
+  "Неверный параметр '%1$s', подходящие фильтры: заклинания, навыки, пассивные, активные, название группы умений, диапазон уровней.\r\n": {
+   "en": "Invalid parameter '%1$s'; valid filters: spells, skills, passive, active, skill group name, level range.\r\n",
+   "ua": "Неправильний параметр '%1$s', допустимі фільтри: заклинання, навички, пасивні, активні, назва групи вмінь, діапазон рівнів.\r\n"
+  }
+ },
+ "plug-ins/learn/glist.cpp": {
+  "Неправильно указана группа.": {
+   "en": "The group was specified incorrectly.",
+   "ua": "Неправильно вказана група."
+  },
+  "Эта группа умений скрыта от тебя.": {
+   "en": "This skill group is hidden from you.",
+   "ua": "Ця група умінь прихована від тебе."
+  }
+ },
+ "plug-ins/learn/practice.cpp": {
+  "%1$^C1 может помочь тебе практиковаться в таких умениях:": {
+   "en": "%1$^C1 can help you practice the following skills:",
+   "ua": "%1$^C1 може допомогти тобі практикувати такі уміння:"
+  },
+  "%^C1 обучает %C4 умению {W%K1{x.": {
+   "en": "%^C1 teaches %C4 the skill {W%K1{x.",
+   "ua": "%^C1 навчає %C4 навичці {W%K1{x."
+  },
+  "%^C1 обучает тебя умению {W%K1{x.": {
+   "en": "%^C1 teaches you the skill {W%K1{x.",
+   "ua": "%^C1 навчає тебе вмінню {W%K1{x."
+  },
+  "%^C1 теперь хорошо владеет умением {W%K1{x.": {
+   "en": "%^C1 now has a good grasp of the skill {W%K1{x.",
+   "ua": "%^C1 тепер добре володіє умінням {W%K1{x."
+  },
+  "Дальше практиковать не получится, просто начни применять его почаще.": {
+   "en": "You can't practice it further, just start using it more often.",
+   "ua": "Далі практикувати не вийде, просто почни застосовувати його частіше."
+  },
+  "Тебе не с кем практиковаться здесь.": {
+   "en": "There's no one here for you to practice with.",
+   "ua": "Тобі немає з ким практикуватися тут."
+  },
+  "Тебе нечему научиться у %C2.": {
+   "en": "There's nothing you can learn from %C2.",
+   "ua": "Тобі нічого навчитися у %C2."
+  },
+  "Теперь ты хорошо владеешь умением {W%K1{x.": {
+   "en": "Now you're skilled in {W%K1{x.",
+   "ua": "Тепер ти добре володієш умінням {W%K1{x."
+  },
+  "Ты не можешь выучить умение {W%K1{x.": {
+   "en": "You can't learn the skill {W%K1{x.",
+   "ua": "Ти не можеш вивчити уміння {W%K1{x."
+  },
+  "Ты обучаешь %C4 умению {W%K1{x.": {
+   "en": "You teach %C4 the skill {W%K1{x.",
+   "ua": "Ти навчаєш %C4 навичці {W%K1{x."
+  },
+  "Ты теперь знаешь умение {W%K1{x на %d процентов.": {
+   "en": "You now know the skill {W%K1{x at %d percent.",
+   "ua": "Ти тепер знаєш уміння {W%K1{x на %d відсотків."
+  },
+  "Ты уже слишком хорошо владеешь умением {W%K1{x, практиковаться бессмысленно.": {
+   "en": "You already know the skill {W%K1{x too well -- practicing is pointless.",
+   "ua": "Ти вже надто добре володієш умінням {W%K1{x, практикуватися немає сенсу."
+  },
+  "У тебя %d сесси%s практики.\n\r": {
+   "en": "You have %d practice session%s.\n\r",
+   "ua": "У тебе %d сесі%s практики.\n\r"
+  },
+  "У тебя сейчас нет сессий практики.": {
+   "en": "You don't have any practice sessions right now.",
+   "ua": "У тебе зараз немає сесій практики."
+  },
+  "Умение {W%N1{x тебе не доступно.": {
+   "en": "The skill {W%N1{x is not available to you.",
+   "ua": "Уміння {W%N1{x тобі не доступне."
+  },
+  "Умение {W%s{x не существует или еще тебе не доступно.": {
+   "en": "The skill {W%s{x doesn't exist or isn't available to you yet.",
+   "ua": "Уміння {W%s{x не існує або ще недоступне тобі."
+  },
+  "Чтобы овладеть умением еще лучше, просто применяй его почаще.": {
+   "en": "To master the skill even better, just use it more often.",
+   "ua": "Щоб опанувати вміння ще краще, просто застосовуй його частіше."
+  },
+  "Во сне или как?": {
+   "en": "In your sleep or what?",
+   "ua": "Уві сні чи як?"
+  }
+ },
+ "plug-ins/learn/showskill.cpp": {
+  "Такого умения нет.": {
+   "en": "There's no such skill.",
+   "ua": "Такого вміння немає."
+  }
+ },
+ "plug-ins/learn/teach.cpp": {
+  "Тебе необходимо достичь уровня Героя.": {
+   "en": "You need to reach the level of Hero.",
+   "ua": "Тобі потрібно досягти рівня Героя."
+  },
+  "Ты передума$gло|л|ла обучать других.": {
+   "en": "You changed your mind about teaching others.",
+   "ua": "Ти передума$gло|в|ла навчати інших."
+  },
+  "Теперь ты можешь обучать других тому, что ты знаешь в совершенстве.": {
+   "en": "Now you can teach others what you have mastered.",
+   "ua": "Тепер ти можеш навчати інших того, що ти знаєш досконало."
+  }
+ },
+ "plug-ins/learn/train.cpp": {
+  "$C1 дает тебе {Y10{x практик в обмен на {Y1{x тренировочную сессию.": {
+   "en": "$C1 gives you {Y10{x practices in exchange for {Y1{x training session.",
+   "ua": "$C1 дає тобі {Y10{x практик в обмін на {Y1{x тренувальну сесію."
+  },
+  "$C1 дает тебе {Y1{x тренировочную сессию в обмен на {Y10{x практик.": {
+   "en": "$C1 gives you {Y1{x training session in exchange for {Y10{x practices.",
+   "ua": "$C1 дає тобі {Y1{x тренувальну сесію в обмін на {Y10{x практик."
+  },
+  "$C1 обменивает для $c2 сессии практики на тренировочные сессии.": {
+   "en": "$C1 exchanges practice sessions for training sessions on behalf of $c2.",
+   "ua": "$C1 обмінює для $c2 сесії практики на тренувальні сесії."
+  },
+  "$C1 обменивает для $c2 тренировочные сессии на сессии практики.": {
+   "en": "$C1 exchanges training sessions for practice sessions on behalf of $c2.",
+   "ua": "$C1 обмінює для $c2 тренувальні сесії на сесії практики."
+  },
+  "$c1 повышает {W$N4!{x": {
+   "en": "$c1 raises {W$N4!{x",
+   "ua": "$c1 підвищує {W$N4!{x"
+  },
+  "Здесь некому тренировать тебя.": {
+   "en": "There's no one here to train you.",
+   "ua": "Тут нема кому тренувати тебе."
+  },
+  "Ты повышаешь {W$N4{x!": {
+   "en": "You raise {W$N4{x!",
+   "ua": "Ти підвищуєш {W$N4{x!"
+  },
+  "Это бесполезно для тебя.": {
+   "en": "This is useless for you.",
+   "ua": "Це марно для тебе."
+  }
+ },
+ "plug-ins/liquid/drink_commands.cpp": {
+  "$c1 зачерпывает и пьет $T.": {
+   "en": "$c1 scoops up and drinks $T.",
+   "ua": "$c1 зачерпує і п'є $T."
+  },
+  "$c1 пьет $T из $o2.": {
+   "en": "$c1 drinks $T from $o2.",
+   "ua": "$c1 п'є $T з $o2."
+  },
+  "%1$^O1 -- не фонтан и не емкость для жидкости.": {
+   "en": "%1$^O1 is neither a fountain nor a liquid container.",
+   "ua": "%1$^O1 -- не фонтан і не ємність для рідини."
+  },
+  "%1$^O1 бездон%1$Gно|eн|на|ны и не нужда%1$nется|ются в заполнении.": {
+   "en": "%1$^O1 is bottomless and need%1$ns| no filling.",
+   "ua": "%1$^O1 бездон%1$Gне|ний|на|ні і не потребу%1$nє|ють заповнення."
+  },
+  "%1$^O1 в руках у %2$C2 уже полностью заполне%1$Gно|н|на|ны.": {
+   "en": "%1$^O1 in %2$C2's hands is already completely full.",
+   "ua": "%1$^O1 в руках у %2$C2 вже повністю заповнен%1$Gо|ий|а|і."
+  },
+  "%1$^O1 уже наполнен%1$Gо||а|ы до краев.": {
+   "en": "%1$^O1 is already filled to the brim.",
+   "ua": "%1$^O1 вже наповнен%1$Gе|ий|а|і по вінця."
+  },
+  "%1$^O1 уже полностью заполне%1$Gно|н|на|ны.": {
+   "en": "%1$^O1 is already completely full.",
+   "ua": "%1$^O1 вже повністю заповнен%1$Gе|ий|а|і."
+  },
+  "%^C1 зачерпывает %N4 и наполняет %O4.": {
+   "en": "%^C1 scoops up %N4 and fills %O4.",
+   "ua": "%^C1 зачерпує %N4 і наповнює %O4."
+  },
+  "%^C1 наливает %N4 для %C2.": {
+   "en": "%^C1 pours %N4 for %C2.",
+   "ua": "%^C1 наливає %N4 для %C2."
+  },
+  "%^C1 наливает %N4 из %O2 в %O4.": {
+   "en": "%^C1 pours %N4 from %O2 into %O4.",
+   "ua": "%^C1 наливає %N4 з %O2 у %O4."
+  },
+  "%^C1 наливает себе %N4.": {
+   "en": "%^C1 pours themselves %N4.",
+   "ua": "%^C1 наливає собі %N4."
+  },
+  "%^C1 наполняет %O4 %N5 из %O2.": {
+   "en": "%^C1 fills %O4 with %N5 from %O2.",
+   "ua": "%^C1 наповнює %O4 %N5 з %O2."
+  },
+  "%^C1 переворачивает %O4.": {
+   "en": "%^C1 flips %O4 over.",
+   "ua": "%^C1 перевертає %O4."
+  },
+  "%^N1 и %N1 смешиваются, образуя лужу %N2.": {
+   "en": "%^N1 and %N1 mix together, forming a puddle of %N2.",
+   "ua": "%^N1 і %N1 змішуються, утворюючи калюжу %N2."
+  },
+  "%^O1 -- не емкость для жидкости.": {
+   "en": "%^O1 is not a container for liquid.",
+   "ua": "%^O1 -- не ємність для рідини."
+  },
+  "В %1$O6, похоже, пусто.": {
+   "en": "%1$O6 looks empty.",
+   "ua": "У %1$O6, схоже, порожньо."
+  },
+  "В %O4 в руках у %C2 налита другая жидкость.": {
+   "en": "%O4 in %C2's hands is filled with a different liquid.",
+   "ua": "У %O4 в руках %C2 налита інша рідина."
+  },
+  "В %O4 налита другая жидкость.": {
+   "en": "%O4 already has a different liquid poured in it.",
+   "ua": "У %O4 налита інша рідина."
+  },
+  "В руках у %C2 зажата совсем не емкость для жидкости.": {
+   "en": "What %C2 is holding is definitely not a liquid container.",
+   "ua": "У руках %C2 затиснута зовсім не ємність для рідини."
+  },
+  "Вода смывает с тебя часть посторонних запахов.": {
+   "en": "The water washes away some of the foreign smells on you.",
+   "ua": "Вода змиває з тебе частину сторонніх запахів."
+  },
+  "Вылить во что?": {
+   "en": "Pour into what?",
+   "ua": "Вилити у що?"
+  },
+  "Вылить на кого?": {
+   "en": "Pour on whom?",
+   "ua": "Вилити на кого?"
+  },
+  "Вылить что и куда?": {
+   "en": "Pour what, and where?",
+   "ua": "Вилити що і куди?"
+  },
+  "Выпить что?": {
+   "en": "Drink what?",
+   "ua": "Випити що?"
+  },
+  "Жидкость в %1$O6, похоже, заморожена -- придется сначала разморозить.": {
+   "en": "The liquid in %1$O6 seems to be frozen -- you'll need to thaw it first.",
+   "ua": "Рідина в %1$O6, схоже, заморожена -- доведеться спершу розморозити."
+  },
+  "Жидкость в %1$O6, похоже, заморожена.": {
+   "en": "The liquid in %1$O6 seems to be frozen.",
+   "ua": "Рідина в %1$O6, схоже, замерзла."
+  },
+  "Здесь нет источника!": {
+   "en": "There's no source here!",
+   "ua": "Тут немає джерела!"
+  },
+  "Здесь нет такого источника.": {
+   "en": "There's no such source here.",
+   "ua": "Тут немає такого джерела."
+  },
+  "Из %O2 не выливается ни капли.": {
+   "en": "Not a single drop pours out of %O2.",
+   "ua": "З %O2 не виливається ні краплі."
+  },
+  "Лужа %N2 из %O2 с шипением испаряется на песке.": {
+   "en": "The puddle of %N2 from %O2 hisses as it evaporates on the sand.",
+   "ua": "Калюжа %N2 з %O2 з шипінням випаровується на піску."
+  },
+  "Лужа %N2 растекается еще шире.": {
+   "en": "The puddle of %N2 spreads even wider.",
+   "ua": "Калюжа %N2 розтікається ще ширше."
+  },
+  "На земле образуется лужа %N2.": {
+   "en": "A puddle of %N2 forms on the ground.",
+   "ua": "На землі утворюється калюжа %N2."
+  },
+  "Наполнить что?": {
+   "en": "Fill what?",
+   "ua": "Наповнити що?"
+  },
+  "Поток %N2 из %O2 выплескивается в %N4.": {
+   "en": "A stream of %N2 splashes out of %O2 into %N4.",
+   "ua": "Потік %N2 з %O2 виплескується в %N4."
+  },
+  "Поток %N2 из %O2 проливается на землю.": {
+   "en": "A stream of %N2 from %O2 spills onto the ground.",
+   "ua": "Потік %N2 з %O2 проливається на землю."
+  },
+  "Ты не можешь наполнить %O4 -- это не емкость для жидкости.": {
+   "en": "You cannot fill %O4 -- it's not a container for liquid.",
+   "ua": "Ти не можеш наповнити %O4 -- це не ємність для рідини."
+  },
+  "Ты не можешь пить из %O2.": {
+   "en": "You can't drink from %O2.",
+   "ua": "Ти не можеш пити з %O2."
+  },
+  "Ты не находишь этого.": {
+   "en": "You don't find that.",
+   "ua": "Ти не знаходиш цього."
+  },
+  "Ты переворачиваешь %O4.": {
+   "en": "You flip %O4 over.",
+   "ua": "Ти перевертаєш %O4."
+  },
+  "Ты пытаешься налить что-то в %O4, а это не фонтан и не емкость для жидкости.": {
+   "en": "You try to pour something into %O4, but it's neither a fountain nor a liquid container.",
+   "ua": "Ти намагаєшся налити щось у %O4, а це не фонтан і не ємність для рідини."
+  },
+  "У %C2 в руках нет бокала или другой емкости.": {
+   "en": "%C2 has no glass or other container in hand.",
+   "ua": "У %C2 в руках немає келиха чи іншої ємності."
+  },
+  "У тебя в инвентаре нет такой емкости для жидкости.": {
+   "en": "You don't have a liquid container like that in your inventory.",
+   "ua": "У тебе в інвентарі немає такої ємності для рідини."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  },
+  "Чтобы наполнить фонтан, попробуй вылить туда емкость с жидкостью.": {
+   "en": "To fill the fountain, try pouring a container of liquid into it.",
+   "ua": "Щоб наповнити фонтан, спробуй вилити туди ємність з рідиною."
+  },
+  "Лицо %^C2 искажается гримасой боли.": {
+   "en": "%^C2's face twists with a grimace of pain.",
+   "ua": "Обличчя %^C2 спотворюється гримасою болю."
+  },
+  "Поток %N2 из %O2 устремляется куда-то вниз и пропадает.": {
+   "en": "A stream of %N2 from %O2 rushes downward and vanishes.",
+   "ua": "Потік %N2 з %O2 стрімко тече кудись вниз і зникає."
+  },
+  "Святость %O2 обжигает твои внутренности!": {
+   "en": "The holiness of %O2 burns your insides!",
+   "ua": "Святість %O2 обпікає твої нутрощі!"
+  },
+  "Тебя начинает тошнить, когда яд проникает в твое тело.": {
+   "en": "You start to feel nauseous as the poison seeps into your body.",
+   "ua": "Тебе починає нудити, коли отрута проникає у твоє тіло."
+  }
+ },
+ "plug-ins/liquid/drink_utils.cpp": {
+  "%1$^O1 закры%1$Gто|т|та|ты крышкой, для начала стоит ее открыть.": {
+   "en": "%1$^O1 is closed with a lid, you should open it first.",
+   "ua": "%1$^O1 закри%1$Gто|тий|та|ті кришкою, спершу варто її відкрити."
+  },
+  "%1$^O1 закупоре%1$Gно|н|на|ны пробкой, для начала стоит ее вынуть.": {
+   "en": "%1$^O1 is corked, you should pull the cork out first.",
+   "ua": "%1$^O1 закоркован%1$Gо|ий|а|і, спершу варто витягти корок."
+  },
+  "%1$^O1 запер%1$Gто|т|та|ты.": {
+   "en": "%1$^O1 is locked.",
+   "ua": "%1$^O1 замкнен%1$Gе|ий|а|і."
+  },
+  "Тут закрыто.": {
+   "en": "It's closed here.",
+   "ua": "Тут закрито."
+  }
+ },
+ "plug-ins/loadsave/character.cpp": {
+  "Песок в глазах мешает тебе что-либо разглядеть.": {
+   "en": "Sand in your eyes keeps you from seeing anything.",
+   "ua": "Пісок в очах заважає тобі щось розгледіти."
+  },
+  "Твои глаза слезятся из-за дыма, и ты ничего не видишь.": {
+   "en": "Your eyes water from the smoke, and you can't see a thing.",
+   "ua": "Твої очі сльозяться від диму, і ти нічого не бачиш."
+  },
+  "Ты еще слишком неопыт{Smен{Sfна{Sx для этого лимита.": {
+   "en": "You're still too inexperienced for this limit.",
+   "ua": "Ти ще занадто недосвідче{Smний{Sfна{Sx для цього ліміту."
+  },
+  "Ты ничего не видишь из-за пыли, попавшей в глаза.": {
+   "en": "You can't see anything because of dust in your eyes.",
+   "ua": "Ти нічого не бачиш через пилюку, що потрапила в очі."
+  },
+  "Ты уже слишком опыт{Smен{Sfна{Sx для этого лимита.": {
+   "en": "You're already too experienced for this limit.",
+   "ua": "Ти вже надто досвідчен{Smий{Sfа{Sx для цього ліміту."
+  },
+  "Чтобы пользоваться лимитами, надо сначала {hhподтвердить{x описание.": {
+   "en": "To use limits, you first need to {hhconfirm{x your description.",
+   "ua": "Щоб користуватися лімітами, спершу треба {hhпідтвердити{x опис."
+  },
+  "Твои глаза слепы, ты ничего не видишь!": {
+   "en": "Your eyes are blind, you see nothing!",
+   "ua": "Твої очі сліпі, ти нічого не бачиш!"
+  }
+ },
+ "plug-ins/loadsave/itemutils.cpp": {
+  "Ты не можешь избавиться от этого.": {
+   "en": "You can't get rid of that.",
+   "ua": "Ти не можеш позбутися цього."
+  }
+ },
+ "plug-ins/loadsave/limited.cpp": {
+  "%^O1 в руках %C2 неумолимо истонча%1$nется|ются.": {
+   "en": "%^O1 wear%1$ns| thin relentlessly in %C2's hands.",
+   "ua": "%^O1 невблаганно тонша%1$nє|ють в руках %C2."
+  },
+  "%^O1 в твоих руках неумолимо истонча%1$nется|ются.": {
+   "en": "%^O1 in your hands inexorably grow%1$ns| thinner.",
+   "ua": "%^O1 у твоїх руках невблаганно витонч%1$nується|уються."
+  },
+  "Лежа на земле, %1$O1 неумолимо истонча%1$nется|ются.": {
+   "en": "Lying on the ground, %1$O1 relentlessly wear%1$ns| thin.",
+   "ua": "Лежачи на землі, %1$O1 невблаганно тонша%1$nє|ють."
+  },
+  "Лимитные вещи созданы для войны, и в {hh86безопасной комнате{x им находиться нельзя.": {
+   "en": "Limited items are made for war, and they can't be in a {hh86safe room{x.",
+   "ua": "Лімітні речі створені для війни, і в {hh86безпечній кімнаті{x їм перебувати не можна."
+  },
+  "%1$^O1 рассыпа%1$nется|ются трухой!": {
+   "en": "%1$^O1 crumble%1$ns| to dust!",
+   "ua": "%1$^O1 розсипа%1$nється|ються трухою!"
+  }
+ },
+ "plug-ins/loadsave/money_utils.cpp": {
+  "Ты можешь указать количество денег в серебре или золоте .": {
+   "en": "You can specify the amount of money in silver or gold.",
+   "ua": "Ти можеш вказати кількість грошей у сріблі або золоті."
+  },
+  "У тебя нет столько золота.": {
+   "en": "You don't have that much gold.",
+   "ua": "У тебе немає стільки золота."
+  },
+  "У тебя нет столько серебра.": {
+   "en": "You don't have that much silver.",
+   "ua": "У тебе немає стільки срібла."
+  },
+  "Укажи название монеты полностью: золото.": {
+   "en": "Specify the coin's full name: gold.",
+   "ua": "Вкажи повну назву монети: золото."
+  },
+  "Укажи название монеты полностью: серебро.": {
+   "en": "Specify the coin name in full: silver.",
+   "ua": "Вкажи назву монети повністю: срібло."
+  },
+  "Ноль монет -- это как?": {
+   "en": "Zero coins -- how does that even work?",
+   "ua": "Нуль монет -- це як?"
+  },
+  "Отрицательное количество денег?": {
+   "en": "A negative amount of money?",
+   "ua": "Від'ємна кількість грошей?"
+  }
+ },
+ "plug-ins/loadsave/objectbehaviormanager.cpp": {
+  "$o1 исчезает!": {
+   "en": "$o1 disappears!",
+   "ua": "$o1 зникає!"
+  },
+  "%2$^C1 не может владеть %1$O5 и бросает %1$P2.": {
+   "en": "%2$^C1 can't wield %1$O5 and drops it.",
+   "ua": "%2$^C1 не може володіти %1$O5 і кидає %1$O4."
+  },
+  "Ты не можешь владеть %1$O5 и бросаешь %1$P2.": {
+   "en": "You can't own %1$O5 and drop it.",
+   "ua": "Ти не можеш володіти %1$O5 і кидаєш %1$O4."
+  }
+ },
+ "plug-ins/loadsave/placement.cpp": {
+  "$c1 выходит из тени.": {
+   "en": "$c1 steps out of the shadows.",
+   "ua": "$c1 виходить з тіні."
+  },
+  "$c1 становится видим$gо|ым|ой для окружающих.": {
+   "en": "$c1 becomes visible to those around.",
+   "ua": "$c1 стає видим$gим|им|ою для оточення."
+  },
+  "Ты выходишь из своего укрытия.": {
+   "en": "You come out of your hiding place.",
+   "ua": "Ти виходиш зі свого укриття."
+  },
+  "Ты выходишь из тени.": {
+   "en": "You step out of the shadows.",
+   "ua": "Ти виходиш з тіні."
+  },
+  "Ты становишься видим$gо|ым|ой для окружающих.": {
+   "en": "You become visible to those around you.",
+   "ua": "Ти стаєш видим$gо|им|ою для оточуючих."
+  },
+  "Земля раскалывается, обнаруживая лежавш$gое|его|ую в ней $c2!": {
+   "en": "The ground splits open, revealing $c2 that had been lying inside it!",
+   "ua": "Земля розколюється, виявляючи $c2, що лежа$gло|в|ла в ній!"
+  },
+  "Земля шевелится, и $c1 выкапывается из своей могилы.": {
+   "en": "The earth stirs, and $c1 digs itself out of its own grave.",
+   "ua": "Земля ворушиться, і $c1 викопується зі своєї могили."
+  },
+  "Землятрясение заставляет тебя выбраться из могилы.": {
+   "en": "An earthquake forces you to claw your way out of the grave.",
+   "ua": "Землетрус змушує тебе вибратися з могили."
+  },
+  "Ты выкапываешься из земли.": {
+   "en": "You dig yourself out of the ground.",
+   "ua": "Ти викопуєшся із землі."
+  }
+ },
+ "plug-ins/loadsave/player_exp.cpp": {
+  "{CТебе открыл%1$Iось|ись|ись {Y%1$d{C нов%1$Iое|ых|ых умени%1$Iе|я|й.{x": {
+   "en": "{CYou've unlocked {Y%1$d{C new skill%1$I|s|s.{x",
+   "ua": "{CТобі відкрил%1$Iося|ися|ися {Y%1$d{C нов%1$Iе|их|их умін%1$Iня|ня|ь.{x"
+  },
+  "{CТы дости$gгло|г|гла следующего уровня!!!{x": {
+   "en": "{CYou have reached the next level!!!{x",
+   "ua": "{CТи дося$gгло|г|гла наступного рівня!!!{x"
+  },
+  "Ты больше не можешь получать опыт, пока не выберешь дом.\n\rПрочитай 'справка родной город'.": {
+   "en": "You can no longer gain experience until you choose a home.\n\rRead 'help home city'.",
+   "ua": "Ти більше не можеш отримувати досвід, поки не обереш дім.\n\rПрочитай 'довідка рідне місто'."
+  },
+  "Ты больше не можешь получать опыт, пока тебя не подтвердили Боги.\n\rПрочитай 'справка подтверждение'.": {
+   "en": "You can no longer gain experience until the Gods confirm you.\n\rRead 'help confirm'.",
+   "ua": "Ти більше не можеш отримувати досвід, поки тебе не підтвердили Боги.\n\rПрочитай 'довідка підтвердження'."
+  },
+  "Ты не можешь получать опыт, пока твой дух во власти противника.": {
+   "en": "You can't gain experience while your spirit is in your opponent's power.",
+   "ua": "Ти не можеш отримувати досвід, поки твій дух у владі противника."
+  },
+  "Ты не можешь больше получать опыт в этой арии.": {
+   "en": "You can no longer gain experience in this area.",
+   "ua": "Ти не можеш більше отримувати досвід у цій арії."
+  }
+ },
+ "plug-ins/loadsave/player_menu.cpp": {
+  "{RТакого варианта не было в списке.{x\n": {
+   "en": "{RThere was no such option in the list.{x\n",
+   "ua": "{RТакого варіанта не було в списку.{x\n"
+  },
+  "Напиши номер из списка.": {
+   "en": "Type a number from the list.",
+   "ua": "Напиши номер зі списку."
+  },
+  "Напиши номер или нажми на вариант из списка.": {
+   "en": "Type the number or click an option from the list.",
+   "ua": "Напиши номер або натисни на варіант зі списку."
+  }
+ },
+ "plug-ins/mansion/homerecall.cpp": {
+  "<room vnum> должно быть числом.": {
+   "en": "<room vnum> must be a number.",
+   "ua": "<room vnum> має бути числом."
+  },
+  "Жертва не найдена.": {
+   "en": "Victim not found.",
+   "ua": "Жертву не знайдено."
+  },
+  "Комнаты с таким номером не существует.": {
+   "en": "There's no room with that number.",
+   "ua": "Кімнати з таким номером не існує."
+  },
+  "Персонажу %s установлен дом с меткой %s в комнате [%d] %s.": {
+   "en": "Character %s has been set a home marked %s in room [%d] %s.",
+   "ua": "Персонажу %s встановлено дім з міткою %s у кімнаті [%d] %s."
+  },
+  "Персонажу %s установлен основной дом в комнате [%d] %s.": {
+   "en": "Character %s's primary home has been set to room [%d] %s.",
+   "ua": "Персонажу %s встановлено основний дім у кімнаті [%d] %s."
+  },
+  "Список всех персонажей, имеющих homerecalls: \r\n": {
+   "en": "List of all characters with homerecalls: \r\n",
+   "ua": "Список усіх персонажів, які мають homerecall: \r\n"
+  },
+  "У тебя нет своего дома.": {
+   "en": "You don't have a home of your own.",
+   "ua": "У тебе немає власного дому."
+  },
+  "В лес!": {
+   "en": "Into the forest!",
+   "ua": "У ліс!"
+  }
+ },
+ "plug-ins/mansion/mkey.cpp": {
+  "$C1 вручает $c3 $o4.": {
+   "en": "$C1 hands $o4 to $c3.",
+   "ua": "$C1 вручає $c3 $o4."
+  },
+  "$C1 вручает тебе $o4.": {
+   "en": "$C1 hands you $o4.",
+   "ua": "$C1 вручає тобі $o4."
+  },
+  "$c1 просит $C4 показать список ключей.": {
+   "en": "$c1 asks $C4 to show the list of keys.",
+   "ua": "$c1 просить $C4 показати список ключів."
+  },
+  "%s владеет такими ключами: ": {
+   "en": "%s owns the following keys: ",
+   "ua": "%s володіє такими ключами: "
+  },
+  "Здесь нет ключника.": {
+   "en": "There's no keykeeper here.",
+   "ua": "Тут немає ключника."
+  },
+  "Ключей не найдено.": {
+   "en": "No keys found.",
+   "ua": "Ключів не знайдено."
+  },
+  "Неправильное имя.": {
+   "en": "Invalid name.",
+   "ua": "Неправильне ім'я."
+  },
+  "Неправильный vnum ключа.": {
+   "en": "Invalid key vnum.",
+   "ua": "Неправильний vnum ключа."
+  },
+  "Такого ключа не существует.": {
+   "en": "No such key exists.",
+   "ua": "Такого ключа не існує."
+  },
+  "Такой ключ не найден.": {
+   "en": "No such key found.",
+   "ua": "Такий ключ не знайдено."
+  },
+  "Такой ключ у него уже есть.": {
+   "en": "He already has a key like that.",
+   "ua": "Такий ключ у нього вже є."
+  },
+  "Ты бездомное.": {
+   "en": "You have no home.",
+   "ua": "У тебе немає домівки."
+  },
+  "Ты просишь у $C4 показать список ключей.": {
+   "en": "You ask $C4 to show you the list of keys.",
+   "ua": "Ти просиш у $C4 показати список ключів."
+  }
+ },
+ "plug-ins/misc_behaviors/ofcolguards.cpp": {
+  "$c1 призывает Богов на помощь.": {
+   "en": "$c1 calls upon the Gods for help.",
+   "ua": "$c1 закликає Богів на допомогу."
+  },
+  "Боги призывают $c4 на помощь Диане.": {
+   "en": "The gods summon $c4 to aid Diana.",
+   "ua": "Боги закликають $c4 на допомогу Діані."
+  }
+ },
+ "plug-ins/mlove/divorce.cpp": {
+  "Попроси кого-то помочь тебе.": {
+   "en": "Ask someone to help you.",
+   "ua": "Попроси когось допомогти тобі."
+  },
+  "Это не для тебя.": {
+   "en": "That's not for you.",
+   "ua": "Це не для тебе."
+  },
+  "И кого разводить будем?": {
+   "en": "And who are we getting divorced?",
+   "ua": "І кого розлучати будемо?"
+  },
+  "Это еще как?": {
+   "en": "How's that now?",
+   "ua": "Це ще як?"
+  }
+ },
+ "plug-ins/mlove/lover.cpp": {
+  "Тебе нельзя.": {
+   "en": "You can't.",
+   "ua": "Тобі не можна."
+  },
+  "$c1 ухмыляется - сердцу не прикажешь.": {
+   "en": "$c1 smirks -- the heart wants what it wants.",
+   "ua": "$c1 посміхається -- серцю не накажеш."
+  },
+  "... но сердцу не прикажешь.": {
+   "en": "...but you can't command the heart.",
+   "ua": "...та серцю не накажеш."
+  }
+ },
+ "plug-ins/mlove/marry.cpp": {
+  "Для это церемонии не хватает одного компонента.": {
+   "en": "This ceremony is missing one component.",
+   "ua": "Для цієї церемонії не вистачає одного компонента."
+  },
+  "Попроси кого-то помочь тебе.": {
+   "en": "Ask someone to help you.",
+   "ua": "Попроси когось допомогти тобі."
+  },
+  "Это не для тебя.": {
+   "en": "This isn't for you.",
+   "ua": "Це не для тебе."
+  },
+  "И кого женить будем?": {
+   "en": "And who are we marrying off, then?",
+   "ua": "І кого одружувати будемо?"
+  },
+  "Это еще как?": {
+   "en": "How's that now?",
+   "ua": "Це ще як?"
+  }
+ },
+ "plug-ins/mlove/mlove.cpp": {
+  "Тебе нельзя.": {
+   "en": "You can't.",
+   "ua": "Тобі не можна."
+  },
+  "$c1 гоняется с похотливым видом за всеми в комнате..берегись!": {
+   "en": "$c1 chases everyone in the room with a lecherous look..watch out!",
+   "ua": "$c1 ганяється хтивим поглядом за всіма в кімнаті..бережись!"
+  },
+  "$c1 срывает с $C2 одежду и страстно занимается с $Y любовью.": {
+   "en": "$c1 tears the clothes off $C2 and passionately makes love to them.",
+   "ua": "$c1 зриває з $C2 одяг і пристрасно займається з ними коханням."
+  },
+  "$c1 срывает с тебя одежду и страстно занимается с тобой любовью. Ах, да! Еще, еще!": {
+   "en": "$c1 tears off your clothes and makes passionate love to you. Oh yes! More, more!",
+   "ua": "$c1 зриває з тебе одяг і пристрасно кохається з тобою. Ах так! Ще, ще!"
+  },
+  "$c1 торжественно произносит: '{gMake love, not war!{x'": {
+   "en": "$c1 solemnly declares: '{gMake love, not war!{x'",
+   "ua": "$c1 урочисто виголошує: '{gMake love, not war!{x'"
+  },
+  "$c1 ухмыляется - сердцу не прикажешь.": {
+   "en": "$c1 smirks -- the heart wants what it wants.",
+   "ua": "$c1 посміхається -- серцю не накажеш."
+  },
+  "... но сердцу не прикажешь.": {
+   "en": "... but you can't command the heart.",
+   "ua": "... але серцю не накажеш."
+  },
+  "Быстро спрячь, пока не отрезали!": {
+   "en": "Hide it quick, before someone cuts it off!",
+   "ua": "Швидко сховай, поки не відрізали!"
+  },
+  "Да! Ты любишь себя! Еще, еще..!": {
+   "en": "Yes! You love yourself! More, more..!",
+   "ua": "Так! Ти любиш себе! Ще, ще..!"
+  },
+  "Куда пойти, куда податься.. кого найти, кому отдаться?": {
+   "en": "Where to go, where to turn... who to find, who to give yourself to?",
+   "ua": "Куди піти, куди податися... кого знайти, кому віддатися?"
+  },
+  "Объект твоей страсти куда-то подевался.": {
+   "en": "The object of your affection has wandered off somewhere.",
+   "ua": "Об'єкт твоєї пристрасті кудись подівся."
+  },
+  "Страсть $c1 к само$gму|му|й себе пользуется полной взаимностью.": {
+   "en": "$c1's passion for themselves is fully reciprocated.",
+   "ua": "Пристрасть $c1 до сам$gого|ого|ої себе є цілком взаємною."
+  },
+  "Ты никак не можешь определиться: куда совать жетон?": {
+   "en": "You just can't decide where to stick the token.",
+   "ua": "Ти ніяк не можеш визначитися: куди совати жетон?"
+  },
+  "Эй, не отвлекайся!": {
+   "en": "Hey, don't get distracted!",
+   "ua": "Гей, не відволікайся!"
+  }
+ },
+ "plug-ins/mlove/mtalk.cpp": {
+  "Сказать что?": {
+   "en": "Say what?",
+   "ua": "Сказати що?"
+  },
+  "Твой муж отсутствует в мире.": {
+   "en": "Your husband is not in the world.",
+   "ua": "Твій чоловік відсутній у світі."
+  },
+  "Твоя жена отсутствует в мире.": {
+   "en": "Your wife is not in the world right now.",
+   "ua": "Твоєї дружини немає у світі."
+  },
+  "Тебе нельзя.": {
+   "en": "You're not allowed.",
+   "ua": "Тобі не можна."
+  },
+  "Сначала женись, потом поговорим.": {
+   "en": "Get married first, then we'll talk.",
+   "ua": "Спершу одружись, потім поговоримо."
+  }
+ },
+ "plug-ins/note/dreams.cpp": {
+  "Смертным приснили {W%1$d{x нов%1$Iый|ых|ых с%1$Iон|на|нов ('{yсон{x').": {
+   "en": "Mortals were sent {W%1$d{x new dream%1$I|s|s ('{ydream{x').",
+   "ua": "Смертним наснилося {W%1$d{x нов%1$Iий|і|их с%1$Iон|ни|нів ('{yсон{x')."
+  }
+ },
+ "plug-ins/note/genericnotes.cpp": {
+  "Тебя ожида%1$Iет|ют|ют {W%1$d{x сообщен%1$Iие|ия|ий о глобальн%1$Iом|ых|ых квест%1$Iе|ах|ах ('{hc{yквестнота{x').": {
+   "en": "You have {W%1$d{x message%1$I|s|s waiting about a global quest%1$I|s|s ('{hc{yquestnote{x').",
+   "ua": "Тебе очіку%1$Iє|ють|ють {W%1$d{x повідомлен%1$Iня|ня|ь про глобальн%1$Iий|і|і квест%1$Iи|и|ів ('{hc{yквестнота{x')."
+  }
+ },
+ "plug-ins/note/notecommand.cpp": {
+  "%^N3 номер %d установлены флаги %s.": {
+   "en": "%^N3 number %d has flags set: %s.",
+   "ua": "%^N3 номер %d встановлено прапорці %s."
+  },
+  "Боги лишили тебя возможности писать сообщения.": {
+   "en": "The gods have stripped you of the ability to write messages.",
+   "ua": "Боги позбавили тебе можливості писати повідомлення."
+  },
+  "Больше нечего удалять.": {
+   "en": "There is nothing more to delete.",
+   "ua": "Більше нічого видаляти."
+  },
+  "Все %N1 помечены как непрочитанные.": {
+   "en": "All %N1 have been marked as unread.",
+   "ua": "Усі %N1 позначено як непрочитані."
+  },
+  "Все %N2, начиная с номера %d, помечены как непрочитанные.": {
+   "en": "All %N2 starting from number %d have been marked as unread.",
+   "ua": "Усі %N2, починаючи з номера %d, позначено як непрочитані."
+  },
+  "Используйте команду '%s save' для сохранения изменений на диск.": {
+   "en": "Use the '%s save' command to save changes to disk.",
+   "ua": "Використовуй команду '%s save' для збереження змін на диск."
+  },
+  "Не найдено ни одного сообщения.": {
+   "en": "No messages found.",
+   "ua": "Не знайдено жодного повідомлення."
+  },
+  "Неверная команда, смотри {W? письмо синтаксис{x.": {
+   "en": "Invalid command, see {W? letter syntax{x.",
+   "ua": "Невірна команда, дивись {W? лист синтаксис{x."
+  },
+  "Неправильный номер письма.": {
+   "en": "Invalid letter number.",
+   "ua": "Неправильний номер листа."
+  },
+  "Перенаправить какой номер?": {
+   "en": "Redirect which number?",
+   "ua": "Перенаправити який номер?"
+  },
+  "Подделка документов запрещена!": {
+   "en": "Forging documents is forbidden!",
+   "ua": "Підробка документів заборонена!"
+  },
+  "Прочесть какой номер?": {
+   "en": "Read which number?",
+   "ua": "Прочитати який номер?"
+  },
+  "Скопировать какой номер?": {
+   "en": "Copy which number?",
+   "ua": "Скопіювати який номер?"
+  },
+  "Так много %N2 еще не написали.": {
+   "en": "So much %N2 hasn't been written yet.",
+   "ua": "Так багато %N2 ще не написали."
+  },
+  "Текущее сообщение скопировано в буфер.": {
+   "en": "The current message has been copied to the buffer.",
+   "ua": "Поточне повідомлення скопійовано в буфер."
+  },
+  "Ты не можешь ничего написать, пока тебя не подтвердили Боги.": {
+   "en": "You can't write anything until the Gods have approved you.",
+   "ua": "Ти не можеш нічого написати, поки тебе не підтвердили Боги."
+  },
+  "Ты не можешь удалить это сообщение, т.к. не являешься его автором.": {
+   "en": "You can't delete this message because you're not its author.",
+   "ua": "Ти не можеш видалити це повідомлення, оскільки не є його автором."
+  },
+  "Ты не можешь читать {W%N4{x.": {
+   "en": "You can't read {W%N4{x.",
+   "ua": "Ти не можеш читати {W%N4{x."
+  },
+  "Ты не редактируешь сообщение, копировать нечего.": {
+   "en": "You're not editing a message, there's nothing to copy.",
+   "ua": "Ти не редагуєш повідомлення, копіювати нічого."
+  },
+  "У тебя недостаточно привилегий для написания {W%N2{x.": {
+   "en": "You don't have enough privileges to write {W%N2{x.",
+   "ua": "У тебе недостатньо привілеїв для написання {W%N2{x."
+  },
+  "У тебя нет непрочитанных %N2.": {
+   "en": "You have no unread %N2.",
+   "ua": "У тебе немає непрочитаних %N2."
+  },
+  "Удалить какой номер?": {
+   "en": "Delete which number?",
+   "ua": "Видалити який номер?"
+  },
+  "Укажите номер письма.": {
+   "en": "Specify the letter number.",
+   "ua": "Вкажи номер листа."
+  },
+  "Флаг не найден.": {
+   "en": "Flag not found.",
+   "ua": "Прапор не знайдено."
+  },
+  "Что-то пошло не так, письмо не найдено.": {
+   "en": "Something went wrong, the letter wasn't found.",
+   "ua": "Щось пішло не так, лист не знайдено."
+  }
+ },
+ "plug-ins/note/notehooks.cpp": {
+  "Все новости и изменения сохранены в %s.": {
+   "en": "All news and changes have been saved to %s.",
+   "ua": "Усі новини та зміни збережено в %s."
+  },
+  "Какой именно вид сообщений нужно сохранить на диск?": {
+   "en": "Which specific type of messages needs to be saved to disk?",
+   "ua": "Який саме вид повідомлень треба зберегти на диск?"
+  },
+  "Команда 'webdump' не поддерживается для этого вида сообщений.": {
+   "en": "The 'webdump' command isn't supported for this type of message.",
+   "ua": "Команда 'webdump' не підтримується для цього типу повідомлень."
+  },
+  "Современные истории сохранены в %s.": {
+   "en": "Current stories saved to %s.",
+   "ua": "Сучасні історії збережено в %s."
+  },
+  "Старые истории сохранены в %s.": {
+   "en": "Old stories have been saved to %s.",
+   "ua": "Старі історії збережено в %s."
+  },
+  "Что?": {
+   "en": "What?",
+   "ua": "Що?"
+  }
+ },
+ "plug-ins/note/unread.cpp": {
+  "Ты не закончи%Gло|л|ла писать {W%N4{x!": {
+   "en": "You haven't finished writing {W%N4{x!",
+   "ua": "Ти не закінчи%Gло|в|ла писати {W%N4{x!"
+  },
+  "У тебя нет непрочитанных сообщений.": {
+   "en": "You have no unread messages.",
+   "ua": "У тебе немає непрочитаних повідомлень."
+  }
+ },
+ "plug-ins/other_skills/draconian.cpp": {
+  "$c1 брызгает кислотой на $C4.": {
+   "en": "$c1 sprays acid on $C4.",
+   "ua": "$c1 бризкає кислотою на $C4."
+  },
+  "$c1 становится сильнее.": {
+   "en": "$c1 grows stronger.",
+   "ua": "$c1 набуває сили."
+  },
+  "Ты брызгаешь кислотой на $C4.": {
+   "en": "You spray acid on $C4.",
+   "ua": "Ти бризкаєш кислотою на $C4."
+  },
+  "$c1 брызгает струей едкой кислоты на тебя.": {
+   "en": "$c1 sprays a jet of caustic acid at you.",
+   "ua": "$c1 бризкає струменем їдкої кислоти на тебе."
+  },
+  "$c1 выдыхает воронку бушующего огня.": {
+   "en": "$c1 exhales a funnel of raging fire.",
+   "ua": "$c1 видихає вирву шаленого вогню."
+  },
+  "$c1 выдыхает воронку ядовитого газа!": {
+   "en": "$c1 exhales a cone of poisonous gas!",
+   "ua": "$c1 видихає конус отруйного газу!"
+  },
+  "$c1 выдыхает леденящую воронку инея!": {
+   "en": "$c1 exhales a chilling vortex of frost!",
+   "ua": "$c1 видихає крижаний вихор інею!"
+  },
+  "$c1 выдыхает на тебя воронку бушующего огня!": {
+   "en": "$c1 breathes out a swirling vortex of raging fire at you!",
+   "ua": "$c1 видихає на тебе вирву шаленого вогню!"
+  },
+  "$c1 выдыхает на тебя леденящую воронку инея!": {
+   "en": "$c1 breathes an icy funnel of frost at you!",
+   "ua": "$c1 видихає на тебе крижану вирву паморозі!"
+  },
+  "Выдох $c2 ударяет по $C3 разрядом молнии.": {
+   "en": "$c2's breath strikes $C3 with a bolt of lightning.",
+   "ua": "Видих $c2 вражає $C3 розрядом блискавки."
+  },
+  "Выдох $c2 ударяет по тебе разрядом молнии!": {
+   "en": "$c2's breath strikes you with a bolt of lightning!",
+   "ua": "Видих $c2 вражає тебе розрядом блискавки!"
+  },
+  "Сила Дракона пронизывает тебя.": {
+   "en": "The Dragon's Power surges through you.",
+   "ua": "Сила Дракона пронизує тебе."
+  },
+  "Сила Дракона уже переполняет тебя.": {
+   "en": "The Dragon's Power already overflows within you.",
+   "ua": "Сила Дракона вже переповнює тебе."
+  },
+  "Твой выдох ударяет по $C3 разрядом молнии.": {
+   "en": "Your breath strikes $C3 with a bolt of lightning.",
+   "ua": "Твій видих вдаряє $C3 розрядом блискавки."
+  },
+  "Ты выдыхаешь воронку бушующего огня.": {
+   "en": "You breathe out a funnel of raging fire.",
+   "ua": "Ти видихаєш вирву шаленого вогню."
+  },
+  "Ты выдыхаешь воронку инея.": {
+   "en": "You breathe out a funnel of frost.",
+   "ua": "Ти видихаєш лійку інею."
+  },
+  "Ты выдыхаешь воронку ядовитого газа.": {
+   "en": "You exhale a funnel of poison gas.",
+   "ua": "Ти видихаєш вирву отруйного газу."
+  }
+ },
+ "plug-ins/other_skills/items.cpp": {
+  "$c1 выглядит лучше.": {
+   "en": "$c1 looks better.",
+   "ua": "$c1 виглядає краще."
+  },
+  "Кассандра использовалась совсем недавно.": {
+   "en": "Cassandra was used quite recently.",
+   "ua": "Кассандра використовувалася зовсім нещодавно."
+  },
+  "Ты совсем недавно пользовал%1$Gось|ся|ась этим заклинанием.": {
+   "en": "You've only just used this spell.",
+   "ua": "Ти зовсім нещодавно користу%1$Gвалося|вався|валася цим закляттям."
+  },
+  "Ты уже чувствуешь присутствие скрытых сил. ": {
+   "en": "You already sense the presence of hidden forces. ",
+   "ua": "Ти вже відчуваєш присутність прихованих сил. "
+  },
+  "$C1 уже чувствует присутствие скрытых сил.": {
+   "en": "$C1 already senses the presence of hidden forces.",
+   "ua": "$C1 вже відчуває присутність прихованих сил."
+  },
+  "Волна тепла согревает твое тело.": {
+   "en": "A wave of warmth heats your body.",
+   "ua": "Хвиля тепла зігріває твоє тіло."
+  },
+  "Кассандра использовалась для этой же цели совсем недавно.": {
+   "en": "The Cassandra was used for this very purpose quite recently.",
+   "ua": "Кассандру використовували з цією ж метою зовсім недавно."
+  },
+  "Таинственный щит окружает $c4.": {
+   "en": "A mysterious shield surrounds $c4.",
+   "ua": "Таємничий щит оточує $c4."
+  },
+  "Таинственный щит окружает тебя.": {
+   "en": "A mysterious shield surrounds you.",
+   "ua": "Таємничий щит оточує тебе."
+  },
+  "Теперь ты чувствуешь присутствие скрытых сил.": {
+   "en": "Now you can feel the presence of hidden forces.",
+   "ua": "Тепер ти відчуваєш присутність прихованих сил."
+  }
+ },
+ "plug-ins/output/messengers.cpp": {
+  "%1$^C1 достиг%1$Gло||ла следующей ступени мастерства.": {
+   "en": "%1$^C1 has reached the next stage of mastery.",
+   "ua": "%1$^C1 досяг%1$Gло||ла наступного ступеня майстерності."
+  },
+  "%1$^C1 достиг%1$Gло||ла уровня героя!": {
+   "en": "%1$^C1 has reached hero level!",
+   "ua": "%1$^C1 досяг%1$Gло||ла рівня героя!"
+  }
+ },
+ "plug-ins/quest/bigquest/bandamobile.cpp": {
+  "{YКто-то из целей текущего задания погиб без твоего участия.{x": {
+   "en": "{YOne of the targets of your current quest has died without your involvement.{x",
+   "ua": "{YХтось із цілей поточного завдання загинув без твоєї участі.{x"
+  },
+  "{YПротив тебя у %2$P4 не было никаких шансов!{x": {
+   "en": "{YThey never stood a chance against you!{x",
+   "ua": "{YПроти тебе в них не було жодних шансів!{x"
+  },
+  "{YТвой согрупник помог тебе уничтожить очередную цель задания.{x": {
+   "en": "{YYour group member helped you destroy another quest target.{x",
+   "ua": "{YТвій согрупник допоміг тобі знищити чергову ціль завдання.{x"
+  },
+  "Он ярко вспыхивает и исчезает.": {
+   "en": "It flares up brightly and disappears.",
+   "ua": "Він яскраво спалахує і зникає."
+  },
+  "{YМолодец, тебе удалось избавить мир от очередной напасти.{x": {
+   "en": "{YWell done, you managed to rid the world of yet another scourge.{x",
+   "ua": "{YМолодець, тобі вдалося позбавити світ від чергової напасті.{x"
+  },
+  "{YТы помог%1$Gло||ла согрупнику уничтожить очередную цель задания, браво.{x": {
+   "en": "{YYou helped a group member destroy another quest target, bravo.{x",
+   "ua": "{YТи допом%1$Gогло|іг|огла товаришу по групі знищити чергову ціль завдання, браво.{x"
+  },
+  "{YТы уничтожил%1$Gо||а очередную цель, браво.{x": {
+   "en": "{YYou destroyed another target, bravo.{x",
+   "ua": "{YТи нада$gло|в|ла неоціненну послугу всьому світові, вбивши його!!!{x"
+  },
+  "Мерцающая аура окружает $o4.": {
+   "en": "A flickering aura surrounds $o4.",
+   "ua": "Мерехтлива аура оточує $o4."
+  },
+  "Он вспыхивает и исчезает, оставив на своем месте {C1000{x очков опыта.": {
+   "en": "It flares up and vanishes, leaving {C1000{x experience points in its place.",
+   "ua": "Він спалахує і зникає, залишивши на своєму місці {C1000{x очок досвіду."
+  }
+ },
+ "plug-ins/quest/bigquest/bigquest.cpp": {
+  "{YВсе разбежались или были уничтожены, сообщи квестору о выполнении задания.{x": {
+   "en": "{YEveryone has fled or been destroyed, report to the quest giver that the task is complete.{x",
+   "ua": "{YУсі розбіглися або були знищені, повідом квестодавцю про виконання завдання.{x"
+  },
+  "{YТебе осталось уничтожить %d из %d, или же сообщить квестору о частичном выполнении задания.{x": {
+   "en": "{YYou have %d of %d left to destroy, or you can report partial completion of the task to the quest giver.{x",
+   "ua": "{YТобі залишилось знищити %d з %d, або повідомити квестодавцю про часткове виконання завдання.{x"
+  },
+  "{YТебе осталось уничтожить %d из %d.{x": {
+   "en": "{YYou have %d out of %d left to destroy.{x",
+   "ua": "{YТобі залишилося знищити %d з %d.{x"
+  },
+  "Уничтожить %1$d преступник%1$Iа|ов|ов из '%2$s' (убито %3$d).": {
+   "en": "Destroy %1$d criminal%1$I|s|s from '%2$s' (killed %3$d).",
+   "ua": "Знищити %1$d злочинц%1$Iя|ів|ів із '%2$s' (вбито %3$d)."
+  }
+ },
+ "plug-ins/quest/butcherquest/steakcustomer.cpp": {
+  "$c1 возвращает $C5 $o4.": {
+   "en": "$c1 returns $o4 to $C5.",
+   "ua": "$c1 повертає $o4 $C5."
+  },
+  "$c1 возвращает тебе $o4.": {
+   "en": "$c1 returns $o4 to you.",
+   "ua": "$c1 повертає тобі $o4."
+  },
+  "$c1 выжидающе смотрит на тебя.": {
+   "en": "$c1 looks at you expectantly.",
+   "ua": "$c1 вичікувально дивиться на тебе."
+  },
+  "$c1 куда-то прячет $o4.": {
+   "en": "$c1 hides $o4 somewhere.",
+   "ua": "$c1 кудись ховає $o4."
+  },
+  "{YЗаказ отменен в связи с кончиной заказчика.{x": {
+   "en": "{YThe order has been cancelled due to the customer's untimely demise.{x",
+   "ua": "{YЗамовлення скасовано у зв'язку зі смертю замовника.{x"
+  }
+ },
+ "plug-ins/quest/command/cquest.cpp": {
+  "%s: имя не найдено.": {
+   "en": "%s: name not found.",
+   "ua": "%s: ім'я не знайдено."
+  },
+  "{WЗадание квестора{x": {
+   "en": "{WQuestor's Task{x",
+   "ua": "{WЗавдання квестора{x"
+  },
+  "Для отмены задания квестора необходимо стоять рядом с ним.": {
+   "en": "To cancel the questor's task, you need to stand next to them.",
+   "ua": "Щоб скасувати завдання квестора, потрібно стояти поруч із ним."
+  },
+  "Здесь нет торговца квестовыми наградами.": {
+   "en": "There's no quest-reward trader here.",
+   "ua": "Тут немає торговця квестовими нагородами."
+  },
+  "Неверное количество побед.": {
+   "en": "Invalid number of victories.",
+   "ua": "Невірна кількість перемог."
+  },
+  "Неправильный ID.": {
+   "en": "Invalid ID.",
+   "ua": "Неправильний ID."
+  },
+  "Список текущих квестов показывает команда {yквест{x.": {
+   "en": "Use the {yквест{x command to see the list of your current quests.",
+   "ua": "Список поточних квестів показує команда {yквест{x."
+  },
+  "Твое задание не нужно отменять, оно исчезнет как только ты сойдешь с корабля.": {
+   "en": "You don't need to cancel your quest, it will disappear as soon as you disembark from the ship.",
+   "ua": "Твоє завдання не потрібно скасовувати, воно зникне, щойно ти зійдеш з корабля."
+  },
+  "У тебя {Y%d{x квестов%s единиц%s.": {
+   "en": "You have {Y%d{x quest%s point%s.",
+   "ua": "У тебе {Y%d{x квестов%s одиниц%s."
+  },
+  "Эта команда недоступна пока ты на корабле.": {
+   "en": "This command isn't available while you're on a ship.",
+   "ua": "Ця команда недоступна, поки ти на кораблі."
+  },
+  "Эту команду можно выполнить только рядом с квестором.": {
+   "en": "This command can only be used near a quest giver.",
+   "ua": "Цю команду можна виконати лише поруч із квестодавцем."
+  },
+  "Наслаждение жизнью недоступно призракам.": {
+   "en": "Enjoying life isn't available to ghosts.",
+   "ua": "Насолода життям недоступна привидам."
+  }
+ },
+ "plug-ins/quest/command/questmaster.cpp": {
+  "$c1 что-то говорит $C3.": {
+   "en": "$c1 says something to $C3.",
+   "ua": "$c1 щось каже $C3."
+  }
+ },
+ "plug-ins/quest/command/questor.cpp": {
+  "$C1 дает $c3 $o4.": {
+   "en": "$C1 gives $o4 to $c3.",
+   "ua": "$C1 дає $o4 $c3."
+  },
+  "$C1 дает тебе $o4.": {
+   "en": "$C1 gives you $o4.",
+   "ua": "$C1 дає тобі $o4."
+  },
+  "$c1 информирует $C4 о выполнении задания.": {
+   "en": "$c1 informs $C4 that the quest has been completed.",
+   "ua": "$c1 інформує $C4 про виконання завдання."
+  },
+  "$c1 просит $C4 дать $m задание.": {
+   "en": "$c1 asks $C4 for a task.",
+   "ua": "$c1 просить $C4 дати завдання."
+  },
+  "$c1 просит $C4 показать список заданий.": {
+   "en": "$c1 asks $C4 to show the list of quests.",
+   "ua": "$c1 просить $C4 показати список завдань."
+  },
+  "$c1 просит помощи у $C2.": {
+   "en": "$c1 asks $C2 for help.",
+   "ua": "$c1 просить допомоги у $C2."
+  },
+  "%1$^C1 возвраща%1$nет|ют %2$O4 %3$C3.": {
+   "en": "%1$^C1 return%1$ns| %2$O4 to %3$C3.",
+   "ua": "%1$^C1 поверта%1$nє|ють %2$O4 %3$C3."
+  },
+  "%1$^C1 возвраща%1$nет|ют тебе %2$O4.": {
+   "en": "%1$^C1 return%1$ns| %2$O4 to you.",
+   "ua": "%1$^C1 поверта%1$nє|ють тобі %2$O4."
+  },
+  "Знания, заключенные в $o6, недоступны тебе.": {
+   "en": "The knowledge contained in $o6 is inaccessible to you.",
+   "ua": "Знання, укладені в $o6, недоступні тобі."
+  },
+  "Ты внимательно изучаешь знаки на $o6.": {
+   "en": "You carefully study the markings on $o6.",
+   "ua": "Ти уважно вивчаєш знаки на $o6."
+  },
+  "Ты информируешь $C4 о выполнении задания.": {
+   "en": "You inform $C4 that the quest is complete.",
+   "ua": "Ти інформуєш $C4 про виконання завдання."
+  },
+  "Ты просишь $C4 дать тебе задание.": {
+   "en": "You ask $C4 to give you a task.",
+   "ua": "Ти просиш $C4 дати тобі завдання."
+  },
+  "Ты просишь $C4 отменить $S задание.": {
+   "en": "You ask $C4 to cancel the quest.",
+   "ua": "Ти просиш $C4 скасувати завдання."
+  },
+  "Ты просишь $C4 показать список заданий.": {
+   "en": "You ask $C4 to show the quest list.",
+   "ua": "Ти просиш $C4 показати список завдань."
+  },
+  "Ты просишь помощи у $C2.": {
+   "en": "You ask $C2 for help.",
+   "ua": "Ти просиш допомоги у $C2."
+  },
+  "Чернила меркнут, и $o1 рассыпается трухой.": {
+   "en": "The ink fades, and $o1 crumbles to dust.",
+   "ua": "Чорнило блякне, і $o1 розсипається трухою."
+  }
+ },
+ "plug-ins/quest/command/questtrader.cpp": {
+  "$C1 дает $t золотых монет $c3.": {
+   "en": "$C1 gives $t gold coins to $c3.",
+   "ua": "$C1 дає $t золотих монет $c3."
+  },
+  "$C1 дает тебе $o4.": {
+   "en": "$C1 gives you $o4.",
+   "ua": "$C1 дає тобі $o4."
+  },
+  "$C1 дает тебе $t золотых монет.": {
+   "en": "$C1 gives you $t gold coins.",
+   "ua": "$C1 дає тобі $t золотих монет."
+  },
+  "$C1 наносит тебе $o4!": {
+   "en": "$C1 hits you with $o4!",
+   "ua": "$C1 завдає тобі удару $o4!"
+  },
+  "$C1 повышает твое телосложение.": {
+   "en": "$C1 increases your constitution.",
+   "ua": "$C1 підвищує твою статуру."
+  },
+  "$C1 повышает телосложение $c2.": {
+   "en": "$C1 increases $c2's constitution.",
+   "ua": "$C1 підвищує статуру $c2."
+  },
+  "$C1 прикрепляет огромный брелок к $o3.": {
+   "en": "$C1 attaches a huge keychain to $o3.",
+   "ua": "$C1 прикріплює величезний брелок до $o3."
+  },
+  "$C1 пришивает $c5 карманы на $o4.": {
+   "en": "$C1 sews pockets for $c5 onto $o4.",
+   "ua": "$C1 пришиває $c5 кишені на $o4."
+  },
+  "$c1 о чем-то просит $C4.": {
+   "en": "$c1 asks $C4 for something.",
+   "ua": "$c1 про щось просить $C4."
+  },
+  "$c1 просит $C4 показать список вещей.": {
+   "en": "$c1 asks $C4 to show the list of items.",
+   "ua": "$c1 просить $C4 показати список речей."
+  },
+  "Перечень квестовых вещей для покупки:": {
+   "en": "List of quest items available for purchase:",
+   "ua": "Перелік квестових речей для покупки:"
+  },
+  "Ты просишь $C4 показать список вещей.": {
+   "en": "You ask $C4 to show the list of items.",
+   "ua": "Ти просиш $C4 показати список речей."
+  },
+  "$C1 дает $o4 $c3.": {
+   "en": "$C1 gives $o4 to $c3.",
+   "ua": "$C1 дає $o4 $c3."
+  },
+  "$C1 достает огромный гвоздь и молниеносно пробивает дырку в мочке уха $c2.": {
+   "en": "$C1 pulls out a huge nail and instantly punches a hole in $c2's earlobe.",
+   "ua": "$C1 дістає величезний цвях і блискавично пробиває дірку в мочці вуха $c2."
+  },
+  "$C1 достает огромный гвоздь и молниеносно пробивает дырку в твоей мочке уха. АЙ!": {
+   "en": "$C1 pulls out a huge nail and instantly punches a hole through your earlobe. OW!",
+   "ua": "$C1 дістає величезного цвяха і блискавично пробиває дірку в твоїй мочці вуха. ОЙ!"
+  },
+  "$C1 наносит $c3 $o4!": {
+   "en": "$C1 hits $c3 with $o4!",
+   "ua": "$C1 б'є $c3 $o4!"
+  },
+  "$C1 пришивает карманы на $o4.": {
+   "en": "$C1 sews pockets onto $o4.",
+   "ua": "$C1 пришиває кишені на $o4."
+  }
+ },
+ "plug-ins/quest/core/areaquestcleanupplugin.cpp": {
+  "\r\n{yЗадание {Y%s{y будет отменено из-за неактивности.{x": {
+   "en": "\r\n{yQuest {Y%s{y will be canceled due to inactivity.{x",
+   "ua": "\r\n{yЗавдання {Y%s{y буде скасовано через бездіяльність.{x"
+  }
+ },
+ "plug-ins/quest/core/questentity.cpp": {
+  "{YТвоё задание уже невозможно выполнить. Через несколько минут сможешь попросить новое.{x": {
+   "en": "{YYour task can no longer be completed. In a few minutes you'll be able to request a new one.{x",
+   "ua": "{YТвоє завдання вже неможливо виконати. За кілька хвилин зможеш попросити нове.{x"
+  }
+ },
+ "plug-ins/quest/core/xmlattributequestdata.cpp": {
+  "Время, отведенное на задание, вышло!": {
+   "en": "Time's up for the quest!",
+   "ua": "Час, відведений на завдання, вийшов!"
+  },
+  "Теперь ты снова можешь взять задание.": {
+   "en": "Now you can take on a quest again.",
+   "ua": "Тепер ти знову можеш взяти завдання."
+  },
+  "Поторопись! Время, отведенное на выполнение задания, заканчивается!": {
+   "en": "Hurry up! The time allotted for the quest is running out!",
+   "ua": "Поспіши! Час, відведений на виконання завдання, закінчується!"
+  }
+ },
+ "plug-ins/quest/healquest/patientbehavior.cpp": {
+  "{YКто-то другой полностью излечил твоего пациента.{x": {
+   "en": "{YSomeone else has fully healed your patient.{x",
+   "ua": "{YХтось інший повністю вилікував твого пацієнта.{x"
+  },
+  "{YТы излечи%Gло|л|ла пациента от одного из недугов.{x": {
+   "en": "{YYou cured the patient of one of their ailments.{x",
+   "ua": "{YТи виліку%Gвало|вав|вала пацієнта від одного з недугів.{x"
+  },
+  "Вернись за вознаграждением к давшему тебе задание до того, как истечет время!": {
+   "en": "Return to whoever gave you the quest for your reward before time runs out!",
+   "ua": "Повернись за винагородою до того, хто дав тобі завдання, поки не сплив час!"
+  },
+  "Вернись к квестору за утешительным призом.": {
+   "en": "Go back to the questor for a consolation prize.",
+   "ua": "Повернись до квестора за втішним призом."
+  },
+  "Это отрицательно скажется на общем размере вознаграждения.": {
+   "en": "This will negatively affect the total reward amount.",
+   "ua": "Це негативно позначиться на загальному розмірі винагороди."
+  },
+  "{YКому-то удалось избавить твоего пациента от одного из недугов.{x": {
+   "en": "{YSomeone managed to rid your patient of one of their ailments.{x",
+   "ua": "{YКомусь вдалося позбавити твого пацієнта від однієї з недуг.{x"
+  },
+  "{YПациент отправился на тот свет без твоей помощи.{x": {
+   "en": "{YThe patient departed for the great beyond without your help.{x",
+   "ua": "{YПацієнт відправився на той світ без твоєї допомоги.{x"
+  },
+  "{YСперва лечим, затем калечим?{x": {
+   "en": "{YFirst we heal, then we maim?{x",
+   "ua": "{YСпершу лікуємо, потім калічимо?{x"
+  },
+  "{YТы вылечи%Gло|л|ла пациента сразу от всех болезней >8){x": {
+   "en": "{YYou cured the patient of all illnesses at once >8){x",
+   "ua": "{YТи вилікува%Gло|в|ла пацієнта одразу від усіх хвороб >8){x"
+  },
+  "{YЧто ж ты творишь! Тебя лечить позвали.{x": {
+   "en": "{YWhat are you doing! You were called to be healed.{x",
+   "ua": "{YЩо ж ти робиш! Тебе лікувати покликали.{x"
+  },
+  "Твое задание {YВЫПОЛНЕНО{x!": {
+   "en": "Your quest is {YCOMPLETE{x!",
+   "ua": "Твоє завдання {YВИКОНАНО{x!"
+  }
+ },
+ "plug-ins/quest/kidnapquest/king.cpp": {
+  "Задание отменено. Через минуту сможешь получить новое.": {
+   "en": "Quest cancelled. You'll be able to get a new one in a minute.",
+   "ua": "Завдання скасовано. Через хвилину зможеш отримати нове."
+  },
+  "Глюк! $C4 нечего тебе дать.": {
+   "en": "Glitch! $C4 has nothing to give you.",
+   "ua": "Глюк! $C4 нема чого тобі дати."
+  }
+ },
+ "plug-ins/quest/kidnapquest/prince.cpp": {
+  "$c1 бросает $o4.": {
+   "en": "$c1 throws $o4.",
+   "ua": "$c1 кидає $o4."
+  }
+ },
+ "plug-ins/quest/kidnapquest/scenario_bidon.cpp": {
+  "$c1 безо всякого интереса смотрит на $o4.": {
+   "en": "$c1 looks at $o4 with no interest whatsoever.",
+   "ua": "$c1 без жодного інтересу дивиться на $o4."
+  },
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "$c1 дает $C3 новый $o4.": {
+   "en": "$c1 gives $C3 a new $o4.",
+   "ua": "$c1 дає $C3 новий $o4."
+  },
+  "$c1 дает тебе новый $o4.": {
+   "en": "$c1 gives you a new $o4.",
+   "ua": "$c1 дає тобі новий $o4."
+  },
+  "$c1 озадаченно оглядывается по сторонам.": {
+   "en": "$c1 looks around in confusion.",
+   "ua": "$c1 спантеличено озирається навколо."
+  },
+  "%s и %s уже встретились.": {
+   "en": "%s and %s have already met.",
+   "ua": "%s і %s вже зустрілися."
+  },
+  "{YЗадание отменяется.{x": {
+   "en": "{YThe quest is being cancelled.{x",
+   "ua": "{YЗавдання скасовується.{x"
+  },
+  "Приди к $C3 за благодарностью!": {
+   "en": "Come to $C3 for your reward!",
+   "ua": "Прийди до $C3 за подякою!"
+  },
+  "$c1 глубоко затягивается огромной сигарой.": {
+   "en": "$c1 takes a deep drag on an enormous cigar.",
+   "ua": "$c1 глибоко затягується величезною сигарою."
+  },
+  "$c1 говорит тебе '{GА предыдущий ты слома$Gло|л|ла?{x'": {
+   "en": "$c1 says to you '{GAnd did you break the previous one?{x'",
+   "ua": "$c1 каже тобі '{GА попередній ти слома$Gло|в|ла?{x'"
+  },
+  "$c1 говорит тебе '{GВозьми этот бидончик и передай ей...{x'": {
+   "en": "$c1 tells you '{GTake this little can and give it to her...{x'",
+   "ua": "$c1 каже тобі '{GВізьми цей бідончик і передай їй...{x'"
+  },
+  "$c1 говорит тебе '{GВот уже прошли сутки, а ее все нет. Я очень волнуюсь.{x'": {
+   "en": "$c1 says to you '{GA whole day has passed already, and she's still not back. I'm very worried.{x'",
+   "ua": "$c1 каже тобі '{GОсь уже минула доба, а її все немає. Я дуже хвилююся.{x'"
+  },
+  "$c1 говорит тебе '{GИ учти, что через {Y%d{G минут%s мое терпение лопнет!{x'": {
+   "en": "$c1 tells you '{GAnd keep in mind, in {Y%d{G minute%s my patience will run out!{x'",
+   "ua": "$c1 каже тобі '{GІ май на увазі, що через {Y%d{G хвилин%s моє терпіння урветься!{x'"
+  },
+  "$c1 говорит тебе '{GИди скорее за наградой к тому, кто дал тебе задание!{x'.": {
+   "en": "$c1 tells you '{GHurry to collect your reward from whoever gave you the quest!{x'.",
+   "ua": "$c1 каже тобі '{GШвидше йди за нагородою до того, хто дав тобі завдання!{x'."
+  },
+  "$c1 говорит тебе '{GМоя дочурка вчера утром ушла за молоком, взяла деньги, но забыла бидончик.{x'": {
+   "en": "$c1 tells you '{GMy little daughter went out for milk yesterday morning, took the money, but forgot the milk can.{x'",
+   "ua": "$c1 каже тобі: '{GМоя донечка вчора вранці пішла по молоко, взяла гроші, але забула бідончик.{x'"
+  },
+  "$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, что если ты не приведешь ее ко мне через {Y%d{G минут%s, с ней случится что-то непоправимое.{x'": {
+   "en": "$c1 says to you '{GHurry! A mother's heart tells me that if you don't bring her to me within {Y%d{G minute%s, something irreparable will happen to her.{x'",
+   "ua": "$c1 каже тобі '{GПоспіши! Материнське серце підказує мені, що якщо ти не приведеш її до мене за {Y%d{G хвилин%s, з нею станеться щось непоправне.{x'"
+  },
+  "$c1 говорит тебе '{GСкорее всего, она заблудилась где-то в районе {W{hh$t{x'": {
+   "en": "$c1 tells you, '{GMost likely, she got lost somewhere around {W{hh$t{x'",
+   "ua": "$c1 каже тобі: '{GШвидше за все, вона заблукала десь у районі {W{hh$t{x'"
+  },
+  "$c1 достает конфетку и подманивает $C4.": {
+   "en": "$c1 pulls out a candy and lures $C4 closer.",
+   "ua": "$c1 дістає цукерку і підманює $C4."
+  },
+  "$c1 ждет прекрасного принца.": {
+   "en": "$c1 is waiting for a handsome prince.",
+   "ua": "$c1 чекає на прекрасного принца."
+  },
+  "$c1 показывает девочке куклу.": {
+   "en": "$c1 shows the girl a doll.",
+   "ua": "$c1 показує дівчинці ляльку."
+  },
+  "$c1 потерянно озирается в поисках $C2.": {
+   "en": "$c1 looks around in confusion, searching for $C2.",
+   "ua": "$c1 розгублено озирається в пошуках $C2."
+  },
+  "$c1 пронзительно кричит '{YЧТОБ БЕЗ МОЛОКА НЕ ВОЗВРАЩАЛАСЬ!...{x'": {
+   "en": "$c1 shrieks '{YDON'T YOU DARE COME BACK WITHOUT THE MILK!...{x'",
+   "ua": "$c1 пронизливо кричить '{YЩОБ БЕЗ МОЛОКА НЕ ВЕРТАЛАСЯ!...{x'"
+  },
+  "$c1 пытается положить деньги в $o4, но ничего не получается.": {
+   "en": "$c1 tries to put the money into $o4, but nothing comes of it.",
+   "ua": "$c1 намагається покласти гроші в $o4, але нічого не виходить."
+  },
+  "$c1 радостно кричит '{YОтведите меня к ней, пожалуйста!{x'": {
+   "en": "$c1 shouts joyfully, '{YPlease take me to her!{x'",
+   "ua": "$c1 радісно кричить: '{YВідведіть мене до неї, будь ласка!{x'"
+  },
+  "$c1 радостно кричит '{YЭто бидончик моей мамочки!{x'": {
+   "en": "$c1 shouts joyfully '{YThis is my mommy's little can!{x'",
+   "ua": "$c1 радісно кричить '{YЦе бідончик моєї мамусі!{x'"
+  },
+  "$c1 с громким ревом бросается на шею $C3. Как гадко...": {
+   "en": "$c1 throws itself onto $C3's neck with a loud roar. How disgusting...",
+   "ua": "$c1 з гучним ревом кидається на шию $C3. Як гидко..."
+  },
+  "$c1 сквозь зубы произносит: '{gА вас я попрошу остаться...{x'.": {
+   "en": "$c1 says through gritted teeth: '{gAnd you, I'll ask to stay...{x'.",
+   "ua": "$c1 крізь зуби промовляє: '{gА тебе я попрошу залишитися...{x'."
+  },
+  "$c1 чмокает $C4 в обе щеки.": {
+   "en": "$c1 kisses $C4 on both cheeks.",
+   "ua": "$c1 цмокає $C4 в обидві щоки."
+  },
+  "$c1 чмокает тебя в обе щеки.": {
+   "en": "$c1 smacks a kiss on both your cheeks.",
+   "ua": "$c1 цьомкає тебе в обидві щоки."
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x": {
+   "en": "{Y$c1 basely killed the one you were tasked with saving.{x",
+   "ua": "{Y$c1 підло уби$gло|в|ла того, кого тобі було доручено врятувати.{x"
+  },
+  "{Y$c1 подло убил того, кто нуждался в твоей помощи.{x": {
+   "en": "{Y$c1 treacherously killed the one who needed your help.{x",
+   "ua": "{Y$c1 підступно вбив того, хто потребував твоєї допомоги.{x"
+  },
+  "{YВнезапно из засады выпрыгивает банда похитителей маленьких детей!{x": {
+   "en": "{YSuddenly a gang of little-children kidnappers leaps out of ambush!{x",
+   "ua": "{YРаптом із засідки вистрибує банда викрадачів маленьких дітей!{x"
+  },
+  "{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x": {
+   "en": "{YIdiot.... You killed the one you were supposed to save.{x",
+   "ua": "{YІдіо$gт|т|тка.... Ти вби$gло|в|ла того, кого повин$gно|ен|на бу$gло|в|ла врятувати.{x"
+  },
+  "{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{YIdiot.... You killed the one who needed your help.{x",
+   "ua": "{YІдіо$gт|т|тка.... Ти вби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  }
+ },
+ "plug-ins/quest/kidnapquest/scenario_cyclop.cpp": {
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 дает $C3 $o4.": {
+   "en": "$c1 gives $C3 $o4.",
+   "ua": "$c1 дає $C3 $o4."
+  },
+  "$c1 качает головой.": {
+   "en": "$c1 shakes its head.",
+   "ua": "$c1 хитає головою."
+  },
+  "$c1 оценивающе смотрит на $C4.": {
+   "en": "$c1 looks $C4 over appraisingly.",
+   "ua": "$c1 оцінювально дивиться на $C4."
+  },
+  "%s и %s уже встретились.": {
+   "en": "%s and %s have already met.",
+   "ua": "%s і %s вже зустрілися."
+  },
+  "{YДля тебя же это означает, что: задание отменяется.{x": {
+   "en": "{YFor you, this means: the quest is being canceled.{x",
+   "ua": "{YДля тебе ж це означає, що: завдання скасовується.{x"
+  },
+  "{YЗадание отменяется.{x": {
+   "en": "{YThe task is cancelled.{x",
+   "ua": "{YЗавдання скасовується.{x"
+  },
+  "Сходи, проведай $C4.": {
+   "en": "Go check on $C4.",
+   "ua": "Сходи, провідай $C4."
+  },
+  "$C1 в {RУЖАСНОМ СОСТОЯНИИ.{x": {
+   "en": "$C1 is in {RTERRIBLE SHAPE.{x",
+   "ua": "$C1 у {RЖАХЛИВОМУ СТАНІ.{x"
+  },
+  "$C1 готов расплакаться.": {
+   "en": "$C1 is about to burst into tears.",
+   "ua": "$C1 готовий розплакатися."
+  },
+  "$C1, держа $c4 за палец, тащит коня-качалку за собой.": {
+   "en": "$C1, holding $c4 by the finger, drags a rocking horse along.",
+   "ua": "$C1, тримаючи $c4 за палець, тягне за собою коня-гойдалку."
+  },
+  "$c1 вертит головой, не понимая, куда же он прискакал.": {
+   "en": "$c1 turns their head, not understanding where they've galloped to.",
+   "ua": "$c1 крутить головою, не розуміючи, куди ж він прискакав."
+  },
+  "$c1 вот-вот расплачется, потеряв $C4.": {
+   "en": "$c1 is about to burst into tears, having lost $C4.",
+   "ua": "$c1 от-от розплачеться, втративши $C4."
+  },
+  "$c1 выжидающе смотрит на $C4.": {
+   "en": "$c1 looks at $C4 expectantly.",
+   "ua": "$c1 вичікувально дивиться на $C4."
+  },
+  "$c1 выжидающе смотрит на тебя.": {
+   "en": "$c1 looks at you expectantly.",
+   "ua": "$c1 вичікувально дивиться на тебе."
+  },
+  "$c1 глядя на $C4 произносит: '{gО, вот и обед подоспел{x'.": {
+   "en": "$c1, looking at $C4, says: '{gOh, lunch has arrived{x'.",
+   "ua": "$c1, дивлячись на $C4, промовляє: '{gО, а ось і обід підоспів{x'."
+  },
+  "$c1 говорит $C3: '{gПойдем, драгоценный мой, а злыдня этого мы проучим.{x": {
+   "en": "$c1 says to $C3: '{gCome along, my precious, we'll teach this scoundrel a lesson.{x",
+   "ua": "$c1 каже $C3: '{gХодімо, мій дорогоцінний, а цього злидня ми провчимо.{x"
+  },
+  "$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'": {
+   "en": "$c1 says to you '{GHere, take this piece of wood, I think it'll work as bait.{x'",
+   "ua": "$c1 каже тобі '{GОсь, візьми цю дерев'яшку, думаю, як приманка спрацює.{x'"
+  },
+  "$c1 говорит тебе '{GЗамечательный экземплярчик...{x'": {
+   "en": "$c1 says to you '{GA wonderful little specimen...{x'",
+   "ua": "$c1 каже тобі '{GЧудовий екземплярчик...{x'"
+  },
+  "$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%d{G минут%s он мне уже не понадобится.{x": {
+   "en": "$c1 tells you '{GAnd hurry! I feel that in {Y%d{G minute%s he won't be of use to me anymore.{x",
+   "ua": "$c1 каже тобі '{GІ поспіши! Відчуваю, що через {Y%d{G хвилин%s він мені вже не знадобиться.{x"
+  },
+  "$c1 говорит тебе '{GЛошадка приглянулась? Ладно, можешь оставить ее себе.{x'": {
+   "en": "$c1 tells you '{GTaken a liking to the little horse? Fine, you can keep her.{x'",
+   "ua": "$c1 каже тобі '{GСподобалася конячка? Гаразд, можеш лишити її собі.{x'"
+  },
+  "$c1 говорит тебе '{GПоспеши! Через {Y%d{G минут%s он должен быть здесь!{x": {
+   "en": "$c1 tells you '{GHurry! In {Y%d{G minute%s he should be here!{x",
+   "ua": "$c1 каже тобі '{GПоспіши! Через {Y%d{G хвилин%s він має бути тут!{x"
+  },
+  "$c1 говорит тебе '{GПриведи его сюда.{x'": {
+   "en": "$c1 says to you '{GBring him here.{x'",
+   "ua": "$c1 каже тобі '{GПриведи його сюди.{x'"
+  },
+  "$c1 говорит тебе '{GТы свое дело сдела$Gло|л|ла, свобод$Gно|ен|на.{x'.": {
+   "en": "$c1 tells you '{GYou've done your part, you're free.{x'.",
+   "ua": "$c1 каже тобі '{GТи свою справу зроби$Gло|в|ла, вільн$Gо|ий|а.{x'."
+  },
+  "$c1 говорит тебе '{GЭто не моя лошадка.{x'": {
+   "en": "$c1 says to you '{GThis isn't my little horse.{x'",
+   "ua": "$c1 каже тобі '{GЦе не моя конячка.{x'"
+  },
+  "$c1 говорит тебе '{GЯ бы и са$gмо|м|ма навести$gло|л|ла его, но жду гостей, надо многое приготовить, а времени нет.{x'": {
+   "en": "$c1 tells you '{GI'd visit him myself, but I'm expecting guests, there's a lot to prepare, and there's no time.{x'",
+   "ua": "$c1 каже тобі '{GЯ б і са$gмо|м|ма навісти$gло|в|ла його, але чекаю на гостей, треба багато приготувати, а часу немає.{x'"
+  },
+  "$c1 говорит тебе '{GЯ бы са$gмо|м|ма навести$gло|л|ла его, но голод ослабил меня.{x'": {
+   "en": "$c1 tells you '{GI would have visited him myself, but hunger has weakened me.{x'",
+   "ua": "$c1 каже тобі '{GЯ б са$gмо|м|ма відвіда$gло|в|ла його, але голод ослабив мене.{x'"
+  },
+  "$c1 горько вздыхает.": {
+   "en": "$c1 sighs bitterly.",
+   "ua": "$c1 гірко зітхає."
+  },
+  "$c1 дает тебе $o4.": {
+   "en": "$c1 gives you $o4.",
+   "ua": "$c1 дає тобі $o4."
+  },
+  "$c1 достает из-за пояса огромную ребристую скалку.": {
+   "en": "$c1 pulls a huge ribbed rolling pin from behind their belt.",
+   "ua": "$c1 дістає з-за пояса величезну ребристу качалку."
+  },
+  "$c1 насупив нос отворачивается от $C4": {
+   "en": "$c1 wrinkles their nose and turns away from $C4",
+   "ua": "$c1 насупивши ніс, відвертається від $C4"
+  },
+  "$c1 насупив нос отворачивается от тебя": {
+   "en": "$c1 wrinkles their nose and turns away from you",
+   "ua": "$c1 насупивши носа відвертається від тебе"
+  },
+  "$c1 оценивающе смотрит на тебя.": {
+   "en": "$c1 looks you over appraisingly.",
+   "ua": "$c1 оцінювально дивиться на тебе."
+  },
+  "$c1 пристально осматривается по сторонам.": {
+   "en": "$c1 looks around intently.",
+   "ua": "$c1 пильно роздивляється навколо."
+  },
+  "$c1 произносит '{gЗдравствуй мил$Gое|ок|ая, куда же это ты направил$Gось|ся|ась с чужим дитенком?{x'.": {
+   "en": "$c1 says '{gHello there, sweetie, where are you off to with someone else's kid?{x'.",
+   "ua": "$c1 промовляє '{gЗдрастуй, мил$Ge|ий|а, куди ж це ти руши$Gло|в|ла з чужою дитиною?{x'."
+  },
+  "$c1 произносит '{gНебось упырю какому-нибудь спихнуть захоте$Gло|л|ла? Ох как не хорошо...{x'.": {
+   "en": "$c1 says, '{gTrying to fob me off on some ghoul, are you? Oh, that's not very nice...{x'.",
+   "ua": "$c1 каже: '{gНебось якомусь упирю спихнути захот$Gіло|ів|іла? Ох як негарно...{x'."
+  },
+  "$c1 произносит: '{gВот и все, пришли,... не туда{x'": {
+   "en": "$c1 says: '{gWell, that's it, we've arrived... at the wrong place{x'",
+   "ua": "$c1 промовляє: '{gОт і все, прийшли,... не туди{x'"
+  },
+  "$c1 хватает дите за руку.": {
+   "en": "$c1 grabs the kid by the hand.",
+   "ua": "$c1 хапає дитину за руку."
+  },
+  "$c1, обняв лошадку, доверчиво смотрит в глаза $C3.": {
+   "en": "$c1, hugging the little horse, looks trustingly into $C3's eyes.",
+   "ua": "$c1, обійнявши конячку, довірливо дивиться в очі $C3."
+  },
+  "$c1, обняв лошадку, доверчиво смотрит тебе в глаза.": {
+   "en": "$c1, hugging the little horse, looks trustingly into your eyes.",
+   "ua": "$c1, обійнявши конячку, довірливо дивиться тобі в очі."
+  },
+  "{Y$c1 жестоко убил страждующего злыдня, слава и почет $c3.{x": {
+   "en": "{Y$c1 brutally killed the suffering wretch -- glory and honor to $c3.{x",
+   "ua": "{Y$c1 жорстоко вбив стражденного злидня, слава і шана $c3.{x"
+  },
+  "{Y$c1 с особым цинизмом уничтожи$gло|л|ла обед для упыря.{x\r\n{YЗадание отменяется.{x": {
+   "en": "{Y$c1 destroyed the ghoul's lunch with particular cynicism.{x\r\n{YThe quest is cancelled.{x",
+   "ua": "{Y$c1 з особливим цинізмом знищи$gло|в|ла обід для упиря.{x\r\n{YЗавдання скасовується.{x"
+  },
+  "{YМолодец, убив злыдня ты соверши$gло|л|ла достойный поступок, он тебе зачтется... со временем.{x": {
+   "en": "{YWell done, by killing the villain you've done a worthy deed, it'll count for you... eventually.{x",
+   "ua": "{YМолодець, вбивши лиходія, ти здійсни$gло|в|ла гідний вчинок, це тобі зарахується... згодом.{x"
+  },
+  "{YНет ребенка - нет обеда.{x\r\n{YЗадание отменяется.{x": {
+   "en": "{YNo child, no dinner.{x\r\n{YThe quest is cancelled.{x",
+   "ua": "{YНемає дитини - немає обіду.{x\r\n{YЗавдання скасовується.{x"
+  },
+  "{YТебя останавливают несколько добродушных старушек.{x": {
+   "en": "{YA few good-natured old women stop you.{x",
+   "ua": "{YТебе зупиняють кілька добродушних бабусь.{x"
+  },
+  "Ты в {RУЖАСНОМ СОСТОЯНИИ.{x": {
+   "en": "You're in {RTERRIBLE CONDITION.{x",
+   "ua": "Ти в {RЖАХЛИВОМУ СТАНІ.{x"
+  }
+ },
+ "plug-ins/quest/kidnapquest/scenario_dragon.cpp": {
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "$c1 дает $C3 $o4.": {
+   "en": "$c1 gives $o4 to $C3.",
+   "ua": "$c1 дає $C3 $o4."
+  },
+  "$c1 дает тебе $o4.": {
+   "en": "$c1 gives you $o4.",
+   "ua": "$c1 дає тобі $o4."
+  },
+  "$c1 озадаченно оглядывается по сторонам.": {
+   "en": "$c1 looks around, puzzled.",
+   "ua": "$c1 спантеличено озирається навколо."
+  },
+  "$c1 сердечно благодарит $C4.": {
+   "en": "$c1 thanks $C4 warmly.",
+   "ua": "$c1 щиро дякує $C4."
+  },
+  "%s и %s уже встретились.": {
+   "en": "%s and %s have already met.",
+   "ua": "%s і %s вже зустрілися."
+  },
+  "{YЗадание отменяется.{x": {
+   "en": "{YThe quest is cancelled.{x",
+   "ua": "{YЗавдання скасовується.{x"
+  },
+  "$c1 безо всякого интереса смотрит на $o4.": {
+   "en": "$c1 looks at $o4 with no interest at all.",
+   "ua": "$c1 без жодного інтересу дивиться на $o4."
+  },
+  "$c1 бросается на шею $C3. Семейная сцена, сопли, слюни.": {
+   "en": "$c1 throws themselves onto $C3's neck. A real family scene -- snot and slobber everywhere.",
+   "ua": "$c1 кидається на шию $C3. Сімейна сцена, шмарклі, слина."
+  },
+  "$c1 говорит тебе '{GВ следующий раз будь повнимательнее.{x'": {
+   "en": "$c1 tells you '{GNext time pay more attention.{x'",
+   "ua": "$c1 каже тобі '{GНаступного разу будь уважнішим.{x'"
+  },
+  "$c1 говорит тебе '{GНайди его и верни, пока до него не добрались охотники за драконами.{x'": {
+   "en": "$c1 tells you '{GFind him and bring him back before the dragon hunters get to him.{x'",
+   "ua": "$c1 каже тобі '{GЗнайди його і поверни, поки до нього не дісталися мисливці за драконами.{x'"
+  },
+  "$c1 говорит тебе '{GОт радости он улетел так далеко, что, похоже, не может найти дороги обратно.{x'": {
+   "en": "$c1 tells you '{GHe flew off so far from joy that he seems unable to find his way back.{x'",
+   "ua": "$c1 каже тобі '{GВід радощів він відлетів так далеко, що, схоже, не може знайти дороги назад.{x'"
+  },
+  "$c1 говорит тебе '{GПередай эту игрушку моему малышу, чтобы он знал, что тебе можно доверять.{x'": {
+   "en": "$c1 says to you, '{GGive this toy to my little one, so he knows he can trust you.{x'",
+   "ua": "$c1 каже тобі: '{GПередай цю іграшку моєму малюку, щоб він знав, що тобі можна довіряти.{x'"
+  },
+  "$c1 говорит тебе '{GУ меня недавно встал на крыло дракончик, не по годам рано.{x'": {
+   "en": "$c1 tells you '{GMy little dragon recently took to the wing, awfully early for its age.{x'",
+   "ua": "$c1 каже тобі '{GУ мене нещодавно став на крило дракончик, не по літах рано.{x'"
+  },
+  "$c1 говорит тебе: '{GДостой$Gное|ный|ная! Ступай за славой к тому, кто дал тебе задание!{x'.": {
+   "en": "$c1 tells you: '{GWorthy one! Go seek glory from the one who gave you this task!{x'.",
+   "ua": "$c1 каже тобі: '{GДосто$Gйне|йний|йна! Йди за славою до того, хто дав тобі завдання!{x'."
+  },
+  "$c1 задумчиво всматривается вдаль.": {
+   "en": "$c1 gazes pensively into the distance.",
+   "ua": "$c1 задумливо вдивляється вдалину."
+  },
+  "$c1 злобно дергает драконенка за поводок.": {
+   "en": "$c1 spitefully yanks the baby dragon's leash.",
+   "ua": "$c1 злобно смикає дракончика за повідець."
+  },
+  "$c1 надевает на $C2 ошейник и тащит за собой.": {
+   "en": "$c1 puts a collar on $C2 and drags them along.",
+   "ua": "$c1 надягає на $C2 нашийник і тягне за собою."
+  },
+  "$c1 оглядывается по сторонам в поисках хоть чего-нибудь знакомого.": {
+   "en": "$c1 looks around for anything familiar at all.",
+   "ua": "$c1 озирається на всі боки в пошуках хоч чогось знайомого."
+  },
+  "$c1 потерянно озирается в поисках $C2.": {
+   "en": "$c1 looks around lost, searching for $C2.",
+   "ua": "$c1 розгублено озирається в пошуках $C2."
+  },
+  "$c1 пшикает себе в пасть $o5. Из носа валит пар. \r\nРебенок счастлив.": {
+   "en": "$c1 sprays $o5 into their own mouth. Steam pours from their nose.\r\nThe child is happy.",
+   "ua": "$c1 пшикає собі в пащу $o5. З носа валить пара.\r\nДитина щаслива."
+  },
+  "$c1 пытается пшикнуть себе в пасть из $o2.": {
+   "en": "$c1 tries to spritz something into their own mouth from $o2.",
+   "ua": "$c1 намагається пшикнути собі в пащу з $o2."
+  },
+  "$c1 разочарованно сопит.": {
+   "en": "$c1 sniffs in disappointment.",
+   "ua": "$c1 розчаровано сопить."
+  },
+  "$c1 сердечно благодарит тебя.": {
+   "en": "$c1 thanks you warmly.",
+   "ua": "$c1 сердечно дякує тобі."
+  },
+  "$c1 сквозь зубы произносит: '{gДракону помогаешь? Может ты и са$Gмо|м|ма дракон?{x'.": {
+   "en": "$c1 says through gritted teeth: '{gHelping the dragon? Maybe you're a dragon yourself?{x'.",
+   "ua": "$c1 крізь зуби каже: '{gДраконові допомагаєш? Може, ти й са$Gмо|м|ма дракон?{x'."
+  },
+  "$c1 сквозь зубы произносит: '{gСейчас посмотрим, какого цвета у тебя кровь...{x'.": {
+   "en": "$c1 mutters through clenched teeth: '{gLet's see what color your blood is...{x'.",
+   "ua": "$c1 крізь зуби каже: '{gЗараз подивимось, якого кольору в тебе кров...{x'."
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x": {
+   "en": "{Y$c1 treacherously killed the one you were sent to save.{x",
+   "ua": "{Y$c1 підло вби$gло|в|ла того, кого тобі було доручено врятувати.{x"
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{Y$c1 treacherously killed the one who needed your help.{x",
+   "ua": "{Y$c1 підло вби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  },
+  "{YВнезапно из засады выпрыгивает банда рыцарей-драконоборцев!{x": {
+   "en": "{YSuddenly a gang of dragon-slaying knights leaps out of ambush!{x",
+   "ua": "{YРаптово із засідки вистрибує банда лицарів-драконоборців!{x"
+  },
+  "{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x": {
+   "en": "{YIdiot.... You killed the one you were supposed to save.{x",
+   "ua": "{YІдіо$gт|т|тко.... Ти вби$gло|в|ла того, кого пови$gнно|нен|нна бу$gло|в|ла врятувати.{x"
+  },
+  "{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{YIdiot.... You killed the one who needed your help.{x",
+   "ua": "{YІдіо$gт|т|тка.... Ти вби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  },
+  "В их глазах можно прочесть смешанные чувства: жадность, праведность, коварность и ненависть.": {
+   "en": "In their eyes you can read mixed feelings: greed, righteousness, cunning, and hatred.",
+   "ua": "У їхніх очах можна прочитати змішані почуття: жадібність, праведність, підступність і ненависть."
+  },
+  "Приди к $C3 за благодарностью!": {
+   "en": "Come to $C3 for your reward!",
+   "ua": "Прийди до $C3 за подякою!"
+  }
+ },
+ "plug-ins/quest/kidnapquest/scenario_urchin.cpp": {
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "$c1 дает $C3 новый $o4.": {
+   "en": "$c1 gives $C3 a new $o4.",
+   "ua": "$c1 дає $C3 новий $o4."
+  },
+  "$c1 дает тебе новый $o4.": {
+   "en": "$c1 gives you a new $o4.",
+   "ua": "$c1 дає тобі новий $o4."
+  },
+  "$c1 озирается в поисках $C2.": {
+   "en": "$c1 looks around for $C2.",
+   "ua": "$c1 озирається в пошуках $C2."
+  },
+  "%s и %s уже встретились.": {
+   "en": "%s and %s have already met.",
+   "ua": "%s і %s вже зустрілися."
+  },
+  "{YЗадание отменяется.{x": {
+   "en": "{YThe quest is being cancelled.{x",
+   "ua": "{YЗавдання скасовується.{x"
+  },
+  "Приди к $C3 за благодарностью!": {
+   "en": "Come to $C3 for your reward!",
+   "ua": "Прийди до $C3 за подякою!"
+  },
+  "$c1 безо всякого интереса смотрит на $o4.": {
+   "en": "$c1 looks at $o4 with zero interest.",
+   "ua": "$c1 без жодного інтересу дивиться на $o4."
+  },
+  "$c1 говорит тебе '{GВы ведь знаете, туда в наши дни берут всех подряд.{x'": {
+   "en": "$c1 tells you '{GYou know, these days they'll take just about anyone in there.{x'",
+   "ua": "$c1 каже тобі '{GВи ж знаєте, туди в наші дні беруть усіх підряд.{x'"
+  },
+  "$c1 говорит тебе '{GК счастью, тако{Smму{Sfй{Sx {Smолуху{Sfдурынде{Sx как ты я дала копию.{x'": {
+   "en": "$c1 says to you '{GLuckily, I gave a copy to a dummy like you.{x'",
+   "ua": "$c1 каже тобі '{GНа щастя, тако{Smму{Sfій{Sx {Smбовдуру{Sfдурепі{Sx як ти я дала копію.{x'"
+  },
+  "$c1 говорит тебе '{GМатеринское сердце подсказывает мне, что, если ты не приведешь его ко мне через {Y%d{G минут%s, с ним случится что-то непоправимое.{x'": {
+   "en": "$c1 tells you '{GA mother's heart tells me that if you don't bring him to me within {Y%d{G minute%s, something irreversible will happen to him.{x'",
+   "ua": "$c1 каже тобі '{GМатеринське серце підказує мені, що якщо ти не приведеш його до мене за {Y%d{G хвилин%s, з ним трапиться щось непоправне.{x'"
+  },
+  "$c1 говорит тебе '{GМой сорванец сын сбежал из дома, спасаясь от призыва в клан Войнов.{x'": {
+   "en": "$c1 tells you '{GMy rascal of a son ran away from home to escape being drafted into the Warriors clan.{x'",
+   "ua": "$c1 каже тобі '{GМій шибеник-син утік з дому, рятуючись від призову в клан Воїнів.{x'"
+  },
+  "$c1 говорит тебе '{GОтыщи его, пока он не попал в беду.{x'": {
+   "en": "$c1 tells you '{GFind him before he gets into trouble.{x'",
+   "ua": "$c1 каже тобі: '{GЗнайди його, поки він не потрапив у біду.{x'"
+  },
+  "$c1 говорит тебе '{GПередай его ему и поскорей!{x'": {
+   "en": "$c1 says to you '{GGive it to him, and quick about it!{x'",
+   "ua": "$c1 каже тобі '{GПередай це йому, і хутчіш!{x'"
+  },
+  "$c1 говорит тебе '{GСкорее всего он скрывается где-то в районе {W{hh$t{x'": {
+   "en": "$c1 tells you, '{GMost likely he's hiding somewhere around {W{hh$t{x'",
+   "ua": "$c1 каже тобі: '{GШвидше за все він ховається десь у районі {W{hh$t{x'"
+  },
+  "$c1 говорит тебе '{GЧто ты надела$Gло|л|ла?!{x'": {
+   "en": "$c1 says to you '{GWhat did you put on?!{x'",
+   "ua": "$c1 каже тобі '{GЩо ти наді$Gло|в|ла?!{x'"
+  },
+  "$c1 говорит тебе '{GЯ продала все, что у меня было, чтобы купить этот белый билет...{x'": {
+   "en": "$c1 tells you '{GI sold everything I had to buy this white ticket...{x'",
+   "ua": "$c1 каже тобі '{GЯ продала все, що в мене було, щоб купити цей білий квиток...{x'"
+  },
+  "$c1 говорит тебе: '{GИди скорее за наградой к тому, кто дал тебе задание!{x'.": {
+   "en": "$c1 tells you: '{GHurry off to collect your reward from whoever gave you the task!{x'.",
+   "ua": "$c1 каже тобі: '{GШвидше йди по нагороду до того, хто дав тобі завдання!{x'."
+  },
+  "$c1 до боли в затылке морщит узкий лоб.": {
+   "en": "$c1 furrows their narrow brow until the back of their head aches.",
+   "ua": "$c1 аж до болю в потилиці морщить вузьке чоло."
+  },
+  "$c1 произносит '{gПошли домой?{x'": {
+   "en": "$c1 says '{gShall we go home?{x'",
+   "ua": "$c1 промовляє '{gПідемо додому?{x'"
+  },
+  "$c1 произносит '{gТеперь они до меня не доберутся!{x'": {
+   "en": "$c1 says '{gNow they won't get to me!{x'",
+   "ua": "$c1 промовляє '{gТепер вони до мене не доберуться!{x'"
+  },
+  "$c1 произносит '{gЭту бумагу надо разъяснить{x'.": {
+   "en": "$c1 says, '{gThis paper needs to be explained{x'.",
+   "ua": "$c1 каже: '{gЦей папір треба роз'яснити{x'."
+  },
+  "$c1 произносит '{gЯ буду тебя воевать!{x'.": {
+   "en": "$c1 says '{gI will war you!{x'.",
+   "ua": "$c1 каже '{gЯ буду тебе воювати!{x'."
+  },
+  "$c1 своим присутствием повышает в этом месте энтропию.": {
+   "en": "$c1's mere presence raises the entropy in this place.",
+   "ua": "$c1 самою своєю присутністю підвищує в цьому місці ентропію."
+  },
+  "$c1 смотрит на белый билет, держа его вверх ногами.": {
+   "en": "$c1 looks at the white ticket, holding it upside down.",
+   "ua": "$c1 дивиться на білий білет, тримаючи його догори ногами."
+  },
+  "$c1 стукается головой об стену.": {
+   "en": "$c1 bangs their head against the wall.",
+   "ua": "$c1 стукається головою об стіну."
+  },
+  "$c1 тащит сорванца за шиворот.": {
+   "en": "$c1 drags the urchin by the scruff of the neck.",
+   "ua": "$c1 тягне шибеника за шкірку."
+  },
+  "$c1 хватает $C4 за шиворот и тащит за собой.": {
+   "en": "$c1 grabs $C4 by the collar and drags them along.",
+   "ua": "$c1 хапає $C4 за комір і тягне за собою."
+  },
+  "$c1 хмуро смотрит на $C4.": {
+   "en": "$c1 scowls at $C4.",
+   "ua": "$c1 похмуро дивиться на $C4."
+  },
+  "$c1 чмокает $C4 в обе щеки.": {
+   "en": "$c1 smacks kisses on both of $C4's cheeks.",
+   "ua": "$c1 цьомкає $C4 в обидві щоки."
+  },
+  "$c1 чмокает тебя в обе щеки.": {
+   "en": "$c1 smooches you on both cheeks.",
+   "ua": "$c1 цмокає тебе в обидві щоки."
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x": {
+   "en": "{Y$c1 treacherously killed the one you were tasked with saving.{x",
+   "ua": "{Y$c1 підло вби$gло|в|ла того, кого тобі було доручено врятувати.{x"
+  },
+  "{YГруппа закованных в латы людей с суровыми лицами преграждает тебе путь.{x": {
+   "en": "{YA group of armor-clad men with stern faces bars your path.{x",
+   "ua": "{YГрупа закутих у лати людей із суворими обличчями перепиняє тобі шлях.{x"
+  },
+  "{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x": {
+   "en": "{YIdiot.... You killed the one you were supposed to save.{x",
+   "ua": "{YІдіо$gт|т|тка.... Ти вби$gло|в|ла того, кого повин$gно|ен|на бу$gло|в|ла врятувати.{x"
+  },
+  "{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{YIdiot.... You killed the one who needed your help.{x",
+   "ua": "{YІдіо$gт|т|тка.... Ти вб$gило|ив|ила того, хто потребував твоєї допомоги.{x"
+  }
+ },
+ "plug-ins/quest/kidnapquest/scenario_urka.cpp": {
+  "$C1 внимательно смотрит на $c4.": {
+   "en": "$C1 looks closely at $c4.",
+   "ua": "$C1 уважно дивиться на $c4."
+  },
+  "$C1 поднимается навстречу $c3.": {
+   "en": "$C1 rises to meet $c3.",
+   "ua": "$C1 підіймається назустріч $c3."
+  },
+  "$c1 вручает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3.",
+   "ua": "$c1 вручає $C3 $o4."
+  },
+  "$c1 вручает тебе $o4.": {
+   "en": "$c1 hands you $o4.",
+   "ua": "$c1 вручає тобі $o4."
+  },
+  "$c1 дает $C3 новый $o4.": {
+   "en": "$c1 gives $C3 a new $o4.",
+   "ua": "$c1 дає $C3 новий $o4."
+  },
+  "$c1 дает тебе новый $o4.": {
+   "en": "$c1 gives you a new $o4.",
+   "ua": "$c1 дає тобі новий $o4."
+  },
+  "$c1 ухмыляется.": {
+   "en": "$c1 smirks.",
+   "ua": "$c1 посміхається."
+  },
+  "%s и %s уже встретились.": {
+   "en": "%s and %s have already met.",
+   "ua": "%s і %s вже зустрілися."
+  },
+  "{YЗадание отменяется.{x": {
+   "en": "{YThe quest is cancelled.{x",
+   "ua": "{YЗавдання скасовується.{x"
+  },
+  "Приди к $C3 за благодарностью!": {
+   "en": "Come to $C3 for your reward!",
+   "ua": "Прийди до $C3 за подякою!"
+  },
+  "$C1 злобно ухмыляется.": {
+   "en": "$C1 grins wickedly.",
+   "ua": "$C1 злостиво вишкіряється."
+  },
+  "$C1 озабоченно бормочет: '{gЧей же паспорт этот идиот мне принес?{x'": {
+   "en": "$C1 mutters anxiously: '{gWhose passport did this idiot bring me?{x'",
+   "ua": "$C1 стурбовано бурмоче: '{gЧий же паспорт цей ідіот мені приніс?{x'"
+  },
+  "$C1 произносит '{gНу, здравствуй, хорошо отдохну$gло|л|ла? Пора и за работу приниматься...{x'": {
+   "en": "$C1 says '{gWell, hello there, had a good rest? Time to get back to work...{x'",
+   "ua": "$C1 промовляє '{gНу, здоров був, добре відпочи$gло|в|ла? Пора й до роботи братися...{x'"
+  },
+  "$c1 бормочет: '{gЗамуровали изверги...{x'": {
+   "en": "$c1 mutters: '{gThe bastards walled me in...{x'",
+   "ua": "$c1 бурмоче: '{gЗамурували вироди...{x'"
+  },
+  "$c1 говорит тебе '{GВсе бы ничего, но какой-то тип, очень похожий на моего товарища, видать так сильно насолил этой Фемиде, что она аж окаменела от ужаса.{x'": {
+   "en": "$c1 says to you '{GEverything would be fine, but some guy who looks a lot like my buddy must have pissed off that Themis so badly that she turned to stone from sheer horror.{x'",
+   "ua": "$c1 каже тобі '{GУсе було б нічого, але якийсь тип, дуже схожий на мого товариша, видно так дошкулив цій Феміді, що вона аж скам'яніла від жаху.{x'"
+  },
+  "$c1 говорит тебе '{GМолодец, вернись к давшему тебе задание!{x'.": {
+   "en": "$c1 tells you '{GWell done, go back to whoever gave you the task!{x'.",
+   "ua": "$c1 каже тобі '{GМолодець, повернись до того, хто дав тобі завдання!{x'."
+  },
+  "$c1 говорит тебе '{GНадо бы его выручить! Вот, у меня тут есть его паспорт, так как в наше время без документа тяжело, а заодно он поймет, что тебе можно доверять.'{x'": {
+   "en": "$c1 tells you '{GWe ought to bail him out! Here, I've got his passport -- can't get by without papers these days -- and it'll show him he can trust you.{x'",
+   "ua": "$c1 каже тобі '{GТреба б його виручити! Ось, у мене тут є його паспорт, бо в наш час без документа важко, а заразом він зрозуміє, що тобі можна довіряти.{x'"
+  },
+  "$c1 говорит тебе '{GНадо бы его выручить! Вот, у меня тут есть его паспорт,{x'": {
+   "en": "$c1 tells you '{GWe ought to bail him out! Here, I've got his passport,{x'",
+   "ua": "$c1 каже тобі '{GТреба б його виручити! Ось, у мене тут є його паспорт,{x'"
+  },
+  "$c1 говорит тебе '{GНадо бы помочь товарищу! Вот, у меня есть его паспорт, так как в наше время без документа никуда, а заодно он поймет, что тебе можно доверять.{x'": {
+   "en": "$c1 says to you '{GWe should help out a comrade! Here, I've got his passport -- can't get anywhere these days without papers -- and this way he'll know he can trust you.{x'",
+   "ua": "$c1 каже тобі '{GТреба б допомогти товаришу! Ось, у мене є його паспорт, бо в наш час без документа нікуди, а заразом він зрозуміє, що тобі можна довіряти.{x'"
+  },
+  "$c1 говорит тебе '{GНо это еще ладно, они хотят его повесить. Понимаешь, невиновного человека повесить!!!{x'": {
+   "en": "$c1 says to you '{GBut that's not even the worst part, they want to hang him. You understand, hang an innocent man!!!{x'",
+   "ua": "$c1 каже тобі '{GАле це ще нічого, вони хочуть його повісити. Розумієш, невинну людину повісити!!!{x'"
+  },
+  "$c1 говорит тебе '{GНо это еще ладно, представляешь, они говорят, что таких хороших людей{x'": {
+   "en": "$c1 tells you '{GBut that's still fine, can you imagine, they say that such good people{x'",
+   "ua": "$c1 каже тобі '{GАле це ще нічого, уявляєш, вони кажуть, що таких хороших людей{x'"
+  },
+  "$c1 говорит тебе '{GНо это только половина беды, представляешь, ОНИ говорят, что таких хороших людей должно быть много и хотят его четвертовать...{x'": {
+   "en": "$c1 says to you '{GBut that's only half the trouble, can you imagine, THEY say there should be a lot more good people like that and want to quarter him...{x'",
+   "ua": "$c1 каже тобі '{GАле це тільки половина біди, уявляєш, ВОНИ кажуть, що таких хороших людей має бути багато, і хочуть його четвертувати...{x'"
+  },
+  "$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%d{G минут%s, пока идут приготовления к казни. Приведи его сюда.{x'": {
+   "en": "$c1 tells you '{GBy my count you have {Y%d{G minute%s while the preparations for the execution are underway. Bring him here.{x'",
+   "ua": "$c1 каже тобі '{GЗа моїми підрахунками, у тебе є {Y%d{G хвилин%s, поки тривають приготування до страти. Приведи його сюди.{x'"
+  },
+  "$c1 говорит тебе '{GСовсем недавно под внеочередную облаву попал один из моих лучших головор... товарищей то есть.'{x": {
+   "en": "$c1 tells you '{GJust recently, one of my best thu... comrades, I mean, got caught in an unscheduled raid.'{x",
+   "ua": "$c1 каже тобі '{GЗовсім нещодавно під позачергову облаву потрапив один з моїх найкращих головоріз... товаришів тобто.'{x"
+  },
+  "$c1 говорит тебе '{GТак и стоит в своем храме, а ее доблестные служители прямо взбесились и без всякого следствия хотят вздернуть моего лучшего голов... товарища.'{x": {
+   "en": "$c1 tells you '{GShe just sits there in her temple, while her valiant servants have gone stark raving mad and want to string up my best chief... comrade, without any trial at all.'{x",
+   "ua": "$c1 каже тобі: '{GТак і стоїть у своєму храмі, а її доблесні служителі геть оскаженіли і без жодного слідства хочуть повісити мого найкращого ватаж... товариша.'{x"
+  },
+  "$c1 говорит тебе '{GТы думаешь у меня тут художественная мастеркая? Аккуратнее надо!!!{x'": {
+   "en": "$c1 says to you '{GYou think this is some kind of art studio? Watch it!!!{x'",
+   "ua": "$c1 каже тобі '{GТи думаєш, у мене тут художня майстерня? Обережніше треба!!!{x'"
+  },
+  "$c1 говорит тебе '{GУ НИХ видите ли указ вышел, чтобы камеры не пустовали.'{x": {
+   "en": "$c1 tells you, '{GTurns out THEY issued a decree that cells shouldn't stand empty.'{x",
+   "ua": "$c1 каже тобі: '{GУ НИХ, бач, указ вийшов, щоб камери не пустували.'{x"
+  },
+  "$c1 говорит тебе '{GУ тебя есть примерно {W%d{G минут%s, пока идут приготовления к казни. Приведи его ко мне.{x'": {
+   "en": "$c1 says to you '{GYou have about {W%d{G minute%s before the execution preparations are done. Bring him to me.{x'",
+   "ua": "$c1 каже тобі '{GУ тебе є приблизно {W%d{G хвилин%s, поки тривають приготування до страти. Приведи його до мене.{x'"
+  },
+  "$c1 говорит тебе '{GХм, пожалуй тебе можно доверить ответственное дельце, слушай:'{x": {
+   "en": "$c1 tells you '{GHmm, I suppose I can trust you with a serious little task, listen:'{x",
+   "ua": "$c1 каже тобі '{GХм, мабуть тобі можна довірити відповідальну справу, слухай:'{x"
+  },
+  "$c1 говорит тебе '{GХм, пожалуй, тебе можно доверить ответственное дельце. Слухай сюды:{x": {
+   "en": "$c1 tells you '{GHmm, I reckon we can trust you with a serious little job. Listen up:{x",
+   "ua": "$c1 каже тобі '{GХм, мабуть, тобі можна довірити відповідальну справу. Слухай сюди:{x"
+  },
+  "$c1 говорит тебе '{GЧто, потеря$Gло|л|ла документ?{x'": {
+   "en": "$c1 tells you '{GWhat, lost your papers?{x'",
+   "ua": "$c1 каже тобі '{GЩо, загуби%Gло|в|ла документ?{x'"
+  },
+  "$c1 говорит тебе '{Gдолжно быть много и хотят его четвертовать...{x'": {
+   "en": "$c1 tells you '{GMust be a lot, and they want to have him drawn and quartered...{x'",
+   "ua": "$c1 каже тобі '{Gмабуть, багато, і хочуть його четвертувати...{x'"
+  },
+  "$c1 говорит тебе '{Gи держат, насколько мне известно, в одной из тюрем в местности {W{hh$t{hx{G. Не курорт однако...{x": {
+   "en": "$c1 tells you, '{Gand they're being held, as far as I know, in one of the prisons in the {W{hh$t{hx{G area. Not exactly a resort...{x'",
+   "ua": "$c1 каже тобі: '{Gі тримають, наскільки мені відомо, в одній з в'язниць у місцевості {W{hh$t{hx{G. Не курорт, втім...{x'"
+  },
+  "$c1 говорит тебе '{Gнедавно мусора поганые ни за что, ни про что схапали моего братишку{x": {
+   "en": "$c1 tells you '{Grecently the filthy pigs grabbed my little brother for no damn reason{x'",
+   "ua": "$c1 каже тобі '{Gнещодавно менти погані ні за що ні про що зацапали мого братика{x'"
+  },
+  "$c1 говорит тебе '{Gтак как в наше время без документа никуда, а заодно братишка поймет, что тебе можно доверять...{x'": {
+   "en": "$c1 tells you '{Gsince these days you can't get anywhere without papers, and it'll also let my brother know he can trust you...{x'",
+   "ua": "$c1 каже тобі '{Gбо в наш час без документа нікуди, а заразом братик зрозуміє, що тобі можна довіряти...{x'"
+  },
+  "$c1 говорит тебе '{gНе хватало того, чтобы меня застукали в твоей кампании.{x'": {
+   "en": "$c1 tells you '{gThat's all I need, getting caught in your company.{x'",
+   "ua": "$c1 каже тобі '{gТільки цього не вистачало -- щоб мене застукали в твоїй компанії.{x'"
+  },
+  "$c1 говорит тебе '{gНормальный документ неси.{x'": {
+   "en": "$c1 says to you, '{gBring me a proper document.{x'",
+   "ua": "$c1 каже тобі: '{gНормальний документ неси.{x'"
+  },
+  "$c1 говорит тебе '{gТы еще кто такой? Давай, давай, топай отсюда,{x'": {
+   "en": "$c1 says to you '{gWho the hell are you? Go on, go on, hit the road,{x'",
+   "ua": "$c1 каже тобі '{gТи ще хто такий? Давай, давай, тупай звідси,{x'"
+  },
+  "$c1 говорит тебе '{gТы на меня посмотри и на то, что в паспорте нарисовано...{x'": {
+   "en": "$c1 says to you '{gTake a look at me and at what's drawn in my passport...{x'",
+   "ua": "$c1 каже тобі '{gТи подивись на мене і на те, що в паспорті намальовано...{x'"
+  },
+  "$c1 говорит тебе '{gТы на меня посмотри и на эту батву в ксиве... Нормальный докУмент неси.{x'": {
+   "en": "$c1 tells you '{gLook at me and at this scrawl in the papers... Bring a proper docUment.{x'",
+   "ua": "$c1 каже тобі '{gТи на мене подивись і на цю каракулю в ксиві... Нормальний докУмент неси.{x'"
+  },
+  "$c1 говорит тебе '{gТы чего мне принес? Совсем мозги в боях повышибали?{x'": {
+   "en": "$c1 tells you '{gWhat's this you brought me? Got your brains knocked clean out in all those fights?{x'",
+   "ua": "$c1 каже тобі '{gЩо ти мені приніс? Зовсім мізки в боях повибивало?{x'"
+  },
+  "$c1 говорит тебе '{gЧто ты мне суешь? Все умы по дороге растерял?{x'": {
+   "en": "$c1 tells you '{gWhat are you shoving at me? Lost your marbles on the way here?{x'",
+   "ua": "$c1 каже тобі '{gЩо ти мені підсовуєш? Всі мізки по дорозі розгубив?{x'"
+  },
+  "$c1 говорит тебе '{gЭээ нет, мой братуха конечно не очень разборчив в персонале,{x'": {
+   "en": "$c1 says to you '{gUh, no, my bro's not exactly picky about personnel, sure,{x'",
+   "ua": "$c1 каже тобі '{gЕее ні, мій братан звісно не дуже перебірливий щодо персоналу,{x'"
+  },
+  "$c1 говорит тебе '{gно такого хмыря как ТЫ, даже он не послал бы на выручку.{x'": {
+   "en": "$c1 says to you '{gbut a sorry sack like YOU, even he wouldn't send to the rescue.{x'",
+   "ua": "$c1 каже тобі '{gале такого хмиря, як ТИ, навіть він не послав би на виручку.{x'"
+  },
+  "$c1 долго и усердно изучает паспорт.": {
+   "en": "$c1 studies the passport long and diligently.",
+   "ua": "$c1 довго і старанно вивчає паспорт."
+  },
+  "$c1 достает из сапога огромное увеличительное стекло и вглядывается в следы.": {
+   "en": "$c1 pulls a huge magnifying glass out of their boot and peers at the tracks.",
+   "ua": "$c1 дістає з чобота величезне збільшувальне скло і вдивляється в сліди."
+  },
+  "$c1 защелкивает наручники на запястьях $C2 и тащит его прочь.": {
+   "en": "$c1 snaps handcuffs onto $C2's wrists and drags him away.",
+   "ua": "$c1 защіпає наручники на зап'ястях $C2 і тягне його геть."
+  },
+  "$c1 злобно ухмыляется.": {
+   "en": "$c1 smirks viciously.",
+   "ua": "$c1 злостиво посміхається."
+  },
+  "$c1 недовольно бурчит.": {
+   "en": "$c1 grumbles discontentedly.",
+   "ua": "$c1 незадоволено бурчить."
+  },
+  "$c1 озабоченно чешет репу": {
+   "en": "$c1 scratches their head, worried",
+   "ua": "$c1 занепокоєно чухає потилицю"
+  },
+  "$c1 пинком придает $C3 нужное направление.": {
+   "en": "$c1 kicks $C3 in the right direction.",
+   "ua": "$c1 копняком надає $C3 потрібного напрямку."
+  },
+  "$c1 поднимает взгляд на $C4 и произносит: '{gКак хорошо, вас-то мы и ищем...{x'": {
+   "en": "$c1 raises their eyes to $C4 and says: '{gWell, well, you're exactly who we're looking for...{x'",
+   "ua": "$c1 підводить погляд на $C4 і промовляє: '{gЯк добре, саме вас ми й шукаємо...{x'"
+  },
+  "$c1 произносит '{gА вас я попрошу задержаться для опознания вашего трупа...{x'.": {
+   "en": "$c1 says '{gAnd you, I'll ask to stay behind for identifying your corpse...{x'.",
+   "ua": "$c1 каже '{gА тебе я попрошу затриматися для впізнання твого трупа...{x'."
+  },
+  "$c1 произносит '{gДаа, узнаю почерк... Такие картины только мой братан может рисовать.{x'": {
+   "en": "$c1 says '{gYeah, I recognize the handiwork... Only my bro can paint pictures like that.{x'",
+   "ua": "$c1 промовляє '{gТааак, впізнаю почерк... Такі картини тільки мій братан може малювати.{x'"
+  },
+  "$c1 произносит '{gДаа, узнаю почерк... Такие картины только мой шеф рисовать умеет.{x'": {
+   "en": "$c1 says, '{gYeah, I recognize the handiwork... Only my boss can paint pictures like that.{x'",
+   "ua": "$c1 промовляє: '{gТаак, впізнаю почерк... Такі картини лише мій шеф вміє малювати.{x'"
+  },
+  "$c1 произносит '{gНу да ладно, пойдем, глядишь прорвемся.{x'": {
+   "en": "$c1 says '{gAlright then, let's go, maybe we'll pull through.{x'",
+   "ua": "$c1 промовляє '{gНу та гаразд, ходімо, глядь і прорвемося.{x'"
+  },
+  "$c1 произносит '{gСержант Петренко, трое детей, предъявите документы{x'.": {
+   "en": "$c1 says '{gSergeant Petrenko, three kids, papers please{x'.",
+   "ua": "$c1 промовляє '{gСержант Петренко, троє дітей, пред'явіть документи{x'."
+  },
+  "$c1 произносит '{gЧто ж, пойдем. Попробуем прорваться.{x'": {
+   "en": "$c1 says '{gWell then, let's go. We'll try to break through.{x'",
+   "ua": "$c1 промовляє '{gЩо ж, ходімо. Спробуємо прорватися.{x'"
+  },
+  "$c1 рявкает: '{gНе оборачиваться!!!{x'": {
+   "en": "$c1 barks, '{gDon't you turn around!!!{x'",
+   "ua": "$c1 гаркає: '{gНе обертатися!!!{x'"
+  },
+  "$c1 скучающим взором окидывает камеру.": {
+   "en": "$c1 casts a bored glance around the cell.",
+   "ua": "$c1 знудженим поглядом окидає камеру."
+  },
+  "$c1 чешет репу в попытке сообразить, куда же делся этот $C1.": {
+   "en": "$c1 scratches their head trying to figure out where $C1 went.",
+   "ua": "$c1 чухає потилицю, намагаючись зрозуміти, куди подівся цей $C1."
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x": {
+   "en": "{Y$c1 basely killed the one you were tasked with saving.{x",
+   "ua": "{Y$c1 підло уби$gло|в|ла того, кого тобі було доручено врятувати.{x"
+  },
+  "{YВдруг откуда ни возьмись появляется отряд охотников на преступников!{x": {
+   "en": "{YSuddenly, out of nowhere, a squad of bounty hunters appears!{x",
+   "ua": "{YРаптом нізвідки з'являється загін мисливців на злочинців!{x"
+  },
+  "{YТем не менее, от тебя ожидали не этого...{x": {
+   "en": "{YStill, that's not what was expected of you...{x",
+   "ua": "{YТим не менш, від тебе очікували не цього...{x"
+  },
+  "{YТы оказа$gло|л|ла неоценимую услугу всему миру, убив его!!!{x": {
+   "en": "{YYou did the whole world an invaluable service by killing him!!!{x",
+   "ua": "{YТи нада$gло|в|ла неоціненну послугу всьому світові, вбивши його!!!{x"
+  },
+  "{YТы уби$gло|л|ла того, кто просил тебя о помощи. Привет тебе от преступного мира...{x": {
+   "en": "{YYou killed the one who asked you for help. Regards from the criminal underworld...{x",
+   "ua": "{YТи вби$gло|в|ла того, хто просив тебе про допомогу. Привіт тобі від злочинного світу...{x"
+  },
+  "Причем сапог явно движется навстречу.": {
+   "en": "And the boot is clearly moving to meet you.",
+   "ua": "Причому чобіт явно рухається назустріч."
+  },
+  "Причем тебе кажется, что сапог движется навстречу.": {
+   "en": "And it seems to you that the boot is moving towards you.",
+   "ua": "Причому тобі здається, що чобіт рухається назустріч."
+  }
+ },
+ "plug-ins/quest/killquest/victimbehavior.cpp": {
+  "{Y%1$^C1 помог%1$Gло||ла тебе выполнить задание, поспеши к квестору за наградой.{x": {
+   "en": "{Y%1$^C1 helped you complete the task, hurry to the quest giver for your reward.{x",
+   "ua": "{Y%1$^C1 допом%1$Gогло|іг|огла тобі виконати завдання, поспіши до квестодавця по нагороду.{x"
+  },
+  "{YЖертва умерла своей смертью.{x": {
+   "en": "{YThe victim died of natural causes.{x",
+   "ua": "{YЖертва померла своєю смертю.{x"
+  },
+  "{YКто-то другой выполнил порученное тебе задание.{x": {
+   "en": "{YSomeone else has completed the quest assigned to you.{x",
+   "ua": "{YХтось інший виконав доручене тобі завдання.{x"
+  },
+  "{YПоздравляю! Ты выполнил%Gо||а задание своего согруппника.": {
+   "en": "{YCongratulations! You've completed your groupmate's task.",
+   "ua": "{YВітаю! Ти виконал%Go||а завдання свого спільника."
+  },
+  "{YПоздравляю! Но это убийство было поручено другому.{x": {
+   "en": "{YCongratulations! But this kill was assigned to someone else.{x",
+   "ua": "{YВітаю! Але це вбивство було доручено іншому.{x"
+  },
+  "Твое задание {YВЫПОЛНЕНО{x!\nВернись за вознаграждением к давшему тебе задание до того, как истечет время!": {
+   "en": "Your quest is {YCOMPLETE{x!\nReturn to whoever gave you the quest for your reward before time runs out!",
+   "ua": "Твоє завдання {YВИКОНАНО{x!\nПовернись за винагородою до того, хто дав тобі завдання, поки не сплив час!"
+  }
+ },
+ "plug-ins/quest/locatequest/mobiles.cpp": {
+  "{Y$c1 внезапно скончал$gось|ся|ась. Задание отменяется.{x": {
+   "en": "{Y$c1 suddenly passed away. The quest is cancelled.{x",
+   "ua": "{Y$c1 раптово скона$gло|в|ла. Завдання скасовується.{x"
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{Y$c1 treacherously killed the one who needed your help.{x",
+   "ua": "{Y$c1 підло вби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  },
+  "{YТы прине$gсло|с|сла $C3 смерть, а тебя просили принести кое-что другое.{x": {
+   "en": "{YYou brought death to $C3, but you were asked to bring something else.{x",
+   "ua": "{YТи прин$gесло|іс|есла $C3 смерть, а тебе просили принести щось інше.{x"
+  }
+ },
+ "plug-ins/quest/locatequest/objects.cpp": {
+  "%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2.": {
+   "en": "%1$^O1 does not belong to you, so you throw it away.",
+   "ua": "%1$^O1 не належить тобі, і ти кидаєш %1$O4."
+  },
+  "%2$^C1 бросает %1$O4.": {
+   "en": "%2$^C1 throws %1$O4.",
+   "ua": "%2$^C1 кидає %1$O4."
+  }
+ },
+ "plug-ins/quest/locatequest/scenarios.cpp": {
+  "$c1 возвращает $C3 $o4.": {
+   "en": "$c1 returns $o4 to $C3.",
+   "ua": "$c1 повертає $C3 $o4."
+  },
+  "$c1 возвращает тебе $o4.": {
+   "en": "$c1 returns $o4 to you.",
+   "ua": "$c1 повертає тобі $o4."
+  },
+  "$c1 произносит '{gТеперь их уже $t, осталось совсем немного.{x'": {
+   "en": "$c1 says '{gNow there are only $t of them left, not many more to go.{x'",
+   "ua": "$c1 каже: '{gТепер їх уже $t, лишилося зовсім небагато.{x'"
+  },
+  "$c1 произносит '{gА вознаграждение я уже переда$gло|л|ла твоему квестору. Сходи и забери его.{x'": {
+   "en": "$c1 says '{gAnd I've already handed the reward over to your quest giver. Go get it.{x'",
+   "ua": "$c1 промовляє '{gА нагороду я вже переда$gло|в|ла твоєму квестору. Піди і забери її.{x'"
+  },
+  "$c1 произносит '{gВот спасибо, $C1. Теперь все найдено и я могу спать спокойно.{x'": {
+   "en": "$c1 says '{gThanks a lot, $C1. Now everything's found and I can sleep soundly.{x'",
+   "ua": "$c1 промовляє '{gОт спасибі, $C1. Тепер усе знайдено і я можу спати спокійно.{x'"
+  },
+  "$c1 произносит '{gДа-да, как говорится, еще 65535 ведер - и золотой ключик у нас в кармане.{x'": {
+   "en": "$c1 says '{gYes yes, as they say, another 65535 buckets and the golden little key is in our pocket.{x'",
+   "ua": "$c1 промовляє '{gТак-так, як то кажуть, ще 65535 відер -- і золотий ключик у нас в кишені.{x'"
+  },
+  "$c1 произносит '{gО, ты наш$Gло|ел|ла еще $t!{x'": {
+   "en": "$c1 says '{gOh, you found another $t!{x'",
+   "ua": "$c1 промовляє '{gО, ти знайш$Gло|ов|ла ще $t!{x'"
+  },
+  "$c1 произносит '{gСпасибо, конечно, но я не об этом проси$gло|л|ла тебя.'{x'": {
+   "en": "$c1 says '{gThanks, sure, but that's not what I asked you for.'{x'",
+   "ua": "$c1 промовляє '{gДякую, звісно, але я не про це проси$gло|в|ла тебе.'{x'"
+  }
+ },
+ "plug-ins/quest/locatequest/scenarios_impl.cpp": {
+  "$c1 отрывает взгляд от пробирок и поворачивается к тебе.": {
+   "en": "$c1 tears their eyes away from the test tubes and turns to you.",
+   "ua": "$c1 відриває погляд від пробірок і повертається до тебе."
+  },
+  "$c1 снова возвращается к работе.": {
+   "en": "$c1 goes back to work.",
+   "ua": "$c1 знову повертається до роботи."
+  },
+  "$c1 думает о чем-то, уставившись в одну точку.": {
+   "en": "$c1 stares at a fixed point, lost in thought.",
+   "ua": "$c1 думає про щось, втупившись в одну точку."
+  },
+  "$c1 жалобно всхлипывает.": {
+   "en": "$c1 sobs pitifully.",
+   "ua": "$c1 жалібно схлипує."
+  },
+  "$c1 отрывает взгляд от пробирок и поворачивается к $C2.": {
+   "en": "$c1 tears their eyes away from the test tubes and turns to $C2.",
+   "ua": "$c1 відриває погляд від пробірок і повертається до $C2."
+  },
+  "$c1 смотрит на $C4 широко раскрытыми от ужаса глазами.": {
+   "en": "$c1 looks at $C4 with eyes wide with horror.",
+   "ua": "$c1 дивиться на $C4 широко розплющеними від жаху очима."
+  },
+  "$c1 смотрит на тебя широко раскрытыми от ужаса глазами.": {
+   "en": "$c1 stares at you with eyes wide with horror.",
+   "ua": "$c1 дивиться на тебе широко розплющеними від жаху очима."
+  },
+  "$c1, всплеснув руками, бросается навстречу $C3.": {
+   "en": "$c1 throws up their hands and rushes to meet $C3.",
+   "ua": "$c1, сплеснувши руками, кидається назустріч $C3."
+  },
+  "$c1, всплеснув руками, бросается тебе навстречу.": {
+   "en": "$c1 throws up their hands and rushes toward you.",
+   "ua": "$c1, сплеснувши руками, кидається тобі назустріч."
+  }
+ },
+ "plug-ins/quest/staffquest/staffquest.cpp": {
+  "$c1 передает $n4 $C3.": {
+   "en": "$c1 hands $n4 to $C3.",
+   "ua": "$c1 передає $n4 $C3."
+  },
+  "Ты передаешь $n4 $C3.": {
+   "en": "You hand $n4 to $C3.",
+   "ua": "Ти передаєш $n4 $C3."
+  }
+ },
+ "plug-ins/quest/stealquest/mobiles.cpp": {
+  "{Y$c1 внезапно скончал$gось|ся|ась. Задание отменяется.{x": {
+   "en": "{Y$c1 has suddenly died. The task is cancelled.{x",
+   "ua": "{Y$c1 раптово поме$gрло|р|рла. Завдання скасовується.{x"
+  },
+  "$c1 восклицает '{gСпасибо тебе, $C1!{x'": {
+   "en": "$c1 exclaims '{gThank you, $C1!{x'",
+   "ua": "$c1 вигукує '{gДякую тобі, $C1!{x'"
+  },
+  "$c1 с равнодушным видом протягивает $C3 $o4.": {
+   "en": "$c1 hands $o4 to $C3 with an indifferent look.",
+   "ua": "$c1 з байдужим виглядом простягає $C3 $o4."
+  },
+  "$c1 с равнодушным видом протягивает тебе $o4.": {
+   "en": "$c1 hands you $o4 with an indifferent look.",
+   "ua": "$c1 з байдужим виглядом простягає тобі $o4."
+  },
+  "{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{Y$c1 basely killed the one who needed your help.{x",
+   "ua": "{Y$c1 підло уби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  },
+  "{YИдио$gт|т|тка! Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
+   "en": "{YIdiot! You killed the one who needed your help.{x",
+   "ua": "{YІдіо$gт|т|тко! Ти вби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  }
+ },
+ "plug-ins/quest/stealquest/objects.cpp": {
+  "%1$^C1 роня%1$nет|ют %2$O4.": {
+   "en": "%1$^C1 drop%1$ns|| %2$O4.",
+   "ua": "%1$^C1 рон%1$nяє|яють %2$O4."
+  },
+  "%1$^O1 выпада%1$nет|ют у тебя из рук.": {
+   "en": "%1$^O1 slip%1$ns| out of your hands.",
+   "ua": "%1$^O1 випада%1$nє|ють у тебе з рук."
+  },
+  "%1$^O1 жажд%1$nет|ут вернуться к хозяину.": {
+   "en": "%1$^O1 yearn%1$ns| to return to its owner.",
+   "ua": "%1$^O1 жад%1$nає|ають повернутися до хазяїна."
+  },
+  "%1$^O1 тускло поблескива%1$nет|ют.": {
+   "en": "%1$^O1 glimmer%1$ns| dimly.",
+   "ua": "%1$^O1 тьмяно поблиску%1$nє|ють."
+  },
+  "Ты роняешь %1$O4.": {
+   "en": "You drop %1$O4.",
+   "ua": "Ти впускаєш %1$O4."
+  }
+ },
+ "plug-ins/questreward/ownercoupon.cpp": {
+  "Какую именно вещь ты хочешь сделать своей собственностью?": {
+   "en": "Which item exactly do you want to make your property?",
+   "ua": "Яку саме річ ти хочеш зробити своєю власністю?"
+  },
+  "Ты превращаешь %O4 в свою личную вещь.": {
+   "en": "You turn %O4 into your personal belonging.",
+   "ua": "Ти перетворюєш %O4 на свою особисту річ."
+  },
+  "У %O2 уже есть постоянный владелец.": {
+   "en": "%O2 already has a permanent owner.",
+   "ua": "У %O2 вже є постійний власник."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе цього немає."
+  },
+  "Это неразумно.": {
+   "en": "That's unwise.",
+   "ua": "Це нерозумно."
+  },
+  "%^C1 проделывает манипуляции с %O5 и %O5.": {
+   "en": "%^C1 fiddles about with %O5 and %O5.",
+   "ua": "%^C1 проробляє маніпуляції з %O5 та %O5."
+  },
+  "%^O1 исчезнет через некоторое время, не жалко купон тратить?": {
+   "en": "%^O1 will vanish after a while -- not a shame to spend the coupon?",
+   "ua": "%^O1 зникне через деякий час, не шкода купон витрачати?"
+  },
+  "Лимиты нельзя приватизировать!": {
+   "en": "Limits can't be privatized!",
+   "ua": "Ліміти не можна приватизувати!"
+  }
+ },
+ "plug-ins/race_aptitude/felar.cpp": {
+  "$c1 теряет равновесие и падает!": {
+   "en": "$c1 loses balance and falls!",
+   "ua": "$c1 втрачає рівновагу і падає!"
+  },
+  "Сейчас ты не сражаешься!": {
+   "en": "You're not fighting right now!",
+   "ua": "Зараз ти не б'єшся!"
+  },
+  "Тебе нужно подождать, пока $E повернется к тебе.": {
+   "en": "You need to wait until they turn to face you.",
+   "ua": "Тобі потрібно почекати, поки вони повернуться до тебе."
+  },
+  "Ты наносишь $C3 удар хвостом!": {
+   "en": "You strike $C3 with your tail!",
+   "ua": "Ти завдаєш $C3 удару хвостом!"
+  },
+  "Этого нет здесь.": {
+   "en": "That's not here.",
+   "ua": "Цього тут немає."
+  },
+  "$c1 наносит $C3 удар хвостом.": {
+   "en": "$c1 delivers a tail strike to $C3.",
+   "ua": "$c1 завдає $C3 удару хвостом."
+  },
+  "$c1 наносит тебе удар хвостом!": {
+   "en": "$c1 strikes you with its tail!",
+   "ua": "$c1 завдає тобі удару хвостом!"
+  },
+  "Но $C1 твой друг!": {
+   "en": "But $C1 is your friend!",
+   "ua": "Але $C1 твій друг!"
+  },
+  "Только не верхом!": {
+   "en": "Just not on horseback!",
+   "ua": "Тільки не верхи!"
+  },
+  "Ты пытаешься огреть себя хвостом, но ничего не выходит.": {
+   "en": "You try to whack yourself with your tail, but nothing happens.",
+   "ua": "Ти намагаєшся вперіщити себе хвостом, але нічого не виходить."
+  },
+  "Ты теряешь равновесие и падаешь!": {
+   "en": "You lose your balance and fall!",
+   "ua": "Ти втрачаєш рівновагу і падаєш!"
+  },
+  "Ты уклоняешься от хвоста $c2, и $e падает.": {
+   "en": "You dodge $c2's tail, and it falls.",
+   "ua": "Ти ухиляєшся від хвоста $c2, і він падає."
+  }
+ },
+ "plug-ins/race_aptitude/hobbit.cpp": {
+  "$c1 подбирает с земли $t.": {
+   "en": "$c1 picks $t up off the ground.",
+   "ua": "$c1 підбирає з землі $t."
+  },
+  "В этой местности бесполезно искать камни.": {
+   "en": "It's pointless to look for stones in this area.",
+   "ua": "У цій місцевості марно шукати каміння."
+  },
+  "Тебе не удалось отыскать ни одного камня.": {
+   "en": "You failed to find a single stone.",
+   "ua": "Тобі не вдалося знайти жодного каменя."
+  },
+  "Ты не в силах удержать %1$O4 и роняешь %1$P2.": {
+   "en": "You can't hold onto %1$O4 and drop it.",
+   "ua": "Ти не в змозі втримати %1$O4 і впускаєш %1$O2."
+  },
+  "Ты не умеешь это делать.": {
+   "en": "You don't know how to do that.",
+   "ua": "Ти не вмієш цього робити."
+  },
+  "Ты подбираешь с земли $t.": {
+   "en": "You pick $t up off the ground.",
+   "ua": "Ти підбираєш із землі $t."
+  }
+ },
+ "plug-ins/race_aptitude/raceaptitude.cpp": {
+  "Тебе не с кем практиковаться здесь.": {
+   "en": "There's no one for you to practice with here.",
+   "ua": "Тобі нема з ким практикуватися тут."
+  },
+  "Ты не можешь практиковать это здесь.": {
+   "en": "You can't practice that here.",
+   "ua": "Ти не можеш практикувати це тут."
+  }
+ },
+ "plug-ins/religion/altar.cpp": {
+  "%^C1 сооружает %O4 для подношений своему божеству.": {
+   "en": "%^C1 builds %O4 as an offering to their deity.",
+   "ua": "%^C1 споруджує %O4 для підношень своєму божеству."
+  },
+  "Здесь неподходящее место для воздвигания алтарей.": {
+   "en": "This is not a suitable place to erect an altar.",
+   "ua": "Тут не підходяще місце для зведення вівтарів."
+  },
+  "Но здесь уже есть какой-то алтарь!": {
+   "en": "But there's already some altar here!",
+   "ua": "Але тут вже є якийсь вівтар!"
+  },
+  "Похоже, %N1 совершенно равнодуш%gно|ен|на к жертвоприношениям.": {
+   "en": "Looks like %N1 is utterly indifferent to sacrifices.",
+   "ua": "Схоже, %N1 цілком байдуж%gе|ий|а до жертвоприношень."
+  },
+  "Ты все еще истощен%Gо||а постройкой предыдущего алтаря.": {
+   "en": "You're still exhausted from building the previous altar.",
+   "ua": "Ти й досі виснажен%Gо|ий|а спорудженням попереднього вівтаря."
+  },
+  "Ты сооружаешь %O4 для подношений %N3.": {
+   "en": "You build %O4 for offerings to %N3.",
+   "ua": "Ти споруджуєш %O4 для підношень %N3."
+  },
+  "Боги вряд ли оценят такое.": {
+   "en": "The gods are unlikely to appreciate that.",
+   "ua": "Боги навряд чи оцінять таке."
+  },
+  "Изыди, глупое животное.": {
+   "en": "Begone, foolish animal.",
+   "ua": "Згинь, дурна тварино."
+  },
+  "Ты слишком возбужден%Gо||а, чтобы воздвигать алтарь.": {
+   "en": "You're too worked up to build an altar.",
+   "ua": "Ти занадто збудж%Gено|ений|ена|ені, щоб зводити вівтар."
+  }
+ },
+ "plug-ins/religion/gods_impl.cpp": {
+  "{C%^O1 загорается голубым светом.{x": {
+   "en": "{C%^O1 lights up with a blue glow.{x",
+   "ua": "{C%^O1 спалахує блакитним світлом.{x"
+  },
+  "{CЭреван Илесир внезапно вселяется в $c4.{x": {
+   "en": "{CErevan Ilesere suddenly possesses $c4.{x",
+   "ua": "{CЕреван Ілесере несподівано вселяється в $c4.{x"
+  },
+  "{CЭреван Илесир внезапно вселяется в тебя.{x": {
+   "en": "{CErevan Ilesere suddenly possesses you.{x",
+   "ua": "{CЕреван Ілесере раптово оволодіває тобою.{x"
+  },
+  "{WТы внезапно ощущаешь повышенную активность!{x": {
+   "en": "{WYou suddenly feel a surge of heightened activity!{x",
+   "ua": "{WТи раптово відчуваєш підвищену активність!{x"
+  }
+ },
+ "plug-ins/religion/sacrifice.cpp": {
+  "%1$^O1 в данный момент использу%1$nется|ются.": {
+   "en": "%1$^O1 %1$nis|are currently being used.",
+   "ua": "%1$^O1 наразі використову%1$nється|ються."
+  },
+  "%1$^O1 не подлеж%1$nит|ат жертвоприношению.": {
+   "en": "%1$^O1 %1$nis|are not subject to sacrifice.",
+   "ua": "%1$^O1 не підляга%1$nє|ють жертвопринесенню."
+  },
+  "%^C1 приносит %O4 в жертву %N3.": {
+   "en": "%^C1 sacrifices %O4 to %N3.",
+   "ua": "%^C1 приносить %O4 в жертву %N3."
+  },
+  "%^C1 приносит содержимое %O2 в жертву своим богам.": {
+   "en": "%^C1 sacrifices the contents of %O2 to their gods.",
+   "ua": "%^C1 приносить вміст %O2 в жертву своїм богам."
+  },
+  "%^O1 выпадает из %O2 %s.": {
+   "en": "%^O1 falls out of %O2 %s.",
+   "ua": "%^O1 випадає з %O2 %s."
+  },
+  "%^O1 посвящен другому божеству.": {
+   "en": "%^O1 is devoted to another deity.",
+   "ua": "%^O1 присвячений іншому божеству."
+  },
+  "...но ничего не происходит.": {
+   "en": "...but nothing happens.",
+   "ua": "...але нічого не відбувається."
+  },
+  "{Y%^N1 благосклонно принимает твою жертву.{x": {
+   "en": "{Y%^N1 graciously accepts your sacrifice.{x",
+   "ua": "{Y%^N1 прихильно приймає твою жертву.{x"
+  },
+  "{YВсю следующую неделю тебе будет сопутствовать удача в %s.{x": {
+   "en": "{YAll next week, luck will be with you in %s.{x",
+   "ua": "{YЦілий наступний тиждень тобі супроводжуватиме удача в %s.{x"
+  },
+  "В этой местности %N3 не удастся принять твою жертву.": {
+   "en": "In this area, %N3 won't be able to accept your sacrifice.",
+   "ua": "У цій місцевості %N3 не вдасться прийняти твою жертву."
+  },
+  "Некоторые вещи внутри %O2 не могут быть принесены в жертву и падают %s.": {
+   "en": "Some things inside %O2 can't be sacrificed and fall %s.",
+   "ua": "Деякі речі всередині %O2 не можуть бути принесені в жертву і падають %s."
+  },
+  "Но на %O6 совсем пусто!": {
+   "en": "But %O6 is completely empty!",
+   "ua": "Але на %O6 зовсім порожньо!"
+  },
+  "Но помни, что не все они для тебя подходят.": {
+   "en": "But remember, not all of them are right for you.",
+   "ua": "Але пам'ятай, що не всі вони тобі підходять."
+  },
+  "Содержимое %O2 падает %s.": {
+   "en": "The contents of %O2 fall %s.",
+   "ua": "Вміст %O2 падає %s."
+  },
+  "Твое скудное жертвоприношение остается без награды от %N2.": {
+   "en": "Your meager sacrifice goes unrewarded by %N2.",
+   "ua": "Твоє скупе жертвопринесення залишається без нагороди від %N2."
+  },
+  "Трупы игроков жертвовать запрещено.": {
+   "en": "Sacrificing player corpses is forbidden.",
+   "ua": "Приносити в жертву трупи гравців заборонено."
+  },
+  "Ты все еще под впечатлением от предыдущего жертвоприношения.": {
+   "en": "You're still shaken from the previous sacrifice.",
+   "ua": "Ти все ще під враженням від попереднього жертвопринесення."
+  },
+  "Ты все еще пользуешься плодами предыдущего жертвоприношения.": {
+   "en": "You're still enjoying the fruits of your previous sacrifice.",
+   "ua": "Ти все ще користуєшся плодами попереднього жертвопринесення."
+  },
+  "Ты и так учишься быстрее других. Попроси божество об иной милости.": {
+   "en": "You already learn faster than others. Ask the deity for a different favor.",
+   "ua": "Ти й так вчишся швидше за інших. Попроси божество про іншу милість."
+  },
+  "Ты можешь попросить богов об одной из таких вещей: опыт, мана, обучаемость, воровские умения{x.": {
+   "en": "You can ask the gods for one of the following: experience, mana, practices, thieving skills{x.",
+   "ua": "Ти можеш попросити богів про одну з таких речей: досвід, ману, здатність до навчання, злодійські вміння{x."
+  },
+  "Ты не находишь ничего подходящего для жертвоприношения.": {
+   "en": "You find nothing suitable for sacrifice.",
+   "ua": "Ти не знаходиш нічого придатного для жертвопринесення."
+  },
+  "Ты не находишь этого.": {
+   "en": "You don't find it.",
+   "ua": "Ти не знаходиш цього."
+  },
+  "Ты получаешь %1$d серебрян%1$Iую|ые|ых монет%1$Iу|ы| от %2$N2 за свое жертвоприношение.": {
+   "en": "You receive %1$d silver coin%1$I|s|s from %2$N2 for your sacrifice.",
+   "ua": "Ти отримуєш %1$d срібн%1$Iу|і|их монет%1$Iу|и| від %2$N2 за своє жертвопринесення."
+  },
+  "Ты приносишь в жертву %N3 все, что находится %s.": {
+   "en": "You sacrifice to %N3 everything that is %s.",
+   "ua": "Ти приносиш у жертву %N3 все, що знаходиться %s."
+  },
+  "Ты устраиваешь торжественное сожжение во славу %1$N3, восстанавливая %2$d очк%2$Iо|а|ов энергии.": {
+   "en": "You hold a solemn burning in honor of %1$N3, restoring %2$d point%2$I|s|s of energy.",
+   "ua": "Ти влаштовуєш урочисте спалення на честь %1$N3, відновлюючи %2$d оч%2$Iко|ки|ок енергії."
+  },
+  "%1$^C1 выглядит просветленн%1$Gым|ым|ой.": {
+   "en": "%1$^C1 looks enlightened.",
+   "ua": "%1$^C1 виглядає просвітлен%1$Gим|им|ою."
+  },
+  "%^C1 предлагает себя в жертву %N3, но слышит в ответ тактичное молчание.": {
+   "en": "%^C1 offers themselves up as a sacrifice to %N3, but hears only a tactful silence in reply.",
+   "ua": "%^C1 пропонує себе в жертву %N3, але чує у відповідь тактовну тишу."
+  },
+  "%^C1 совершает бессмысленные манипуляции с %O5.": {
+   "en": "%^C1 performs pointless manipulations with %O5.",
+   "ua": "%^C1 здійснює безглузді маніпуляції з %O5."
+  },
+  "%^C1 устраивает торжественное сожжение во славу %N3, восстанавливая энергию.": {
+   "en": "%^C1 holds a solemn burning in honor of %N3, restoring energy.",
+   "ua": "%^C1 влаштовує урочисте спалення на славу %N3, відновлюючи енергію."
+  },
+  "%^N1 игнорирует твое скудное подношение.": {
+   "en": "%^N1 ignores your meager offering.",
+   "ua": "%^N1 ігнорує твоє мізерне підношення."
+  },
+  "{R%^N1 гневается на тебя за попытку принести в жертву %s!{x": {
+   "en": "{R%^N1 is enraged at you for attempting to sacrifice %s!{x",
+   "ua": "{R%^N1 гнівається на тебе за спробу принести в жертву %s!{x"
+  },
+  "{Y%1^N1{x скупо кряхтит и добавляет тебе еще %2$d монет%2$Iу|ы|.": {
+   "en": "{Y%1^N1{x grunts stingily and tosses in %2$d more coin%2$I|s|s.",
+   "ua": "{Y%1^N1{x скупо крекче і додає тобі ще %2$d монет%2$Iу|и|."
+  },
+  "Гнев %^N2 обрушивается на %C4!": {
+   "en": "%^N2's wrath comes crashing down on %C4!",
+   "ua": "Гнів %^N2 обрушується на %C4!"
+  },
+  "Изыди, глупое животное.": {
+   "en": "Begone, foolish animal.",
+   "ua": "Згинь, дурна тварино."
+  },
+  "Но ты же закоренел%1$Gое|ый|ая атеист%1$G||ка.": {
+   "en": "But you're a die-hard atheist.",
+   "ua": "Але ж ти закорен%1$Gіле|ілий|іла атеїст%1$G||ка."
+  },
+  "Похоже, %N1 совершенно равнодуш%gно|ен|на к жертвоприношениям.": {
+   "en": "Looks like %N1 is completely indifferent to sacrifices.",
+   "ua": "Схоже, %N1 цілком байдуж%gе|ий|а до жертвопринесень."
+  },
+  "Ты предлагаешь себя в жертву %N3, но слышишь в ответ лишь тактичное молчание.": {
+   "en": "You offer yourself as a sacrifice to %N3, but hear only tactful silence in reply.",
+   "ua": "Ти пропонуєш себе в жертву %N3, але чуєш у відповідь лише тактовну мовчанку."
+  },
+  "Ты слышишь насмешливый голос с неба, говорящий тебе, что то, о чем ты просишь, тебе ни к чему.": {
+   "en": "You hear a mocking voice from the sky telling you that what you're asking for is of no use to you.",
+   "ua": "Ти чуєш глузливий голос з неба, що каже тобі, що те, про що ти просиш, тобі ні до чого."
+  },
+  "Это было действительно {rБОЛЬНО{x!": {
+   "en": "That really {rHURT{x!",
+   "ua": "Це було справді {rБОЛЯЧЕ{x!"
+  }
+ },
+ "plug-ins/remort/cmlt.cpp": {
+  "     %1$d уров%1$Iень|ня|ней \n": {
+   "en": "     %1$d level%1$I|s|s \n",
+   "ua": "     %1$d рів%1$Iень|ні|нів \n"
+  },
+  "     %N1 %N1, переродил%Gось|ся|ась в возрасте %d %s": {
+   "en": "     %N1 %N1, was reborn at the age of %d %s",
+   "ua": "     %N1 %N1, переродил%Gося|ся|ася у віці %d %s"
+  },
+  "     %d здоровья\n": {
+   "en": "     %d health\n",
+   "ua": "     %d здоров'я\n"
+  },
+  "     %d маны\n": {
+   "en": "     %d mana\n",
+   "ua": "     %d мани\n"
+  },
+  "     +%d к %s\n": {
+   "en": "     +%d to %s\n",
+   "ua": "     +%d до %s\n"
+  },
+  "В DreamLand нет жителя с таким именем.": {
+   "en": "There is no resident of DreamLand by that name.",
+   "ua": "У DreamLand немає жителя з таким ім'ям."
+  },
+  "Всего ты выполни%1$Gло|л|ла {W%2$d{x персональн%2$Iый|ых|ых квес%2$Iт|та|тов, ": {
+   "en": "In total you have completed {W%2$d{x personal quest%2$I|s|s, ",
+   "ua": "Всього ти викона%1$Gло|в|ла {W%2$d{x особист%2$Iий|і|их квес%2$Iт|ти|тів, "
+  },
+  "Никого нет.": {
+   "en": "There's no one here.",
+   "ua": "Нікого немає."
+  },
+  "Ты выкупи%1$Gло|л|ла {W%2$d{x купо%2$Iн|на|нов владельца и выбра%1$Gло|л|ла в качестве бонусов:": {
+   "en": "You redeemed {W%2$d{x owner coupon%2$I|s|s and chose as bonuses:",
+   "ua": "Ти викупи%1$Gло|в|ла {W%2$d{x купо%2$Iн|ни|нів власника і обра%1$Gло|в|ла як бонуси:"
+  },
+  "Ты пока не выполни%1$Gло|л|ла ни одного персонального квеста.": {
+   "en": "You haven't completed a single personal quest yet.",
+   "ua": "Ти поки не викона%1$Gло|в|ла жодного особистого квесту."
+  },
+  "Ты прожи%1$Gло|л|ла {W%2$d{x жизн%2$Iь|и|ей, ": {
+   "en": "You have lived {W%2$d{x life%2$I|s|s, ",
+   "ua": "Ти прожи%1$Gло|в|ла {W%2$d{x житт%2$Iя|я|ів, "
+  },
+  "Эта информация скрыта от Вас.": {
+   "en": "This information is hidden from you.",
+   "ua": "Ця інформація прихована від тебе."
+  },
+  "Их слишком много. %d тел.": {
+   "en": "There are too many of them. %d bodies.",
+   "ua": "Їх занадто багато. %d тіл."
+  },
+  "Ты обменя%1$Gло|л|ла {W%2$d{x побед%2$Iу|ы| на плюшки.": {
+   "en": "You traded {W%2$d{x victor%2$Iy|ies|ies for treats.",
+   "ua": "Ти обміня%1$Gло|в|ла {W%2$d{x перемог%2$Iу|и| на смаколики."
+  },
+  "Ты пока не обменя%1$Gло|л|ла ни одну победу на плюшки.": {
+   "en": "You haven't traded a single win for perks yet.",
+   "ua": "Ти поки що не обміня%1$Gло|в|ла жодної перемоги на плюшки."
+  }
+ },
+ "plug-ins/remort/cremort.cpp": {
+  "{RВнимание! Все вещи в твоем инвентаре и на тебе исчезнут с перерождением!{x": {
+   "en": "{RWarning! All items in your inventory and worn will disappear upon rebirth!{x",
+   "ua": "{RУвага! Усі речі в твоєму інвентарі та на тобі зникнуть після переродження!{x"
+  },
+  "Неверный пароль.": {
+   "en": "Incorrect password.",
+   "ua": "Невірний пароль."
+  },
+  "Подожди пока вещь, выставленная на аукцион, будет продана или возвращена.": {
+   "en": "Wait until the item put up for auction is sold or returned.",
+   "ua": "Зачекай, поки річ, виставлена на аукціон, буде продана або повернена."
+  },
+  "Ты еще не искупи%1$Gло|л|ла провинности ЭТОЙ жизни.": {
+   "en": "You haven't yet atoned for the sins of THIS life.",
+   "ua": "Ти ще не спокутува%1$Gло|в|ла провини ЦЬОГО життя."
+  },
+  "Не удалось сохранить твой профайл: сообщи Богам!": {
+   "en": "Failed to save your profile: tell the Gods!",
+   "ua": "Не вдалося зберегти твій профайл: повідом Богам!"
+  }
+ },
+ "plug-ins/remort/remortnanny.cpp": {
+  "{cУ твоей расы теперь выше параметр '%s', тебе нет нужды покупать его дополнительно за реморты.{x": {
+   "en": "{cYour race's '%s' parameter is now higher, you don't need to buy it further with remorts.{x",
+   "ua": "{cУ твоєї раси тепер вищий параметр '%s', тобі нема потреби купувати його додатково за реморти.{x"
+  },
+  "{cТы попадаешь в избушку к Бабе Яге, чтобы снова выбрать плюшки за реморты.{x": {
+   "en": "{cYou end up at Baba Yaga's hut to pick your remort perks again.{x",
+   "ua": "{cТи потрапляєш до хатинки Баби Яги, щоб знову обрати плюшки за реморти.{x"
+  }
+ },
+ "plug-ins/services/petshop/mixedpetshop.cpp": {
+  "Извини, ты не можешь купить этого здесь.": {
+   "en": "Sorry, you can't buy that here.",
+   "ua": "Вибач, ти не можеш купити це тут."
+  },
+  "Магазин не работает.": {
+   "en": "The shop isn't open.",
+   "ua": "Крамниця не працює."
+  }
+ },
+ "plug-ins/services/petshop/pet.cpp": {
+  "$c1 приобретает $C4.": {
+   "en": "$c1 acquires $C4.",
+   "ua": "$c1 набуває $C4."
+  },
+  "%s\r\nТы понимаешь, что %s будет защищать и следовать за {C%s{x до самой смерти.\n\r": {
+   "en": "%s\r\nYou realize that %s will protect and follow {C%s{x until death.\n\r",
+   "ua": "%s\r\nТи розумієш, що %s буде захищати і слідувати за {C%s{x до самої смерті.\n\r"
+  },
+  "Тебе не хватит опыта справиться с этим скакуном.": {
+   "en": "You don't have enough experience to handle this mount.",
+   "ua": "Тобі не вистачить досвіду впоратися з цим скакуном."
+  },
+  "Ты торгуешься и цена снижается до %d монет.": {
+   "en": "You haggle and the price drops to %d coins.",
+   "ua": "Ти торгуєшся і ціна знижується до %d монет."
+  },
+  "У тебя не хватает %N2, чтобы заплатить за это.": {
+   "en": "You don't have enough %N2 to pay for this.",
+   "ua": "У тебе не вистачає %N2, щоб заплатити за це."
+  },
+  "У тебя недостаточно опыта, чтобы справиться с этим питомцем.": {
+   "en": "You don't have enough experience to handle this pet.",
+   "ua": "У тебе недостатньо досвіду, щоб впоратися з цим улюбленцем."
+  },
+  "У тебя уже есть один питомец.": {
+   "en": "You already have one pet.",
+   "ua": "У тебе вже є один улюбленець."
+  },
+  "У тебя уже есть скакун.": {
+   "en": "You already have a mount.",
+   "ua": "У тебе вже є скакун."
+  },
+  "улета%1$nет|ют ": {
+   "en": "fl%1$nies| away ",
+   "ua": "відліта%1$nє|ють "
+  },
+  "уплыва%1$nет|ют ": {
+   "en": "swim%1$ns| away ",
+   "ua": "заплива%1$nє|ють "
+  },
+  "уполза%1$nет|ют ": {
+   "en": "craw%1$nls|l away ",
+   "ua": "повза%1$nє|ють геть "
+  },
+  "уход%1$nит|ят ": {
+   "en": "leave%1$ns| ",
+   "ua": "йд%1$nе|уть "
+  },
+  "$c1 приобретает для верховой езды $C4.": {
+   "en": "$c1 acquires $C4 for riding.",
+   "ua": "$c1 здобуває $C4 для верхової їзди."
+  },
+  "Брошенн%1$Gый|ый|ая|ые %1$C1 горько вздыха%1$nет|ют напоследок и ": {
+   "en": "The abandoned %1$C1 sighs bitterly one last time and ",
+   "ua": "Покинут%1$Gий|ий|а|і %1$C1 гірко зітха%1$nє|ють востаннє і "
+  },
+  "Наслаждайся своим скакуном.": {
+   "en": "Enjoy your steed.",
+   "ua": "Насолоджуйся своїм скакуном."
+  },
+  "Тебе омерзительна сама мысль о покупке этих несчастных порабощенных созданий.": {
+   "en": "The very thought of buying these poor enslaved creatures disgusts you.",
+   "ua": "Тобі огидна сама думка про купівлю цих нещасних поневолених створінь."
+  },
+  "Ты надеешься, что если перестать покупать питомцев, то их просто выпустят на волю.": {
+   "en": "You hope that if people stop buying pets, they'll just be set free.",
+   "ua": "Ти сподіваєшся, що якщо перестати купувати улюбленців, то їх просто відпустять на волю."
+  }
+ },
+ "plug-ins/services/petshop/petshopstorage.cpp": {
+  "Извини, ты не можешь купить этого здесь.": {
+   "en": "Sorry, you can't buy that here.",
+   "ua": "Вибач, ти не можеш купити це тут."
+  },
+  "Существа на продажу:": {
+   "en": "Creatures for sale:",
+   "ua": "Істоти на продаж:"
+  },
+  "Ты можешь купить только одного питомца.": {
+   "en": "You can only buy one pet.",
+   "ua": "Ти можеш купити тільки одного улюбленця."
+  },
+  "Извини, все животные давно разбежались.": {
+   "en": "Sorry, all the animals ran off long ago.",
+   "ua": "Вибач, усі тварини давно розбіглися."
+  }
+ },
+ "plug-ins/services/shop/oldshop.cpp": {
+  "$c1 говорит тебе '{GУ меня нет денег.{x'": {
+   "en": "$c1 tells you '{GI don't have any money.{x'",
+   "ua": "$c1 каже тобі '{GУ мене немає грошей.{x'"
+  },
+  "$c1 говорит тебе '{gУ тебя нет нужной суммы, чтоб купить $o4.{x'": {
+   "en": "$c1 tells you '{gYou don't have the right amount to buy $o4.{x'",
+   "ua": "$c1 каже тобі '{gУ тебе немає потрібної суми, щоб купити $o4.{x'"
+  },
+  "$c1 говорит тебе '{gУ тебя нет этого.{x'": {
+   "en": "$c1 tells you '{gYou don't have that.{x'",
+   "ua": "$c1 каже тобі '{gУ тебе цього немає.{x'"
+  },
+  "$c1 не видит этого.": {
+   "en": "$c1 doesn't see that.",
+   "ua": "$c1 не бачить цього."
+  },
+  "$c1 не интересуется $o5.": {
+   "en": "$c1 isn't interested in $o5.",
+   "ua": "$c1 не цікавиться $o5."
+  },
+  "$c1 покупает $o4.": {
+   "en": "$c1 buys $o4.",
+   "ua": "$c1 купує $o4."
+  },
+  "$c1 покупает $o4[%d].": {
+   "en": "$c1 buys $o4[%d].",
+   "ua": "$c1 купує $o4[%d]."
+  },
+  "$c1 продает $o4.": {
+   "en": "$c1 sells $o4.",
+   "ua": "$c1 продає $o4."
+  },
+  "%^C1 не видит %O4.": {
+   "en": "%^C1 doesn't see %O4.",
+   "ua": "%^C1 не бачить %O4."
+  },
+  "%^C1 не интересуется %O5.": {
+   "en": "%^C1 isn't interested in %O5.",
+   "ua": "%^C1 не цікавиться %O5."
+  },
+  "%^C1 предлагает тебе %s за %O4.": {
+   "en": "%^C1 offers you %s for %O4.",
+   "ua": "%^C1 пропонує тобі %s за %O4."
+  },
+  "%^C1 торгуется с %C5, но безуспешно.": {
+   "en": "%^C1 haggles with %C5, but unsuccessfully.",
+   "ua": "%^C1 торгується з %C5, але безуспішно."
+  },
+  "Здесь нет продавцов.": {
+   "en": "There are no vendors here.",
+   "ua": "Тут немає продавців."
+  },
+  "Купить что?": {
+   "en": "Buy what?",
+   "ua": "Купити що?"
+  },
+  "Продать что?": {
+   "en": "Sell what?",
+   "ua": "Продати що?"
+  },
+  "Ты не можешь избавиться от этого.": {
+   "en": "You can't get rid of that.",
+   "ua": "Ти не можеш позбутися цього."
+  },
+  "Ты не можешь нести так много вещей.": {
+   "en": "You can't carry that many things.",
+   "ua": "Ти не можеш нести так багато речей."
+  },
+  "Ты не можешь нести такую тяжесть.": {
+   "en": "You can't carry that much weight.",
+   "ua": "Ти не можеш нести таку вагу."
+  },
+  "Ты не сможешь избавиться от %O2.": {
+   "en": "You won't be able to get rid of %O2.",
+   "ua": "Ти не зможеш позбутися %O2."
+  },
+  "Ты покупаешь $o4[%d] за %d серебрян%s.": {
+   "en": "You buy $o4[%d] for %d silver%s.",
+   "ua": "Ти купуєш $o4[%d] за %d срібн%s."
+  },
+  "Ты продаешь %O4 за %s.": {
+   "en": "You sell %O4 for %s.",
+   "ua": "Ти продаєш %O4 за %s."
+  },
+  "Ты торгуешься с %C5, но безуспешно.": {
+   "en": "You haggle with %C5, but without success.",
+   "ua": "Ти торгуєшся з %C5, але безуспішно."
+  },
+  "Узнать характеристики чего?": {
+   "en": "Check the stats of what?",
+   "ua": "Дізнатися характеристики чого?"
+  },
+  "Узнать цену чего?": {
+   "en": "Check the price of what?",
+   "ua": "Дізнатися ціну чого?"
+  },
+  "$c1 говорит тебе '{gТакого количества ништяков у меня нету.{x'": {
+   "en": "$c1 tells you '{gI don't have that much good stuff.{x'",
+   "ua": "$c1 каже тобі: '{gТакої кількості добра у мене нема.{x'"
+  },
+  "$c1 говорит тебе '{gТы не можешь заплатить за столько.{x'": {
+   "en": "$c1 says to you '{gYou can't afford that much.{x'",
+   "ua": "$c1 каже тобі '{gТи не можеш заплатити за стільки.{x'"
+  },
+  "$c1 говорит тебе '{gУ меня нет денег, чтоб заплатить тебе за $o4.{x'": {
+   "en": "$c1 tells you, '{gI don't have the money to pay you for $o4.{x'",
+   "ua": "$c1 каже тобі: '{gУ мене немає грошей, щоб заплатити тобі за $o4.{x'"
+  },
+  "$c1 говорит тебе '{gУ меня нет столько.{x'": {
+   "en": "$c1 says to you '{gI don't have that much.{x'",
+   "ua": "$c1 каже тобі '{gУ мене немає стільки.{x'"
+  },
+  "$c1 пытается дать тебе деньги, но ты не можешь их удержать.": {
+   "en": "$c1 tries to give you money, but you can't hold onto it.",
+   "ua": "$c1 намагається дати тобі гроші, але ти не можеш їх втримати."
+  },
+  "$c1 роняет на пол кучку монет.": {
+   "en": "$c1 drops a pile of coins on the floor.",
+   "ua": "$c1 роняє на підлогу купку монет."
+  },
+  "%1$C1 -- преступни%1$Gк|к|ца|ки! Хватайте %1$P2!": {
+   "en": "%1$C1 is a criminal! Seize them!",
+   "ua": "%1$C1 -- злочин%1$Gець|ець|ниця|ці! Хапайте %1$O2!"
+  },
+  "%^C1 торгуется с %C5 и выбивает наценок!": {
+   "en": "%^C1 haggles with %C5 and knocks the markup down!",
+   "ua": "%^C1 торгується з %C5 і вибиває знижку!"
+  },
+  "%^C1 торгуется с %C5 и выбивает скидку!": {
+   "en": "%^C1 haggles with %C5 and wrangles a discount!",
+   "ua": "%^C1 торгується з %C5 і вибиває знижку!"
+  },
+  "Ты торгуешься с %C5 и выбиваешь наценок!": {
+   "en": "You haggle with %C5 and knock down the markup!",
+   "ua": "Ти торгуєшся з %C5 і збиваєш націнку!"
+  },
+  "Ты торгуешься с %C5 и выбиваешь скидку!": {
+   "en": "You haggle with %C5 and score a discount!",
+   "ua": "Ти торгуєшся з %C5 і вибиваєш знижку!"
+  }
+ },
+ "plug-ins/services/shop/shoptrader.cpp": {
+  "$c1 роняет $o4.": {
+   "en": "$c1 drops $o4.",
+   "ua": "$c1 упускає $o4."
+  },
+  "%1$^C1 взя%1$Gло|л|ла с тебя {W%2$d{x моне%2$Iту|ты|т за услуги.": {
+   "en": "%1$^C1 took {W%2$d{x coin%2$I|s|s from you for services.",
+   "ua": "%1$^C1 взя%1$Gло|в|ла з тебе {W%2$d{x моне%2$Iту|ти|т за послуги."
+  },
+  "%^C1 просит %C4 подробнее рассказать о %O6.": {
+   "en": "%^C1 asks %C4 to tell more about %O6.",
+   "ua": "%^C1 просить %C4 детальніше розповісти про %O6."
+  },
+  "%1$^C1 говорит тебе '{gЯ раньше в глаза не виде%1$Gло|л|ла %2$O4.{x'": {
+   "en": "%1$^C1 says to you '{gI've never laid eyes on %2$O4 before.{x'",
+   "ua": "%1$^C1 каже тобі '{gЯ раніше в очі не бачи%1$Gло|в|ла %2$O4.{x'"
+  }
+ },
+ "plug-ins/skills_impl/basicskill.cpp": {
+  "{GТы учишься на своих ошибках, и твое умение '%K1' совершенствуется.{x": {
+   "en": "{GYou learn from your mistakes, and your skill '%K1' improves.{x",
+   "ua": "{GТи вчишся на своїх помилках, і твоя навичка '%K1' вдосконалюється.{x"
+  },
+  "{WТишина и покой в этой местности расслабляют тебя, препятствуя прокачке умений.{x": {
+   "en": "{WThe silence and peace of this place relax you, hindering skill training.{x",
+   "ua": "{WТиша і спокій цієї місцевості розслабляють тебе, заважаючи прокачуванню умінь.{x"
+  },
+  "Задержка при выполнении {W%1$d{x секунд%1$Iу|ы|. ": {
+   "en": "Execution delay {W%1$d{x second%1$I|s|s. ",
+   "ua": "Затримка при виконанні {W%1$d{x секунд%1$Iу|и|. "
+  },
+  "У тебя бонус {C%1$d{x уров%1$Iень|ня|ней на это умение.": {
+   "en": "You have a {C%1$d{x level%1$I|s|s bonus to this skill.",
+   "ua": "У тебе бонус {C%1$d{x рів%1$Iень|ні|нів до цього вміння."
+  },
+  "У тебя штраф {r%1$d{x уров%1$Iень|ня|ней на это умение.": {
+   "en": "You have a {r%1$d{x level%1$I|s|s penalty on this skill.",
+   "ua": "У тебе штраф {r%1$d{x рів%1$Iень|ні|нів на це вміння."
+  },
+  "{GТеперь ты гораздо лучше владеешь искусством '%K1'!{x": {
+   "en": "{GYou now have a much better grasp of the art of '%K1'!{x",
+   "ua": "{GТепер ти набагато краще володієш мистецтвом '%K1'!{x"
+  },
+  "{WТеперь ты {Cмастерски{W владеешь искусством {C%K1{W!{x": {
+   "en": "{WNow you {Cmasterfully{W wield the art of {C%K1{W!{x",
+   "ua": "{WТепер ти {Cмайстерно{W володієш мистецтвом {C%K1{W!{x"
+  }
+ },
+ "plug-ins/skills_impl/ccast.cpp": {
+  "%1$^C1 пыта%1$nется|ются сотворить заклинание, но ловушка мешает %1$P3 сосредоточиться.": {
+   "en": "%1$^C1 tr%1$nies|y to cast a spell, but the trap keeps them from concentrating.",
+   "ua": "%1$^C1 намага%1$nється|ються сотворити заклинання, але пастка заважає %1$C1 зосередитися."
+  },
+  "%1$^C1 пыта%1$nется|ются сотворить заклинание, но теря%1$nет|ют концентрацию и терп%1$nит|ят неудачу.": {
+   "en": "%1$^C1 tr%1$nies|y to cast the spell, but los%1$nes|e concentration and fail%1$ns|.",
+   "ua": "%1$^C1 намага%1$nється|ються сотворити заклинання, але втрача%1$nє|ють концентрацію і зазна%1$nє|ють невдачі."
+  },
+  "%1$^C1 пыта%1$nется|ются сотворить заклинание, но что-то в этой местности блокирует %1$P2.": {
+   "en": "%1$^C1 tr%1$nies|y to cast a spell, but something in this area blocks them.",
+   "ua": "%1$^C1 намага%1$nється|ються сотворити заклинання, але щось у цій місцевості блокує їх."
+  },
+  "Глухота мешает %1$C3 как следует произнести заклинание.": {
+   "en": "Deafness prevents %1$C3 from casting the spell properly.",
+   "ua": "Глухота заважає %1$C3 як слід вимовити заклинання."
+  },
+  "Глухота мешает тебе как следует произнести заклинание.": {
+   "en": "Deafness prevents you from properly casting the spell.",
+   "ua": "Глухота заважає тобі як слід вимовити закляття."
+  },
+  "Колдовать что и на кого?": {
+   "en": "Cast what on whom?",
+   "ua": "Чаклувати що і на кого?"
+  },
+  "Ловушка, в которой ты оказал%1$Gось|ся|ась, препятствует сотворению заклинаний.": {
+   "en": "The trap you're caught in prevents you from casting spells.",
+   "ua": "Пастка, в якій ти опини%1$Gлося|вся|лася, заважає накладати закляття."
+  },
+  "Ты не знаешь такого заклинания.": {
+   "en": "You don't know that spell.",
+   "ua": "Ти не знаєш такого заклинання."
+  },
+  "Ты пытаешься сотворить заклинание '{W%K1{x', но теряешь концентрацию и терпишь неудачу.": {
+   "en": "You try to cast the spell '{W%K1{x', but lose your concentration and fail.",
+   "ua": "Ти намагаєшся сотворити заклинання '{W%K1{x', але втрачаєш концентрацію і зазнаєш невдачі."
+  },
+  "Ты пытаешься сотворить заклинание, но изолирующий экран блокирует тебя.": {
+   "en": "You try to cast a spell, but an isolating screen blocks you.",
+   "ua": "Ти намагаєшся сотворити заклинання, але ізолюючий екран блокує тебе."
+  },
+  "Ты слишком уста%Gло|л|ла для этого.": {
+   "en": "You are too tired for this.",
+   "ua": "Ти надто втомлен%Gе|ий|а для цього."
+  },
+  "У тебя не хватает энергии.": {
+   "en": "You don't have enough energy.",
+   "ua": "Тобі не вистачає енергії."
+  },
+  "Эта местность поглощает и блокирует твое заклинание.": {
+   "en": "This terrain absorbs and blocks your spell.",
+   "ua": "Ця місцевість поглинає і блокує твоє заклинання."
+  },
+  "%1$^C1 пыта%1$nется|ются сотворить заклинание, но тень не дает %1$P3 сосредоточиться.": {
+   "en": "%1$^C1 tr%1$nies|y to cast the spell, but the shadow won't let them focus.",
+   "ua": "%1$^C1 намага%1$nється|ються сотворити заклинання, але тінь не дає %1$C3 зосередитися."
+  },
+  "%1$^C1 хотел%1$Gо||а|и бы помочь, но, к сожалению, совершенно не способ%1$Gно|ен|на|ны колдовать.": {
+   "en": "%1$^C1 would like to help, but unfortunately is completely unable to cast spells.",
+   "ua": "%1$^C1 хоті%1$Gло|в|ла|ли б допомогти, але, на жаль, зовсім не здатн%1$Gе|ий|а|і чаклувати."
+  },
+  "Твой язык заплетается, и ты не можешь как следует произнести заклинание.": {
+   "en": "Your tongue trips over itself, and you can't pronounce the spell properly.",
+   "ua": "Твій язик заплітається, і ти не можеш як слід вимовити заклинання."
+  },
+  "Твоя тень поглощает всякую попытку сотворить заклинание.": {
+   "en": "Your shadow swallows up any attempt to cast a spell.",
+   "ua": "Твоя тінь поглинає будь-яку спробу сотворити заклинання."
+  },
+  "Ты вои{Smн{Sfтельница{Sx {RКлана Ярости{x, а не презренный маг!": {
+   "en": "You're a warrior of the {RClan of Fury{x, not some despicable mage!",
+   "ua": "Ти войов{Smник{Sfниця{Sx {RКлану Люті{x, а не мерзенний маг!"
+  },
+  "У тебя нет сил даже пошевелить языком.": {
+   "en": "You don't even have the strength to wag your tongue.",
+   "ua": "У тебе немає сил навіть поворухнути язиком."
+  }
+ },
+ "plug-ins/skills_impl/defaultskillcommand.cpp": {
+  "%^C1 не владеет навыком {y{hh%s{x.": {
+   "en": "%^C1 doesn't know the skill {y{hh%s{x.",
+   "ua": "%^C1 не володіє вмінням {y{hh%s{x."
+  },
+  "Ты не владеешь навыком {y{hh%s{x.": {
+   "en": "You don't have the skill {y{hh%s{x.",
+   "ua": "Ти не володієш навичкою {y{hh%s{x."
+  },
+  "Ты слишком уста%Gло|л|ла для этого.": {
+   "en": "You're too tired for that.",
+   "ua": "Ти занадто втом%Gлене|лений|лена для цього."
+  },
+  "У тебя не хватает энергии.": {
+   "en": "You don't have enough energy.",
+   "ua": "У тебе не вистачає енергії."
+  }
+ },
+ "plug-ins/skills_impl/defaultspell.cpp": {
+  "$C1 отклоняет заклинание $c2!": {
+   "en": "$C1 deflects $c2's spell!",
+   "ua": "$C1 відхиляє заклинання $c2!"
+  },
+  "%^C1 возносит молитву %N3.": {
+   "en": "%^C1 offers up a prayer to %N3.",
+   "ua": "%^C1 підносить молитву %N3."
+  },
+  "%^C1 молится своим богам.": {
+   "en": "%^C1 prays to their gods.",
+   "ua": "%^C1 молиться своїм богам."
+  },
+  "Боги $c2 не благосклонны к $C3.": {
+   "en": "$c2's gods are not favorable toward $C3.",
+   "ua": "Боги $c2 не прихильні до $C3."
+  },
+  "Боги $c2 не благосклонны к тебе.": {
+   "en": "$c2's gods are not favorable to you.",
+   "ua": "Боги $c2 не прихильні до тебе."
+  },
+  "Заклинание '%K1' нельзя использовать во время сражения.": {
+   "en": "The spell '%K1' can't be used during combat.",
+   "ua": "Заклинання '%K1' не можна використовувати під час бою."
+  },
+  "Никто из богов больше не откликнется на твои молитвы, пока ты не изберешь себе {hh1религию{x.": {
+   "en": "None of the gods will answer your prayers anymore until you choose a {hh1religion{x for yourself.",
+   "ua": "Жоден з богів більше не відгукнеться на твої молитви, поки ти не обереш собі {hh1релігію{x."
+  },
+  "Твои боги не благосклонны к $C3.": {
+   "en": "Your gods are not favorable toward $C3.",
+   "ua": "Твої боги не прихильні до $C3."
+  },
+  "Твою просьбу исполняет %N1 и советует поскорее выбрать себе {hh1религию{x.": {
+   "en": "%N1 grants your request and advises you to pick a {hh1religion{x soon.",
+   "ua": "Твоє прохання виконує %N1 і радить якнайшвидше обрати собі {hh1релігію{x."
+  },
+  "Ты возносишь молитву %N3.": {
+   "en": "You offer up a prayer to %N3.",
+   "ua": "Ти підносиш молитву %N3."
+  },
+  "Ты неумело молишься, прося богов о помощи.": {
+   "en": "You pray clumsily, asking the gods for help.",
+   "ua": "Ти невправно молишся, просячи богів про допомогу."
+  },
+  "Ты отклоняешь заклинание $c2!": {
+   "en": "You resist $c2's spell!",
+   "ua": "Ти відхиляєш заклинання $c2!"
+  },
+  "Ты отклоняешь заклинание!": {
+   "en": "You resist the spell!",
+   "ua": "Ти відхиляєш закляття!"
+  },
+  "$C1 отклоняет заклинание!": {
+   "en": "$C1 deflects the spell!",
+   "ua": "$C1 відхиляє заклинання!"
+  },
+  "$C1 отклоняет твое заклинание!": {
+   "en": "$C1 deflects your spell!",
+   "ua": "$C1 відхиляє твоє заклинання!"
+  },
+  "%^C1 неумело молится, прося богов о помощи.": {
+   "en": "%^C1 prays clumsily, begging the gods for help.",
+   "ua": "%^C1 невміло молиться, просячи богів про допомогу."
+  },
+  "Глаза $c2 на мгновение вспыхивают {1{Yзолотом{2.": {
+   "en": "$c2's eyes flash {1{Ygolden{2 for a moment.",
+   "ua": "Очі $c2 на мить спалахують {1{Yзолотом{2."
+  },
+  "Глаза $c2 на мгновение вспыхивают {1{rбагровым{2.": {
+   "en": "$c2's eyes flash {1{rcrimson{2 for a moment.",
+   "ua": "Очі $c2 на мить спалахують {1{rбагряним{2."
+  },
+  "Свет на мгновение пронизывает ладони $c2.": {
+   "en": "Light pierces through $c2's palms for a moment.",
+   "ua": "Світло на мить пронизує долоні $c2."
+  },
+  "Свет на мгновение пронизывает твои ладони.": {
+   "en": "Light briefly pierces through your palms.",
+   "ua": "Світло на мить пронизує твої долоні."
+  },
+  "Твои глаза на мгновение вспыхивают {1{Yзолотом{2.": {
+   "en": "Your eyes flash {1{Ygolden{2 for a moment.",
+   "ua": "Твої очі на мить спалахують {1{Yзолотом{2."
+  },
+  "Твои глаза на мгновение вспыхивают {1{rбагровым{2.": {
+   "en": "Your eyes flash {1{rcrimson{2 for a moment.",
+   "ua": "Твої очі на мить спалахують {1{rбагряним{2."
+  },
+  "Яркая искра вспыхивает между ладоней $c2, фокусируя магический заряд.": {
+   "en": "A bright spark flares between $c2's palms, focusing the magical charge.",
+   "ua": "Яскрава іскра спалахує між долонь $c2, фокусуючи магічний заряд."
+  },
+  "Яркая искра вспыхивает между твоих ладоней, фокусируя магический заряд.": {
+   "en": "A bright spark flares between your palms, focusing the magical charge.",
+   "ua": "Яскрава іскра спалахує між твоїх долонь, фокусуючи магічний заряд."
+  }
+ },
+ "plug-ins/skills_impl/objthrow.cpp": {
+  "$C1 ловит руками $o4.": {
+   "en": "$C1 catches $o4 with their hands.",
+   "ua": "$C1 ловить руками $o4."
+  },
+  "$C1 уклоняется от $o2.": {
+   "en": "$C1 dodges $o2.",
+   "ua": "$C1 ухиляється від $o2."
+  },
+  "$c1 отравле$gно|н|на ядом от $o2.": {
+   "en": "$c1 is poisoned by $o2.",
+   "ua": "$c1 отруєн$gо|ий|а отрутою від $o2."
+  },
+  "$c1 уклоняется от $o2.": {
+   "en": "$c1 dodges $o2.",
+   "ua": "$c1 ухиляється від $o2."
+  },
+  "$o1 обжигает $c4.": {
+   "en": "$o1 burns $c4.",
+   "ua": "$o1 обпікає $c4."
+  },
+  "$o1 обжигает тебя.": {
+   "en": "$o1 burns you.",
+   "ua": "$o1 обпікає тебе."
+  },
+  "$o1 обмораживает $c4.": {
+   "en": "$o1 frostbites $c4.",
+   "ua": "$o1 обморожує $c4."
+  },
+  "$o1 обмораживает тебя.": {
+   "en": "$o1 frostbites you.",
+   "ua": "$o1 обморожує тебе."
+  },
+  "$o1 падает на землю у твоих ног!": {
+   "en": "$o1 falls to the ground at your feet!",
+   "ua": "$o1 падає на землю біля твоїх ніг!"
+  },
+  "$o1 парализует $c4 разрядом молнии.": {
+   "en": "$o1 paralyzes $c4 with a bolt of lightning.",
+   "ua": "$o1 паралізує $c4 розрядом блискавки."
+  },
+  "$o1 парализует тебя разрядом молнии.": {
+   "en": "$o1 paralyzes you with a bolt of lightning.",
+   "ua": "$o1 паралізує тебе розрядом блискавки."
+  },
+  "$o1 поражает $C4!": {
+   "en": "$o1 strikes $C4!",
+   "ua": "$o1 вражає $C4!"
+  },
+  "$o1 поражает $c4!": {
+   "en": "$o1 strikes $c4!",
+   "ua": "$o1 вражає $c4!"
+  },
+  "$o1 поражает тебя!": {
+   "en": "$o1 strikes you!",
+   "ua": "$o1 вражає тебе!"
+  },
+  "$o1 прилетает $T!": {
+   "en": "$o1 comes flying in $T!",
+   "ua": "$o1 прилітає $T!"
+  },
+  "Ты ловишь руками $o4.": {
+   "en": "You catch $o4 with your hands.",
+   "ua": "Ти ловиш руками $o4."
+  },
+  "Ты уклоняешься от $o2.": {
+   "en": "You dodge $o2.",
+   "ua": "Ти ухиляєшся від $o2."
+  },
+  "$c1 ловит руками $o4.": {
+   "en": "$c1 catches $o4 with their hands.",
+   "ua": "$c1 ловить руками $o4."
+  },
+  "$o1 $c2 поражает $C4!": {
+   "en": "$c2's $o1 strikes $C4!",
+   "ua": "$o1 $c2 вражає $C4!"
+  },
+  "$o1 отскакивает от $c2, не причиняя вреда...": {
+   "en": "$o1 bounces off $c2, causing no harm...",
+   "ua": "$o1 відскакує від $c2, не завдаючи шкоди..."
+  },
+  "Ты чувствуешь как яд растекается по твоим венам.": {
+   "en": "You feel the poison spreading through your veins.",
+   "ua": "Ти відчуваєш, як отрута розтікається по твоїх венах."
+  }
+ },
+ "plug-ins/skills_impl/transportspell.cpp": {
+  "Адреналин в крови мешает тебе сконцентрироваться.": {
+   "en": "Adrenaline in your blood keeps you from concentrating.",
+   "ua": "Адреналін у крові заважає тобі сконцентруватися."
+  },
+  "Вторая тень блокирует транспортные заклинания.": {
+   "en": "The Second Shadow blocks transportation spells.",
+   "ua": "Друга Тінь блокує транспортні заклинання."
+  },
+  "Местность, в которой находится твоя цель, защищена Богами.": {
+   "en": "The area where your target is located is protected by the Gods.",
+   "ua": "Місцевість, де знаходиться твоя ціль, захищена Богами."
+  },
+  "На этой местности висит временное проклятие.": {
+   "en": "A temporary curse hangs over this terrain.",
+   "ua": "Над цією місцевістю висить тимчасове прокляття."
+  },
+  "Непроницаемый экран защищает твою цель, тебе не удается установить ментальную связь.": {
+   "en": "An impenetrable shield protects your target, you fail to establish a mental link.",
+   "ua": "Непроникний екран захищає твою ціль, тобі не вдається встановити ментальний зв'язок."
+  },
+  "Открыть портал на твою цель удастся только в пределах одной зоны.": {
+   "en": "You can only open a portal to your target within a single zone.",
+   "ua": "Відкрити портал на твою ціль вдасться лише в межах однієї зони."
+  },
+  "Проклятие на тебе блокирует транспортные заклинания.": {
+   "en": "A curse on you blocks transportation spells.",
+   "ua": "Прокляття на тобі блокує транспортні заклинання."
+  },
+  "Твоя попытка закончилась неудачей.": {
+   "en": "Your attempt ended in failure.",
+   "ua": "Твоя спроба закінчилася невдачею."
+  },
+  "Транспортные заклинания в этой местности запрещены Богами.": {
+   "en": "Transport spells are forbidden by the Gods in this area.",
+   "ua": "Транспортні заклинання в цій місцевості заборонені Богами."
+  },
+  "А вдруг тебя вообще не существует?! Вопросы, вопросы...": {
+   "en": "What if you don't even exist at all?! Questions, questions...",
+   "ua": "А раптом тебе взагалі не існує?! Питання, питання..."
+  },
+  "Перейти на сам{Smого{Sfу{Sx себя? Но как узнать, где настоящ{Smий{Sfая{Sx ты -- здесь или там?": {
+   "en": "Teleport to yourself? But how would you know which one is the real you -- here or there?",
+   "ua": "Перейти на сам{Smого{Sfу{Sx себе? Але як дізнатися, де справжн{Smій{Sfя{Sx ти -- тут чи там?"
+  },
+  "Разум твоей жертвы во власти кого-то другого, тебе не удается установить ментальную связь.": {
+   "en": "Your victim's mind is in someone else's power -- you fail to establish a mental link.",
+   "ua": "Розум твоєї жертви у владі когось іншого, тобі не вдається встановити ментальний зв'язок."
+  },
+  "Таким способом Бессмертных лучше не беспокоить.": {
+   "en": "It's best not to bother the Immortals that way.",
+   "ua": "Таким способом Безсмертних краще не турбувати."
+  }
+ },
+ "plug-ins/social/mysocial.cpp": {
+  "В этом сообщении может встречаться только имя жертвы в нуждом падеже ($C1, .. $C6).": {
+   "en": "This message may only contain the victim's name in the required case ($C1, .. $C6).",
+   "ua": "У цьому повідомленні може зустрічатися лише ім'я жертви у потрібному відмінку ($C1, .. $C6)."
+  },
+  "Слишком много долларов! В этом сообщении нельзя использовать переменные.": {
+   "en": "Too many dollar signs! This message cannot use variables.",
+   "ua": "Забагато доларів! У цьому повідомленні не можна використовувати змінні."
+  },
+  "Сообщение должно начинаться с твоего имени (в нужном падеже) и не содержать других переменных. Используй $c1, $c2...$c6.": {
+   "en": "The message must begin with your name (in the correct case) and must not contain any other variables. Use $c1, $c2...$c6.",
+   "ua": "Повідомлення повинно починатися з твого імені (у потрібному відмінку) і не містити інших змінних. Використовуй $c1, $c2...$c6."
+  },
+  "Социал с таким именем не найден.": {
+   "en": "No social with that name was found.",
+   "ua": "Соціал з такою назвою не знайдено."
+  },
+  "Ты пока не придума$gло|л|ла ни одного собственного социала.": {
+   "en": "You haven't come up with a single social of your own yet.",
+   "ua": "Ти поки не придума$gло|в|ла жодного власного соціала."
+  },
+  "Укажи имя социала.": {
+   "en": "Specify the social's name.",
+   "ua": "Вкажи ім'я соціалу."
+  }
+ },
+ "plug-ins/social/social.cpp": {
+  "$c1 шлепает тебя.": {
+   "en": "$c1 spanks you.",
+   "ua": "$c1 ляскає тебе."
+  },
+  "$c1 шлепает $C4.": {
+   "en": "$c1 smacks $C4.",
+   "ua": "$c1 ляскає $C4."
+  },
+  "Ты шлепаешь $C4.": {
+   "en": "You spank $C4.",
+   "ua": "Ти ляскаєш $C4."
+  }
+ },
+ "plug-ins/social/socialbase.cpp": {
+  "Выйди сначала из {WAFK{x": {
+   "en": "Exit {WAFK{x mode first",
+   "ua": "Спочатку вийди з {WAFK{x"
+  },
+  "Нет этого здесь.": {
+   "en": "That's not here.",
+   "ua": "Немає цього тут."
+  },
+  "Тебе не до того, ты же сражаешься!": {
+   "en": "You've got no time for that, you're fighting!",
+   "ua": "Тобі не до того, ти ж б'єшся!"
+  },
+  "Ты видишь только %1$C4 здесь, кто такой %s?": {
+   "en": "You only see %1$C4 here, who is %s?",
+   "ua": "Ти бачиш тут лише %1$C4, хто такий %s?"
+  },
+  "Ты не в состоянии сделать это.": {
+   "en": "You're not able to do that.",
+   "ua": "Ти не в змозі зробити це."
+  },
+  "Ты не можешь выражать эмоции, не прервав ритуал.": {
+   "en": "You can't express emotions without interrupting the ritual.",
+   "ua": "Ти не можеш виражати емоції, не перервавши ритуал."
+  },
+  "Ты полностью замороже%Gно|н|на!": {
+   "en": "You are completely frozen!",
+   "ua": "Ти повністю заморожен%Gе|ий|а!"
+  },
+  "Во сне? Или может сначала проснешься...": {
+   "en": "In your sleep? Or maybe you should wake up first...",
+   "ua": "Уві сні? Чи, може, спершу прокинешся..."
+  },
+  "Даже не думай об этом! Ты в ужасном состоянии.": {
+   "en": "Don't even think about it! You're in terrible shape.",
+   "ua": "Навіть не думай про це! Ти в жахливому стані."
+  },
+  "Лежи смирно! Ты {RТРУП{x.": {
+   "en": "Lie still! You're a {RCORPSE{x.",
+   "ua": "Лежи тихо! Ти {RТРУП{x."
+  },
+  "Сидя? Или может сначала встанешь...": {
+   "en": "While sitting? Maybe you should stand up first...",
+   "ua": "Сидячи? Чи може спершу встанеш..."
+  },
+  "Ты анти-социал%Gьно|ен|ьна!": {
+   "en": "You're antisocial!",
+   "ua": "Ти антисоціальн%Gо|ий|а!"
+  },
+  "Ты видишь только себя здесь, кто такой %s?": {
+   "en": "You only see yourself here, who is %s?",
+   "ua": "Ти бачиш тут лише себе, хто такий %s?"
+  },
+  "Уфф... Но ведь ты отдыхаешь...": {
+   "en": "Ugh... But you're resting...",
+   "ua": "Уфф... Але ж ти відпочиваєш..."
+  }
+ },
+ "plug-ins/traverse/commands.cpp": {
+  "Всего нашл%1$Iась|ись|ось {Y%1$d{x подходящ%1$Iая|ие|их местност%1$Iь|и|ей. Уточни название, чтобы увидеть остальные.": {
+   "en": "A total of {Y%1$d{x matching location%1$I|s|s found. Refine the name to see the rest.",
+   "ua": "Всього знайш%1$Iлася|лися|лося {Y%1$d{x відповідн%1$Iа|і|их місцевост%1$Iь|і|ей. Уточни назву, щоб побачити решту."
+  },
+  "К сожалению, в этой зоне проложить путь не получится.": {
+   "en": "Unfortunately, a path cannot be plotted in this zone.",
+   "ua": "На жаль, у цій зоні прокласти шлях не вийде."
+  },
+  "Найдены такие местности в зоне {c%s{x:": {
+   "en": "Found the following locations in zone {c%s{x:",
+   "ua": "Знайдено такі місцевості в зоні {c%s{x:"
+  },
+  "Не забывай, что на пути могут встретиться запертые или потайные выходы.": {
+   "en": "Don't forget that locked or hidden exits may lie along the way.",
+   "ua": "Не забувай, що на шляху можуть трапитися замкнені або потаємні виходи."
+  },
+  "Не могу найти местность с названием '{W%s{x' в зоне {c%s{x.": {
+   "en": "Can't find a location named '{W%s{x' in zone {c%s{x.",
+   "ua": "Не можу знайти місцевість з назвою '{W%s{x' у зоні {c%s{x."
+  },
+  "Не удалось проложить путь ни к одной из местностей:": {
+   "en": "Failed to plot a route to any of the locations:",
+   "ua": "Не вдалося прокласти шлях до жодної з місцевостей:"
+  },
+  "Но ты уже здесь!": {
+   "en": "But you're already here!",
+   "ua": "Але ти вже тут!"
+  },
+  "Ты не сможешь проложить путь, если даже не видишь, где сейчас находишься.": {
+   "en": "You can't plot a course if you don't even see where you currently are.",
+   "ua": "Ти не зможеш прокласти шлях, якщо навіть не бачиш, де зараз перебуваєш."
+  },
+  "Укажи название местности, куда нужно проложить путь.": {
+   "en": "Specify the name of the place to plot a route to.",
+   "ua": "Вкажи назву місцевості, куди потрібно прокласти шлях."
+  }
+ },
+ "plug-ins/updates/update.cpp": {
+  "$c1 вооружается вторичным оружием, как основным!": {
+   "en": "$c1 wields their secondary weapon as their main one!",
+   "ua": "$c1 озброюється другорядною зброєю, як основною!"
+  },
+  "$c1 исчезает.": {
+   "en": "$c1 disappears.",
+   "ua": "$c1 зникає."
+  },
+  "$c1 не в силах удержать $o4.": {
+   "en": "$c1 isn't strong enough to hold onto $o4.",
+   "ua": "$c1 не в силах втримати $o4."
+  },
+  "$c1 полностью возвращается в мир живых.": {
+   "en": "$c1 fully returns to the world of the living.",
+   "ua": "$c1 повністю повертається у світ живих."
+  },
+  "%1$^O1 дела%1$nет|ют пузыри на поверхности %2$N2.": {
+   "en": "%1$^O1 make%1$ns| bubbles on the surface of %2$N2.",
+   "ua": "%1$^O1 роб%1$nить|лять бульбашки на поверхні %2$N2."
+  },
+  "%1$^O1 мига%1$nет|ют.": {
+   "en": "%1$^O1 blink%1$ns|.",
+   "ua": "%1$^O1 мига%1$nє|ють."
+  },
+  "%1$^O1 мигну%1$Gло|л|ла|ли и поту%1$Gхло|х|хла|хли.": {
+   "en": "%1$^O1 flickered and went out.",
+   "ua": "%1$^O1 мигну%1$Gло|в|ла|ли і зга%1$Gсло|с|сла|сли."
+  },
+  "%1$^O1 поту%1$Gхло|х|хла|хли.": {
+   "en": "%1$^O1 went out.",
+   "ua": "%1$^O1 пога%1$Gсло|снув|сла|сли."
+  },
+  "%1$^s громко кричит '{R%2$s{x'": {
+   "en": "%1$^s shouts loudly '{R%2$s{x'",
+   "ua": "%1$^s голосно кричить '{R%2$s{x'"
+  },
+  "%^C1 умирает от неизлечимых ран.": {
+   "en": "%^C1 dies from incurable wounds.",
+   "ua": "%^C1 помирає від невиліковних ран."
+  },
+  "Аура проклятия вокруг $c2 исчезает.": {
+   "en": "The aura of the curse around $c2 fades away.",
+   "ua": "Аура прокляття навколо $c2 зникає."
+  },
+  "Внимание! Через %1$d мину%1$Iту|ты|т будет перезагрузка Мира Мечты!": {
+   "en": "Attention! Dreamland will reboot in %1$d minute%1$I|s|s!",
+   "ua": "Увага! Через %1$d хвилин%1$Iу|и| відбудеться перезавантаження Світу Мрії!"
+  },
+  "Правда о твоем поражении забывается.": {
+   "en": "The truth of your defeat fades from memory.",
+   "ua": "Правда про твою поразку забувається."
+  },
+  "Тебе нужно отдохнуть!": {
+   "en": "You need to rest!",
+   "ua": "Тобі потрібно відпочити!"
+  },
+  "Ты вооружаешься вторичным оружием, как основным!": {
+   "en": "You wield your secondary weapon as your primary!",
+   "ua": "Ти озброюєшся вторинною зброєю, як основною!"
+  },
+  "Ты не в силах удержать $o4 в левой руке.": {
+   "en": "You're not strong enough to hold $o4 in your left hand.",
+   "ua": "Ти не в силі утримати $o4 у лівій руці."
+  },
+  "Ты не в силах удержать $o4 в правой руке.": {
+   "en": "You don't have the strength to hold $o4 in your right hand.",
+   "ua": "Ти не в силі втримати $o4 у правій руці."
+  },
+  "Ты прячешься обратно в тень.": {
+   "en": "You slip back into the shadow.",
+   "ua": "Ти ховаєшся назад у тінь."
+  },
+  "Ты пытаешься двигаться незаметно.": {
+   "en": "You try to move unnoticed.",
+   "ua": "Ти намагаєшся рухатися непомітно."
+  },
+  "$c1 развалил$gось|ся|ась на куски.": {
+   "en": "$c1 fell apart into pieces.",
+   "ua": "$c1 розвали$gлося|вся|лася на шматки."
+  },
+  "$c1 растворяется в воздухе.": {
+   "en": "$c1 dissolves into thin air.",
+   "ua": "$c1 розчиняється в повітрі."
+  },
+  "Боги забывают убийство, совершенное тобой.": {
+   "en": "The gods forget the murder you committed.",
+   "ua": "Боги забувають вбивство, скоєне тобою."
+  },
+  "В комнате начинает сгущаться божественная энергия и $c1 обретает плоть.\n\rНо похоже $c1 еще в мире мертвых.": {
+   "en": "Divine energy begins to gather in the room and $c1 takes on flesh.\n\rBut it seems $c1 is still in the world of the dead.",
+   "ua": "У кімнаті починає згущуватися божественна енергія, і $c1 набуває плоті.\n\rАле схоже, $c1 ще у світі мертвих."
+  },
+  "Все забывается... и даже записи жрецов Мира Мечты превращаются в прах.": {
+   "en": "Everything is forgotten... and even the records of Dreamland's priests turn to dust.",
+   "ua": "Все забувається... і навіть записи жерців Світу Мрій перетворюються на порох."
+  },
+  "Лихорадочный блеск смертоубийства в глазах $c2 пропадает.": {
+   "en": "The feverish gleam of bloodlust in $c2's eyes fades away.",
+   "ua": "Гарячковий блиск смертовбивства в очах $c2 зникає."
+  },
+  "Твоя вторая тень исчезает.": {
+   "en": "Your second shadow disappears.",
+   "ua": "Твоя друга тінь зникає."
+  },
+  "Ты вздыхаешь с облегчением, ведь все забывают о твоей неспособности\n\rхоть что-то украсть.": {
+   "en": "You sigh with relief, since everyone forgets about your inability\n\rto steal anything at all.",
+   "ua": "Ти зітхаєш з полегшенням, адже всі забувають про твою нездатність\n\rбодай щось вкрасти."
+  },
+  "Ты полностью возвращаешься в мир живых.": {
+   "en": "You fully return to the world of the living.",
+   "ua": "Ти повністю повертаєшся у світ живих."
+  },
+  "Ты растворяешься в воздухе.": {
+   "en": "You dissolve into thin air.",
+   "ua": "Ти розчиняєшся в повітрі."
+  },
+  "Ты слышишь далекий колокольный звон.\n\rНа тебя накатывается волна ужасной боли...\n\rТы рождаешься заново, обретая плоть.\n\rНо ты пока еще между живыми и мертвыми.": {
+   "en": "You hear a distant bell tolling.\n\rA wave of terrible pain washes over you...\n\rYou are born anew, taking on flesh.\n\rBut you are still caught between the living and the dead.",
+   "ua": "Ти чуєш далекий дзвін дзвонів.\n\rНа тебе накочується хвиля жахливого болю...\n\rТи народжуєшся знову, набуваючи плоті.\n\rАле ти поки що між живими і мертвими."
+  },
+  "Ты умираешь от неизлечимых ран.": {
+   "en": "You die from incurable wounds.",
+   "ua": "Ти помираєш від невиліковних ран."
+  },
+  "Ты успокаиваешься от недавнего смертоубийства.": {
+   "en": "You calm down after your recent killing.",
+   "ua": "Ти заспокоюєшся від недавнього смертовбивства."
+  },
+  "Ты успокаиваешься после недавнего смертоубийства.": {
+   "en": "You calm down after your recent killing spree.",
+   "ua": "Ти заспокоюєшся після недавнього смертовбивства."
+  }
+ },
+ "plug-ins/updates/update_areas.cpp": {
+  "%^C1 встает.": {
+   "en": "%^C1 stands up.",
+   "ua": "%^C1 встає."
+  },
+  "%^C1 засыпает.": {
+   "en": "%^C1 falls asleep.",
+   "ua": "%^C1 засинає."
+  },
+  "%^C1 садится отдыхать.": {
+   "en": "%^C1 sits down to rest.",
+   "ua": "%^C1 сідає відпочити."
+  },
+  "%^C1 садится.": {
+   "en": "%^C1 sits down.",
+   "ua": "%^C1 сідає."
+  },
+  "Внезапно налетевший дождь смывает все следы.": {
+   "en": "A sudden downpour washes away all traces.",
+   "ua": "Раптовий дощ, що налетів, змиває всі сліди."
+  },
+  "Милость богов снисходит на %C2, принося с собой %O4.": {
+   "en": "The gods' mercy descends upon %C2, bringing %O4 with it.",
+   "ua": "Милість богів сходить на %C2, приносячи з собою %O4."
+  }
+ },
+ "plug-ins/updates/weather.cpp": {
+  ": осталось %1$d дн%1$Iень|я|ей (до %2$d числа месяца %3$s)": {
+   "en": ": %1$d day%1$I|s|s left (until day %2$d of %3$s)",
+   "ua": ": залишилось %1$d дн%1$Iень|і|ів (до %2$d числа місяця %3$s)"
+  },
+  ": через %1$d дн%1$Iень|я|ей (%2$d числа месяца %3$s)": {
+   "en": ": in %1$d day%1$I|s|s (on day %2$d of the month of %3$s)",
+   "ua": ": через %1$d дн%1$Iень|і|ів (%2$d числа місяця %3$s)"
+  },
+  "В помещении погоду не видно -- попробуй выйти наружу!": {
+   "en": "You can't see the weather indoors -- try going outside!",
+   "ua": "У приміщенні погоду не видно -- спробуй вийти назовні!"
+  },
+  "Мир Мечты загружен %s\r\nСистемное время: %s": {
+   "en": "Dreamland loaded %s\r\nSystem time: %s",
+   "ua": "Світ Мрії завантажено %s\r\nСистемний час: %s"
+  },
+  "Небо %s и дует %s ветер.": {
+   "en": "The sky is %s and a %s wind is blowing.",
+   "ua": "Небо %s і дме %s вітер."
+  },
+  "Похоже, в этом месте погода всегда одинаковая.": {
+   "en": "Looks like the weather here is always the same.",
+   "ua": "Схоже, у цьому місці погода завжди однакова."
+  },
+  "Сегодня -- %d число месяца %s, год %d.": {
+   "en": "Today is -- the %d day of the month of %s, year %d.",
+   "ua": "Сьогодні -- %d число місяця %s, рік %d."
+  },
+  "Похоже, в этом месте время остановило свой ход.": {
+   "en": "Looks like time has stopped its course in this place.",
+   "ua": "Схоже, у цьому місці час зупинив свій хід."
+  }
+ },
+ "plug-ins/wearlocation/defaultwearlocation.cpp": {
+  "%1$^C1 безуспешно пытается надеть %2$O4.": {
+   "en": "%1$^C1 unsuccessfully tries to put on %2$O4.",
+   "ua": "%1$^C1 безуспішно намагається надіти %2$O4."
+  },
+  "%1$^C3 не хватает опыта, чтобы использовать %2$O4.": {
+   "en": "%1$^C3 doesn't have enough experience to use %2$O4.",
+   "ua": "%1$^C3 бракує досвіду, щоб використати %2$O4."
+  },
+  "%^C1 пытается надеть %O4 на несуществующую часть тела.": {
+   "en": "%^C1 tries to put %O4 on a body part that doesn't exist.",
+   "ua": "%^C1 намагається одягнути %O4 на неіснуючу частину тіла."
+  },
+  "Магия $o2 аннигилирует с твоим спеллбаном!": {
+   "en": "The magic of $o2 annihilates with your spellban!",
+   "ua": "Магія $o2 анігілює з твоїм спелбаном!"
+  },
+  "Уровень %1$^C2 слишком велик, чтобы использовать %2$O4.": {
+   "en": "%1$^C2's level is too high to use %2$O4.",
+   "ua": "Рівень %1$^C2 занадто великий, щоб використовувати %2$O4."
+  },
+  "Магия $o2 аннигилирует со спеллбаном $c2!": {
+   "en": "The magic of $o2 annihilates against $c2's spellban!",
+   "ua": "Магія $o2 анігілює зі спелбаном $c2!"
+  }
+ },
+ "plug-ins/wearlocation/misc_wearlocs.cpp": {
+  "%1$^C1 пытается вооружиться %2$O4, но %1$P3 не хватает обеих свободных рук.": {
+   "en": "%1$^C1 tries to arm themselves with %2$O4, but doesn't have two free hands.",
+   "ua": "%1$^C1 намагається озброїтися %2$O4, але не має двох вільних рук."
+  },
+  "%1$^C1 пытается ухватить %2$O4, но %1$P2 руки уже заняты двуручным оружием.": {
+   "en": "%1$^C1 tries to grab %2$O4, but the hands are already full with a two-handed weapon.",
+   "ua": "%1$^C1 намагається схопити %2$O4, але руки вже зайняті дворучною зброєю."
+  },
+  "%^C1 пытается взять %O4 в левую руку, но понимает, что сначала стоит взять что-то в правую.": {
+   "en": "%^C1 tries to take %O4 in their left hand, but realizes they should take something in their right hand first.",
+   "ua": "%^C1 намагається взяти %O4 в ліву руку, але розуміє, що спершу варто взяти щось у праву."
+  },
+  "%^C1 пытается ухватить %O4, но одновременно со щитом это надеть не получается.": {
+   "en": "%^C1 tries to grab %O4, but it can't be worn together with a shield.",
+   "ua": "%^C1 намагається вхопити %O4, але водночас зі щитом це вдягти не виходить."
+  },
+  "В твоей левой руке уже что-то зажато.": {
+   "en": "You already have something clenched in your left hand.",
+   "ua": "У твоїй лівій руці вже щось затиснуто."
+  },
+  "Обе руки заняты двуручным оружием!": {
+   "en": "Both hands are occupied with a two-handed weapon!",
+   "ua": "Обидві руки зайняті дворучною зброєю!"
+  },
+  "Твои руки уже заняты щитом.": {
+   "en": "Your hands are already full with a shield.",
+   "ua": "Твої руки вже зайняті щитом."
+  },
+  "Ты не можешь взять двуручное оружие в левую руку!": {
+   "en": "You cannot hold a two-handed weapon in your left hand!",
+   "ua": "Ти не можеш взяти дворучну зброю в ліву руку!"
+  },
+  "Ты не можешь этим вооружиться. Оно слишком тяжело для тебя.": {
+   "en": "You can't arm yourself with this. It's too heavy for you.",
+   "ua": "Ти не можеш цим озброїтися. Це надто важко для тебе."
+  },
+  "Чтобы вооружиться этим, у тебя должны быть свободны обе руки.": {
+   "en": "To wield this, you need both hands free.",
+   "ua": "Щоб озброїтися цим, у тебе мають бути вільні обидві руки."
+  },
+  "Это оружие слишком тяжело для тебя, чтобы использовать его как вторичное.": {
+   "en": "This weapon is too heavy for you to use as a secondary.",
+   "ua": "Ця зброя занадто важка для тебе, щоб використовувати її як вторинну."
+  },
+  "%^C1 крутит в руках %O4, но одновременно с оружием это надеть никак не выходит.": {
+   "en": "%^C1 turns %O4 over in their hands, but there's just no way to wear it while wielding a weapon.",
+   "ua": "%^C1 крутить у руках %O4, але одночасно зі зброєю це надіти ніяк не виходить."
+  },
+  "%^C1 пытается взять %O4 в левую руку, но сил явно не хватает.": {
+   "en": "%^C1 tries to take %O4 in their left hand, but clearly doesn't have the strength.",
+   "ua": "%^C1 намагається взяти %O4 в ліву руку, але сил явно не вистачає."
+  },
+  "%^C1 пытается взять %O4 в левую руку, но такое под силу только гигантам.": {
+   "en": "%^C1 tries to take %O4 in their left hand, but only giants can manage that.",
+   "ua": "%^C1 намагається взяти %O4 в ліву руку, але таке під силу лише гігантам."
+  },
+  "%^C1, кряхтя, пытается надеть %O4, но сил к сожалению не хватает.": {
+   "en": "%^C1 grunts, trying to put on %O4, but sadly doesn't have the strength.",
+   "ua": "%^C1, крекчучи, намагається одягнути %O4, але, на жаль, сил не вистачає."
+  },
+  "Ничего не видя, ты никак не можешь нащупать и выдернуть %1$O4.": {
+   "en": "Unable to see anything, you simply can't feel out and yank %1$O4 free.",
+   "ua": "Нічого не бачачи, ти ніяк не можеш намацати і висмикнути %1$O4."
+  },
+  "У тебя нет даже первичного оружия!": {
+   "en": "You don't even have a primary weapon!",
+   "ua": "У тебе немає навіть первинної зброї!"
+  }
+ },
+ "plug-ins/wearlocation/wearloc_commands.cpp": {
+  "$C1 в состоянии одеться са$Gмо|м|ма!": {
+   "en": "$C1 is capable of dressing without help!",
+   "ua": "$C1 у стані одягтися са$Gмо|м|ма!"
+  },
+  "$c1 надевает на $C4 $o4.": {
+   "en": "$c1 puts $o4 on $C4.",
+   "ua": "$c1 надягає на $C4 $o4."
+  },
+  "$c1 надевает на тебя $o4.": {
+   "en": "$c1 puts $o4 on you.",
+   "ua": "$c1 одягає на тебе $o4."
+  },
+  "$c1 пытается надеть на $C4 $o4, но не может.": {
+   "en": "$c1 tries to put $o4 on $C4, but can't.",
+   "ua": "$c1 намагається надіти на $C4 $o4, але не може."
+  },
+  "$c1 пытается надеть на тебя $o4, но не может.": {
+   "en": "$c1 tries to put $o4 on you, but can't.",
+   "ua": "$c1 намагається одягнути на тебе $o4, але не може."
+  },
+  "$c1 снимает с $C2 $o4.": {
+   "en": "$c1 removes $o4 from $C2.",
+   "ua": "$c1 знімає з $C2 $o4."
+  },
+  "$c1 снимает с тебя $o4.": {
+   "en": "$c1 takes $o4 off you.",
+   "ua": "$c1 знімає з тебе $o4."
+  },
+  "На кого ты хочешь это надеть?": {
+   "en": "Who do you want to put this on?",
+   "ua": "На кого ти хочеш це надіти?"
+  },
+  "Надеть, вооружиться или взять это в руки?": {
+   "en": "Wear it, wield it, or take it in hand?",
+   "ua": "Одягнути, озброїтися чи взяти це до рук?"
+  },
+  "Снять что?": {
+   "en": "Remove what?",
+   "ua": "Зняти що?"
+  },
+  "Ты надеваешь $o4 на $C4.": {
+   "en": "You put $o4 on $C4.",
+   "ua": "Ти надягаєш $o4 на $C4."
+  },
+  "Ты пытаешься надеть $o4 на $C4, но безуспешно.": {
+   "en": "You try to put $o4 on $C4, but fail.",
+   "ua": "Ти намагаєшся надіти $o4 на $C4, але безуспішно."
+  },
+  "Ты пытаешься снять $o4 с $C2, но безуспешно.": {
+   "en": "You try to take $o4 off $C2, but fail.",
+   "ua": "Ти намагаєшся зняти $o4 з $C2, але безуспішно."
+  },
+  "Ты снимаешь $o4 с $C2.": {
+   "en": "You remove $o4 from $C2.",
+   "ua": "Ти знімаєш $o4 з $C2."
+  },
+  "$c1 пытается снять с $C2 $o4, но не может.": {
+   "en": "$c1 tries to strip $C2 of $o4, but fails.",
+   "ua": "$c1 намагається зняти з $C2 $o4, але не може."
+  },
+  "$c1 пытается снять с тебя $o4, но не может.": {
+   "en": "$c1 tries to strip $o4 off you, but can't.",
+   "ua": "$c1 намагається зняти з тебе $o4, але не може."
+  }
+ },
+ "plug-ins/ai/ranger.cpp": {
+  "$c1 пристально смотрит $T и натягивает тетиву $o2.": {
+   "en": "$c1 stares intently at $T and draws the string of $o2.",
+   "ua": "$c1 пильно дивиться на $T і натягує тятиву $o2."
+  }
+ },
+ "plug-ins/clan/impl/flowers.cpp": {
+  "$C1 вежливо выпроваживает $c2 восвояси.": {
+   "en": "$C1 politely shows $c2 the door.",
+   "ua": "$C1 ввічливо випроваджує $c2 геть."
+  },
+  "$C1 вежливо выпроваживает тебя восвояси.": {
+   "en": "$C1 politely shows you the door.",
+   "ua": "$C1 ввічливо випроваджує тебе геть."
+  }
+ },
+ "plug-ins/clan/impl/ghost.cpp": {
+  "$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает.": {
+   "en": "$C1 casts a fleeting glance at $c4 and $c1 instantly disappears.",
+   "ua": "$C1 кидає на $c4 миттєвий погляд, і $c1 миттю зникає."
+  },
+  "$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон.": {
+   "en": "$C1 casts a fleeting glance at you.\n\rAnd at once you feel some magical force hurl you out.",
+   "ua": "$C1 кидає на тебе швидкоплинний погляд.\n\rІ одразу ти відчуваєш, як якась магічна сила виштовхує тебе геть."
+  }
+ },
+ "plug-ins/gquest/gangsters/gangchef.cpp": {
+  "$c1 вопит '{RВОН ОТСЮДА!{x'": {
+   "en": "$c1 screams '{RGET OUT OF HERE!{x'",
+   "ua": "$c1 верещить '{RГЕТЬ ЗВІДСИ!{x'"
+  },
+  "$c1 тушит сигару о ладонь одного из гангстеров и выхватывает кинжал.": {
+   "en": "$c1 puts out a cigar on one of the gangsters' palm and draws a dagger.",
+   "ua": "$c1 гасить сигару об долоню одного з гангстерів і вихоплює кинджал."
+  },
+  "Ну даешь! Как ты сюда вообще попал?": {
+   "en": "Well, look at you! How the hell did you even get in here?",
+   "ua": "Ну ти даєш! Як ти взагалі сюди потрапив?"
+  }
+ },
+ "plug-ins/gquest/gangsters/objects.cpp": {
+  "$c1 с озадаченным видом роняет $o4.": {
+   "en": "$c1 drops $o4 with a puzzled look.",
+   "ua": "$c1 зі спантеличеним виглядом впускає $o4."
+  },
+  "Почему-то тебе кажется, что Боги этого не одобрят.\r\nПораженн$gое|ый|ая этой мыслью, ты роняешь $o4.": {
+   "en": "For some reason it seems to you that the Gods wouldn't approve.\r\nStruck by this thought, you drop $o4.",
+   "ua": "Чомусь тобі здається, що Боги цього не схвалять.\r\nВражен$gе|ий|а цією думкою, ти впускаєш $o4."
+  }
+ },
+ "plug-ins/gquest/rainbow/scenarios.cpp": {
+  "\r\nДемоническая мантия окутывает $c4!": {
+   "en": "\r\nA demonic mantle envelops $c4!",
+   "ua": "\r\nДемонічна мантія огортає $c4!"
+  },
+  "\r\nИз дымки появляется cекретарша Ада и произносит '{rТы приня%Gто|т|та!{x'.": {
+   "en": "\r\nSecretary Ada appears from the haze and says, '{rYou're accepted!{x'",
+   "ua": "\r\nІз серпанку з'являється секретарка Ада і промовляє: '{rТи прийня%Gто|тий|та|ті!{x'"
+  },
+  "\r\nИз дымки появляется секретарша Ада и что-то говорит $c3.": {
+   "en": "\r\nSecretary Ada appears out of the haze and says something to $c3.",
+   "ua": "\r\nЗ туману з'являється секретарка Ада і щось каже $c3."
+  },
+  "\r\nТебя окутывает демоническая мантия!": {
+   "en": "\r\nA demonic mantle envelops you!",
+   "ua": "\r\nТебе огортає демонічна мантія!"
+  },
+  "$c1 достает откуда-то цветной булыжник и отламывает от него кусочек.": {
+   "en": "$c1 produces a colored pebble from somewhere and breaks off a small piece.",
+   "ua": "$c1 дістає звідкись кольоровий камінець і відламує від нього шматочок."
+  },
+  "$c1 поднимает ладони к небу.": {
+   "en": "$c1 raises their palms to the sky.",
+   "ua": "$c1 підіймає долоні до неба."
+  },
+  "$c1 понимающе ухмыляется, узнав в $C6 достойного преемника.": {
+   "en": "$c1 smirks knowingly, recognizing $C6 as a worthy successor.",
+   "ua": "$c1 розуміюче посміхається, впізнавши в $C6 достойного наступника."
+  },
+  "$c1 понимающе ухмыляется, узнав в тебе достойного преемника.": {
+   "en": "$c1 grins knowingly, recognizing you as a worthy successor.",
+   "ua": "$c1 розуміюче посміхається, впізнавши в тобі гідного наступника."
+  },
+  "Ты поднимаешь к небу ладони, полные разноцветных осколков.": {
+   "en": "You raise your palms to the sky, full of multicolored shards.",
+   "ua": "Ти піднімаєш до неба долоні, повні різнокольорових скалок."
+  }
+ },
+ "plug-ins/groups/chance.cpp": {
+  "%^O1 распахивает {Dпризрачные {Cкрылья{x над головой %C2, и реальность неуловимо меняется!": {
+   "en": "%^O1 spreads {Dghostly {Cwings{x above %C2's head, and reality shifts imperceptibly!",
+   "ua": "%^O1 розкриває {Dпривидні {Cкрила{x над головою %C2, і реальність невловимо змінюється!"
+  },
+  "%^O1 распахивает {Dпризрачные {Cкрылья{x над твоей головой, перемещая тебя на долю секунды назад во времени!": {
+   "en": "%^O1 spreads {Dghostly {Cwings{x above your head, shifting you a fraction of a second back in time!",
+   "ua": "%^O1 розкриває {Dпримарні {Cкрила{x над твоєю головою, переміщуючи тебе на частку секунди назад у часі!"
+  },
+  "Ты пробуешь исправить свою ошибку... и {Gдобиваешься успеха!{x": {
+   "en": "You try to fix your mistake... and {Gsucceed!{x",
+   "ua": "Ти намагаєшся виправити свою помилку... і {Gдосягаєш успіху!{x"
+  },
+  "Ты пробуешь исправить свою ошибку... но снова терпишь неудачу!{x": {
+   "en": "You try to fix your mistake... but fail again!{x",
+   "ua": "Ти намагаєшся виправити свою помилку... але знову зазнаєш невдачі!{x"
+  }
+ },
+ "plug-ins/languages/impl/ahenn.cpp": {
+  "Из звуков мелодии, древней, как сам мир, рождается слово {c%s{x.": {
+   "en": "From the sounds of a melody as ancient as the world itself, a word is born: {c%s{x.",
+   "ua": "Зі звуків мелодії, давньої, як сам світ, народжується слово {c%s{x."
+  }
+ },
+ "plug-ins/languages/impl/arcadian.cpp": {
+  "В веселом гаме и цокоте копыт ты различаешь слово {c%s{x.": {
+   "en": "Amid the cheerful din and clatter of hooves, you make out the word {c%s{x.",
+   "ua": "У веселому гаморі і цокоті копит ти розрізняєш слово {c%s{x."
+  }
+ },
+ "plug-ins/languages/impl/arcadian_behaviors.cpp": {
+  "$c1 дышит на тебя перегаром!": {
+   "en": "$c1 breathes stale booze-breath on you!",
+   "ua": "$c1 дихає на тебе перегаром!"
+  },
+  "$c1 дышит перегаром на $C4!": {
+   "en": "$c1 breathes stale booze fumes on $C4!",
+   "ua": "$c1 дихає перегаром на $C4!"
+  },
+  "$c1 окончательно усыхает и исчезает.": {
+   "en": "$c1 shrivels up completely and vanishes.",
+   "ua": "$c1 остаточно всихає і зникає."
+  }
+ },
+ "plug-ins/languages/impl/khuzdul.cpp": {
+  "Отзвуком древних битв приходит в твои сны слово {c%s{x.": {
+   "en": "The word {c%s{x comes to you in your dreams, an echo of ancient battles.",
+   "ua": "Відлунням давніх битв приходить у твої сни слово {c%s{x."
+  }
+ },
+ "plug-ins/languages/impl/quenia.cpp": {
+  "Сквозь зыбкую пелену сна тебе является слово {c%s{x.": {
+   "en": "Through the hazy veil of sleep, the word {c%s{x appears to you.",
+   "ua": "Крізь хитку пелену сну тобі з'являється слово {c%s{x."
+  }
+ },
+ "plug-ins/languages/impl/quenia_effects.cpp": {
+  "{CВ глазах $c2 стальным блеском вспыхивает наконечник стрелы.{x": {
+   "en": "{CAn arrowhead flashes with a steely gleam in $c2's eyes.{x",
+   "ua": "{CУ очах $c2 сталевим блиском спалахує наконечник стріли.{x"
+  },
+  "{CСила древнего благословения проникает в мир.{x": {
+   "en": "{CThe power of an ancient blessing seeps into the world.{x",
+   "ua": "{CСила прадавнього благословення проникає у світ.{x"
+  },
+  "{CТеперь твой взгляд способен различить каждое перышко жаворонка в небе.{x": {
+   "en": "{CNow your eyes can make out every feather of a lark in the sky.{x",
+   "ua": "{CТепер твій погляд здатен розрізнити кожну пір'їнку жайворонка в небі.{x"
+  }
+ },
+ "plug-ins/loadsave/save.cpp": {
+  "$o1 рассыпается трухой!": {
+   "en": "$o1 crumbles to dust!",
+   "ua": "$o1 розсипається трухою!"
+  }
+ },
+ "plug-ins/misc_behaviors/midgaardfountain.cpp": {
+  "Вода в $o6 медленно окрашивается {rкрасным{x.": {
+   "en": "The water in $o6 slowly turns {rred{x.",
+   "ua": "Вода в $o6 повільно забарвлюється в {rчервоне{x."
+  },
+  "Кровь в $o6 снова превращается в воду..": {
+   "en": "The blood in $o6 turns back into water..",
+   "ua": "Кров у $o6 знову перетворюється на воду.."
+  }
+ },
+ "plug-ins/misc_behaviors/rats.cpp": {
+  "$c1 говорит тебе '{GЯ не желаю служить тебе..{x'": {
+   "en": "$c1 says to you, '{GI have no wish to serve you..{x'",
+   "ua": "$c1 каже тобі: '{GЯ не бажаю служити тобі..{x'"
+  },
+  "$c1 отправляется в крысиный рай.": {
+   "en": "$c1 departs for rat heaven.",
+   "ua": "$c1 вирушає до щурячого раю."
+  }
+ },
+ "plug-ins/quest/staffquest/staffbehavior.cpp": {
+  "$o1 загорается голубым пламенем.": {
+   "en": "$o1 bursts into blue flame.",
+   "ua": "$o1 спалахує блакитним полум'ям."
+  },
+  "Мерцающая аура окружает $o4.": {
+   "en": "A flickering aura surrounds $o4.",
+   "ua": "Мерехтлива аура оточує $o4."
+  }
+ },
+ "plug-ins/questreward/personalquestreward.cpp": {
+  "{BМерцающая аура окружает $o4.\n\r{x": {
+   "en": "{BA shimmering aura surrounds $o4.\n\r{x",
+   "ua": "{BМерехтлива аура оточує $o4.\n\r{x"
+  }
+ },
+ "plug-ins/questreward/questgirth.cpp": {
+  "{CТвой пояс ярко вспыхивает.{x": {
+   "en": "{CYour belt flares up brightly.{x",
+   "ua": "{CТвій пояс яскраво спалахує.{x"
+  }
+ },
+ "plug-ins/questreward/questring.cpp": {
+  "{CТвое кольцо ярко вспыхивает.{x": {
+   "en": "{CYour ring flashes brightly.{x",
+   "ua": "{CТвій перстень яскраво спалахує.{x"
+  }
+ },
+ "plug-ins/questreward/questweapon.cpp": {
+  "{CТвое оружие ярко вспыхивает.{x": {
+   "en": "{CYour weapon flares up brightly.{x",
+   "ua": "{CТвоя зброя яскраво спалахує.{x"
+  }
+ },
+ "plug-ins/questreward/valentineprise.cpp": {
+  "{CАура {Rлюбви{C окружает $c4.{x": {
+   "en": "{CAn aura of {Rlove{C surrounds $c4.{x",
+   "ua": "{CАура {Rкохання{C оточує $c4.{x"
+  },
+  "{CАура {Rлюбви{C окружает тебя.{x": {
+   "en": "{CAn aura of {Rlove{C surrounds you.{x",
+   "ua": "{CАура {Rкохання{C оточує тебе.{x"
   }
  }
 }


### PR DESCRIPTION
## What

Machine-translated **RU→EN+UA catalog** for the ~3443 hardcoded-RU C++ output literals wrapped in dreamland_code #655/#656/#657/#658. Adds them to `config/translations/plug-ins.json`.

- **Mechanical lane** (2285: errors, prompts, status) — clean/literal.
- **Voice lane** (1158: flavour, jibes, mid-level profanity where the RU carries it) — reviewed via a side-by-side sample.

RU stays the runtime **key and fallback**, so any gap or slip degrades to Russian, never a crash.

## Process

Produced by the `l10n-bulk-translate` Workflow (24 chunks × Sonnet), then `assemble` + `lint-l10n.py`: **0 HARD across all 25 shards**. Held back for a manual pass: 15 lint-HARD entries ($-code reorder / RU-pronoun leak) + 191 self-flagged `hard`. 1159 warns are non-blocking (RU-declension passthrough, colour drift, mixed-script hints).

## Tooling calibrated (scripts/, local — not a game repo)

The first C++ bulk surfaced three gaps, all fixed:
- **lint** exempts `$G` and the RU-only `$`-pronoun act-codes from parity (`act.cpp:39/42-60` proves `$G`→`%3$G` is a gender selector, `$e/$s/…`→`%P`); HARD-flags a pronoun code surviving into en/ua.
- **assemble** normalizes non-KOI8 punctuation (modifier apostrophe `ʼ`, curly quotes, em/en dash, ellipsis) → the ASCII forms the KOI8-U runtime needs.
- **translator brief** gained a `$`-act-code section (~1/3 of the corpus).

## Deploy

Activates on the next reboot (once the wrapped binary #655-658 is live) + `plug reload most`. Until then RU renders unchanged — safe to merge now.