### PR TITLE
l10n catalog: class/race list frames for skill info (2594 #3)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -10977,6 +10977,14 @@
   "Тебе не с кем практиковаться здесь.": {
    "en": "There's no one here for you to practice with.",
    "ua": "Тобі немає з ким практикуватися тут."
+  },
+  "Доступно классам:": {
+   "en": "Available to classes:",
+   "ua": "Доступно класам:"
+  },
+  "Бонус для рас:": {
+   "en": "Bonus for races:",
+   "ua": "Бонус для рас:"
   }
  },
  "plug-ins/groups/group_arcane.cpp": {


### PR DESCRIPTION
EN/UA for the two skill-info availability frames, paired with code #755. lint-l10n 0 HARD on the new entries; JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)