### PR TITLE
config revamp Phase 3: rename options + old-name synonyms (Trello 709)

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -99,8 +99,8 @@
         <hint>показывать аффекты по команде счет</hint>
         <msgOff>Аффекты не видны по команде счет.</msgOff>
         <msgOn>Аффекты видны по команде счет.</msgOn>
-        <name>affects</name>
-        <rname>аффекты</rname>
+        <name>affscore</name>
+        <rname>аффектывсчет</rname>
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">brief</bit>
@@ -123,8 +123,8 @@
         <hint>показывать флаги на предметах в сокращенной форме</hint>
         <msgOff>Флаги на предметах отображаются в развернутом виде.</msgOff>
         <msgOn>Флаги на предметах отображаются в сокращенном виде.</msgOn>
-        <name>objflag</name>
-        <rname>предмфлаги</rname>
+        <name>shortflags</name>
+        <rname>краткофлаги</rname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">objname_hint</bit>
@@ -139,8 +139,8 @@
         <hint>режим поддержки screen reader</hint>
         <msgOff>Режим поддержки читалки для незрячих{x выключен.</msgOff>
         <msgOn>Режим поддержки читалки для незрячих{x включен.</msgOn>
-        <name>screenreader</name>
-        <rname>скринридер</rname>
+        <name>blind</name>
+        <rname>незрячий</rname>
       </node>
       <name>Настройки отображения:</name>
     </node>

--- a/grammar/synonyms.json
+++ b/grammar/synonyms.json
@@ -177,7 +177,11 @@
 "lang":    ["language", "мова", "язык"],
 "color":   ["colour", "цвет", "колір"],
 "mild":    ["мягкий", "мʼякий", "мягкийцвет"],
-"scroll":  ["экран", "буфер"],
+"lines":   ["scroll", "буфер", "строк", "экран", "рядки"],
+// config option renames -- old names kept as synonyms so muscle memory + profiles keep working
+"shortflags": ["objflag", "предмфлаги"],
+"affscore":   ["affects", "аффекты"],
+"blind":      ["screenreader", "скринридер"],
 "en":      ["english", "англійська", "английский"],
 "ua":      ["ukrainian", "українська", "украинский"],
 "ru":      ["russian", "російська", "русский"],


### PR DESCRIPTION
Pairs with code #760. Renames affects/objflag/screenreader/scroll in config.xml + synonyms.json keeps old names (objflag/affects/screenreader/scroll/буфер) working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)