### PR TITLE
l10n: nanny language options as endonyms

### DIFF
--- a/config/translations/newbie.json
+++ b/config/translations/newbie.json
@@ -250,14 +250,6 @@
    "en": "A character with this or a similar name already exists, give me another name.",
    "ua": "Персонаж з таким або схожим іменем уже існує, назви мені інше імʼя."
   },
-  "На каком языке ты хочешь видеть игру: {1{hc{yукраинский{hx{2, {1{hc{yрусский{hx {2или {1{hc{yанглийский{x{2?": {
-   "en": "In which language do you want to see the game: {1{hc{yUkrainian{hx{2, {1{hc{yRussian{hx {2or {1{hc{yEnglish{x{2?",
-   "ua": "Якою мовою ти хочеш бачити гру: {1{hc{yукраїнська{hx{2, {1{hc{yросійська{hx {2чи {1{hc{yанглійська{x{2?"
-  },
-  "Выбери: {1{yукраинский{2, {1{yрусский{2 или {1{yанглийский{2.": {
-   "en": "Choose: {1{yUkrainian{2, {1{yRussian{2 or {1{yEnglish{2.",
-   "ua": "Обери: {1{yукраїнська{2, {1{yросійська{2 чи {1{yанглійська{2."
-  },
   "открывает Книгу Имен на новой странице и макает перо в чернильницу.": {
    "en": "opens the Book of Names to a new page and dips his quill in the inkwell.",
    "ua": "розгортає Книгу Імен на новій сторінці й вмочає перо в чорнильницю."
@@ -397,6 +389,14 @@
   "Поддержка включена, подробности читай по команде {hc{yсправка скринридер{x.": {
    "en": "Support enabled, read the details with the {hc{yhelp screenreader{x command.",
    "ua": "Підтримку ввімкнено, подробиці читай командою {hc{yдовідка скринрідер{x."
+  },
+  "На каком языке ты хочешь видеть игру: {1{hc{yукраїнська{hx{2, {1{hc{yрусский{hx {2или {1{hc{yEnglish{x{2?": {
+   "en": "In which language do you want to see the game: {1{hc{yукраїнська{hx{2, {1{hc{yрусский{hx {2or {1{hc{yEnglish{x{2?",
+   "ua": "Якою мовою ти хочеш бачити гру: {1{hc{yукраїнська{hx{2, {1{hc{yрусский{hx {2чи {1{hc{yEnglish{x{2?"
+  },
+  "Выбери: {1{yукраїнська{2, {1{yрусский{2 или {1{yEnglish{2.": {
+   "en": "Choose: {1{yукраїнська{2, {1{yрусский{2 or {1{yEnglish{2.",
+   "ua": "Обери: {1{yукраїнська{2, {1{yрусский{2 чи {1{yEnglish{2."
   }
  },
  "newbie/newnanny": {
@@ -644,14 +644,6 @@
    "en": "A character with this or a similar name already exists, give me another name.",
    "ua": "Персонаж з таким або схожим іменем уже існує, назви мені інше імʼя."
   },
-  "На каком языке ты хочешь видеть игру: {1{hc{yукраинский{hx{2, {1{hc{yрусский{hx {2или {1{hc{yанглийский{x{2?": {
-   "en": "In which language do you want to see the game: {1{hc{yUkrainian{hx{2, {1{hc{yRussian{hx {2or {1{hc{yEnglish{x{2?",
-   "ua": "Якою мовою ти хочеш бачити гру: {1{hc{yукраїнська{hx{2, {1{hc{yросійська{hx {2чи {1{hc{yанглійська{x{2?"
-  },
-  "Выбери: {1{yукраинский{2, {1{yрусский{2 или {1{yанглийский{2.": {
-   "en": "Choose: {1{yUkrainian{2, {1{yRussian{2 or {1{yEnglish{2.",
-   "ua": "Обери: {1{yукраїнська{2, {1{yросійська{2 чи {1{yанглійська{2."
-  },
   "открывает Книгу Имен на новой странице и макает перо в чернильницу.": {
    "en": "opens the Book of Names to a new page and dips his quill in the inkwell.",
    "ua": "розгортає Книгу Імен на новій сторінці й вмочає перо в чорнильницю."
@@ -783,6 +775,14 @@
   "Поддержка включена, подробности читай по команде {hc{yсправка скринридер{x.": {
    "en": "Support enabled, read the details with the {hc{yhelp screenreader{x command.",
    "ua": "Підтримку ввімкнено, подробиці читай командою {hc{yдовідка скринрідер{x."
+  },
+  "На каком языке ты хочешь видеть игру: {1{hc{yукраїнська{hx{2, {1{hc{yрусский{hx {2или {1{hc{yEnglish{x{2?": {
+   "en": "In which language do you want to see the game: {1{hc{yукраїнська{hx{2, {1{hc{yрусский{hx {2or {1{hc{yEnglish{x{2?",
+   "ua": "Якою мовою ти хочеш бачити гру: {1{hc{yукраїнська{hx{2, {1{hc{yрусский{hx {2чи {1{hc{yEnglish{x{2?"
+  },
+  "Выбери: {1{yукраїнська{2, {1{yрусский{2 или {1{yEnglish{2.": {
+   "en": "Choose: {1{yукраїнська{2, {1{yрусский{2 or {1{yEnglish{2.",
+   "ua": "Обери: {1{yукраїнська{2, {1{yрусский{2 чи {1{yEnglish{2."
   }
  },
  "newbie/questcommon": {


### PR DESCRIPTION
Language-pick option labels shown in their own language across all viewer variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)