### PR TITLE
translations: EN/UA for look-condition strings

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -5693,6 +5693,14 @@
   "$W: тут открыто.": {
    "en": "$W: it's open here.",
    "ua": "$W: тут відчинено."
+  },
+  "{C в прекрасном состоянии": {
+   "en": "{C in excellent condition",
+   "ua": "{C у чудовому стані"
+  },
+  "{R в ужасном состоянии": {
+   "en": "{R in terrible condition",
+   "ua": "{R у жахливому стані"
   }
  },
  "plug-ins/comm/move.cpp": {


### PR DESCRIPTION
Pairs with code #686. EN/UA for the excellent/terrible character-condition brackets.