### PR TITLE
config revamp Phase 4b: rewrite help #1087 (Trello 709)

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -276,17 +276,14 @@
     </node>
   </groups>
   <help id="1087" labels="info" level="-1" type="CommandHelp">
-    <extra l="en">autoassist autoexit autogold autolook autoloot autosac autosplit autostore autoflee</extra>
-    <extra l="ru">автобуфер автодележ автограбеж автолут автомонеты автонастройка автоподбор автопомощь автожертва автовыходы автовзгляд</extra>
-    <extra l="ua">автобуфер автоділ автограбунок автолут автомонети автонастройка автопідбір автодопомога автожертва автовиходи автовзгляд</extra>
-    <text l="en">Write *%CMD%* to see all current settings. To toggle any of them, write *%CMD%* _option_ *%YES%*|*%NO%* -- for example, *%CMD%* _autoload_ *%NO%* to stop looting everything from corpses.
+    <extra l="en">autoassist autoloot autosac nocancel nofollow damage brief shortflags affscore prompt screenreader color lines lang objname holylight noiac notelnet telnetga</extra>
+    <extra l="ru">автопомощь автограбеж автожертва неотменять неследовать урон кратко краткофлаги аффектывсчет состояние незрячий цвет строк язык имяпредмета боговзор</extra>
+    <extra l="ua">автодопомога автограбунок автожертва невідміняти неслідувати шкода стисло короткофлаги афективрахунок стан незрячий колір рядки мова назвапредмета боговзір</extra>
+    <text l="en">Write *%CMD%* to see all your settings, grouped by section. To change one, write *%CMD%* _option_ *%YES%*|*%NO%* -- for example, *%CMD%* _autoloot_ *%NO%* to stop looting items from corpses.
 
-*autoassist* - allows your character to automatically assist players
-             in your group in combat. *autoexit* - enables display of visible room exits. *autogold* - automatically takes money from the fallen enemies&apos; 
-             corpses. *autoloot* - automatically takes items from the fallen enemies&apos; 
-             corpses. *(autosac ,aвтожертва)* - automatically sacrifices the corpse of a fallen enemy to the Gods. *autosplit * - automatically shares the money from fallen enemies&apos;
-             corpses among your group&apos;s players. *autostore * - allows you to view everything said to you by other players
-             after the battle ends.
+A few useful ones: *autoassist* makes you join your group's fights; *autoloot* and *autosac* deal with enemy corpses; *nocancel* and *nofollow* keep others from cancelling your spells or following you; *brief* shortens room descriptions; *shortflags* abbreviates item flags; *damage* shows damage as numbers or as a percentage; *screenreader* turns on screen-reader support.
+
+Some options take a value instead of on/off: *color* (_on_|_off_|_mild_), *lines* (scroll buffer) and *lang* (interface language).
 
 %FMT% *%CMD%* _option_
 Shows the current state of the specified option.
@@ -295,14 +292,11 @@ Shows the current state of the specified option.
 Toggles the specified option.
 
 %SA% %H% {hh1088brief{x, [noiac]</text>
-    <text l="ru">Напиши *%CMD%*, чтобы увидеть список всех текущих настроек. Чтобы переключить любую из них, напиши *%CMD%* _опция_ *%YES%*|*%NO%* -- например, *%CMD%* _автограбеж_ *%NO%*, чтобы перестать брать все подряд из трупов. 
+    <text l="ru">Напиши *%CMD%*, чтобы увидеть все свои настройки по разделам. Чтобы изменить любую, напиши *%CMD%* _опция_ *%YES%*|*%NO%* -- например, *%CMD%* _автограбеж_ *%NO%*, чтобы перестать подбирать вещи из трупов.
 
-*автопомощь* -- позволяет твоему персонажу автоматически помогать игрокам
-             твоей группы в бою. *автовыходы* -- включает отображение видимых выходов из комнаты. *автомонеты* -- автоматически забирает деньги из трупов поверженных
-             тобой врагов. *автограбеж* -- автоматически забирает вещи из трупов поверженных тобой 
-             врагов. *(autosac ,aвтожертва)* -- автоматически жертвует Богам труп поверженного тобой врага. *автодележ * -- автоматически делит деньги из трупов поверженных тобой
-             врагов между игроками твоей группы. *автобуфер * -- позволяет просматривать все сказанное тебе другими игроками,
-             после окончания сражения.
+Несколько полезных: *автопомощь* вступает в бой за твою группу; *автограбеж* и *автожертва* разбираются с трупами врагов; *неотменять* и *неследовать* защищают тебя от чужих отмен и слежки; *кратко* сокращает описания комнат; *краткофлаги* сокращают флаги на предметах; *урон* показывает урон числами или в процентах; *незрячий* включает поддержку читалки экрана.
+
+Некоторые опции принимают значение, а не да/нет: *цвет* (_вкл_|_выкл_|_мягкий_), *строк* (буфер прокрутки) и *язык* (язык интерфейса).
 
 %FMT% *%CMD%* _опция_
 Показывает текущее состояние указанной опции.
@@ -310,24 +304,20 @@ Toggles the specified option.
 %FMT% *%CMD%* _опция_ *%YES%*|*%NO%*|*переключить*
 Включает-выключает указанную опцию.
 
-%SA% %H% {hh1088кратко{x, [noiac]
-</text>
-    <text l="ua">Напиши *%CMD%*, щоб побачити список усіх поточних налаштувань. Щоб переключити будь-яке з них, напиши *%CMD%* _опція_ *%YES%*|*%NO%* -- наприклад, *%CMD%* _автограбунок_ *%NO%*, щоб перестати брати все підряд з трупів.
+%SA% %H% {hh1088кратко{x, [noiac]</text>
+    <text l="ua">Напиши *%CMD%*, щоб побачити всі свої налаштування за розділами. Щоб змінити будь-яке, напиши *%CMD%* _опція_ *%YES%*|*%NO%* -- наприклад, *%CMD%* _автограбунок_ *%NO%*, щоб перестати підбирати речі з трупів.
 
-*автодопомога* - дозволяє вашому персонажу автоматично допомагати гравцям
-             у вашій групі у бою. *автовиходи* - включає відображення видимих виходів із кімнати. *автомонети* - автоматично бере гроші з трупів повалених
-             вашим ворогів. *автограбунок* - автоматично бере речі з трупів повалених вами 
-             ворогів. *(autosac ,автожертва)* - автоматично жертвує Богам труп поваленого вами ворога. *автоділ* - автоматично ділить гроші з трупів повалених вами
-             ворогів між гравцями вашої групи. *автобуфер * - дозволяє переглядати все, що сказано вам іншими гравцями,
-             після закінчення бою.
+Кілька корисних: *автодопомога* вступає в бій за твою групу; *автограбунок* і *автожертва* розбираються з трупами ворогів; *невідміняти* і *неслідувати* захищають тебе від чужих відмін і стеження; *стисло* скорочує описи кімнат; *короткофлаги* скорочують флаги на предметах; *шкода* показує шкоду числами чи у відсотках; *незрячий* вмикає підтримку читача екрана.
+
+Деякі опції приймають значення, а не так/ні: *колір* (_увімк_|_вимк_|_мʼякий_), *рядки* (буфер прокрутки) і *мова* (мова інтерфейсу).
 
 %FMT% *%CMD%* _опція_
 Показує поточний стан зазначеної опції.
 
 %FMT% *%CMD%* _опція_ *%YES%*|*%NO%*|*переключити*
-Включає-виключає зазначену опцію.
+Вмикає-вимикає зазначену опцію.
 
-%SA% %H% {hh1088кратко{x, [noiac]</text>
+%SA% %H% {hh1088стисло{x, [noiac]</text>
     <title l="en">Gameplay, Input-Output {CSettings{x</title>
     <title l="ru">{CНастройки{x игрового процесса, ввода-вывода</title>
     <title l="ua">Налаштування ігрового процесу, вводу-виводу</title>


### PR DESCRIPTION
Config help text/extra (en/ru/ua) rewritten for the revamped option set (dropped retired options, fixed example, noted value-options). Also fixed pre-existing UA formal-'ви' + mixed-script 'aвтожертва' bugs. De-wrapped, macros/links preserved. Bundle #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)