### PR TITLE
l10n: EN/UA for quest-plugin speech (101 phrases, Trello 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -5365,6 +5365,18 @@
   "Твой питомец не в состоянии ответить на твой вопрос.": {
    "en": "Your pet isn't able to answer your question.",
    "ua": "Твій улюбленець не в змозі відповісти на твоє запитання."
+  },
+  "%s, тут слишком темно, я ничего не вижу!": {
+   "en": "%s, it's too dark here, I can't see anything!",
+   "ua": "%s, тут занадто темно, я нічого не бачу!"
+  },
+  "%s, я нахожусь в {hh%s{hx - %s": {
+   "en": "%s, I'm in {hh%s{hx - %s",
+   "ua": "%s, я перебуваю в {hh%s{hx - %s"
+  },
+  "%s, я ничего не вижу!": {
+   "en": "%s, I can't see anything!",
+   "ua": "%s, я нічого не бачу!"
   }
  },
  "plug-ins/comm/help.cpp": {
@@ -5995,6 +6007,10 @@
   "Напиши {y{hcприказать %1$N3 рапорт все{x, и я расскажу, что ещё я умею делать.": {
    "en": "Write {y{hcorder %1$N3 report all{x, and I'll tell you what else I can do.",
    "ua": "Напиши {y{hcнаказати %1$N3 рапорт всі{x, і я розповім, що ще я вмію робити."
+  },
+  "%s, больше я ничегошеньки не умею!": {
+   "en": "%s, I don't know how to do anything else at all!",
+   "ua": "%s, більше я нічогісінько не вмію!"
   }
  },
  "plug-ins/comm/run.cpp": {
@@ -11823,6 +11839,34 @@
   "Ты просишь у $C4 показать список ключей.": {
    "en": "You ask $C4 to show you the list of keys.",
    "ua": "Ти просиш у $C4 показати список ключів."
+  },
+  "За свою работу я потребую $n4.": {
+   "en": "For my work I will require $n4.",
+   "ua": "За свою роботу я вимагатиму $n4."
+  },
+  "Извини, $c1, но тебе не принадлежит ключ с таким именем.": {
+   "en": "Sorry, $c1, but you don't own a key with that name.",
+   "ua": "Вибач, $c1, але тобі не належить ключ з таким ім'ям."
+  },
+  "Извини, $c1, но тебе не принадлежит ни одного ключа. ": {
+   "en": "Sorry, $c1, but you don't own a single key. ",
+   "ua": "Вибач, $c1, але тобі не належить жоден ключ. "
+  },
+  "Какой именно ключ ты хочешь купить?": {
+   "en": "Which key exactly do you want to buy?",
+   "ua": "Який саме ключ ти хочеш купити?"
+  },
+  "У тебя недостаточно $n2, чтобы оплатить мою работу, $c1.": {
+   "en": "You don't have enough $n2 to pay for my work, $c1.",
+   "ua": "У тебе недостатньо $n2, щоб оплатити мою роботу, $c1."
+  },
+  "У тебя нет ключей ни от какого дома.": {
+   "en": "You don't have keys to any house.",
+   "ua": "У тебе немає ключів від жодного будинку."
+  },
+  "Я могу изготовить для тебя такие ключи: ": {
+   "en": "I can make you the following keys: ",
+   "ua": "Я можу виготовити для тебе такі ключі: "
   }
  },
  "plug-ins/misc_behaviors/ofcolguards.cpp": {
@@ -12385,6 +12429,34 @@
   "{YЗаказ отменен в связи с кончиной заказчика.{x": {
    "en": "{YThe order has been cancelled due to the customer's untimely demise.{x",
    "ua": "{YЗамовлення скасовано у зв'язку зі смертю замовника.{x"
+  },
+  "Маловато будет...": {
+   "en": "That won't quite cut it...",
+   "ua": "Замало буде..."
+  },
+  "Спасибо за помощь! Вернись к квестору за наградой.": {
+   "en": "Thanks for the help! Go back to the questor for your reward.",
+   "ua": "Дякую за допомогу! Повернися до квестора за нагородою."
+  },
+  "Ужас, с кого ты это среза%1$Gло|л|ла?!": {
+   "en": "Good grief, who did you carve this off of?!",
+   "ua": "Жах, з кого ти це зріза%1$Gло|в|ла|ли?!"
+  },
+  "Хватит, родн%1$Gое|ой|ая.": {
+   "en": "That's enough, dear.",
+   "ua": "Досить, рідн%1$Gе|ий|а|і."
+  },
+  "Хороший кусок, но я заказыва%2$Gло|л|ла мясо %3$N2.": {
+   "en": "Good cut, but I ordered %3$N2 meat.",
+   "ua": "Гарний шматок, але я замовля%2$Gло|в|ла|ли м'ясо %3$N2."
+  },
+  "Что ты мне приволок%1$Gло|л|ла! Это даже не мясо!": {
+   "en": "What did you drag in for me?! This isn't even meat!",
+   "ua": "Що ти мені притяг%1$Gло||ла|ли! Це навіть не м'ясо!"
+  },
+  "Эти звери водятся в %s, а не в %s.": {
+   "en": "Those animals live in %s, not in %s.",
+   "ua": "Ці звірі водяться в %s, а не в %s."
   }
  },
  "plug-ins/quest/command/cquest.cpp": {
@@ -12465,6 +12537,14 @@
   "$c1 что-то говорит $C3.": {
    "en": "$c1 says something to $C3.",
    "ua": "$c1 щось каже $C3."
+  },
+  "Изучи справку по теме {hh125квестор{hx, а когда будешь готов%1$Gо||а, набери {y{hcквест попросить{x.": {
+   "en": "Study the help on {hh125questor{hx, and when you're ready, type {y{hcquest request{x.",
+   "ua": "Вивчи довідку за темою {hh125квестор{hx, а коли будеш готов%1$Gе|ий|а|і, набери {y{hcквест попросити{x."
+  },
+  "Ты очень отваж%1$Gно|ен|на, %1$C1!": {
+   "en": "You're very brave, %1$C1!",
+   "ua": "Ти дуже відваж%1$Gно|ний|на|ні, %1$C1!"
   }
  },
  "plug-ins/quest/command/questor.cpp": {
@@ -13353,6 +13433,14 @@
   "$c1 берет за руку $C4 и уводит $S прочь.": {
    "en": "$c1 takes $C4 by the hand and leads them away.",
    "ua": "$c1 бере за руку $C4 і веде його геть."
+  },
+  "{W%s{G зачем-то понадобилась твоя помощь.": {
+   "en": "{W%s{G needs your help for some reason.",
+   "ua": "{W%s{G навіщось знадобилася твоя допомога."
+  },
+  "Ищи %s в местности под названием {W%s{G ({W{hh%s{hx{G).": {
+   "en": "Look for %s in the area called {W%s{G ({W{hh%s{hx{G).",
+   "ua": "Шукай %s в місцевості під назвою {W%s{G ({W{hh%s{hx{G)."
   }
  },
  "plug-ins/quest/kidnapquest/scenario_dragon.cpp": {
@@ -14061,6 +14149,54 @@
   "$c1, всплеснув руками, бросается тебе навстречу.": {
    "en": "$c1 throws up their hands and rushes toward you.",
    "ua": "$c1, сплеснувши руками, кидається тобі назустріч."
+  },
+  "Всего их было {W%d{G. Пожалуйста, отыщи их и принеси мне! Ты моя последняя надежда!": {
+   "en": "There were {W%d{G of them in total. Please find them and bring them to me! You're my last hope!",
+   "ua": "Усього їх було {W%d{G. Будь ласка, знайди їх і принеси мені! Ти моя остання надія!"
+  },
+  "Всего там {W%d{G железок. Приволоки их сюда, если ты действительно такой хороший сыщик, как о тебе рассказывают.": {
+   "en": "There are {W%d{G bits of scrap there in total. Haul them back here, if you're really as good a detective as they say.",
+   "ua": "Всього там {W%d{G залізяк. Притягни їх сюди, якщо ти справді такий гарний нишпорка, як про тебе розказують."
+  },
+  "Да, так вот.. в моей лаборатории прогремел взрыв, и {W$n4{G расшвыряло в разные стороны.": {
+   "en": "Yeah, so... there was an explosion in my lab, and it flung $n4 in every direction.",
+   "ua": "Так, ось... у моїй лабораторії гримнув вибух, і $n4 розкидало в різні боки."
+  },
+  "Если я их не соберу, меня казнят, а не то и уволят.": {
+   "en": "If I don't collect them, they'll have me executed -- or worse, fired.",
+   "ua": "Якщо я їх не зберу, мене стратять, а то й звільнять."
+  },
+  "Заказа$Gло|л|ла я на днях набор отменнейших пыточных приспособлений. Железные девы 'от кутюр', наручники под ключ.. ну, вы меня понимаете.": {
+   "en": "I ordered a batch of the finest torture devices the other day. Iron maidens 'haute couture', turnkey handcuffs.. well, you know how it is.",
+   "ua": "Замови$Gло|в|ла|ли я днями набір найвишуканіших знарядь для тортур. Залізні діви 'від кутюр', наручники під ключ.. ну, ти ж мене розумієш."
+  },
+  "Недавно я что-то смешал не в тех пропорциях..": {
+   "en": "I recently mixed something in the wrong proportions...",
+   "ua": "Нещодавно я щось змішав не в тих пропорціях..."
+  },
+  "Но балбес поставщик растерял все по пути от {W$t{G сюда. На нем мне пришлось опробовать старые средства, а вот заказанное добро до сих пор валяется где-то на дороге.": {
+   "en": "But the doofus of a supplier lost everything on the way here from {W$t{G. I had to try some old methods on him, and the goods I ordered are still lying around somewhere on the road.",
+   "ua": "Та бовдур постачальник розгубив усе по дорозі від {W$t{G сюди. На ньому довелося випробувати старі методи, а замовлений товар досі валяється десь на дорозі."
+  },
+  "Но попробуй собери хотя бы {W%d{G штук. Жду с нетерпением.": {
+   "en": "But at least try to gather {W%d{G of them. I'll be waiting eagerly.",
+   "ua": "Але спробуй зібрати хоча б {W%d{G штук. Чекаю з нетерпінням."
+  },
+  "По моим подсчетам, их около {W%d{G. Поищи, вдруг тебе повезет.": {
+   "en": "By my count, there are about {W%d{G of them. Have a look -- you might get lucky.",
+   "ua": "За моїми підрахунками, їх близько {W%d{G. Пошукай, раптом тобі пощастить."
+  },
+  "Подлые мыши, спасу от них нет никакого. Чем я их только не травила!": {
+   "en": "Filthy mice, there's no escaping them. I've tried everything to poison them!",
+   "ua": "Підступні миші, рятунку від них нема жодного. Чим я їх тільки не труїла!"
+  },
+  "Растащили из кладовки {W$n4{G. Всех их уже, конечно, не отыскать.": {
+   "en": "They looted {W$n4{G from the storeroom. Of course, there's no finding them all now.",
+   "ua": "З комори розтягли {W$n4{G. Усіх їх уже, звісно, не відшукати."
+  },
+  "Случилось ужасное. С моего рабочего стола сквозняком выдуло в окно пачку {W$n2{G и расшвыряло по окрестностям!": {
+   "en": "Something terrible happened. A draft blew a pack of {W$n2{G off my desk and out the window, scattering it all over the neighborhood!",
+   "ua": "Сталося щось жахливе. Протягом здуло з мого робочого столу пачку {W$n2{G у вікно і розкидало по околицях!"
   }
  },
  "plug-ins/quest/staffquest/staffquest.cpp": {
@@ -14071,6 +14207,30 @@
   "Ты передаешь $n4 $C3.": {
    "en": "You hand $n4 to $C3.",
    "ua": "Ти передаєш $n4 $C3."
+  },
+  "И находится это место в районе под названием - {W{hh%s{hx{G": {
+   "en": "And this place is located in the area called -- {W{hh%s{hx{G",
+   "ua": "І знаходиться це місце в районі під назвою -- {W{hh%s{hx{G"
+  },
+  "Из королевской сокровищницы похитили {W%s{G!": {
+   "en": "The {W%s{G was stolen from the royal treasury!",
+   "ua": "З королівської скарбниці викрали {W%s{G!"
+  },
+  "Место, где оно спрятано, называется {W%s{G": {
+   "en": "The place where it's hidden is called {W%s{G",
+   "ua": "Місце, де воно сховане, зветься {W%s{G"
+  },
+  "Придворные волшебники определили, где спрятано украденное сокровище.": {
+   "en": "The court wizards have determined where the stolen treasure is hidden.",
+   "ua": "Придворні чарівники визначили, де сховано викрадений скарб."
+  },
+  "Тебе поручается доставить его мне!": {
+   "en": "You've been ordered to deliver it to me!",
+   "ua": "Тобі доручається доставити це мені!"
+  },
+  "У тебя есть {Y%d{G минут%s на выполнение задания.": {
+   "en": "You have {Y%d{G minute%s to complete the task.",
+   "ua": "У тебе є {Y%d{G хвилин%s на виконання завдання."
   }
  },
  "plug-ins/quest/stealquest/mobiles.cpp": {
@@ -14097,6 +14257,38 @@
   "{YИдио$gт|т|тка! Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x": {
    "en": "{YIdiot! You killed the one who needed your help.{x",
    "ua": "{YІдіо$gт|т|тко! Ти вби$gло|в|ла того, хто потребував твоєї допомоги.{x"
+  },
+  "%3$^p1 родом из {1{W{hh%4$s{hx{2, и чаще всего ошивается в районе {1{W%5$s{2.": {
+   "en": "They hail from {1{W{hh%4$s{hx{2, and are most often found lurking around {1{W%5$s{2.",
+   "ua": "%3$^gвоно|він|вона родом з {1{W{hh%4$s{hx{2, і найчастіше ошивається в районі {1{W%5$s{2."
+  },
+  "{1{W%3$N1{2, подл%4$gое|ый|ая вор%4$gье|юга|овка, укра%4$gло|л|ла у меня {1{W%5$N4{2.": {
+   "en": "{1{W%3$N1{2, you sneaky thief, stole {1{W%5$N4{2 from me.",
+   "ua": "{1{W%3$N1{2, підл%4$gе|ий|а злод%4$gійня|юга|ійка, вкра%4$gло|в|ла у мене {1{W%5$N4{2."
+  },
+  "А награбленное добро, по слухам, прячет около {1{W%3$s{2, точнее сказать не могу.": {
+   "en": "As for the loot, rumor has it he hides it near {1{W%3$s{2 -- I can't say anything more precise.",
+   "ua": "А награбоване добро, подейкують, ховає біля {1{W%3$s{2, точніше сказати не можу."
+  },
+  "Верни мне украденное! Жду с нетерпением.": {
+   "en": "Give me back what was stolen! I'm waiting impatiently.",
+   "ua": "Поверни мені вкрадене! Чекаю з нетерпінням."
+  },
+  "Вернись за вознаграждением к тому, кто рассказал тебе о моем несчастье.": {
+   "en": "Go back for your reward to whoever told you about my misfortune.",
+   "ua": "Повернися по нагороду до того, хто розповів тобі про моє нещастя."
+  },
+  "Но мне удалось кое-что выяснить о грабител%3$gе|е|ьнице.": {
+   "en": "But I did manage to find out something about the thief.",
+   "ua": "Але мені вдалося дещо з'ясувати про грабіжн%3$gика|ика|ицю|ників."
+  },
+  "Ну и зачем мне это?": {
+   "en": "And why exactly would I need that?",
+   "ua": "Ну і нащо мені це?"
+  },
+  "Скорее всего, именно туда %3$p1 припрята%3$gло|л|ла мои вещички, и теперь не расстается с ключом.": {
+   "en": "Most likely, that's exactly where they hid my stuff, and now they won't part with the key.",
+   "ua": "Скоріш за все, саме туди схова%3$gло|в|ла мої речі, і тепер не розлучається з ключем."
   }
  },
  "plug-ins/quest/stealquest/objects.cpp": {
@@ -14835,6 +15027,46 @@
   "$c1 говорит тебе '{gЯ не продаю этого -- используй команду список{x'.": {
    "en": "$c1 tells you '{gI don't sell that -- use the list command{x'.",
    "ua": "$c1 каже тобі '{gЯ не продаю цього -- використовуй команду список{x'."
+  },
+  "Мне сегодня нечего тебе предложить.": {
+   "en": "I have nothing to offer you today.",
+   "ua": "Мені сьогодні нічого тобі запропонувати."
+  },
+  "Но у тебя же ничего нет!": {
+   "en": "But you don't have anything!",
+   "ua": "Та в тебе ж нічого немає!"
+  },
+  "Сегодня в моем магазине невероятно низкие цены.": {
+   "en": "Today my shop has incredibly low prices.",
+   "ua": "Сьогодні в моїй крамниці неймовірно низькі ціни."
+  },
+  "Скажи мне название товара, и я расскажу всё, что о нем знаю, за 1%% от стоимости.": {
+   "en": "Tell me the name of the item, and I'll tell you everything I know about it, for 1%% of its value.",
+   "ua": "Скажи мені назву товару, і я розповім усе, що про нього знаю, за 1%% від вартості."
+  },
+  "У тебя нет этого.": {
+   "en": "You don't have that.",
+   "ua": "У тебе немає цього."
+  },
+  "Я дал%2$Gо||а бы тебе %3s за %4$O4, но у меня нет денег.": {
+   "en": "I would have given you %3s for %4$O4, but I don't have any money.",
+   "ua": "Я да%2$Gло|в|ла|ли б тобі %3s за %4$O4, але в мене немає грошей."
+  },
+  "Я дам тебе %3s за %4$O4.": {
+   "en": "I'll give you %3s for %4$O4.",
+   "ua": "Я дам тобі %3s за %4$O4."
+  },
+  "Я не вижу у тебя ничего, что могло бы меня заинтересовать.": {
+   "en": "I don't see anything of yours that would interest me.",
+   "ua": "Я не бачу в тебе нічого, що могло б мене зацікавити."
+  },
+  "Я не продаю '$t'.": {
+   "en": "I don't sell '$t'.",
+   "ua": "Я не продаю '$t'."
+  },
+  "Я ничего не покупаю! Мне некуда ставить товар!": {
+   "en": "I'm not buying anything! I've got nowhere to put my stock!",
+   "ua": "Я нічого не купую! Мені нема куди ставити товар!"
   }
  },
  "plug-ins/services/shop/shoptrader.cpp": {
@@ -14853,6 +15085,26 @@
   "%1$^C1 говорит тебе '{gЯ раньше в глаза не виде%1$Gло|л|ла %2$O4.{x'": {
    "en": "%1$^C1 says to you '{gI've never laid eyes on %2$O4 before.{x'",
    "ua": "%1$^C1 каже тобі '{gЯ раніше в очі не бачи%1$Gло|в|ла %2$O4.{x'"
+  },
+  "Извини, но я не беру взяток!": {
+   "en": "Sorry, but I don't take bribes!",
+   "ua": "Вибач, але я не беру хабарів!"
+  },
+  "Нигде больше не найдешь такого замечательного товара:": {
+   "en": "Nowhere else will you find such wonderful goods:",
+   "ua": "Ніде більше не знайдеш такого чудового товару:"
+  },
+  "Я не продаю этого - используй 'список{x'.": {
+   "en": "I don't sell that -- use 'list{x'.",
+   "ua": "Я не продаю цього -- скористайся 'список{x'."
+  },
+  "Я не справочная контора. Будут деньги, тогда и возвращайся.": {
+   "en": "I'm not an information booth. Come back when you've got money.",
+   "ua": "Я не довідкове бюро. Будуть гроші -- тоді й повертайся."
+  },
+  "Я сообщаю тебе это совершенно бесплатно.": {
+   "en": "I'm telling you this completely free of charge.",
+   "ua": "Я повідомляю тобі це абсолютно безкоштовно."
   }
  },
  "plug-ins/skills_impl/basicskill.cpp": {
@@ -16153,6 +16405,172 @@
   "%1$^O1 исчеза%1$nет|ют, рассыпая все содержимое.": {
    "en": "%1$^O1 %1$nvanishes|vanish, spilling all its contents.",
    "ua": "%1$^O1 зника%1$nє|ють, розсипаючи весь вміст."
+  }
+ },
+ "plug-ins/quest/butcherquest/butcherquest.cpp": {
+  "{W%s{G из местности {W{hh%s{hx{G хочет подать к столу {W%d{G кус%s мяса {W%s{G из местности {W{hh%s{hx{G.": {
+   "en": "{W%s{G from the region {W{hh%s{hx{G wants to have served at the table {W%d{G piece%s of meat {W%s{G from the region {W{hh%s{hx{G.",
+   "ua": "{W%s{G з місцевості {W{hh%s{hx{G хоче, щоб подали до столу {W%d{G шмат%s м'яса {W%s{G з місцевості {W{hh%s{hx{G."
+  },
+  "Доставь мясо заказчику и вернись сюда за вознаграждением.": {
+   "en": "Deliver the meat to the customer and come back here for your reward.",
+   "ua": "Достав м'ясо замовнику і повернись сюди за винагородою."
+  },
+  "У меня есть для тебя срочное поручение!": {
+   "en": "I have an urgent task for you!",
+   "ua": "У мене є для тебе термінове доручення!"
+  },
+  "У тебя есть {Y%d{G минут%s на выполнение задания.": {
+   "en": "You have {Y%d{G minute%s to complete the task.",
+   "ua": "У тебе є {Y%d{G хвилин%s на виконання завдання."
+  }
+ },
+ "plug-ins/quest/healquest/healquest.cpp": {
+  "{W%3$#^C1{G чем-то серьезно бол%3$Gьно|ен|ьна и нуждается в помощи лекаря.": {
+   "en": "{W%3$#^C1{G is seriously ill with something and needs a healer's help.",
+   "ua": "{W%3$#^C1{G чимось серйозно хвор%3$Gе|ий|а|і і потребує допомоги лікаря."
+  },
+  "Место, где %3$P2 видели в последний раз - {W%4$s{x.": {
+   "en": "The place where they were last seen -- {W%4$s{x.",
+   "ua": "Місце, де їх бачили востаннє -- {W%4$s{x."
+  },
+  "Поторопись, пока болезнь не доконала %3$P2!": {
+   "en": "Hurry, before the illness finishes off %3$C2!",
+   "ua": "Поспіши, поки хвороба не доконала %3$C2!"
+  },
+  "У меня есть для тебя срочное поручение!": {
+   "en": "I have an urgent errand for you!",
+   "ua": "У мене є для тебе термінове доручення!"
+  },
+  "У тебя есть {Y%3$d{G мину%3$Iта|ты|т на выполнение задания.": {
+   "en": "You have {Y%3$d{G minute%3$I|s|s to complete the task.",
+   "ua": "У тебе є {Y%3$d{G хвилин%3$Iа|и| на виконання завдання."
+  },
+  "Это находится в районе под названием {W{hh%3$s{x.": {
+   "en": "It's located in an area called {W{hh%3$s{x.",
+   "ua": "Це знаходиться в місцевості під назвою {W{hh%3$s{x."
+  }
+ },
+ "plug-ins/quest/kidnapquest/kidnapquest.cpp": {
+  "%1$^C1, тебе необходимо следовать по такому пути: eeeennnwwnewseesennnnnnnnwwnnn.": {
+   "en": "%1$^C1, you need to follow this path: eeeennnwwnewseesennnnnnnnwwnnn.",
+   "ua": "%1$^C1, тобі потрібно пройти таким шляхом: eeeennnwwnewseesennnnnnnnwwnnn."
+  },
+  "Извини, но на этом этапе задания тебе придется искать путь само%1$Gму|му|ой.": {
+   "en": "Sorry, but at this stage of the quest you'll have to find the way on your own.",
+   "ua": "Вибач, але на цьому етапі завдання тобі доведеться шукати шлях сам%1$Gому|ому|ій|им."
+  },
+  "Извини, я сейчас не могу тебе помочь - придется искать путь само%1$Gму|му|ой.": {
+   "en": "Sorry, I can't help you right now -- you'll have to find the way yourself.",
+   "ua": "Вибач, я зараз не можу тобі допомогти -- доведеться шукати шлях сам%1$Gому|ому|ій|им."
+  },
+  "О, %1$^C1, как же ты меня утоми%1$Gло|л|ла.. Ступай... Ищи са%1$Gмо|м|ма.": {
+   "en": "Oh, %1$^C1, you've really worn me out... Go on... find it yourself.",
+   "ua": "О, %1$^C1, як же ти мене стоми%1$Gло|в|ла|ли... Йди... Шукай сам%1$Gо||а|і."
+  },
+  "Последний раз {W%s{G видели в местности {W{hh%s{hx{G.": {
+   "en": "{W%s{G was last seen in the area {W{hh%s{hx{G.",
+   "ua": "Востаннє {W%s{G бачили в місцевості {W{hh%s{hx{G."
+  },
+  "У тебя есть {Y%d{G минут%s, чтобы добраться туда и узнать, в чем дело.": {
+   "en": "You have {Y%d{G minute%s to get there and find out what's going on.",
+   "ua": "У тебе є {Y%d{G хвилин%s, щоб дістатися туди і з'ясувати, в чому річ."
+  },
+  "Я помогу тебе, но награда будет не так велика.": {
+   "en": "I'll help you, but the reward won't be quite as big.",
+   "ua": "Я допоможу тобі, але винагорода буде не такою великою."
+  }
+ },
+ "plug-ins/quest/kidnapquest/scenario.cpp": {
+  "Ищи %s в местности под названием {W%s{G ({W{hh%s{hx{G).": {
+   "en": "Look for %s in an area called {W%s{G ({W{hh%s{hx{G).",
+   "ua": "Шукай %s у місцевості під назвою {W%s{G ({W{hh%s{hx{G)."
+  },
+  "У {W%s{G случилось несчастье. Срочно требуется твоя помощь.": {
+   "en": "Misfortune has struck {W%s{G. Your help is urgently needed.",
+   "ua": "У {W%s{G сталося нещастя. Терміново потрібна твоя допомога."
+  }
+ },
+ "plug-ins/quest/killquest/killquest.cpp": {
+  "В этом винов%3$Gно|ен|на {W%3$#C1{G, я поручаю тебе наказать %3$P2.": {
+   "en": "{W%3$#C1{G is guilty of this, so I'm tasking you with punishing them.",
+   "ua": "У цьому вин%3$Gне|ен|на|ні {W%3$#C1{G, тож доручаю тобі покарати %3$C4."
+  },
+  "Место, где %3$P2 видели в последний раз - {W%4$s{G!": {
+   "en": "The place where %3$C4 was last seen -- {W%4$s{G!",
+   "ua": "Місце, де %3$C4 бачили востаннє -- {W%4$s{G!"
+  },
+  "Равновесие нашего Мира было нарушено!": {
+   "en": "The balance of our World has been disturbed!",
+   "ua": "Рівновагу нашого Світу порушено!"
+  },
+  "Спокойствие нашего Мира было нарушено!": {
+   "en": "The peace of our World has been disturbed!",
+   "ua": "Спокій нашого Світу було порушено!"
+  },
+  "Тебе поручается убить %3$P2!": {
+   "en": "You are ordered to kill %3$C4!",
+   "ua": "Тобі доручається вбити %3$C4!"
+  },
+  "Темные силы нашего Мира ослаблены действиями {W%3$#C2{G.": {
+   "en": "The dark forces of our World have been weakened by the deeds of {W%3$#C2{G.",
+   "ua": "Темні сили нашого Світу ослаблені діяннями {W%3$#C2{G."
+  },
+  "У меня есть для тебя срочное поручение!": {
+   "en": "I have an urgent task for you!",
+   "ua": "У мене є для тебе термінове доручення!"
+  },
+  "У тебя есть {Y%3$d{G мину%3$Iта|ты|т на выполнение задания.": {
+   "en": "You have {Y%3$d{G minute%3$I|s|s to complete the task.",
+   "ua": "У тебе є {Y%3$d{G хвилин%3$Iа|и| на виконання завдання."
+  },
+  "Это находится в районе под названием {W{hh%3$s{hx{G.": {
+   "en": "It is located in an area called {W{hh%3$s{hx{G.",
+   "ua": "Це знаходиться в районі під назвою {W{hh%3$s{hx{G."
+  },
+  "Я поручаю тебе наказать {W%3$#C4{G, совершивш%3$Gее|его|ую множество злодеяний.": {
+   "en": "I'm charging you with punishing {W%3$#C4{G, who has committed countless atrocities.",
+   "ua": "Я доручаю тобі покарати {W%3$#C4{G, що вчин%3$Gило|ив|ила безліч лиходійств."
+  }
+ },
+ "plug-ins/quest/locatequest/locatequest.cpp": {
+  "%3$#^P1 ждет тебя в районе {W%4$s{G ({W{hh%5$s{hx{G).": {
+   "en": "%3$#^C1 awaits you in the {W%4$s{G area ({W{hh%5$s{hx{G).",
+   "ua": "%3$#^C1 чекає на тебе в районі {W%4$s{G ({W{hh%5$s{hx{G)."
+  },
+  "{W%3$#^C1{G хочет отыскать некоторые принадлежащие %3$P3 вещи.": {
+   "en": "{W%3$#^C1{G wants to find some of their own belongings.",
+   "ua": "{W%3$#^C1{G хоче відшукати деякі свої речі."
+  },
+  "У тебя есть {Y%3$d{G мину%3$Iта|ты|т, чтобы добраться туда и узнать подробности.": {
+   "en": "You have {Y%3$d{G minute%3$I|s|s to get there and find out the details.",
+   "ua": "У тебе є {Y%3$d{G хвилин%3$Iа|и|, щоб дістатися туди і дізнатися подробиці."
+  }
+ },
+ "plug-ins/quest/stealquest/stealquest.cpp": {
+  "{W%3$#^C1{G ста%3$Gло|л|ла жертвой грабителей и просит вернуть украденную вещь.": {
+   "en": "{W%3$#^C1{G has fallen victim to robbers and is asking for the stolen item back.",
+   "ua": "{W%3$#^C1{G ста%3$Gло|в|ла жертвою грабіжників і просить повернути вкрадену річ."
+  },
+  "{W%3$#^C4{G обворовали, %3$P1 просит помочь в поимке негодяев.": {
+   "en": "{W%3$#^C4{G got robbed, and %3$C1 is asking for help catching the crooks.",
+   "ua": "{W%3$#^C4{G обікрали, і %3$C1 просить допомогти впіймати мерзотників."
+  },
+  "Воры ограбили {W%3$#C4{G, и теперь %3$P1 нуждается в твоей помощи.": {
+   "en": "Thieves have robbed {W%3$#C4{G, and now %3$#C1 needs your help.",
+   "ua": "Злодії пограбували {W%3$#C4{G, і тепер %3$#C1 потребує твоєї допомоги."
+  },
+  "Пострадавшего ищи в районе {W%s{G ({W{hh%s{hx{G).": {
+   "en": "Look for the victim in the {W%s{G area ({W{hh%s{hx{G).",
+   "ua": "Постраждалого шукай в місцевості {W%s{G ({W{hh%s{hx{G)."
+  },
+  "У меня есть для тебя срочное поручение!": {
+   "en": "I have an urgent task for you!",
+   "ua": "У мене є термінове доручення для тебе!"
+  },
+  "У тебя есть {Y%3$d{G мину%3$Iта|ты|т, чтобы добраться туда и узнать подробности.": {
+   "en": "You have {Y%3$d{G minute%3$I|s|s to get there and find out the details.",
+   "ua": "У тебе є {Y%3$d{G хвилин%3$Iа|и|, щоб дістатися туди і дізнатися подробиці."
   }
  }
 }


### PR DESCRIPTION
Translate the phrases newly wrapped by dreamland_code #680 (quest plugins kidnap/steal/staff/locate/kill/heal/butcher + questmaster, shops, mansion, comm). RU = key + universal fallback (untranslated byte-identical). **train.cpp excluded** — the train command is fully overridden in Fenia (already trilingual), C++ dead; see #681 un-wrap. Command-link (questmaster) uses the registered synonym. Lint 0 HARD. Staged for the next bundled reboot.