### PR TITLE
config revamp Phase 4a: UA names + trilingual headers (Trello 709)

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -10,166 +10,193 @@
       <node type="ConfigElement">
         <bit table="add_comm_flags">nocancel</bit>
         <hint>запрет не-соклановикам применять заклинание отмена</hint>
-        <msgOff>Заклинание &apos;отмена&apos; на тебя смогут применить все.</msgOff>
-        <msgOn>Заклинание &apos;отмена&apos; на тебя смогут применить только соклановцы.</msgOn>
+        <msgOff l="ru">Заклинание &apos;отмена&apos; на тебя смогут применить все.</msgOff>
+        <msgOn l="ru">Заклинание &apos;отмена&apos; на тебя смогут применить только соклановцы.</msgOn>
         <name>nocancel</name>
         <rname>неотменять</rname>
+        <uaname>невідміняти</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">nofollow</bit>
         <hint>запретить следовать за собой</hint>
-        <msgOff>Ты разрешаешь следовать за собой.</msgOff>
-        <msgOn>Ты запрещаешь следовать за собой.</msgOn>
+        <msgOff l="ru">Ты разрешаешь следовать за собой.</msgOff>
+        <msgOn l="ru">Ты запрещаешь следовать за собой.</msgOn>
         <name>nofollow</name>
         <rname>неследовать</rname>
+        <uaname>неслідувати</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autoassist</bit>
         <hint>вступать в бой при нападении на группу</hint>
-        <msgOff>Ты не будешь вступать в бой при нападении на твою группу.</msgOff>
-        <msgOn>Ты будешь вступать в бой при нападении на твою группу.</msgOn>
+        <msgOff l="ru">Ты не будешь вступать в бой при нападении на твою группу.</msgOff>
+        <msgOn l="ru">Ты будешь вступать в бой при нападении на твою группу.</msgOn>
         <name>autoassist</name>
         <rname>автопомощь</rname>
+        <uaname>автодопомога</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autoloot</bit>
         <hint>забирать вещи из трупов</hint>
-        <msgOff>Ты не будешь автоматически забирать все вещи из трупа врага.</msgOff>
-        <msgOn>Ты будешь автоматически забирать все вещи из трупа врага.</msgOn>
+        <msgOff l="ru">Ты не будешь автоматически забирать все вещи из трупа врага.</msgOff>
+        <msgOn l="ru">Ты будешь автоматически забирать все вещи из трупа врага.</msgOn>
         <name>autoloot</name>
         <rname>автограбеж</rname>
+        <uaname>автограбунок</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autosac</bit>
         <hint>приносить трупы в жертву после убийства</hint>
-        <msgOff>Ты не будешь приносить в жертву труп после убийства.</msgOff>
-        <msgOn>Ты будешь приносить в жертву труп после убийства.</msgOn>
+        <msgOff l="ru">Ты не будешь приносить в жертву труп после убийства.</msgOff>
+        <msgOn l="ru">Ты будешь приносить в жертву труп после убийства.</msgOn>
         <name>autosac</name>
         <rname>автожертва</rname>
+        <uaname>автожертва</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">newdamage</bit>
         <hint>альтернативная система отображения повреждений</hint>
-        <msgOff>Ты используешь обычную систему отображения повреждений.</msgOff>
-        <msgOn>Ты используешь новую систему отображения повреждений.</msgOn>
+        <msgOff l="ru">Ты используешь обычную систему отображения повреждений.</msgOff>
+        <msgOn l="ru">Ты используешь новую систему отображения повреждений.</msgOn>
         <name>newdamage</name>
         <rname>повреждения</rname>
+        <uaname>пошкодження</uaname>
       </node>
-      <name>Настройки игрового процесса:</name>
+      <name l="en">Gameplay settings:</name>
+      <name l="ru">Настройки игрового процесса:</name>
+      <name l="ua">Налаштування ігрового процесу:</name>
     </node>
     <node>
       <node type="ConfigElement">
         <bit table="config_flags">short_objflag</bit>
         <hint>показывать флаги на предметах в сокращенной форме</hint>
-        <msgOff>Флаги на предметах отображаются в развернутом виде.</msgOff>
-        <msgOn>Флаги на предметах отображаются в сокращенном виде.</msgOn>
+        <msgOff l="ru">Флаги на предметах отображаются в развернутом виде.</msgOff>
+        <msgOn l="ru">Флаги на предметах отображаются в сокращенном виде.</msgOn>
         <name>shortflags</name>
         <rname>краткофлаги</rname>
+        <uaname>короткофлаги</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">fightspam</bit>
         <hint>показывать ли боевые автоумения</hint>
-        <msgOff>Ты не видишь парирований, уворотов и так далее.</msgOff>
-        <msgOn>Тебе отображаются парирования, увороты и так далее.</msgOn>
+        <msgOff l="ru">Ты не видишь парирований, уворотов и так далее.</msgOff>
+        <msgOn l="ru">Тебе отображаются парирования, увороты и так далее.</msgOn>
         <name>fightspam</name>
         <rname>спамбой</rname>
+        <uaname>спамбій</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">skillspam</bit>
         <hint>показывать ли промахи умений</hint>
-        <msgOff>Ты не видишь промахи умений.</msgOff>
-        <msgOn>Тебе отображаются промахи умений.</msgOn>
+        <msgOff l="ru">Ты не видишь промахи умений.</msgOff>
+        <msgOn l="ru">Тебе отображаются промахи умений.</msgOn>
         <name>skillspam</name>
         <rname>спамумения</rname>
+        <uaname>спамумінь</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">weaponspam</bit>
         <hint>не показывать действия флагов оружия</hint>
-        <msgOff>Ты видишь все действия {hh96флагов оружия{x.</msgOff>
-        <msgOn>Ты не видишь действия {hh96флагов оружия{x.</msgOn>
+        <msgOff l="ru">Ты видишь все действия {hh96флагов оружия{x.</msgOff>
+        <msgOn l="ru">Ты не видишь действия {hh96флагов оружия{x.</msgOn>
         <name>noweaponspam</name>
         <rname>нетспаморужия</rname>
+        <uaname>нетспамзброї</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">show_affects</bit>
         <hint>показывать аффекты по команде счет</hint>
-        <msgOff>Аффекты не видны по команде счет.</msgOff>
-        <msgOn>Аффекты видны по команде счет.</msgOn>
+        <msgOff l="ru">Аффекты не видны по команде счет.</msgOff>
+        <msgOn l="ru">Аффекты видны по команде счет.</msgOn>
         <name>affscore</name>
         <rname>аффектывсчет</rname>
+        <uaname>афективрахунок</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">brief</bit>
         <hint>видеть сокращенное описание комнаты</hint>
-        <msgOff>Описание комнаты отображается в полном виде.</msgOff>
-        <msgOn>Описание комнаты отображается в сокращенном виде.</msgOn>
+        <msgOff l="ru">Описание комнаты отображается в полном виде.</msgOff>
+        <msgOn l="ru">Описание комнаты отображается в сокращенном виде.</msgOn>
         <name>brief</name>
         <rname>кратко</rname>
+        <uaname>стисло</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">prompt</bit>
         <hint>выводить подсказку с параметрами персонажа</hint>
-        <msgOff>Вывод {hh1012строки подсказки{x отключен.</msgOff>
-        <msgOn>Вывод {hh1012строки подсказки{x включен.</msgOn>
+        <msgOff l="ru">Вывод {hh1012строки подсказки{x отключен.</msgOff>
+        <msgOn l="ru">Вывод {hh1012строки подсказки{x включен.</msgOn>
         <name>prompt</name>
         <rname>подсказка</rname>
+        <uaname>підказка</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">screenreader</bit>
         <hint>режим поддержки screen reader</hint>
-        <msgOff>Режим поддержки читалки для незрячих{x выключен.</msgOff>
-        <msgOn>Режим поддержки читалки для незрячих{x включен.</msgOn>
+        <msgOff l="ru">Режим поддержки читалки для незрячих{x выключен.</msgOff>
+        <msgOn l="ru">Режим поддержки читалки для незрячих{x включен.</msgOn>
         <name>blind</name>
         <rname>незрячий</rname>
+        <uaname>незрячий</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">holylight</bit>
         <hint>божественный взор</hint>
         <level>102</level>
-        <msgOff>Божественный взор выключен.</msgOff>
-        <msgOn>Божественный взор включен.</msgOn>
+        <msgOff l="ru">Божественный взор выключен.</msgOff>
+        <msgOn l="ru">Божественный взор включен.</msgOn>
         <name>holylight</name>
         <rname>боговзор</rname>
+        <uaname>боговзір</uaname>
       </node>
-      <name>Комфортный вывод:</name>
+      <name l="en">Comfortable output:</name>
+      <name l="ru">Комфортный вывод:</name>
+      <name l="ua">Комфортний вивід:</name>
     </node>
     <node>
       <node type="ConfigElement">
         <bit table="config_flags">objname_hint</bit>
         <hint>показывать английское название предмета</hint>
-        <msgOff>У предметов не будут показываться английские названия.</msgOff>
-        <msgOn>Английские названия для предметов включены.</msgOn>
+        <msgOff l="ru">У предметов не будут показываться английские названия.</msgOff>
+        <msgOn l="ru">Английские названия для предметов включены.</msgOn>
         <name>objname</name>
         <rname>имяпредмета</rname>
+        <uaname>назвапредмета</uaname>
       </node>
-      <name>Настройки языка:</name>
+      <name l="en">Language settings:</name>
+      <name l="ru">Настройки языка:</name>
+      <name l="ua">Мовні налаштування:</name>
     </node>
     <node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">noiac</bit>
         <hint>не заменять IAC на большое YA при выводе текста</hint>
-        <msgOff>IAC-и будут заменяться другой буквой (YA в кодировке cp1251).</msgOff>
-        <msgOn>Тебе будет пересылаться немодифицированный текст.</msgOn>
+        <msgOff l="ru">IAC-и будут заменяться другой буквой (YA в кодировке cp1251).</msgOff>
+        <msgOn l="ru">Тебе будет пересылаться немодифицированный текст.</msgOn>
         <name>noiac</name>
         <rname>noiac</rname>
+        <uaname>noiac</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">notelnet</bit>
         <hint>отключить фильтр TELNET на приходящий текст</hint>
-        <msgOff>Фильтр TELNET включен.</msgOff>
-        <msgOn>Фильтр TELNET отключен.</msgOn>
+        <msgOff l="ru">Фильтр TELNET включен.</msgOff>
+        <msgOn l="ru">Фильтр TELNET отключен.</msgOn>
         <name>notelnet</name>
         <rname>notelnet</rname>
+        <uaname>notelnet</uaname>
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">telnet_ga</bit>
         <hint>посылать последовательность TELNET GA после строки состояния</hint>
-        <msgOff>Отправка TELNET GA отключена.</msgOff>
-        <msgOn>Отправка TELNET GA включена.</msgOn>
+        <msgOff l="ru">Отправка TELNET GA отключена.</msgOff>
+        <msgOn l="ru">Отправка TELNET GA включена.</msgOn>
         <name>telnetga</name>
         <rname>telnetga</rname>
+        <uaname>telnetga</uaname>
       </node>
-      <name>Настройки клиента:</name>
+      <name l="en">Client settings:</name>
+      <name l="ru">Настройки клиента:</name>
+      <name l="ua">Налаштування клієнта:</name>
     </node>
   </groups>
   <help id="1087" labels="info" level="-1" type="CommandHelp">


### PR DESCRIPTION
Pairs code #761. 19 uaname + 4 trilingual group headers + msgOn/msgOff labeled l=ru. RU byte-identical. Boot-loaded, bundle #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)