### PR TITLE
content: rtalk channel RU/UA names -- keep the race pun

### DIFF
--- a/commands/channels.xml
+++ b/commands/channels.xml
@@ -332,8 +332,8 @@ The comma *,* is a synonym for this command.
       <msgOther>%1$^C1 говор%1$nит|ят %2$N3 &apos;{g%3$s{x&apos;</msgOther>
       <msgSelf>Ты говоришь %2$N3 &apos;{g%3$s{x&apos;</msgSelf>
       <name l="en">rtalk</name>
-      <name l="ru">расговорить</name>
-      <name l="ua">расказати</name>
+      <name l="ru">расеговорить</name>
+      <name l="ua">расіказати</name>
       <nochannel>true</nochannel>
       <nomob>true</nomob>
       <off>noracetalk</off>


### PR DESCRIPTION
Race-channel (`rtalk`) RU/UA names `расговорить`/`расказати` → `расеговорить`/`расіказати`, keeping the `рас` (раса) pun with an explicit connecting vowel. Player-facing content per Kit, not a spelling fix. Old RU form remains typeable via the existing `<extra l="ru">` alias list.

Activates on next reboot (data synced to live share/DL; not plug-reloaded — a C++ change is staged unrebooted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)