### PR TITLE
l10n: EN/UA for vorpal Jabberwocky messages (Carroll)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -8397,6 +8397,78 @@
   "Ты и %C1 наводите {Rстрах и ужас{x на противников, нанося дополнительный урон!": {
    "en": "You and %C1 strike {Rfear and terror{x into your enemies, dealing extra damage!",
    "ua": "Ти і %C1 наводите {Rстрах і жах{x на ворогів, завдаючи додаткової шкоди!"
+  },
+  "{mРаз-два! Раз-два! Горит трава, взы-взы свирчит бердыш!{x": {
+   "en": "{mOne, two! One, two! And through and through, the vorpal pole-axe went snicker-snack!{x",
+   "ua": "{mРаз-два! Раз-два! Горить трава, взи-взи свирчить бердиш!{x"
+  },
+  "{mРаз-два! Раз-два! Горит трава, взы-взы свирчит клинок!{x": {
+   "en": "{mOne, two! One, two! And through and through, the vorpal blade went snicker-snack!{x",
+   "ua": "{mРаз-два! Раз-два! Горить трава, взи-взи свирчить клинок!{x"
+  },
+  "{mРаз-два! Раз-два! Горит трава, взы-взы свирчит топор!{x": {
+   "en": "{mOne, two! One, two! And through and through, the vorpal axe went snicker-snack!{x",
+   "ua": "{mРаз-два! Раз-два! Горить трава, взи-взи свирчить топір!{x"
+  },
+  "{mРаз-два! Раз-два! Горит трава, взы-взы стрижает нож!{x": {
+   "en": "{mOne, two! One, two! And through and through, the vorpal knife went snicker-snack!{x",
+   "ua": "{mРаз-два! Раз-два! Горить трава, взи-взи стрижає ніж!{x"
+  },
+  "{mРаз-два! Раз-два! Горит трава, взы-взы стрижает плеть!{x": {
+   "en": "{mOne, two! One, two! And through and through, the vorpal lash went snicker-snack!{x",
+   "ua": "{mРаз-два! Раз-два! Горить трава, взи-взи стрижає батіг!{x"
+  },
+  "{mРаз-два, раз-два! Горит трава, взы-взы стрижает меч!{x": {
+   "en": "{mOne, two! One, two! And through and through, the vorpal blade went snicker-snack!{x",
+   "ua": "{mРаз-два, раз-два! Горить трава, взи-взи стрижає меч!{x"
+  },
+  "{mУва! %1$C2 голова лежит у твоих ног!{x": {
+   "en": "{mCallooh! The head of %1$C2 lies galumphing at their feet!{x",
+   "ua": "{mУва! Голова %1$C2 лежить біля твоїх ніг!{x"
+  },
+  "{mУва! %1$C2 котелок скосило как камыш!{x": {
+   "en": "{mCallooh! The beamish noggin of %1$C2 is mown down like a reed!{x",
+   "ua": "{mУва! Казанок %1$C2 скосило, як комиш!{x"
+  },
+  "{mУва! %1$C3 с головой не подружиться впредь!{x": {
+   "en": "{mCallooh! %1$C3 and their own head shall never more be friends!{x",
+   "ua": "{mУва! %1$C3 з головою вже не потоваришувати надалі!{x"
+  },
+  "{mУва! %1$^C1 без головы остал%1$Gось|ся|ась|ись с этих пор!{x": {
+   "en": "{mCallooh! %1$^C1 is left dead and headless from this day on!{x",
+   "ua": "{mУва! %1$^C1 без голови зостал%1$Gося|ся|ася|ися відтепер!{x"
+  },
+  "{mУва! И твоя голова барабардает с плеч!{x": {
+   "en": "{mCallooh! Callay! And with your head it went galumphing back!{x",
+   "ua": "{mУва! І твоя голова барабардає з плечей!{x"
+  },
+  "{mУва! И твоя голова лежит у твоих ног!{x": {
+   "en": "{mCallooh! Callay! Your head lies galumphing at your feet!{x",
+   "ua": "{mУва! І твоя голова лежить біля твоїх ніг!{x"
+  },
+  "{mУва! И тебе с головой не подружиться впредь!{x": {
+   "en": "{mCallooh! You and your own head shall never more be friends!{x",
+   "ua": "{mУва! І тобі з головою вже не потоваришувати надалі!{x"
+  },
+  "{mУва! И ты без головы остал%1$Gось|ся|ась|ись с этих пор!{x": {
+   "en": "{mCallooh! He left you dead, and headless from this day on!{x",
+   "ua": "{mУва! І ти без голови зостал%1$Gося|ся|ася|ися відтепер!{x"
+  },
+  "{mУва! Ты голову %1$C2 у ног своих найдешь!{x": {
+   "en": "{mCallooh! You'll find the head of %1$C2 a-lying at their feet!{x",
+   "ua": "{mУва! Ти голову %1$C2 у ногах своїх знайдеш!{x"
+  },
+  "{mУва! Ты голову свою у ног своих найдешь!{x": {
+   "en": "{mCallooh! You'll find your own head a-lying at your feet!{x",
+   "ua": "{mУва! Ти голову свою у ногах своїх знайдеш!{x"
+  },
+  "{mУва! Ува! И %1$C2 голова барабардает с плеч!{x": {
+   "en": "{mCallooh! Callay! And the head of %1$C2 went galumphing off the shoulders!{x",
+   "ua": "{mУва! Ува! І голова %1$C2 барабардає з плечей!{x"
+  },
+  "{mУва! Ува! Твой котелок скосило как камыш!{x": {
+   "en": "{mCallooh! Callay! Your beamish noggin is mown down like a reed!{x",
+   "ua": "{mУва! Ува! Твій казанок скосило, як комиш!{x"
   }
  },
  "plug-ins/fight/onehit_weapon.cpp": {


### PR DESCRIPTION
Catalog for dreamland_code #678. 18 vorpal behead messages; EN = Carroll's original Jabberwocky (RU key = Orlovskaya's Russian translation), UA in matching register with 4-way %1$G gender. Placeholders + color codes preserved, lint 0 HARD, additions-only.