### PR TITLE
weather.xml: enrich 8 events to full 5x4-season coverage

### DIFF
--- a/config/weather.xml
+++ b/config/weather.xml
@@ -218,126 +218,850 @@
 
   
   <event id="day_begin">
-    <variant season="any">
-      <line l="ru">Начался новый день.</line>
-      <line l="en">A new day has begun.</line>
-      <line l="ua">Почався новий день.</line>
+    <variant season="winter">
+      <line l="ru">Морозное зимнее утро вступило в свои права.</line>
+      <line l="en">A frosty winter morning has taken hold.</line>
+      <line l="ua">Морозний зимовий ранок вступив у свої права.</line>
     </variant>
-    <variant season="any">
-      <line l="ru">Солнце поднялось высоко, и мир окончательно проснулся.</line>
-      <line l="en">The sun has climbed high, and the world is fully awake.</line>
-      <line l="ua">Сонце піднялося високо, і світ остаточно прокинувся.</line>
+    <variant season="winter">
+      <line l="ru">Короткий зимний день начался, и снег скрипит под ногами.</line>
+      <line l="en">The short winter day has begun, and snow squeaks underfoot.</line>
+      <line l="ua">Короткий зимовий день почався, і сніг рипить під ногами.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Солнце поднялось невысоко и светит холодно, без тепла.</line>
+      <line l="en">The sun has risen only low, shining cold and without warmth.</line>
+      <line l="ua">Сонце піднялося невисоко і світить холодно, без тепла.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Зимний день разгорелся, ясный и звонкий от мороза.</line>
+      <line l="en">The winter day comes up clear and ringing with frost.</line>
+      <line l="ua">Зимовий день розгорівся, ясний і дзвінкий від морозу.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Наступил новый день, и над снегами висит белесое солнце.</line>
+      <line l="en">A new day has come, and a whitish sun hangs over the snows.</line>
+      <line l="ua">Настав новий день, і над снігами висить білясте сонце.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">Свежее весеннее утро полнится птичьим гомоном.</line>
+      <line l="en">A fresh spring morning fills with the clamour of birds.</line>
+      <line l="ua">Свіжий весняний ранок повниться пташиним гамором.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Начался новый день, теплый и полный молодой зелени.</line>
+      <line l="en">A new day has begun, warm and full of young green.</line>
+      <line l="ua">Почався новий день, теплий і повний молодої зелені.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Солнце поднялось высоко, и весенний мир окончательно проснулся.</line>
+      <line l="en">The sun has climbed high, and the spring world is fully awake.</line>
+      <line l="ua">Сонце піднялося високо, і весняний світ остаточно прокинувся.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Весенний день разгорается, пахнущий землей и цветами.</line>
+      <line l="en">The spring day warms up, smelling of earth and blossom.</line>
+      <line l="ua">Весняний день розгорається, пахнучи землею і квітами.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Утренний свет заливает пробудившиеся поля.</line>
+      <line l="en">Morning light floods the wakened fields.</line>
+      <line l="ua">Ранкове світло заливає пробуджені поля.</line>
+    </variant>
+
+    <variant season="summer">
+      <line l="ru">Летнее утро уже дышит зноем -- день будет жарким.</line>
+      <line l="en">The summer morning already breathes heat -- the day will be hot.</line>
+      <line l="ua">Літній ранок уже дихає спекою -- день буде гарячим.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Солнце поднялось высоко и принялось печь всерьез.</line>
+      <line l="en">The sun has climbed high and set to baking in earnest.</line>
+      <line l="ua">Сонце піднялося високо і взялося пекти всерйоз.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Начался долгий летний день, знойный и белый от солнца.</line>
+      <line l="en">A long summer day has begun, sultry and white with sun.</line>
+      <line l="ua">Почався довгий літній день, спекотний і білий від сонця.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Жаркий день вступил в силу, и воздух дрожит над дорогой.</line>
+      <line l="en">The hot day has taken hold, and the air shivers above the road.</line>
+      <line l="ua">Гарячий день вступив у силу, і повітря тремтить над дорогою.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Солнце Атум-Ра забралось в зенит и жжет без пощады.</line>
+      <line l="en">Atum-Ra's sun has climbed to its height and burns without mercy.</line>
+      <line l="ua">Сонце Атум-Ра забралося в зеніт і пече без пощади.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">Зябкое осеннее утро занялось нехотя.</line>
+      <line l="en">A chilly autumn morning comes on reluctantly.</line>
+      <line l="ua">Зимкий осінній ранок зайнявся знехотя.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Начался серый осенний день, пахнущий прелой листвой.</line>
+      <line l="en">A grey autumn day has begun, smelling of rotting leaves.</line>
+      <line l="ua">Почався сірий осінній день, що пахне прілим листям.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Солнце поднялось невысоко и тускло светит сквозь дымку.</line>
+      <line l="en">The sun has risen low and shines dully through the haze.</line>
+      <line l="ua">Сонце піднялося невисоко і тьмяно світить крізь імлу.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Осенний день разгорелся хмурый и короткий.</line>
+      <line l="en">The autumn day comes up sullen and short.</line>
+      <line l="ua">Осінній день розгорівся похмурий і короткий.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Мир проснулся под низким осенним небом.</line>
+      <line l="en">The world wakes under a low autumn sky.</line>
+      <line l="ua">Світ прокинувся під низьким осіннім небом.</line>
     </variant>
   </event>
 
   <event id="sunset">
-    <variant season="any">
-      <line l="ru">Солнце медленно прячется за горизонтом.</line>
-      <line l="en">The sun slowly hides below the horizon.</line>
-      <line l="ua">Сонце поволі ховається за обрієм.</line>
-    </variant>
-    <variant season="any">
-      <line l="ru">Солнце тонет на западе, в водах Моря Золотого Круга.</line>
-      <line l="en">The sun sinks in the west, into the waters of the Sea of the Golden Circle.</line>
-      <line l="ua">Сонце тоне на заході, у водах Моря Золотого Кола.</line>
-    </variant>
     <variant season="winter">
       <line l="ru">Короткий зимний день гаснет, и с запада наползает стужа.</line>
       <line l="en">The short winter day burns out, and cold creeps in from the west.</line>
       <line l="ua">Короткий зимовий день гасне, і з заходу насувається холод.</line>
     </variant>
+    <variant season="winter">
+      <line l="ru">Солнце садится в Море Золотого Круга, и мороз крепчает.</line>
+      <line l="en">The sun sets into the Sea of the Golden Circle, and the frost tightens.</line>
+      <line l="ua">Сонце сідає в Море Золотого Кола, і мороз міцнішає.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Багровый закат догорает над стылыми снегами.</line>
+      <line l="en">A crimson sunset burns down over the frozen snows.</line>
+      <line l="ua">Багряний захід догоряє над мерзлими снігами.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Солнце скатилось за западный край, и сразу пахнуло стужей.</line>
+      <line l="en">The sun rolls off the western edge, and cold bites at once.</line>
+      <line l="ua">Сонце скотилося за західний край, і одразу дихнуло холодом.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Зимнее солнце тонет рано, оставляя небо цвета льда.</line>
+      <line l="en">The winter sun sinks early, leaving a sky the colour of ice.</line>
+      <line l="ua">Зимове сонце тоне рано, лишаючи небо кольору льоду.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">Весенний закат гаснет тихо и розово над западными водами.</line>
+      <line l="en">The spring sunset fades soft and pink over the western waters.</line>
+      <line l="ua">Весняний захід гасне тихо і рожево над західними водами.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Солнце садится в Море Золотого Круга, и вечер пахнет сыростью.</line>
+      <line l="en">The sun sets into the Sea of the Golden Circle, and the evening smells of damp.</line>
+      <line l="ua">Сонце сідає в Море Золотого Кола, і вечір пахне вологою.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Долгие весенние сумерки ложатся на молодую зелень.</line>
+      <line l="en">Long spring twilight settles over the young green.</line>
+      <line l="ua">Довгі весняні сутінки лягають на молоду зелень.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Солнце ушло за горизонт, и защелкали первые соловьи.</line>
+      <line l="en">The sun has gone below the horizon, and the first nightingales strike up.</line>
+      <line l="ua">Сонце зайшло за обрій, і заклацали перші солов'ї.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Закат медленно тает над западом, обещая теплую ночь.</line>
+      <line l="en">The sunset melts slowly over the west, promising a warm night.</line>
+      <line l="ua">Захід поволі тане над обрієм, обіцяючи теплу ніч.</line>
+    </variant>
+
     <variant season="summer">
       <line l="ru">Долгий летний закат заливает запад червонным золотом.</line>
       <line l="en">A long summer sunset floods the west with red-gold.</line>
-      <line l="ua">Довгий літній захід заливає захід червоним золотом.</line>
+      <line l="ua">Довгий літній захід заливає небокрай червоним золотом.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Солнце неспешно тонет в Море Золотого Круга, и жара спадает.</line>
+      <line l="en">The sun sinks unhurried into the Sea of the Golden Circle, and the heat eases.</line>
+      <line l="ua">Сонце неквапом тоне в Морі Золотого Кола, і спека спадає.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Раскаленный диск садится за западный край, но зной еще держится.</line>
+      <line l="en">The blazing disc sets past the western edge, but the heat still lingers.</line>
+      <line l="ua">Розжарений диск сідає за західний край, та спека ще тримається.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Летний вечер долго не темнеет, и небо на западе тлеет углями.</line>
+      <line l="en">The summer evening is long in darkening, the western sky smouldering like coals.</line>
+      <line l="ua">Літній вечір довго не темніє, і небо на заході жевріє вуглинами.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Солнце ушло, оставив теплые сумерки и звон цикад.</line>
+      <line l="en">The sun is gone, leaving warm dusk and the ring of cicadas.</line>
+      <line l="ua">Сонце зайшло, лишивши теплі сутінки і дзвін цикад.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">Осеннее солнце тускло догорает и рано прячется на западе.</line>
+      <line l="en">The autumn sun burns down dully and hides early in the west.</line>
+      <line l="ua">Осіннє сонце тьмяно догоряє і рано ховається на заході.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Солнце село в Море Золотого Круга, и потянуло промозглым холодом.</line>
+      <line l="en">The sun has set into the Sea of the Golden Circle, and a raw cold draws in.</line>
+      <line l="ua">Сонце сіло в Море Золотого Кола, і потягло промозклим холодом.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Серый закат угас без красок, и сразу стемнело.</line>
+      <line l="en">The grey sunset fades without colour, and night comes at once.</line>
+      <line l="ua">Сірий захід згас без барв, і одразу стемніло.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Короткий осенний день погас, и с полей поползла сырость.</line>
+      <line l="en">The short autumn day dies, and damp creeps up from the fields.</line>
+      <line l="ua">Короткий осінній день згас, і з полів поповзла вогкість.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Закат утонул в тучах над западом, не оставив и полоски света.</line>
+      <line l="en">The sunset drowns in cloud over the west, leaving not a strip of light.</line>
+      <line l="ua">Захід потонув у хмарах над обрієм, не лишивши й смужки світла.</line>
     </variant>
   </event>
 
   <event id="night_begin">
-    <variant season="any">
-      <line l="ru">Начинается ночь.</line>
-      <line l="en">Night falls.</line>
-      <line l="ua">Настає ніч.</line>
-    </variant>
-    <variant season="any">
-      <line l="ru">Тьма растекается по земле, и в небе зажигаются звезды Варды.</line>
-      <line l="en">Darkness spreads across the land, and Varda's stars kindle overhead.</line>
-      <line l="ua">Темрява розтікається землею, і в небі спалахують зорі Варди.</line>
-    </variant>
     <variant season="winter">
       <line l="ru">Длинная зимняя ночь смыкается над миром, черная и морозная.</line>
       <line l="en">The long winter night closes over the world, black and frozen.</line>
       <line l="ua">Довга зимова ніч змикається над світом, чорна і морозна.</line>
     </variant>
+    <variant season="winter">
+      <line l="ru">Настала стылая ночь, и звезды Варды колют небо ледяными иглами.</line>
+      <line l="en">A frozen night has come, and Varda's stars prick the sky like icy needles.</line>
+      <line l="ua">Настала студена ніч, і зорі Варди колють небо крижаними голками.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Мороз с Мертвого моря крепчает, едва сгущается тьма.</line>
+      <line l="en">The frost off the Dead Sea tightens the moment the darkness thickens.</line>
+      <line l="ua">Мороз від Мертвого Моря міцнішає, щойно згущується темрява.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Черное зимнее небо усыпано колючими звездами.</line>
+      <line l="en">The black winter sky is strewn with prickling stars.</line>
+      <line l="ua">Чорне зимове небо всіяне колючими зорями.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Длинная ночь Королевы Воронов ложится на снега.</line>
+      <line l="en">The Raven Queen's long night settles over the snows.</line>
+      <line l="ua">Довга ніч Королеви Воронів лягає на сніги.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">Теплая весенняя ночь опускается на землю.</line>
+      <line l="en">A warm spring night descends upon the land.</line>
+      <line l="ua">Тепла весняна ніч опускається на землю.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Стемнело, и в небе зажглись звезды Варды над молодой листвой.</line>
+      <line l="en">Darkness falls, and Varda's stars kindle over the young leaves.</line>
+      <line l="ua">Стемніло, і в небі спалахнули зорі Варди над молодим листям.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Весенняя ночь пахнет сырой землей и первыми цветами.</line>
+      <line l="en">The spring night smells of wet earth and the first blossoms.</line>
+      <line l="ua">Весняна ніч пахне вогкою землею і першими квітами.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Ночь пришла короткая и мягкая, полная лягушачьих трелей.</line>
+      <line l="en">The night comes short and soft, full of the trilling of frogs.</line>
+      <line l="ua">Ніч прийшла коротка і м'яка, повна жаб'ячих трелей.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">На землю спустилась тихая весенняя ночь.</line>
+      <line l="en">A quiet spring night has come down upon the land.</line>
+      <line l="ua">На землю спустилася тиха весняна ніч.</line>
+    </variant>
+
+    <variant season="summer">
+      <line l="ru">Душная летняя ночь никак не приносит прохлады.</line>
+      <line l="en">A sultry summer night brings no coolness at all.</line>
+      <line l="ua">Задушлива літня ніч ніяк не приносить прохолоди.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Стемнело, и звезды Варды густо высыпали на теплое небо.</line>
+      <line l="en">Darkness falls, and Varda's stars spill thick across the warm sky.</line>
+      <line l="ua">Стемніло, і зорі Варди густо висипали на тепле небо.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Короткая летняя ночь звенит цикадами и не спешит остывать.</line>
+      <line l="en">The short summer night rings with cicadas and is slow to cool.</line>
+      <line l="ua">Коротка літня ніч дзвенить цикадами і не поспішає холонути.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Тьма Тайфоэн легла на землю, но зной все еще держится.</line>
+      <line l="en">Taiphoen's darkness lies over the land, yet the heat still holds.</line>
+      <line l="ua">Темрява Тайфоен лягла на землю, та спека все ще тримається.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Настала тихая теплая ночь, и над садами замерцали светлячки.</line>
+      <line l="en">A still, warm night has come, and fireflies glimmer over the gardens.</line>
+      <line l="ua">Настала тиха тепла ніч, і над садами замерехтіли світлячки.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">Холодная осенняя ночь наступает рано и надолго.</line>
+      <line l="en">A cold autumn night comes early and stays long.</line>
+      <line l="ua">Холодна осіння ніч настає рано і надовго.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Стемнело быстро, и звезды Варды проступили сквозь рваные тучи.</line>
+      <line l="en">Darkness comes fast, and Varda's stars show through ragged cloud.</line>
+      <line l="ua">Стемніло швидко, і зорі Варди проступили крізь подерті хмари.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Сырая осенняя ночь пахнет прелой листвой и туманом.</line>
+      <line l="en">The damp autumn night smells of rotting leaves and mist.</line>
+      <line l="ua">Вогка осіння ніч пахне прілим листям і туманом.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Тьма легла на озябшие поля, и потянуло промозглым ветром.</line>
+      <line l="en">Darkness settles over the chilled fields, and a raw wind draws in.</line>
+      <line l="ua">Темрява лягла на змерзлі поля, і потягло промозклим вітром.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Долгая осенняя ночь смыкается под низкими тучами.</line>
+      <line l="en">The long autumn night closes in under low cloud.</line>
+      <line l="ua">Довга осіння ніч змикається під низькими хмарами.</line>
+    </variant>
   </event>
 
   <event id="clouds_gather">
-    <variant season="any">
-      <line l="ru">Небо затягивается тучами.</line>
-      <line l="en">The sky clouds over.</line>
-      <line l="ua">Небо затягує хмарами.</line>
+    <variant season="winter">
+      <line l="ru">С севера, от Мертвого моря, наползают снеговые тучи.</line>
+      <line l="en">Snow-laden clouds crawl up from the north, off the Dead Sea.</line>
+      <line l="ua">З півночі, від Мертвого Моря, насуваються снігові хмари.</line>
     </variant>
-    <variant season="any">
-      <line l="ru">С севера наползают тяжелые тучи, глотая синеву.</line>
-      <line l="en">Heavy clouds crawl up from the north, swallowing the blue.</line>
-      <line l="ua">З півночі насуваються важкі хмари, ковтаючи блакить.</line>
+    <variant season="winter">
+      <line l="ru">Небо затянуло серой мглой, тяжелой от близкого снега.</line>
+      <line l="en">The sky is veiled in grey murk, heavy with snow to come.</line>
+      <line l="ua">Небо затягло сірою імлою, важкою від близького снігу.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Свинцовые тучи сомкнулись, и день померк.</line>
+      <line l="en">Leaden clouds close in, and the day dims.</line>
+      <line l="ua">Свинцеві хмари зімкнулися, і день померкнув.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Небо набрякло снегом и опустилось совсем низко.</line>
+      <line l="en">The sky swells with snow and sinks down very low.</line>
+      <line l="ua">Небо набрякло снігом і опустилося зовсім низько.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Мертвое море дохнуло стужей, и небо заволокло тучами.</line>
+      <line l="en">The Dead Sea breathes out cold, and the sky is smothered in cloud.</line>
+      <line l="ua">Мертве Море дихнуло холодом, і небо заволокло хмарами.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">Небо затягивается легкими весенними тучами.</line>
+      <line l="en">The sky veils over with light spring clouds.</line>
+      <line l="ua">Небо затягує легкими весняними хмарами.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">С запада наплывают дождевые облака, набухшие влагой.</line>
+      <line l="en">Rain clouds drift in from the west, swollen with water.</line>
+      <line l="ua">Із заходу напливають дощові хмари, набряклі вологою.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Небо помрачнело, обещая теплый весенний дождь.</line>
+      <line l="en">The sky darkens, promising a warm spring rain.</line>
+      <line l="ua">Небо спохмурніло, обіцяючи теплий весняний дощ.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Молодая синева затянулась пеленой облаков.</line>
+      <line l="en">The young blue veils over with a film of cloud.</line>
+      <line l="ua">Молода блакить затягнулася пеленою хмар.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Тучи собираются, но пахнут они не бедой, а дождем.</line>
+      <line l="en">Clouds gather, but they smell not of trouble, only of rain.</line>
+      <line l="ua">Хмари збираються, та пахнуть вони не бідою, а дощем.</line>
+    </variant>
+
+    <variant season="summer">
+      <line l="ru">На горизонте вспухают тяжелые грозовые тучи.</line>
+      <line l="en">Heavy thunderheads swell up along the horizon.</line>
+      <line l="ua">На обрії набухають важкі грозові хмари.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Небо потемнело, и в духоте запахло близкой грозой.</line>
+      <line l="en">The sky darkens, and the sultry air smells of a storm to come.</line>
+      <line l="ua">Небо потемніло, і в задусі запахло близькою грозою.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">С юго-востока громоздятся черные тучи.</line>
+      <line l="en">Black clouds pile up out of the south-east.</line>
+      <line l="ua">З південного сходу громадяться чорні хмари.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Раскаленное небо затягивает мутной пеленой.</line>
+      <line l="en">The scorched sky veils over with a murky film.</line>
+      <line l="ua">Розжарене небо затягує каламутною пеленою.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Тучи копятся, суля долгожданную грозу.</line>
+      <line l="en">Clouds build up, boding a long-awaited storm.</line>
+      <line l="ua">Хмари громадяться, віщуючи довгождану грозу.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">С Кровавого моря нагоняет низкие свинцовые тучи.</line>
+      <line l="en">Low leaden clouds are driven in off the Bloody Sea.</line>
+      <line l="ua">З Кривавого Моря наганяє низькі свинцеві хмари.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Небо заволокло сплошной серой хмарью.</line>
+      <line l="en">The sky is smothered in unbroken grey overcast.</line>
+      <line l="ua">Небо заволокло суцільною сірою хмарою.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Тучи сомкнулись наглухо, и стало сумрачно, как в сумерки.</line>
+      <line l="en">The clouds seal shut, and it grows as gloomy as dusk.</line>
+      <line l="ua">Хмари зімкнулися наглухо, і стало похмуро, як у сутінки.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Осеннее небо набрякло дождем и придавило поля.</line>
+      <line l="en">The autumn sky swells with rain and presses down on the fields.</line>
+      <line l="ua">Осіннє небо набрякло дощем і придавило поля.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Серая муть затянула небо от края до края.</line>
+      <line l="en">Grey murk veils the sky from edge to edge.</line>
+      <line l="ua">Сіра каламуть затягла небо від краю до краю.</line>
     </variant>
   </event>
 
   <event id="clouds_clear">
-    <variant season="any">
-      <line l="ru">Тучи рассеиваются.</line>
-      <line l="en">The clouds break apart.</line>
-      <line l="ua">Хмари розходяться.</line>
+    <variant season="winter">
+      <line l="ru">Тучи разошлись, открыв стеклянно-синее зимнее небо.</line>
+      <line l="en">The clouds part, baring a glassy-blue winter sky.</line>
+      <line l="ua">Хмари розійшлися, відкривши скляно-синє зимове небо.</line>
     </variant>
-    <variant season="any">
+    <variant season="winter">
+      <line l="ru">Небо расчистилось, и мороз сразу стал злее под ясным Гек Тенгри.</line>
+      <line l="en">The sky clears, and the frost bites keener at once under clear Goktengri.</line>
+      <line l="ua">Небо розчистилося, і мороз одразу став лютіший під ясним Гьок Тенгрі.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Тучи ушли, и над снегами повисло холодное солнце.</line>
+      <line l="en">The clouds move off, and a cold sun hangs over the snows.</line>
+      <line l="ua">Хмари відійшли, і над снігами зависло холодне сонце.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Снеговые тучи откатились к северу, к Мертвому морю.</line>
+      <line l="en">The snow clouds roll back north, toward the Dead Sea.</line>
+      <line l="ua">Снігові хмари відкотилися на північ, до Мертвого Моря.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Небо очистилось до звонкой синевы, и заискрился иней.</line>
+      <line l="en">The sky clears to a ringing blue, and the frost begins to sparkle.</line>
+      <line l="ua">Небо очистилося до дзвінкої блакиті, і заіскрилася паморозь.</line>
+    </variant>
+
+    <variant season="spring">
       <line l="ru">Тучи расходятся, и снова открывается бескрайнее небо Гек Тенгри.</line>
       <line l="en">The clouds part, and the boundless sky of Goktengri opens once more.</line>
       <line l="ua">Хмари розходяться, і знову відкривається безкрає небо Гьок Тенгрі.</line>
     </variant>
+    <variant season="spring">
+      <line l="ru">Небо расчистилось, и весеннее солнце заиграло на мокрой листве.</line>
+      <line l="en">The sky clears, and the spring sun plays on the wet leaves.</line>
+      <line l="ua">Небо розчистилося, і весняне сонце заграло на мокрому листі.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Облака разбежались, оставив умытую синеву.</line>
+      <line l="en">The clouds scatter, leaving a rain-washed blue.</line>
+      <line l="ua">Хмари розбіглися, лишивши вмиту блакить.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Тучи растаяли, и запахло свежестью и молодой травой.</line>
+      <line l="en">The clouds melt away, and the air smells of freshness and young grass.</line>
+      <line l="ua">Хмари розтанули, і запахло свіжістю та молодою травою.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Небо прояснилось, и в вышине зазвенел жаворонок.</line>
+      <line l="en">The sky brightens, and high above a lark begins to sing.</line>
+      <line l="ua">Небо прояснилося, і у високості задзвенів жайворонок.</line>
+    </variant>
+
+    <variant season="summer">
+      <line l="ru">Тучи разошлись, и на землю обрушился летний зной.</line>
+      <line l="en">The clouds part, and summer heat crashes back down on the land.</line>
+      <line l="ua">Хмари розійшлися, і на землю ринула літня спека.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Небо очистилось до слепящей синевы Гек Тенгри.</line>
+      <line l="en">The sky clears to the blinding blue of Goktengri.</line>
+      <line l="ua">Небо очистилося до сліпучої блакиті Гьок Тенгрі.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Грозовые тучи ушли, оставив парное умытое небо.</line>
+      <line l="en">The thunderheads move off, leaving a steamy, rain-washed sky.</line>
+      <line l="ua">Грозові хмари відійшли, лишивши парке вмите небо.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Облака растаяли, и солнце снова взялось печь.</line>
+      <line l="en">The clouds melt away, and the sun sets back to baking.</line>
+      <line l="ua">Хмари розтанули, і сонце знову взялося пекти.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Небо расчистилось, и над горизонтом встала радуга.</line>
+      <line l="en">The sky clears, and a rainbow rises over the horizon.</line>
+      <line l="ua">Небо розчистилося, і над обрієм встала веселка.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">Тучи нехотя расползлись, приоткрыв блеклую синеву.</line>
+      <line l="en">The clouds drag apart reluctantly, baring a faded blue.</line>
+      <line l="ua">Хмари знехотя розповзлися, відкривши бліду блакить.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Небо расчистилось, но солнце светит скупо и без тепла.</line>
+      <line l="en">The sky clears, but the sun shines meanly and without warmth.</line>
+      <line l="ua">Небо розчистилося, та сонце світить скупо і без тепла.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Серая пелена расползлась, и проглянуло прохладное небо.</line>
+      <line l="en">The grey veil pulls apart, and a cool sky peers through.</line>
+      <line l="ua">Сіра пелена розповзлася, і визирнуло прохолодне небо.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Тучи откатились к Кровавому морю, оставив ясный холодок.</line>
+      <line l="en">The clouds roll back toward the Bloody Sea, leaving a clear chill.</line>
+      <line l="ua">Хмари відкотилися до Кривавого Моря, лишивши ясний холодок.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Небо прояснилось ненадолго, обещая скорые заморозки.</line>
+      <line l="en">The sky brightens briefly, promising an early frost.</line>
+      <line l="ua">Небо прояснилося ненадовго, обіцяючи скорі приморозки.</line>
+    </variant>
   </event>
 
   <event id="lightning_start">
-    <variant season="any">
-      <line l="ru">{WМолнии{x сверкают на небе.</line>
-      <line l="en">{WLightning{x flashes across the sky.</line>
-      <line l="ua">{WБлискавки{x спалахують у небі.</line>
+    <variant season="winter">
+      <line l="ru">{WМолнии{x вспарывают снеговые тучи -- зимняя гроза, редкая и злая.</line>
+      <line l="en">{WLightning{x rips through the snow clouds -- a rare and vicious winter storm.</line>
+      <line l="ua">{WБлискавки{x шматують снігові хмари -- зимова гроза, рідкісна і люта.</line>
     </variant>
-    <variant season="any">
+    <variant season="winter">
+      <line l="ru">Сквозь метель полыхнули {Wмолнии{x, и грянул гром.</line>
+      <line l="en">{WLightning{x flares through the blizzard, and thunder crashes.</line>
+      <line l="ua">Крізь заметіль спалахнули {Wблискавки{x, і вдарив грім.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Тешуб взялся за молот даже в стужу -- небо раскололось огнем.</line>
+      <line l="en">Teshub takes up his hammer even in the cold -- the sky splits with fire.</line>
+      <line l="ua">Тешуб узявся за молот навіть у холоднечу -- небо розкололося вогнем.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Над мерзлой землей заплясали синие сполохи молний.</line>
+      <line l="en">Blue flashes of lightning dance above the frozen earth.</line>
+      <line l="ua">Над мерзлою землею затанцювали сині спалахи блискавок.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Ледяной ветер принес грозу с юго-востока, из Пространств Хаоса.</line>
+      <line l="en">An icy wind brings a storm from the south-east, out of the Reaches of Chaos.</line>
+      <line l="ua">Крижаний вітер приніс грозу з південного сходу, з Просторів Хаосу.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">{WМолнии{x распороли небо -- пришла первая весенняя гроза.</line>
+      <line l="en">{WLightning{x tears the sky open -- the first spring storm has come.</line>
+      <line l="ua">{WБлискавки{x розпанахали небо -- прийшла перша весняна гроза.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Небо озарилось {Wмолниями{x, и свежо запахло грозой.</line>
+      <line l="en">The sky lights up with {Wlightning{x, and the air smells sharp with storm.</line>
+      <line l="ua">Небо осяялося {Wблискавками{x, і свіжо запахло грозою.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Тешуб пробует молот -- по молодой листве хлещет гроза.</line>
+      <line l="en">Teshub tries out his hammer -- a storm lashes the young leaves.</line>
+      <line l="ua">Тешуб пробує молот -- по молодому листю шмагає гроза.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Первая гроза года катится с юго-востока, из Пространств Хаоса.</line>
+      <line l="en">The year's first storm rolls in from the south-east, out of the Reaches of Chaos.</line>
+      <line l="ua">Перша гроза року котиться з південного сходу, з Просторів Хаосу.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">{WМолнии{x вспыхнули над полями, и раскатился молодой гром.</line>
+      <line l="en">{WLightning{x flashes over the fields, and young thunder rolls out.</line>
+      <line l="ua">{WБлискавки{x спалахнули над полями, і розкотився молодий грім.</line>
+    </variant>
+
+    <variant season="summer">
       <line l="ru">{WМолнии{x раскалывают небо -- где-то Тешуб взялся за свой молот.</line>
       <line l="en">{WLightning{x splits the sky -- somewhere Teshub has taken up his hammer.</line>
       <line l="ua">{WБлискавки{x розколюють небо -- десь Тешуб узявся за свій молот.</line>
     </variant>
-    <variant season="any">
-      <line l="ru">С юго-востока, из Пространств Хаоса, накатывает гроза.</line>
-      <line l="en">A storm rolls in from the south-east, out of the Reaches of Chaos.</line>
-      <line l="ua">З південного сходу, з Просторів Хаосу, накочується гроза.</line>
+    <variant season="summer">
+      <line l="ru">Тяжелая летняя гроза встала стеной от юго-востока, от Пространств Хаоса.</line>
+      <line l="en">A heavy summer storm rises like a wall from the south-east, from the Reaches of Chaos.</line>
+      <line l="ua">Важка літня гроза стала стіною з південного сходу, від Просторів Хаосу.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Духота лопнула, и небо полыхнуло {Wмолниями{x.</line>
+      <line l="en">The sultry air bursts, and the sky blazes with {Wlightning{x.</line>
+      <line l="ua">Задуха луснула, і небо спалахнуло {Wблискавками{x.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Гром грянул так, что задрожала земля -- молот Тешуба в полную силу.</line>
+      <line l="en">Thunder crashes hard enough to shake the ground -- Teshub's hammer at full force.</line>
+      <line l="ua">Грім ударив так, що здригнулася земля -- молот Тешуба на повну силу.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Слепящие {Wмолнии{x рвут черное грозовое небо.</line>
+      <line l="en">Blinding {Wlightning{x rends the black storm sky.</line>
+      <line l="ua">Сліпучі {Wблискавки{x шматують чорне грозове небо.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">{WМолнии{x полыхнули в свинцовых тучах -- поздняя осенняя гроза.</line>
+      <line l="en">{WLightning{x flares in the leaden clouds -- a late autumn storm.</line>
+      <line l="ua">{WБлискавки{x спалахнули у свинцевих хмарах -- пізня осіння гроза.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Тешуб бьет молотом сквозь холодный ливень.</line>
+      <line l="en">Teshub strikes his hammer through the cold downpour.</line>
+      <line l="ua">Тешуб б'є молотом крізь холодну зливу.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">С юго-востока, из Пространств Хаоса, надвинулась хмурая гроза.</line>
+      <line l="en">A sullen storm looms in from the south-east, out of the Reaches of Chaos.</line>
+      <line l="ua">З південного сходу, з Просторів Хаосу, насунулася похмура гроза.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Небо распорото {Wмолниями{x, и по лужам хлещет дождь.</line>
+      <line l="en">The sky is torn with {Wlightning{x, and rain lashes the puddles.</line>
+      <line l="ua">Небо розпанахане {Wблискавками{x, і по калюжах шмагає дощ.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Гром прокатился над озябшими полями, глухой и долгий.</line>
+      <line l="en">Thunder rolls over the chilled fields, dull and long.</line>
+      <line l="ua">Грім прокотився над змерзлими полями, глухий і довгий.</line>
     </variant>
   </event>
 
   <event id="precip_stop">
-    <variant season="any">
-      <line l="ru">Дождь прекращается.</line>
-      <line l="en">The rain lets up.</line>
-      <line l="ua">Дощ ущухає.</line>
-    </variant>
     <variant season="winter">
       <line l="ru">Снегопад стихает, и наступает белая морозная тишина.</line>
       <line l="en">The snowfall dies down, and a white, frozen silence settles in.</line>
       <line l="ua">Снігопад стихає, і настає біла морозна тиша.</line>
     </variant>
+    <variant season="winter">
+      <line l="ru">Метель улеглась, и снег лежит нетронутым покрывалом.</line>
+      <line l="en">The blizzard has died away, and the snow lies in an untouched blanket.</line>
+      <line l="ua">Заметіль уляглася, і сніг лежить незайманим покривалом.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Последние снежинки осели, и мир застыл в морозном покое.</line>
+      <line l="en">The last snowflakes settle, and the world freezes into frosty stillness.</line>
+      <line l="ua">Останні сніжинки осіли, і світ завмер у морозному спокої.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Снег перестал, и над белыми полями повисла тишина.</line>
+      <line l="en">The snow has stopped, and silence hangs over the white fields.</line>
+      <line l="ua">Сніг перестав, і над білими полями зависла тиша.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Пурга унялась, оставив сугробы и колючий морозный воздух.</line>
+      <line l="en">The snowstorm lets up, leaving drifts and sharp, frosty air.</line>
+      <line l="ua">Хуртовина вгамувалася, лишивши кучугури і колюче морозне повітря.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">Весенний дождь выдохся, и с листьев скатываются капли.</line>
+      <line l="en">The spring rain spends itself, and drops slide from the leaves.</line>
+      <line l="ua">Весняний дощ видихнувся, і з листя скрапують краплі.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Дождь прошел, и умытый воздух запах свежестью.</line>
+      <line l="en">The rain passes, and the washed air smells of freshness.</line>
+      <line l="ua">Дощ минув, і вмите повітря запахло свіжістю.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Морось развеялась, и в разрывах туч блеснуло солнце.</line>
+      <line l="en">The drizzle disperses, and sun glints through the breaks in the cloud.</line>
+      <line l="ua">Мжичка розвіялася, і в розривах хмар блиснуло сонце.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Дождик перестал, и на мокрых ветках защебетали птицы.</line>
+      <line l="en">The rain stops, and birds begin to chirp on the wet branches.</line>
+      <line l="ua">Дощик перестав, і на мокрих гілках защебетали птахи.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Ливень отступил, оставив звонкие лужи и запах земли.</line>
+      <line l="en">The downpour retreats, leaving ringing puddles and the smell of earth.</line>
+      <line l="ua">Злива відступила, лишивши дзвінкі калюжі і запах землі.</line>
+    </variant>
+
+    <variant season="summer">
+      <line l="ru">Летний ливень оборвался так же внезапно, как начался.</line>
+      <line l="en">The summer downpour breaks off as suddenly as it began.</line>
+      <line l="ua">Літня злива обірвалася так само раптово, як почалася.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Дождь прошел, и от разогретой земли поднялся пар.</line>
+      <line l="en">The rain passes, and steam rises from the heated ground.</line>
+      <line l="ua">Дощ минув, і від розігрітої землі піднялася пара.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Гроза отгремела, и дождь сошел на нет.</line>
+      <line l="en">The storm has thundered itself out, and the rain trails off.</line>
+      <line l="ua">Гроза відгриміла, і дощ зійшов нанівець.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Ливень выдохся, оставив свежесть и звонкую капель.</line>
+      <line l="en">The downpour spends itself, leaving freshness and ringing drips.</line>
+      <line l="ua">Злива видихнулася, лишивши свіжість і дзвінке скрапування.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Дождь кончился, и парная духота снова наползла на землю.</line>
+      <line l="en">The rain ends, and steamy closeness creeps back over the land.</line>
+      <line l="ua">Дощ скінчився, і парка задуха знову насунула на землю.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">Осенний дождь наконец выдохся, оставив мокрый унылый мир.</line>
+      <line l="en">The autumn rain finally spends itself, leaving a wet, dreary world.</line>
+      <line l="ua">Осінній дощ нарешті видихнувся, лишивши мокрий понурий світ.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Морось перестала, но небо так и осталось серым.</line>
+      <line l="en">The drizzle stops, but the sky stays grey all the same.</line>
+      <line l="ua">Мжичка перестала, та небо так і лишилося сірим.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Дождь утих, и с голых веток срываются последние капли.</line>
+      <line l="en">The rain quiets, and the last drops fall from the bare branches.</line>
+      <line l="ua">Дощ ущух, і з голого гілля зриваються останні краплі.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Ливень отступил, оставив хлюпающую грязь и промозглый холод.</line>
+      <line l="en">The downpour retreats, leaving squelching mud and a raw chill.</line>
+      <line l="ua">Злива відступила, лишивши хлюпку багнюку і промозклий холод.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Дождь иссяк, и над мокрыми полями заклубился туман.</line>
+      <line l="en">The rain runs dry, and mist curls up over the wet fields.</line>
+      <line l="ua">Дощ вичерпався, і над мокрими полями заклубочився туман.</line>
+    </variant>
   </event>
 
   <event id="storm_ease">
-    <variant season="any">
+    <variant season="winter">
+      <line l="ru">Зимняя гроза откатилась, и снова повалил тихий снег.</line>
+      <line l="en">The winter storm rolls off, and quiet snow begins to fall again.</line>
+      <line l="ua">Зимова гроза відкотилася, і знову повалив тихий сніг.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Молот Тешуба смолк, и метель улеглась в морозную тишину.</line>
+      <line l="en">Teshub's hammer falls silent, and the blizzard settles into frosty stillness.</line>
+      <line l="ua">Молот Тешуба стих, і заметіль уляглася в морозну тишу.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Сполохи молний угасли над снегами, гром откатился к северу.</line>
+      <line l="en">The flashes of lightning die over the snows, and thunder rolls off to the north.</line>
+      <line l="ua">Спалахи блискавок згасли над снігами, грім відкотився на північ.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Гроза утихла, и мороз тут же взялся сковывать талый снег.</line>
+      <line l="en">The storm dies down, and the frost sets at once to locking the melted snow.</line>
+      <line l="ua">Гроза вщухла, і мороз одразу взявся сковувати талий сніг.</line>
+    </variant>
+    <variant season="winter">
+      <line l="ru">Гром смолк, и над стылой землей повисла белая тишь.</line>
+      <line l="en">The thunder falls quiet, and a white hush hangs over the frozen land.</line>
+      <line l="ua">Грім стих, і над холодною землею зависла біла тиша.</line>
+    </variant>
+
+    <variant season="spring">
+      <line l="ru">Весенняя гроза откатилась, оставив ровный шум дождя.</line>
+      <line l="en">The spring storm rolls off, leaving the steady hiss of rain.</line>
+      <line l="ua">Весняна гроза відкотилася, лишивши рівний шум дощу.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Молот Тешуба стих вдали, и над полями встала радуга.</line>
+      <line l="en">Teshub's hammer falls quiet in the distance, and a rainbow rises over the fields.</line>
+      <line l="ua">Молот Тешуба стих удалині, і над полями встала веселка.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Молнии унялись, и дождь стал теплым и ласковым.</line>
+      <line l="en">The lightning settles, and the rain turns warm and gentle.</line>
+      <line l="ua">Блискавки вгамувалися, і дощ став теплим і лагідним.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Гроза ушла на запад, и посвежевший воздух зазвенел птицами.</line>
+      <line l="en">The storm moves off to the west, and the freshened air rings with birds.</line>
+      <line l="ua">Гроза відійшла на захід, і посвіжіле повітря задзвеніло птахами.</line>
+    </variant>
+    <variant season="spring">
+      <line l="ru">Гром откатился, оставив умытую зелень и капли на ветках.</line>
+      <line l="en">The thunder rolls away, leaving rain-washed green and drops on the branches.</line>
+      <line l="ua">Грім відкотився, лишивши вмиту зелень і краплі на гіллі.</line>
+    </variant>
+
+    <variant season="summer">
       <line l="ru">Гроза понемногу утихает, молний больше нет.</line>
       <line l="en">The storm eases little by little; the lightning is gone.</line>
       <line l="ua">Гроза потроху вщухає, блискавок більше немає.</line>
     </variant>
-    <variant season="any">
+    <variant season="summer">
       <line l="ru">Молот Тешуба смолкает вдали, остается лишь ровный шум дождя.</line>
       <line l="en">Teshub's hammer falls quiet in the distance, leaving only the steady hiss of rain.</line>
       <line l="ua">Молот Тешуба стихає вдалині, лишається тільки рівний шум дощу.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Гроза откатилась за горизонт, и от земли повалил густой пар.</line>
+      <line l="en">The storm rolls off beyond the horizon, and thick steam rises from the ground.</line>
+      <line l="ua">Гроза відкотилася за обрій, і від землі повалила густа пара.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Молнии отгуляли, и над остывшими полями протянулась радуга.</line>
+      <line l="en">The lightning has run its course, and a rainbow stretches over the cooled fields.</line>
+      <line l="ua">Блискавки відгуляли, і над охололими полями простяглася веселка.</line>
+    </variant>
+    <variant season="summer">
+      <line l="ru">Гром удаляется, ворча, и ливень сходит на ровный шелест.</line>
+      <line l="en">The thunder recedes, grumbling, and the downpour eases to a steady patter.</line>
+      <line l="ua">Грім віддаляється, буркочучи, і злива спадає до рівного шелесту.</line>
+    </variant>
+
+    <variant season="autumn">
+      <line l="ru">Осенняя гроза отгремела, и зарядил ровный холодный дождь.</line>
+      <line l="en">The autumn storm has thundered out, and a steady cold rain sets in.</line>
+      <line l="ua">Осіння гроза відгриміла, і зарядив рівний холодний дощ.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Молот Тешуба стих, оставив промозглую морось.</line>
+      <line l="en">Teshub's hammer falls silent, leaving a raw drizzle.</line>
+      <line l="ua">Молот Тешуба стих, лишивши промозклу мжичку.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Молнии угасли в тучах, и гром уполз к Кровавому морю.</line>
+      <line l="en">The lightning dies in the clouds, and thunder crawls off toward the Bloody Sea.</line>
+      <line l="ua">Блискавки згасли у хмарах, і грім уповз до Кривавого Моря.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Гроза утихла, но небо так и осталось свинцовым.</line>
+      <line l="en">The storm dies down, but the sky stays leaden all the same.</line>
+      <line l="ua">Гроза вщухла, та небо так і лишилося свинцевим.</line>
+    </variant>
+    <variant season="autumn">
+      <line l="ru">Гром откатился вдаль, и по лужам зашуршал унылый дождь.</line>
+      <line l="en">The thunder rolls off into the distance, and a dreary rain rustles on the puddles.</line>
+      <line l="ua">Грім відкотився вдалину, і по калюжах зашурхотів понурий дощ.</line>
     </variant>
   </event>
 


### PR DESCRIPTION
Brings the 8 seeded weather/time events (day_begin, sunset, night_begin, clouds_gather, clouds_clear, lightning_start, precip_stop, storm_ease) up to the same depth as sunrise/precip_start: **5 trilingual variants per season** across all four seasons.

- 160 new variants, **200 total across 10 events**
- All season-specific now (no more `season="any"` placeholders)
- Geography + lore per event: Sea of the Golden Circle (sunset), snow clouds off the Dead Sea, storms out of the Reaches of Chaos, Goktengri's clear sky, Teshub's hammer (lightning), Varda's stars and Taiphoen's dark (night), the Raven Queen's winter
- ASCII punctuation, no yo in RU, no e-oborotne in UA; validated well-formed, 3-language complete, no mixed-script

Loaded live via `plug reload most` (WeatherMessages plugin reloads from disk); no reboot.