### PR TITLE
l10n: add $w/$W catalog keys for keyhole/scan direction frames

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -207,6 +207,10 @@
   "Этот замок защищен от взлома.": {
    "en": "This lock is pick-proof.",
    "ua": "Цей замок захищений від зламу."
+  },
+  "$c1 ковыряется в замке двери $w отсюда.": {
+   "en": "$c1 fiddles with the door lock $w from here.",
+   "ua": "$c1 колупається в замку дверей $w звідси."
   }
  },
  "plug-ins/movement/movement.cpp": {
@@ -6003,6 +6007,10 @@
   "Ты ничего не видишь, кроме звезд...": {
    "en": "You see nothing but stars...",
    "ua": "Ти нічого не бачиш, окрім зірок..."
+  },
+  "$c1 пристально смотрит $W.": {
+   "en": "$c1 stares intently $W.",
+   "ua": "$c1 пильно дивиться $W."
   }
  },
  "plug-ins/comm/score.cpp": {


### PR DESCRIPTION
The keyhole "picks the lock ... <dir> from here" and scan "peers <dir>" room frames switched their direction arg from the plain `$t`/`$T` act code to the per-recipient `$w`/`$W` LangText code (dreamland_code #671/#672). This adds matching catalog entries under the new `$w`/`$W` keys (same EN/UA text) so the frames stay translated once that engine build is live. The old `$t`/`$T` entries are kept alongside so there is no regression window before the reboot.