### PR TITLE
l10n: EN/UA for 'size' noun in look-at-character (pairs code #692)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -5546,6 +5546,10 @@
   }
  },
  "plug-ins/comm/look.cpp": {
+  "размера": {
+   "en": "size",
+   "ua": "розміру"
+  },
   "\n\rТы заглядываешь в инвентарь: ": {
    "en": "\n\rYou peek into the inventory: ",
    "ua": "\n\rТи заглядаєш в інвентар: "


### PR DESCRIPTION
Catalog pair for dreamland_code #692. Adds `plug-ins/comm/look.cpp` → `размера`: en `size`, ua `розміру`, so `show_char_sexrace`'s `_()`-wrapped suffix renders per viewer instead of leaking RU (`(female angel, medium размера)` → `... medium size)`).