### PR TITLE
l10n: re-key practice/scroll plurals to %I (pairs code #702, 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -4348,10 +4348,6 @@
    "en": "Your character is linked to Telegram user {C%s{x. Use {hc{ymode telegram clear{x to clear it.\r\n",
    "ua": "Твій персонаж пов'язаний з користувачем Telegram {C%s{x. Використай {hc{yрежим телеграм очистити{x для очищення.\r\n"
   },
-  "Тебе непрерывно выводится %d лин%s текста.": {
-   "en": "You're constantly being shown %d line%s of text.",
-   "ua": "Тобі безперервно виводиться %d рядк%s тексту."
-  },
   "\nИспользуй команду {hc{yрежим %s %s{x для изменения.": {
    "en": "\nUse the command {hc{ymode %s %s{x to change it.",
    "ua": "\nВикористовуй команду {hc{yрежим %s %s{x, щоб змінити."
@@ -4359,6 +4355,10 @@
   "\r\nПодробнее смотри по команде {yрежим {Dнастройка{w.": {
    "en": "\r\nFor details see the {yрежим {Dнастройка{w command.",
    "ua": "\r\nДетальніше дивись команду {yрежим {Dнастройка{w."
+  },
+  "Тебе непрерывно выводится %1$d лин%1$Iия|ии|ий текста.": {
+   "en": "You're constantly being shown %1$d line%1$I|s|s of text.",
+   "ua": "Тобі безперервно виводиться %1$d ряд%1$Iок|ки|ків тексту."
   }
  },
  "plug-ins/comm/corder.cpp": {
@@ -11670,10 +11670,6 @@
    "en": "You already know the skill {W%K1{x too well -- practicing is pointless.",
    "ua": "Ти вже надто добре володієш умінням {W%K1{x, практикуватися немає сенсу."
   },
-  "У тебя %d сесси%s практики.\n\r": {
-   "en": "You have %d practice session%s.\n\r",
-   "ua": "У тебе %d сесі%s практики.\n\r"
-  },
   "У тебя сейчас нет сессий практики.": {
    "en": "You don't have any practice sessions right now.",
    "ua": "У тебе зараз немає сесій практики."
@@ -11693,6 +11689,10 @@
   "Во сне или как?": {
    "en": "In your sleep or what?",
    "ua": "Уві сні чи як?"
+  },
+  "У тебя %1$d сесси%1$Iя|и|й практики.\n\r": {
+   "en": "You have %1$d practice session%1$I|s|s.\n\r",
+   "ua": "У тебе %1$d сесі%1$Iя|ї|й практики.\n\r"
   }
  },
  "plug-ins/learn/showskill.cpp": {


### PR DESCRIPTION
Re-keys the practice-session-count and scroll-line-count entries from GET_COUNT %s-ending (which leaked a RU ending into EN/UA) to %I count-inflection, paired with code #702. 2 old removed, 2 new with EN/UA %I branches. lint 0 HARD.