### PR TITLE
l10n: re-key 3 clan jail-timer broadcasts to %I (pairs code #701, 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -2718,10 +2718,6 @@
    "en": "$c1 withdraws a few gold coins from $C4's account as a fine.",
    "ua": "$c1 знімає з рахунку $C4 кілька золотих монет як штраф."
   },
-  "%s выйдет на свободу через %d час%s": {
-   "en": "%s will be released in %d hour%s",
-   "ua": "%s вийде на свободу через %d годин%s"
-  },
   "%s обитает в местности под названием %s (%s).": {
    "en": "%s lives in the area called %s (%s).",
    "ua": "%s мешкає в місцевості під назвою %s (%s)."
@@ -2801,10 +2797,6 @@
   "Руки $C4 закованы в кандалы!": {
    "en": "$C4's hands are shackled in chains!",
    "ua": "Руки $C4 закуті в кайдани!"
-  },
-  "С %s спадут кандалы через %d час%s": {
-   "en": "%s's shackles fall off in %d hour%s",
-   "ua": "З %s спадуть кайдани через %d годин%s"
   },
   "Синтаксис: confiscate <наказуемый> <% от кол-ва вещей>": {
    "en": "Syntax: confiscate <target> <% of items>",
@@ -3226,13 +3218,21 @@
    "en": "%1$#C2 has %2$s ethos and %3$s nature.\n\rTheir merits before the law: %4$d.",
    "ua": "У %1$#C2 %2$s етос і %3$s натура.\n\r%1$#^C2 заслуги перед законом: %4$d."
   },
-  "Повестка в суд для %s истекает через %d час%s": {
-   "en": "The summons to court for %s expires in %d hour%s",
-   "ua": "Виклик до суду для %s спливає через %d годин%s"
-  },
   "$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает.": {
    "en": "$C1 casts a fleeting glance at $c4 and $c1 instantly vanishes.",
    "ua": "$C1 кидає на $c4 швидкоплинний погляд, і $c1 миттєво зникає."
+  },
+  "%1$s выйдет на свободу через %2$d ча%2$Iс|са|сов": {
+   "en": "%1$s will be free in %2$d hour%2$I|s|s",
+   "ua": "%1$s вийде на волю через %2$d годин%2$Iу|и|"
+  },
+  "С %1$s спадут кандалы через %2$d ча%2$Iс|са|сов": {
+   "en": "The shackles will fall off %1$s in %2$d hour%2$I|s|s",
+   "ua": "З %1$s спадуть кайдани через %2$d годин%2$Iу|и|"
+  },
+  "Повестка в суд для %1$s истекает через %2$d ча%2$Iс|са|сов": {
+   "en": "The court summons for %1$s expires in %2$d hour%2$I|s|s",
+   "ua": "Повістка до суду для %1$s спливає через %2$d годин%2$Iу|и|"
   }
  },
  "plug-ins/clan/impl/shalafi.cpp": {


### PR DESCRIPTION
The 3 "…in %d hours" clan-broadcast timers (ruler jail/manacles/suspect) had GET_COUNT-injected RU-ending %s keys that couldn't localize per-viewer. Code #701 rewrote them to %I count-inflection; this re-keys their catalog entries accordingly (3 old removed, 3 new with EN/UA %I branches). lint 0 HARD.