### PR TITLE
l10n: profession help-article chrome catalog entries (defaultprofession)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -17148,5 +17148,23 @@
    "en": "You weaken from hunger",
    "ua": "Ти слабшаєш від голоду"
   }
+ },
+ "plug-ins/profession/defaultprofession.cpp": {
+  "Навыки и заклинания класса": {
+   "en": "Skills and spells of class",
+   "ua": "Уміння та закляття класу"
+  },
+  "Уровень": {
+   "en": "Level",
+   "ua": "Рівень"
+  },
+  "Класс": {
+   "en": "Class",
+   "ua": "Клас"
+  },
+  "или": {
+   "en": "or",
+   "ua": "або"
+  }
  }
 }


### PR DESCRIPTION
4 catalog entries under `plug-ins/profession/defaultprofession.cpp` for the profession help-article headers/labels localized in **code #712** ("Навыки и заклинания класса", "Уровень", "Класс", "или"). The help **bodies** are already trilingual in `professions/*.xml` — no catalog entry needed (code reads them via `getForLang`). lint-l10n clean (koi8-safe, no U+02BC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)