### PR TITLE
helps: status line = 'строка состояния' not 'подсказка' (Trello 709)

### DIFF
--- a/commands/battleprompt.xml
+++ b/commands/battleprompt.xml
@@ -4,9 +4,9 @@
   <extra>keep_hide ghost afk</extra>
   <help id="5013" level="-1" refby="prompt" type="CommandHelp">
   </help>
-  <hint l="en">set the type of hint during battle</hint>
-  <hint l="ru">задать вид подсказки во время боя</hint>
-  <hint l="ua">встановити тип підказки під час бою</hint>
+  <hint l="en">set the status line during battle</hint>
+  <hint l="ru">задать вид строки состояния в бою</hint>
+  <hint l="ua">встановити вигляд рядка стану у бою</hint>
   <name l="en">battleprompt</name>
   <name l="ru">боеваяподсказка</name>
   <name l="ua">бойовапідказка</name>

--- a/commands/config.xml
+++ b/commands/config.xml
@@ -170,12 +170,12 @@
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">prompt</bit>
-        <hint>выводить подсказку с параметрами персонажа</hint>
-        <msgOff l="en">The {hh1012prompt line{x is off.</msgOff>
-        <msgOff l="ru">Вывод {hh1012строки подсказки{x отключен.</msgOff>
+        <hint>выводить строку состояния с параметрами персонажа</hint>
+        <msgOff l="en">The {hh1012status line{x is off.</msgOff>
+        <msgOff l="ru">Вывод {hh1012строки состояния{x отключен.</msgOff>
         <msgOff l="ua">Виведення {hh1012рядка стану{x вимкнено.</msgOff>
-        <msgOn l="en">The {hh1012prompt line{x is on.</msgOn>
-        <msgOn l="ru">Вывод {hh1012строки подсказки{x включен.</msgOn>
+        <msgOn l="en">The {hh1012status line{x is on.</msgOn>
+        <msgOn l="ru">Вывод {hh1012строки состояния{x включен.</msgOn>
         <msgOn l="ua">Виведення {hh1012рядка стану{x увімкнено.</msgOn>
         <name>prompt</name>
         <rname>состояние</rname>

--- a/commands/prompt.xml
+++ b/commands/prompt.xml
@@ -121,9 +121,9 @@
     <title l="ru">{CНастройка: {xстрока состояния, промпт</title>
     <title l="ua">{CНалаштування: {xрядок стану, підказка</title>
   </help>
-  <hint l="en">set prompt appearance</hint>
-  <hint l="ru">задать вид подсказки</hint>
-  <hint l="ua">налаштувати вигляд підказки</hint>
+  <hint l="en">set the status line appearance</hint>
+  <hint l="ru">задать вид строки состояния</hint>
+  <hint l="ua">налаштувати вигляд рядка стану</hint>
   <name l="en">prompt</name>
   <name l="ru">подсказка</name>
   <name l="ua">підказка</name>

--- a/commands/time.xml
+++ b/commands/time.xml
@@ -11,7 +11,7 @@
 You can leave messages that are only visible at certain times of the day (see %H% {hh61tags{x)
 
 %FMT% *%CMD%*
-This command shows the time of day and date. In some parts of our world, time flows differently. If you have a watch, the time of day can be seen in the status line (%H% {hh1012hint{x).
+This command shows the time of day and date. In some parts of our world, time flows differently. If you have a watch, the time of day can be seen in the status line (%H% {hh1012status line{x).
 
 %SA% %H% {hh16update{x, {hh1027calendar{x
 </text>
@@ -20,7 +20,7 @@ This command shows the time of day and date. In some parts of our world, time fl
 Можно оставлять сообщения, которые видно только в определенное время суток (см. %H% {hh61тэги{x)
 
 %FMT% *%CMD%*
-Эта команда показывает время суток и дату. В некоторых точках нашего мира время течет по-иному. Если у тебя есть часы, время суток можно видеть в строке статуса (%H% {hh1012подсказка{x).
+Эта команда показывает время суток и дату. В некоторых точках нашего мира время течет по-иному. Если у тебя есть часы, время суток можно видеть в строке статуса (%H% {hh1012состояние{x).
 
 %SA% %H% {hh16обновление{x, {hh1027календарь{x
 </text>
@@ -29,7 +29,7 @@ This command shows the time of day and date. In some parts of our world, time fl
 Можна залишати повідомлення, які видно тільки в певний час доби (див. %H% {hh61теги{x)
 
 %FMT% *%CMD%*
-Ця команда показує час доби та дату. У деяких точках нашого світу час тече по-іншому. Якщо у тебе є години, час доби можна бачити в рядку статусу (%H% {hh1012підказка{x).
+Ця команда показує час доби та дату. У деяких точках нашого світу час тече по-іншому. Якщо у тебе є години, час доби можна бачити в рядку статусу (%H% {hh1012стан{x).
 
 %SA% %H% {hh16оновлення{x, {hh1027календар{x
 </text>

--- a/helps/help.xml
+++ b/helps/help.xml
@@ -5551,7 +5551,7 @@ All combat flags expire automatically after some time.
 Enables and disables room description output when moving, greatly reducing the amount of text sent and processed.
 
 %FMT% *mode* *compact* *%YES%*|*%NO%*
-Removes the extra blank line before the prompt line.
+Removes the extra blank line before the status line.
 
 %SA% %H% {hh1087mode{x, {hh1087autosacrifice{x
 	</text>
@@ -5561,7 +5561,7 @@ Removes the extra blank line before the prompt line.
 Включает и выключает вывод описаний комнат при движении, намного уменьшая количество текста для пересылки и обработки.
 
 %FMT% *режим* *компактно* *%YES%*|*%NO%*
-Убирает дополнительную пустую строку перед строкой-подсказкой (prompt).
+Убирает дополнительную пустую строку перед строкой состояния (prompt).
 
 %SA% %H% {hh1087режим{x, {hh1087автожертва{x
 	</text>
@@ -5571,7 +5571,7 @@ Removes the extra blank line before the prompt line.
 Вмикає і вимикає виведення описів кімнат при русі, значно зменшуючи кількість тексту для пересилання та обробки.
 
 %FMT% *режим* *компактно* *%YES%*|*%NO%*
-Прибирає додатковий порожній рядок перед рядком-підказкою (prompt).
+Прибирає додатковий порожній рядок перед рядком стану (prompt).
 
 %SA% %H% {hh1087режим{x, {hh1087автожертва{x
 	</text>


### PR DESCRIPTION
Fixes 'Вывод строки подсказки включен' → 'строки состояния' + the same mislabel across time.xml/prompt.xml/battleprompt.xml/help.xml. prompt COMMAND name kept (rename = separate decision). Reload via plug reload most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)