### PR TITLE
l10n: externalize target_table + spell_types flag messages (2594)

### DIFF
--- a/config/flagmessages.json
+++ b/config/flagmessages.json
@@ -595,5 +595,29 @@
         "nowalk":        { "ru": "нельзя пройти пешком", "ua": "не пройти пішки", "en": "no walk" },
         "swim_only":     { "ru": "только вплавь", "ua": "лише вплав", "en": "swim only" },
         "bash_only":     { "ru": "только выломать", "ua": "лише виламати", "en": "bash only" }
+    },
+    // Shown by 'skill <name>' on the spell-target line: noun phrases, comma-joined.
+    // Every bit name is snake_case, so each needs an "en" override.
+    "target_table": {
+        "ignore":      { "ua": "рядок", "en": "a string" },
+        "char_self":   { "ua": "твій персонаж (або без цілі)", "en": "yourself (or no target)" },
+        "char_room":   { "ua": "персонаж поряд", "en": "a character nearby" },
+        "char_world":  { "ua": "персонаж у світі", "en": "a character in the world" },
+        "obj_inv":     { "ua": "предмет в інвентарі", "en": "an item in your inventory" },
+        "obj_equip":   { "ua": "предмет в екіпіруванні", "en": "an item you wear" },
+        "obj_room":    { "ua": "предмет на підлозі", "en": "an item on the ground" },
+        "obj_world":   { "ua": "предмет у світі", "en": "an item in the world" },
+        "room":        { "ua": "ця місцевість", "en": "this location" },
+        "people":      { "ua": "усе живе в цій місцевості", "en": "everything alive in this location" },
+        "create_mob":  { "ua": "виклик істоти", "en": "summoning a creature" },
+        "create_obj":  { "ua": "створення предмета", "en": "creating an item" },
+        "exit":        { "ua": "вихід", "en": "an exit" }
+    },
+    // Shown by 'skill <name>' on the spell-type line, immediately followed by the
+    // word for magic/prayer, so RU/UA are feminine adjectives agreeing with it.
+    "spell_types": {
+        "none":      { "ua": "службова", "en": "utility" },
+        "offensive": { "ua": "атакувальна", "en": "offensive" },
+        "defensive": { "ua": "захисна", "en": "defensive" }
     }
 }


### PR DESCRIPTION
The spell-target and spell-type tables were the last two consulted by the `skill <name>` info block with no entry in `flagmessages.json`, so their messages came from the in-binary RU column for every viewer.

- Adds both tables with full `ua` + `en` coverage (13 + 3 flags).
- Flag names verified one-to-one against `plug-ins/fight_core/damageflags.conf`.
- Every bit name is snake_case, hence an `en` override on each.
- RU keeps falling back to the in-binary message, so RU output is byte-identical.

Follows the file's own rule that a table is only added once every flag has `ua`.

Inert until the `basicskill.cpp` call sites thread `viewerLang(ch)` (a separate, reboot-gated PR); loadable with `plug reload most` in the meantime.