### PR TITLE
l10n: EN/UA for the shopkeeper (Продавец) marker (pairs code #699, 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -15517,6 +15517,10 @@
   "Я сообщаю тебе это совершенно бесплатно.": {
    "en": "I'm telling you this completely free of charge.",
    "ua": "Я повідомляю тобі це абсолютно безкоштовно."
+  },
+  "{y({GПродавец{y){x": {
+   "en": "{y({GMerchant{y){x",
+   "ua": "{y({GПродавець{y){x"
   }
  },
  "plug-ins/skills_impl/basicskill.cpp": {


### PR DESCRIPTION
One catalog entry for the `ShopTrader::show` mob marker wrapped in dreamland_code #699: EN `{y({GMerchant{y){x` / UA `{y({GПродавець{y){x` (colors identical to RU). The note-count spool fixes in #699 need no catalog (entries already exist). lint 0 HARD.