### PR TITLE
l10n: race + religion help-article chrome catalog entries

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -17166,5 +17166,29 @@
    "en": "or",
    "ua": "або"
   }
+ },
+ "plug-ins/religion/defaultreligion.cpp": {
+  "Религия": {
+   "en": "Religion",
+   "ua": "Релігія"
+  },
+  ", доступна для тебя.": {
+   "en": ", available to you.",
+   "ua": ", доступна тобі."
+  },
+  ", недоступна тебе.": {
+   "en": ", not available to you.",
+   "ua": ", недоступна тобі."
+  }
+ },
+ "plug-ins/race/defaultrace.cpp": {
+  "Раса": {
+   "en": "Race",
+   "ua": "Раса"
+  },
+  "или": {
+   "en": "or",
+   "ua": "або"
+  }
  }
 }


### PR DESCRIPTION
Chrome entries for the race/religion help-article headers localized in **code #713** (`defaultrace.cpp`: "Раса"/"или"; `defaultreligion.cpp`: "Религия" + availability clauses). Bodies already trilingual in `races/*.xml` + `religions/*.xml`. lint-l10n 0 HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)