### PR TITLE
l10n: fix U+02BC apostrophes dropped by catalog loader (newbie nanny + fightspam)

### DIFF
--- a/config/translations/newbie.json
+++ b/config/translations/newbie.json
@@ -112,7 +112,7 @@
   },
   "Ты прогневил Богов, и они запретили тебе появляться в мире.": {
    "en": "You have angered the Gods, and they have forbidden you to appear in the world.",
-   "ua": "Ти прогнівив Богів, і вони заборонили тобі зʼявлятися у світі."
+   "ua": "Ти прогнівив Богів, і вони заборонили тобі з'являтися у світі."
   },
   "С вопросами обращайся в наш Телеграм: https://t.me/dreamland_rocks": {
    "en": "With any questions, reach out to our Telegram: https://t.me/dreamland_rocks",
@@ -216,11 +216,11 @@
   },
   "Как твое имя, странник?": {
    "en": "What is your name, wanderer?",
-   "ua": "Як твоє імʼя, мандрівнику?"
+   "ua": "Як твоє ім'я, мандрівнику?"
   },
   "Назови, пожалуйста, другое имя.": {
    "en": "Please give me another name.",
-   "ua": "Назви, будь ласка, інше імʼя."
+   "ua": "Назви, будь ласка, інше ім'я."
   },
   "Мне нравятся только имена, состоящие из русских или английских букв, без пробелов или дефисов.": {
    "en": "I only like names made of Russian or English letters, without spaces or hyphens.",
@@ -240,7 +240,7 @@
   },
   "Если хочешь выбрать другое имя, напиши {1{hc{yНЕТ{hx{2.": {
    "en": "If you want to pick another name, type {1{hc{yNO{hx{2.",
-   "ua": "Якщо хочеш обрати інше імʼя, напиши {1{hc{yНІ{hx{2."
+   "ua": "Якщо хочеш обрати інше ім'я, напиши {1{hc{yНІ{hx{2."
   },
   "Так кто же ты?": {
    "en": "So who are you, then?",
@@ -248,7 +248,7 @@
   },
   "Персонаж с таким или похожим именем уже существует, назови мне другое имя.": {
    "en": "A character with this or a similar name already exists, give me another name.",
-   "ua": "Персонаж з таким або схожим іменем уже існує, назви мені інше імʼя."
+   "ua": "Персонаж з таким або схожим іменем уже існує, назви мені інше ім'я."
   },
   "открывает Книгу Имен на новой странице и макает перо в чернильницу.": {
    "en": "opens the Book of Names to a new page and dips his quill in the inkwell.",
@@ -256,7 +256,7 @@
   },
   "%2$^C1 -- это мужское или женское имя? (напиши {1{hc{yмуж{hx {2или {hc{yжен{x)": {
    "en": "%2$^C1 -- is that a male or a female name? (type {1{hc{ymale{hx {2or {hc{yfemale{x)",
-   "ua": "%2$^C1 -- це чоловіче чи жіноче імʼя? (напиши {1{hc{yчол{hx {2або {hc{yжін{x)"
+   "ua": "%2$^C1 -- це чоловіче чи жіноче ім'я? (напиши {1{hc{yчол{hx {2або {hc{yжін{x)"
   },
   "И все же?": {
    "en": "And still?",
@@ -348,7 +348,7 @@
   },
   "Пароль должен быть длиннее пяти символов. Попробуй еще раз.": {
    "en": "The password must be longer than five characters. Try again.",
-   "ua": "Пароль має бути довшим за пʼять символів. Спробуй ще раз."
+   "ua": "Пароль має бути довшим за п'ять символів. Спробуй ще раз."
   },
   "Повтори этот пароль еще раз, для подтверждения": {
    "en": "Repeat this password once more, for confirmation",
@@ -360,7 +360,7 @@
   },
   "Если тебя устраивает имя, напиши {1{y{hcда{x{2, если хочешь изменить имя, напиши {y{hcнет{x.": {
    "en": "If the name suits you, type {1{y{hcyes{x{2; if you want to change the name, type {y{hcno{x.",
-   "ua": "Якщо імʼя тебе влаштовує, напиши {1{y{hcтак{x{2; якщо хочеш змінити імʼя, напиши {y{hcні{x."
+   "ua": "Якщо ім'я тебе влаштовує, напиши {1{y{hcтак{x{2; якщо хочеш змінити ім'я, напиши {y{hcні{x."
   },
   "Если тебя всё устраивает, напиши {1{y{hcда{x{2, если хочешь предложить другой вариант, напиши {y{hcнет{x.": {
    "en": "If everything suits you, type {1{y{hcyes{x{2; if you want to suggest another variant, type {y{hcno{x.",
@@ -376,7 +376,7 @@
   },
   "Имя может содержать только русские буквы!": {
    "en": "A name may contain only Russian letters!",
-   "ua": "Імʼя може містити лише російські літери!"
+   "ua": "Ім'я може містити лише російські літери!"
   },
   "Хочешь начать с веселого и простого обучения, чтобы лучше разобраться в текстовых играх?": {
    "en": "Do you want to start with a fun and simple tutorial, to get the hang of text games?",
@@ -506,7 +506,7 @@
   },
   "Ты прогневил Богов, и они запретили тебе появляться в мире.": {
    "en": "You have angered the Gods, and they have forbidden you to appear in the world.",
-   "ua": "Ти прогнівив Богів, і вони заборонили тобі зʼявлятися у світі."
+   "ua": "Ти прогнівив Богів, і вони заборонили тобі з'являтися у світі."
   },
   "С вопросами обращайся в наш Телеграм: https://t.me/dreamland_rocks": {
    "en": "With any questions, reach out to our Telegram: https://t.me/dreamland_rocks",
@@ -610,11 +610,11 @@
   },
   "Как твое имя, странник?": {
    "en": "What is your name, wanderer?",
-   "ua": "Як твоє імʼя, мандрівнику?"
+   "ua": "Як твоє ім'я, мандрівнику?"
   },
   "Назови, пожалуйста, другое имя.": {
    "en": "Please give me another name.",
-   "ua": "Назви, будь ласка, інше імʼя."
+   "ua": "Назви, будь ласка, інше ім'я."
   },
   "Мне нравятся только имена, состоящие из русских или английских букв, без пробелов или дефисов.": {
    "en": "I only like names made of Russian or English letters, without spaces or hyphens.",
@@ -634,7 +634,7 @@
   },
   "Если хочешь выбрать другое имя, напиши {1{hc{yНЕТ{hx{2.": {
    "en": "If you want to pick another name, type {1{hc{yNO{hx{2.",
-   "ua": "Якщо хочеш обрати інше імʼя, напиши {1{hc{yНІ{hx{2."
+   "ua": "Якщо хочеш обрати інше ім'я, напиши {1{hc{yНІ{hx{2."
   },
   "Так кто же ты?": {
    "en": "So who are you, then?",
@@ -642,7 +642,7 @@
   },
   "Персонаж с таким или похожим именем уже существует, назови мне другое имя.": {
    "en": "A character with this or a similar name already exists, give me another name.",
-   "ua": "Персонаж з таким або схожим іменем уже існує, назви мені інше імʼя."
+   "ua": "Персонаж з таким або схожим іменем уже існує, назви мені інше ім'я."
   },
   "открывает Книгу Имен на новой странице и макает перо в чернильницу.": {
    "en": "opens the Book of Names to a new page and dips his quill in the inkwell.",
@@ -650,7 +650,7 @@
   },
   "%2$^C1 -- это мужское или женское имя? (напиши {1{hc{yмуж{hx {2или {hc{yжен{x)": {
    "en": "%2$^C1 -- is that a male or a female name? (type {1{hc{ymale{hx {2or {hc{yfemale{x)",
-   "ua": "%2$^C1 -- це чоловіче чи жіноче імʼя? (напиши {1{hc{yчол{hx {2або {hc{yжін{x)"
+   "ua": "%2$^C1 -- це чоловіче чи жіноче ім'я? (напиши {1{hc{yчол{hx {2або {hc{yжін{x)"
   },
   "И все же?": {
    "en": "And still?",
@@ -742,7 +742,7 @@
   },
   "Пароль должен быть длиннее пяти символов. Попробуй еще раз.": {
    "en": "The password must be longer than five characters. Try again.",
-   "ua": "Пароль має бути довшим за пʼять символів. Спробуй ще раз."
+   "ua": "Пароль має бути довшим за п'ять символів. Спробуй ще раз."
   },
   "Повтори этот пароль еще раз, для подтверждения": {
    "en": "Repeat this password once more, for confirmation",
@@ -754,7 +754,7 @@
   },
   "Если тебя устраивает имя, напиши {1{y{hcда{x{2, если хочешь изменить имя, напиши {y{hcнет{x.": {
    "en": "If the name suits you, type {1{y{hcyes{x{2; if you want to change the name, type {y{hcno{x.",
-   "ua": "Якщо імʼя тебе влаштовує, напиши {1{y{hcтак{x{2; якщо хочеш змінити імʼя, напиши {y{hcні{x."
+   "ua": "Якщо ім'я тебе влаштовує, напиши {1{y{hcтак{x{2; якщо хочеш змінити ім'я, напиши {y{hcні{x."
   },
   "Если тебя всё устраивает, напиши {1{y{hcда{x{2, если хочешь предложить другой вариант, напиши {y{hcнет{x.": {
    "en": "If everything suits you, type {1{y{hcyes{x{2; if you want to suggest another variant, type {y{hcno{x.",
@@ -770,7 +770,7 @@
   },
   "Имя может содержать только русские буквы!": {
    "en": "A name may contain only Russian letters!",
-   "ua": "Імʼя може містити лише російські літери!"
+   "ua": "Ім'я може містити лише російські літери!"
   },
   "Поддержка включена, подробности читай по команде {hc{yсправка скринридер{x.": {
    "en": "Support enabled, read the details with the {hc{yhelp screenreader{x command.",

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -8700,7 +8700,7 @@
  "plug-ins/fight/fight.cpp": {
   "Ты сражаешься!": {
    "en": "You're fighting!",
-   "ua": "Ти бʼєшся!"
+   "ua": "Ти б'єшся!"
   },
   "$o1 наносит повреждения $O3.": {
    "en": "$o1 deals damage to $O3.",


### PR DESCRIPTION
The catalog JSON loader (KOI8-U //IGNORE) silently drops U+02BC at load, so UA values written with it lost their apostrophe on live (nanny registration prompts, fightspam 'Ти б'єшся!'). Replaced 21 U+02BC with ASCII apostrophe. Reboot-free (TranslationsLoader, plug reload most). lint-l10n 0 HARD.