### PR TITLE
config revamp: drop 9 retired ConfigElement nodes (Trello 709)

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -16,14 +16,6 @@
         <rname>автопомощь</rname>
       </node>
       <node type="ConfigElement">
-        <bit table="plr_flags">autogold</bit>
-        <hint>забирать деньги из трупов</hint>
-        <msgOff>Ты не будешь автоматически забирать деньги из трупов.</msgOff>
-        <msgOn>Ты будешь автоматически забирать деньги из трупов.</msgOn>
-        <name>autogold</name>
-        <rname>автомонеты</rname>
-      </node>
-      <node type="ConfigElement">
         <bit table="plr_flags">autoloot</bit>
         <hint>забирать вещи из трупов</hint>
         <msgOff>Ты не будешь автоматически забирать все вещи из трупа врага.</msgOff>
@@ -32,28 +24,12 @@
         <rname>автограбеж</rname>
       </node>
       <node type="ConfigElement">
-        <bit table="add_comm_flags">autolook</bit>
-        <hint>заглядывать в труп после убийства</hint>
-        <msgOff>Ты не будешь заглядывать в труп после убийства.</msgOff>
-        <msgOn>Ты будешь заглядывать в труп после убийства.</msgOn>
-        <name>autolook</name>
-        <rname>автовзгляд</rname>
-      </node>
-      <node type="ConfigElement">
         <bit table="plr_flags">autosac</bit>
         <hint>приносить трупы в жертву после убийства</hint>
         <msgOff>Ты не будешь приносить в жертву труп после убийства.</msgOff>
         <msgOn>Ты будешь приносить в жертву труп после убийства.</msgOn>
         <name>autosac</name>
         <rname>автожертва</rname>
-      </node>
-      <node type="ConfigElement">
-        <bit table="plr_flags">autosplit</bit>
-        <hint>делиться с группой деньгами из трупов</hint>
-        <msgOff>Ты не будешь делить деньги из трупа врага между членами своей группы.</msgOff>
-        <msgOn>Ты будешь делить деньги из трупа врага между членами своей группы.</msgOn>
-        <name>autosplit</name>
-        <rname>автодележ</rname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">fightspam</bit>
@@ -106,14 +82,6 @@
         <name>nofollow</name>
         <rname>неследовать</rname>
       </node>
-      <node type="ConfigElement">
-        <bit table="plr_flags">nosummon</bit>
-        <hint>запретить не-соклановикам призывать вне ПК</hint>
-        <msgOff>Тебя сможет призвать кто угодно.</msgOff>
-        <msgOn>Вне твоего ПК тебя смогут призвать только соклановики.</msgOn>
-        <name>nosummon</name>
-        <rname>непризывать</rname>
-      </node>
       <name>Защитные настройки:</name>
     </node>
     <node>
@@ -135,22 +103,6 @@
         <rname>аффекты</rname>
       </node>
       <node type="ConfigElement">
-        <bit table="plr_flags">autoexit</bit>
-        <hint>отображать выходы из комнаты</hint>
-        <msgOff>Выходы не отображаются автоматически.</msgOff>
-        <msgOn>Выходы отображаются автоматически.</msgOn>
-        <name>autoexit</name>
-        <rname>автовыходы</rname>
-      </node>
-      <node type="ConfigElement">
-        <bit table="add_comm_flags">autostore</bit>
-        <hint>во время боя сохранять сообщения в буфер</hint>
-        <msgOff>Сообщения, поступившие во время сражения, отображаются сразу же.</msgOff>
-        <msgOn>Сообщения, поступившие во время сражения, сохраняются в буфере.</msgOn>
-        <name>autostore</name>
-        <rname>автобуфер</rname>
-      </node>
-      <node type="ConfigElement">
         <bit table="comm_flags">brief</bit>
         <hint>видеть сокращенное описание комнаты</hint>
         <msgOff>Описание комнаты отображается в полном виде.</msgOff>
@@ -165,22 +117,6 @@
         <msgOn>{RЦ{Yв{yе{Gт{gо{Cм{cу{Bз{bы{Mк{mа{x, уиии!</msgOn>
         <name>color</name>
         <rname>цвет</rname>
-      </node>
-      <node type="ConfigElement">
-        <bit table="comm_flags">combine</bit>
-        <hint>комбинировать одинаковые вещи в списке</hint>
-        <msgOff>Одинаковые вещи в списке предметов не группируются вместе.</msgOff>
-        <msgOn>Одинаковые вещи в списке предметов группируются вместе.</msgOn>
-        <name>combine</name>
-        <rname>комбинировать</rname>
-      </node>
-      <node type="ConfigElement">
-        <bit table="comm_flags">compact</bit>
-        <hint>не выводить дополнительных строк</hint>
-        <msgOff>Перед строкой подсказки будет выводиться дополнительная строка.</msgOff>
-        <msgOn>Перед строкой подсказки не будет выводиться дополнительная строка.</msgOn>
-        <name>compact</name>
-        <rname>компактно</rname>
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">prompt</bit>
@@ -225,14 +161,6 @@
       <name>Настройки отображения:</name>
     </node>
     <node>
-      <node type="ConfigElement">
-        <bit table="config_flags">autoafk</bit>
-        <hint>автоматическое АФК после 10 минут бездействия</hint>
-        <msgOff>Ты не будешь уходить в АФК после 10 минут бездействия.</msgOff>
-        <msgOn>Ты будешь уходить в АФК после 10 минут бездействия.</msgOn>
-        <name>autoafk</name>
-        <rname>автовок</rname>
-      </node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">noiac</bit>
         <hint>не заменять IAC на большое YA при выводе текста</hint>


### PR DESCRIPTION
Removes the 9 retired config options (paired with code #757). 30→21 options. XML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)