### PR TITLE
l10n: EN/UA for dream-skill prose (pairs code #720, 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -17432,5 +17432,91 @@
    "en": "any",
    "ua": "будь-яка"
   }
+ },
+ "plug-ins/groups/dreamskill.cpp": {
+  "Тебе снится битва с Лаеркаи Мастером.": {
+   "en": "You dream of a battle with Laerkai the Master.",
+   "ua": "Тобі сниться битва з Лаеркаї Майстром."
+  },
+  "Внезапно у тебя в руке оказывается {c%1$s{x, и ты одним движением уничтожаешь противника!": {
+   "en": "Suddenly {c%1$s{x turns up in your hand, and you destroy your opponent with a single stroke!",
+   "ua": "Раптом у твоїй руці опиняється {c%1$s{x, і ти одним рухом знищуєш супротивника!"
+  },
+  "Ловко применив навык {c%1$s{x, ты одним движением разделываешься с противником!": {
+   "en": "Deftly applying {c%1$s{x, you finish your opponent off with a single stroke!",
+   "ua": "Спритно застосувавши навичку {c%1$s{x, ти одним рухом розправляєшся із супротивником!"
+  },
+  "Во сне ты видишь свое недавнее неудачное сражение.\nВ самый ответственный момент ты уверенно пользуешься навыком {c%1$s{x,\nразворачивая исход сражения в выгодную для тебя сторону.": {
+   "en": "In your dream you see your recent losing battle.\nAt the decisive moment you confidently use {c%1$s{x,\nturning the outcome of the fight your way.",
+   "ua": "Уві сні ти бачиш свою нещодавню невдалу битву.\nУ найвідповідальніший момент ти впевнено користуєшся навичкою {c%1$s{x,\nповертаючи наслідок битви на свою користь."
+  },
+  "Во сне ты видишь свое недавнее сражение.\nТы пользуешься невесть откуда взявшимся навыком {c%1$s{x,\nзавершая битву еще быстрее и эффектнее, чем это было на самом деле.": {
+   "en": "In your dream you see your recent battle.\nYou use {c%1$s{x, come by out of nowhere,\nending the fight even faster and more spectacularly than it really went.",
+   "ua": "Уві сні ти бачиш свою нещодавню битву.\nТи користуєшся навичкою {c%1$s{x, що взялася невідь-звідки,\nзавершуючи битву ще швидше й ефектніше, ніж це було насправді."
+  },
+  "В леденящем душу замогильном шепоте к тебе приходит тайна заклинания {c%1$s{x.": {
+   "en": "A soul-freezing whisper from beyond the grave brings you the secret of the {c%1$s{x spell.",
+   "ua": "У крижаному замогильному шепоті до тебе приходить таємниця закляття {c%1$s{x."
+  },
+  "В леденящем душу замогильном шепоте к тебе приходит тайна умения {c%1$s{x.": {
+   "en": "A soul-freezing whisper from beyond the grave brings you the secret of the {c%1$s{x skill.",
+   "ua": "У крижаному замогильному шепоті до тебе приходить таємниця вміння {c%1$s{x."
+  },
+  "Тебе снится, как ловко ты разделываешься со Здрени Мстителем, применив на него навык {c%1$s{x.": {
+   "en": "You dream of how deftly you deal with Zdreni the Avenger by using {c%1$s{x on him.",
+   "ua": "Тобі сниться, як спритно ти розправляєшся зі Здрені Месником, застосувавши на нього навичку {c%1$s{x."
+  },
+  "Во сне ты бродишь по городу, исцеляя всех, кто попадется тебе под руку, с помощью {c%1$s{x.": {
+   "en": "In your dream you wander the city, healing everyone who comes to hand with {c%1$s{x.",
+   "ua": "Уві сні ти блукаєш містом, зцілюючи всіх, хто трапиться під руку, за допомогою {c%1$s{x."
+  },
+  "Перед тобой как будто парит темное и прекрасное лицо женщины-дроу.\nОна шепчет тебе: '{c%1$s'{x. Что бы это могло означать?": {
+   "en": "The dark and beautiful face of a drow woman seems to hover before you.\nShe whispers to you: '{c%1$s'{x. Whatever could that mean?",
+   "ua": "Перед тобою наче ширяє темне і прекрасне обличчя жінки-дроу.\nВона шепоче тобі: '{c%1$s'{x. Що б це могло означати?"
+  },
+  "Монашеская жизнь в приснившемся тебе сюжете кажется очень заманчивой.\nТы вряд ли вспомнишь детали, когда проснешься, за исключением одной молитвы:\n                   {c%1$s{x.": {
+   "en": "The monastic life in the story you dream up looks very tempting.\nYou will hardly recall the details when you wake, save for a single prayer:\n                   {c%1$s{x.",
+   "ua": "Чернече життя у сюжеті, що тобі наснився, здається дуже звабливим.\nТи навряд чи згадаєш подробиці, коли прокинешся, окрім однієї молитви:\n                   {c%1$s{x."
+  },
+  "Прошептав во сне заклинание {c%1$s{x, ты отправляешься на битву с Лагом и, конечно же, побеждаешь его.": {
+   "en": "Whispering the {c%1$s{x spell in your sleep, you set off to battle the Lag and, of course, defeat it.",
+   "ua": "Прошепотівши уві сні закляття {c%1$s{x, ти вирушаєш на битву з Лагом і, звісно ж, перемагаєш його."
+  },
+  "Ты видишь себя как будто со стороны: ты склоняешься над толстым фолиантом \nгде-то на седьмом этаже Башни Высшего Волшебства. На открытой странице написана формула:\n                    {c%1$s{x.": {
+   "en": "You see yourself as if from the outside: you are bending over a thick tome \nsomewhere on the seventh floor of the Tower of High Sorcery. A formula is written on the open page:\n                    {c%1$s{x.",
+   "ua": "Ти бачиш себе наче збоку: ти схиляєшся над товстим фоліантом \nдесь на сьомому поверсі Вежі Вищого Чаклунства. На розгорнутій сторінці написана формула:\n                    {c%1$s{x."
+  },
+  "И уносят тебя, и уносят тебя... три белых кентавра!\nВо сне магия перемещения не выглядит такой уж загадочной, оставляя в твоей памяти одно из заклинаний:\n                      {c%1$s{x.": {
+   "en": "And they bear you away, and bear you away... three white centaurs!\nIn a dream the magic of travel does not look all that mysterious, leaving one of its spells in your memory:\n                      {c%1$s{x.",
+   "ua": "І несуть тебе, і несуть тебе... три білих кентаври!\nУві сні магія переміщення не видається аж такою загадковою, лишаючи у твоїй пам'яті одне із заклять:\n                      {c%1$s{x."
+  },
+  "В довольно запутанном сне ты постоянно превращаешь вино в воду, а большие камни -- в летающие диски.\nОдно из заклинаний все же задерживается в твоей памяти: это {c%1$s{x.": {
+   "en": "In a rather tangled dream you keep turning wine into water, and big rocks -- into flying discs.\nOne of the spells does linger in your memory after all: it is {c%1$s{x.",
+   "ua": "У досить заплутаному сні ти постійно перетворюєш вино на воду, а великі камені -- на летючі диски.\nОдне із заклять усе ж затримується у твоїй пам'яті: це {c%1$s{x."
+  },
+  "Никто не может устоять перед тобой -- ты в этом сне такой милашка!\nСоблазнительно хлопая своими длинными ресницами, ты применяешь заклинание {c%1$s{x.": {
+   "en": "No one can resist you -- what a cutie you are in this dream!\nBatting your long eyelashes seductively, you cast the {c%1$s{x spell.",
+   "ua": "Ніхто не може встояти перед тобою -- ти в цьому сні такий милашка!\nЗвабливо кліпаючи своїми довгими віями, ти застосовуєш закляття {c%1$s{x."
+  },
+  "Никто не может устоять перед тобой -- ты в этом сне такая милашка!\nСоблазнительно хлопая своими длинными ресницами, ты применяешь заклинание {c%1$s{x.": {
+   "en": "No one can resist you -- what a cutie you are in this dream!\nBatting your long eyelashes seductively, you cast the {c%1$s{x spell.",
+   "ua": "Ніхто не може встояти перед тобою -- ти в цьому сні така милашка!\nЗвабливо кліпаючи своїми довгими віями, ти застосовуєш закляття {c%1$s{x."
+  },
+  "Во сне тебе открываются тайны ранее недоступного заклинания {c%1$s{x.": {
+   "en": "In your dream the secrets of the previously unreachable {c%1$s{x spell open up to you.",
+   "ua": "Уві сні тобі відкриваються таємниці раніше недоступного закляття {c%1$s{x."
+  },
+  "Тебе снится странный сон, будто бы ты владеешь заклинанием {c%1$s{x.": {
+   "en": "You dream a strange dream in which you have mastered the {c%1$s{x spell.",
+   "ua": "Тобі сниться дивний сон, ніби ти володієш закляттям {c%1$s{x."
+  },
+  "Тебе снится странный сон, будто бы ты владеешь умением {c%1$s{x.": {
+   "en": "You dream a strange dream in which you have mastered the {c%1$s{x skill.",
+   "ua": "Тобі сниться дивний сон, ніби ти володієш умінням {c%1$s{x."
+  },
+  "Тебя переполняет неизвестно откуда взявшаяся уверенность, что, проснувшись,\nты будешь знать умение {c%1$s{x не хуже любого профессионала!": {
+   "en": "You are brimming with a confidence come from nowhere that, once you wake,\nyou will know {c%1$s{x as well as any professional!",
+   "ua": "Тебе переповнює невідомо звідки взята впевненість, що, прокинувшись,\nти знатимеш уміння {c%1$s{x не гірше за будь-якого професіонала!"
+  }
  }
 }


### PR DESCRIPTION
21 phrases for `plug-ins/groups/dreamskill.cpp` — the 14 dream variants shown when a player dreams up a skill.

Keys byte-match the C++ literals (verified by extracting them from the source and diffing). Placeholder and newline parity checked; lint 0 HARD in this catalog.

Pairs dreamland_code #720; inert until that reboots.