### PR TITLE
l10n: re-key gquest reward amount lines to numbered %I plurals

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -16808,21 +16808,21 @@
   }
  },
  "plug-ins/gquest/core/xmlattributereward.cpp": {
-  "%s%s%4d %sзолот%s\r\n": {
-   "en": "%s%s%4d %sgold%s\r\n",
-   "ua": "%s%s%4d %sзолот%s\r\n"
+  "%1$s%2$s%3$4d %4$sзолот%3$Iую|ые|ых монет%3$Iу|ы|\r\n": {
+   "en": "%1$s%2$s%3$4d %4$sgold coin%3$I|s|s\r\n",
+   "ua": "%1$s%2$s%3$4d %4$sзолот%3$Iу|і|их монет%3$Iу|и|\r\n"
   },
-  "%s%s%4d %sквестов%s\r\n": {
-   "en": "%s%s%4d %squests%s\r\n",
-   "ua": "%s%s%4d %sквестів%s\r\n"
+  "%1$s%2$s%3$4d %4$sквестов%3$Iую|ые|ых едини%3$Iцу|цы|ц\r\n": {
+   "en": "%1$s%2$s%3$4d %4$squest point%3$I|s|s\r\n",
+   "ua": "%1$s%2$s%3$4d %4$sквестов%3$Iу|і|их одини%3$Iцю|ці|ць\r\n"
   },
-  "%s%s%4d %sочк%s опыта\r\n": {
-   "en": "%s%s%4d %spoint%s of experience\r\n",
-   "ua": "%s%s%4d %sочк%s досвіду\r\n"
+  "%1$s%2$s%3$4d %4$sочк%3$Iо|а|ов опыта\r\n": {
+   "en": "%1$s%2$s%3$4d %4$spoint%3$I|s|s of experience\r\n",
+   "ua": "%1$s%2$s%3$4d %4$sочк%3$Iо|а|ів досвіду\r\n"
   },
-  "%s%s%4d %sпрактик%s\r\n": {
-   "en": "%s%s%4d %spractice%s\r\n",
-   "ua": "%s%s%4d %sпрактик%s\r\n"
+  "%1$s%2$s%3$4d %4$sпрактик%3$Iу|и|\r\n": {
+   "en": "%1$s%2$s%3$4d %4$spractice%3$I|s|s\r\n",
+   "ua": "%1$s%2$s%3$4d %4$sпрактик%3$Iу|и|\r\n"
   }
  },
  "plug-ins/iomanager/commonlayers.cpp": {


### PR DESCRIPTION
Re-keys the 4 gquest reward-panel amount lines (gold/qp/practice/exp) from the old fmt(0)+GET_COUNT form to numbered two-%I with correct RU/UA Slavic plurals. Pairs with dreamland_code #710; activates at the next reboot (old keys fell back to RU, no interim regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)