### PR TITLE
l10n: utils .fmt-conversion catalog entries (EN/UA)

### DIFF
--- a/config/translations/utils.json
+++ b/config/translations/utils.json
@@ -575,6 +575,14 @@
   "%^C1 -- {hhспецмоб{x, а их очаровывать запрещено Богами.": {
    "en": "%^C1 is a {hhspecial mob{x, and charming them is forbidden by the Gods.",
    "ua": "%^C1 -- це {hhспецмоб{x, а зачаровувати їх заборонено Богами."
+  },
+  "Также попробуй найти и {hhпереподчинить{x %1$C4 где-то в зоне {hh%2$s{x.": {
+   "en": "You could also try to find and {hhre-subjugate{x %1$C4 somewhere in the {hh%2$s{x zone.",
+   "ua": "Також спробуй знайти і {hhперепідкорити{x %1$C4 десь у зоні {hh%2$s{x."
+  },
+  "Попробуй найти и {hhпереподчинить{x %1$C4 где-то в зоне {hh%2$s{x.": {
+   "en": "Try to find and {hhre-subjugate{x %1$C4 somewhere in the {hh%2$s{x zone.",
+   "ua": "Спробуй знайти і {hhперепідкорити{x %1$C4 десь у зоні {hh%2$s{x."
   }
  },
  "utils/mob: spirits": {
@@ -1065,6 +1073,14 @@
   "Ты чудом уворачиваешься, и %s %C2 пролетает мимо!": {
    "en": "You dodge by sheer miracle, and %C2's %s flies right past you!",
    "ua": "Ти дивом ухиляєшся, і %s %C2 пролітає повз!"
+  },
+  "%1$^O1 пада%1$nет|ют %2$s в районе {g%3$s{x.": {
+   "en": "%1$^O1 fall%1$ns| %2$s in the area of {g%3$s{x.",
+   "ua": "%1$^O1 пада%1$nє|ють %2$s в районі {g%3$s{x."
+  },
+  "%1$^O1 пада%1$nет|ют %2$s.": {
+   "en": "%1$^O1 fall%1$ns| %2$s.",
+   "ua": "%1$^O1 пада%1$nє|ють %2$s."
   }
  },
  "utils/player/common": {
@@ -1537,6 +1553,10 @@
   "{1{W%^C1 смиренно воздевает руки и просит милости у Варды.{x": {
    "en": "{1{W%^C1 humbly raises their hands, begging Varda for mercy.{x",
    "ua": "{1{W%^C1 смиренно здіймає руки, благаючи Варду про милість.{x"
+  },
+  "Великая Матерь, спаси и сохрани %1$Gсына|сына|дочь|чад тво%1$Gего|его|ю|их, %1$C4.": {
+   "en": "Great Mother, save and keep your %1$Gchild|son|daughter|children, %1$C4.",
+   "ua": "Велика Матір, врятуй і збережи %1$Gсина|сина|доньку|чад тво%1$Gго|го|ю|їх, %1$C4."
   }
  },
  "utils/samurai": {
@@ -1717,6 +1737,10 @@
   "%1$^C1 -- рыба, а не амфибия, %1$P3 нельзя выходить на сушу.": {
    "en": "%1$^C1 is a fish, not an amphibian -- %1$C1 can't go ashore.",
    "ua": "%1$^C1 -- риба, а не амфібія, %1$C3 не можна виходити на суходіл."
+  },
+  "Ты не видишь выхода %s.": {
+   "en": "You don't see an exit %s.",
+   "ua": "Ти не бачиш виходу %s."
   }
  },
  "utils/mob: lure and traps": {


### PR DESCRIPTION
6 EN/UA catalog entries for utils `.fmt`->`._()` (companion to dreamland_fenia). lint-l10n 0 HARD. **Deploy-pending (offline).**