### PR TITLE
Re-key kidnapquest + shop broadcast catalog to numbered %I form

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -13548,9 +13548,9 @@
    "en": "$c1 says to you '{GA whole day has passed already, and she's still not back. I'm very worried.{x'",
    "ua": "$c1 каже тобі '{GОсь уже минула доба, а її все немає. Я дуже хвилююся.{x'"
   },
-  "$c1 говорит тебе '{GИ учти, что через {Y%d{G минут%s мое терпение лопнет!{x'": {
-   "en": "$c1 tells you '{GAnd keep in mind, in {Y%d{G minute%s my patience will run out!{x'",
-   "ua": "$c1 каже тобі '{GІ май на увазі, що через {Y%d{G хвилин%s моє терпіння урветься!{x'"
+  "$c1 говорит тебе '{GИ учти, что через {Y%4$d{G минут%4$Iу|ы| мое терпение лопнет!{x'": {
+   "en": "$c1 tells you '{GAnd keep in mind, in {Y%4$d{G minute%4$I|s|s my patience will run out!{x'",
+   "ua": "$c1 каже тобі '{GІ май на увазі, що через {Y%4$d{G хвилин%4$Iу|и| моє терпіння урветься!{x'"
   },
   "$c1 говорит тебе '{GИди скорее за наградой к тому, кто дал тебе задание!{x'.": {
    "en": "$c1 tells you '{GHurry to collect your reward from whoever gave you the quest!{x'.",
@@ -13560,9 +13560,9 @@
    "en": "$c1 tells you '{GMy little daughter went out for milk yesterday morning, took the money, but forgot the milk can.{x'",
    "ua": "$c1 каже тобі: '{GМоя донечка вчора вранці пішла по молоко, взяла гроші, але забула бідончик.{x'"
   },
-  "$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, что если ты не приведешь ее ко мне через {Y%d{G минут%s, с ней случится что-то непоправимое.{x'": {
-   "en": "$c1 says to you '{GHurry! A mother's heart tells me that if you don't bring her to me within {Y%d{G minute%s, something irreparable will happen to her.{x'",
-   "ua": "$c1 каже тобі '{GПоспіши! Материнське серце підказує мені, що якщо ти не приведеш її до мене за {Y%d{G хвилин%s, з нею станеться щось непоправне.{x'"
+  "$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, что если ты не приведешь ее ко мне через {Y%4$d{G минут%4$Iу|ы|, с ней случится что-то непоправимое.{x'": {
+   "en": "$c1 says to you '{GHurry! A mother's heart tells me that if you don't bring her to me within {Y%4$d{G minute%4$I|s|s, something irreparable will happen to her.{x'",
+   "ua": "$c1 каже тобі '{GПоспіши! Материнське серце підказує мені, що якщо ти не приведеш її до мене за {Y%4$d{G хвилин%4$Iу|и|, з нею станеться щось непоправне.{x'"
   },
   "$c1 говорит тебе '{GСкорее всего, она заблудилась где-то в районе {W{hh$t{x'": {
    "en": "$c1 tells you, '{GMost likely, she got lost somewhere around {W{hh$t{x'",
@@ -13714,17 +13714,17 @@
    "en": "$c1 says to you '{GA wonderful little specimen...{x'",
    "ua": "$c1 каже тобі '{GЧудовий екземплярчик...{x'"
   },
-  "$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%d{G минут%s он мне уже не понадобится.{x": {
-   "en": "$c1 tells you '{GAnd hurry! I feel that in {Y%d{G minute%s he won't be of use to me anymore.{x",
-   "ua": "$c1 каже тобі '{GІ поспіши! Відчуваю, що через {Y%d{G хвилин%s він мені вже не знадобиться.{x"
+  "$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%4$d{G минут%4$Iу|ы| он мне уже не понадобится.{x": {
+   "en": "$c1 tells you '{GAnd hurry! I feel that in {Y%4$d{G minute%4$I|s|s he won't be of use to me anymore.{x",
+   "ua": "$c1 каже тобі '{GІ поспіши! Відчуваю, що через {Y%4$d{G хвилин%4$Iу|и| він мені вже не знадобиться.{x"
   },
   "$c1 говорит тебе '{GЛошадка приглянулась? Ладно, можешь оставить ее себе.{x'": {
    "en": "$c1 tells you '{GTaken a liking to the little horse? Fine, you can keep her.{x'",
    "ua": "$c1 каже тобі '{GСподобалася конячка? Гаразд, можеш лишити її собі.{x'"
   },
-  "$c1 говорит тебе '{GПоспеши! Через {Y%d{G минут%s он должен быть здесь!{x": {
-   "en": "$c1 tells you '{GHurry! In {Y%d{G minute%s he should be here!{x",
-   "ua": "$c1 каже тобі '{GПоспіши! Через {Y%d{G хвилин%s він має бути тут!{x"
+  "$c1 говорит тебе '{GПоспеши! Через {Y%4$d{G минут%4$Iу|ы| он должен быть здесь!{x": {
+   "en": "$c1 tells you '{GHurry! In {Y%4$d{G minute%4$I|s|s he should be here!{x",
+   "ua": "$c1 каже тобі '{GПоспіши! Через {Y%4$d{G хвилин%4$Iу|и| він має бути тут!{x"
   },
   "$c1 говорит тебе '{GПриведи его сюда.{x'": {
    "en": "$c1 says to you '{GBring him here.{x'",
@@ -13988,9 +13988,9 @@
    "en": "Come to $C3 for your reward!",
    "ua": "Прийди до $C3 за подякою!"
   },
-  "$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%d{G минут%s, чтобы вернуть его в целости и сохранности.{x'": {
-   "en": "$c1 says to you '{GHurry! You'll have only {Y%d{G minute%s to bring it back safe and sound.{x'",
-   "ua": "$c1 каже тобі '{GПоспіши! У тебе буде лише {Y%d{G хвилин%s, щоб повернути його цілим і неушкодженим.{x'"
+  "$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%4$d{G минут%4$Iа|ы|, чтобы вернуть его в целости и сохранности.{x'": {
+   "en": "$c1 says to you '{GHurry! You'll have only {Y%4$d{G minute%4$I|s|s to bring it back safe and sound.{x'",
+   "ua": "$c1 каже тобі '{GПоспіши! У тебе буде лише {Y%4$d{G хвилин%4$Iу|и|, щоб повернути його цілим і неушкодженим.{x'"
   },
   "$c1 говорит тебе '{GСкорее всего ты встретишь его в местности {W{hh$t{hx{G.{x'": {
    "en": "$c1 says to you '{GMost likely you'll meet him in the area {W{hh$t{hx{G.{x'",
@@ -14232,9 +14232,9 @@
    "en": "$c1 says to you '{GBut that's only half the trouble, can you imagine, THEY say there should be a lot more good people like that and want to quarter him...{x'",
    "ua": "$c1 каже тобі '{GАле це тільки половина біди, уявляєш, ВОНИ кажуть, що таких хороших людей має бути багато, і хочуть його четвертувати...{x'"
   },
-  "$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%d{G минут%s, пока идут приготовления к казни. Приведи его сюда.{x'": {
-   "en": "$c1 tells you '{GBy my count you have {Y%d{G minute%s while the preparations for the execution are underway. Bring him here.{x'",
-   "ua": "$c1 каже тобі '{GЗа моїми підрахунками, у тебе є {Y%d{G хвилин%s, поки тривають приготування до страти. Приведи його сюди.{x'"
+  "$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%4$d{G минут%4$Iа|ы|, пока идут приготовления к казни. Приведи его сюда.{x'": {
+   "en": "$c1 tells you '{GBy my count you have {Y%4$d{G minute%4$I|s|s while the preparations for the execution are underway. Bring him here.{x'",
+   "ua": "$c1 каже тобі '{GЗа моїми підрахунками, у тебе є {Y%4$d{G хвилин%4$Iу|и|, поки тривають приготування до страти. Приведи його сюди.{x'"
   },
   "$c1 говорит тебе '{GСовсем недавно под внеочередную облаву попал один из моих лучших головор... товарищей то есть.'{x": {
    "en": "$c1 tells you '{GJust recently, one of my best thu... comrades, I mean, got caught in an unscheduled raid.'{x",
@@ -14252,9 +14252,9 @@
    "en": "$c1 tells you, '{GTurns out THEY issued a decree that cells shouldn't stand empty.'{x",
    "ua": "$c1 каже тобі: '{GУ НИХ, бач, указ вийшов, щоб камери не пустували.'{x"
   },
-  "$c1 говорит тебе '{GУ тебя есть примерно {W%d{G минут%s, пока идут приготовления к казни. Приведи его ко мне.{x'": {
-   "en": "$c1 says to you '{GYou have about {W%d{G minute%s before the execution preparations are done. Bring him to me.{x'",
-   "ua": "$c1 каже тобі '{GУ тебе є приблизно {W%d{G хвилин%s, поки тривають приготування до страти. Приведи його до мене.{x'"
+  "$c1 говорит тебе '{GУ тебя есть примерно {W%4$d{G минут%4$Iа|ы|, пока идут приготовления к казни. Приведи его ко мне.{x'": {
+   "en": "$c1 says to you '{GYou have about {W%4$d{G minute%4$I|s|s before the execution preparations are done. Bring him to me.{x'",
+   "ua": "$c1 каже тобі '{GУ тебе є приблизно {W%4$d{G хвилин%4$Iу|и|, поки тривають приготування до страти. Приведи його до мене.{x'"
   },
   "$c1 говорит тебе '{GХм, пожалуй тебе можно доверить ответственное дельце, слушай:'{x": {
    "en": "$c1 tells you '{GHmm, I suppose I can trust you with a serious little task, listen:'{x",
@@ -15312,9 +15312,9 @@
    "en": "$c1 buys $o4.",
    "ua": "$c1 купує $o4."
   },
-  "$c1 покупает $o4[%d].": {
-   "en": "$c1 buys $o4[%d].",
-   "ua": "$c1 купує $o4[%d]."
+  "$c1 покупает $o4[%4$d].": {
+   "en": "$c1 buys $o4[%4$d].",
+   "ua": "$c1 купує $o4[%4$d]."
   },
   "$c1 продает $o4.": {
    "en": "$c1 sells $o4.",
@@ -15364,9 +15364,9 @@
    "en": "You won't be able to get rid of %O2.",
    "ua": "Ти не зможеш позбутися %O2."
   },
-  "Ты покупаешь $o4[%d] за %d серебрян%s.": {
-   "en": "You buy $o4[%d] for %d silver%s.",
-   "ua": "Ти купуєш $o4[%d] за %d срібн%s."
+  "Ты покупаешь $o4[%4$d] за %5$d серебрян%5$Iую|ые|ых монет%5$Iу|ы|.": {
+   "en": "You buy $o4[%4$d] for %5$d silver coin%5$I|s|s.",
+   "ua": "Ти купуєш $o4[%4$d] за %5$d срібн%5$Iу|і|их монет%5$Iу|и|."
   },
   "Ты продаешь %O4 за %s.": {
    "en": "You sell %O4 for %s.",
@@ -15428,9 +15428,9 @@
    "en": "You haggle with %C5 and score a discount!",
    "ua": "Ти торгуєшся з %C5 і вибиваєш знижку!"
   },
-  "Ты покупаешь $o4 за %d серебрян%s.": {
-   "en": "You buy $o4 for %d silver%s.",
-   "ua": "Ти купуєш $o4 за %d срібн%s."
+  "Ты покупаешь $o4 за %4$d серебрян%4$Iую|ые|ых монет%4$Iу|ы|.": {
+   "en": "You buy $o4 for %4$d silver coin%4$I|s|s.",
+   "ua": "Ти купуєш $o4 за %4$d срібн%4$Iу|і|их монет%4$Iу|и|."
   },
   "$c1 говорит тебе '{gЯ не продаю этого -- используй команду список{x'.": {
    "en": "$c1 tells you '{gI don't sell that -- use the list command{x'.",


### PR DESCRIPTION
Companion to dreamland_code #705. Re-keys 10 plug-ins.json entries (kidnapquest quest-timers + oldshop buy lines) to the numbered `%4$d`/`%5$d` + `%I` count-inflection keys the converted C++ literals now emit; EN/UA gain proper per-viewer plurals instead of the leaked RU GET_COUNT ending. lint-l10n 0 HARD; C++<->catalog keys byte-match verified.