### PR TITLE
l10n: shorten areas difficulty labels that overflow the column

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -18095,7 +18095,7 @@
  },
  "plug-ins/system/areabehaviorplugin.cpp": {
   "{Cмирная{x": {
-   "en": "{Cpeaceful{x",
+   "en": "{Csafe{x",
    "ua": "{Cмирна{x"
   },
   "{Gлегко{x": {
@@ -18108,7 +18108,7 @@
   },
   "{Rопасно{x": {
    "en": "{Rdeadly{x",
-   "ua": "{Rнебезпечно{x"
+   "ua": "{Rубивчо{x"
   }
  }
 }


### PR DESCRIPTION
EN `peaceful`(8)→`safe`(4), UA `небезпечно`(10)→`убивчо`(6). Both overran the ~6-char difficulty column in the `areas` command and misaligned the second area column. RU + other tiers already fit. Pure `config/translations/plug-ins.json` catalog change — reloads via `plug reload most`, no C++/reboot.