### PR TITLE
l10n: EN/UA for empty-inventory + prof-help footer (pairs code #718, 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -5829,6 +5829,10 @@
   "[{DБез связи{x]": {
    "en": "[{DLink-dead{x]",
    "ua": "[{DНема зв'язку{x]"
+  },
+  "Ничего.": {
+   "en": "Nothing.",
+   "ua": "Нічого."
   }
  },
  "plug-ins/comm/move.cpp": {
@@ -17225,6 +17229,10 @@
   "Бонус к уровню вещей": {
    "en": "Item level bonus",
    "ua": "Бонус до рівня речей"
+  },
+  "Подробнее обо всех параметрах читай в %H% {hh28таблица классов{x. ": {
+   "en": "For details on all parameters, see the %H% {hh28class table{x. ",
+   "ua": "Детальніше про всі параметри читай у %H% {hh28таблиці класів{x. "
   }
  },
  "plug-ins/religion/defaultreligion.cpp": {


### PR DESCRIPTION
Paired catalog for dreamland_code #718 (reboot-gated). 2 entries in plug-ins.json. Trello 2594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)