### PR TITLE
config data: nobuff/notransfer options + refusal-message catalog

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -21,6 +21,32 @@
         <uaname>невідміняти</uaname>
       </node>
       <node type="ConfigElement">
+        <bit table="add_comm_flags">nobuff</bit>
+        <hint>запрет посторонним накладывать на тебя и твоих питомцев положительные заклинания</hint>
+        <msgOff l="en">Anyone can cast beneficial spells on you and your pets.</msgOff>
+        <msgOff l="ru">Положительные заклинания на тебя и твоих питомцев смогут накладывать все.</msgOff>
+        <msgOff l="ua">Позитивні закляття на тебе й твоїх улюбленців зможуть накладати всі.</msgOff>
+        <msgOn l="en">Only you, your group and clanmates can cast beneficial spells on you and your pets.</msgOn>
+        <msgOn l="ru">Положительные заклинания на тебя и твоих питомцев смогут накладывать только твоя группа и соклановцы.</msgOn>
+        <msgOn l="ua">Позитивні закляття на тебе й твоїх улюбленців зможуть накладати лише твоя група та соклановці.</msgOn>
+        <name>nobuff</name>
+        <rname>небаф</rname>
+        <uaname>небаф</uaname>
+      </node>
+      <node type="ConfigElement">
+        <bit table="add_comm_flags">notransfer</bit>
+        <hint>запрет посторонним игрокам передавать тебе вещи и деньги</hint>
+        <msgOff l="en">Anyone can give items and money to you.</msgOff>
+        <msgOff l="ru">Передавать тебе вещи и деньги смогут все.</msgOff>
+        <msgOff l="ua">Передавати тобі речі й гроші зможуть усі.</msgOff>
+        <msgOn l="en">Only your group and clanmates can give items and money to you.</msgOn>
+        <msgOn l="ru">Передавать тебе вещи и деньги смогут только твоя группа и соклановцы.</msgOn>
+        <msgOn l="ua">Передавати тобі речі й гроші зможуть лише твоя група та соклановці.</msgOn>
+        <name>notransfer</name>
+        <rname>непередавать</rname>
+        <uaname>непередавати</uaname>
+      </node>
+      <node type="ConfigElement">
         <bit table="plr_flags">nofollow</bit>
         <hint>запретить следовать за собой</hint>
         <msgOff l="en">You allow others to follow you.</msgOff>
@@ -276,7 +302,7 @@
     </node>
   </groups>
   <help id="1087" labels="info" level="-1" type="CommandHelp">
-    <extra l="en">autoassist autoloot autosac nocancel nofollow damage brief shortflags affscore prompt screenreader color lines lang objname holylight noiac notelnet telnetga</extra>
+    <extra l="en">autoassist autoloot autosac nocancel nobuff notransfer nofollow damage brief shortflags affscore prompt screenreader color lines lang objname holylight noiac notelnet telnetga</extra>
     <extra l="ru">автопомощь автограбеж автожертва неотменять неследовать урон кратко краткофлаги аффектывсчет состояние незрячий цвет строк язык имяпредмета боговзор</extra>
     <extra l="ua">автодопомога автограбунок автожертва невідміняти неслідувати шкода стисло короткофлаги афективрахунок стан незрячий колір рядки мова назвапредмета боговзір</extra>
     <text l="en">Write *%CMD%* to see all your settings, grouped by section. To change one, write *%CMD%* _option_ *%YES%*|*%NO%* -- for example, *%CMD%* _autoloot_ *%NO%* to stop looting items from corpses.

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -5747,6 +5747,14 @@
   "Разве можно что-то дать призраку?": {
    "en": "Can you even give something to a ghost?",
    "ua": "Хіба можна щось дати привиду?"
+  },
+  "%1$^C1 не принима%1$nет|ют вещей от посторонних.": {
+   "en": "%1$^C1 do%1$nes| not accept items from outsiders.",
+   "ua": "%1$^C1 не прийма%1$nє|ють речей від сторонніх."
+  },
+  "%1$^C1 не принима%1$nет|ют денег от посторонних.": {
+   "en": "%1$^C1 do%1$nes| not accept money from outsiders.",
+   "ua": "%1$^C1 не прийма%1$nє|ють грошей від сторонніх."
   }
  },
  "plug-ins/comm/groupchannel.cpp": {
@@ -16441,6 +16449,14 @@
   "Хозя%2$Gин|ин|йка, я %3$Gего|его|её боюсь!": {
    "en": "Master, I'm afraid of %3$Git|him|her!",
    "ua": "Хазя%2$Gїне|їне|йко, я %3$Gйого|його|її боюся!"
+  },
+  "$C1 не принимает магической помощи от посторонних.": {
+   "en": "$C1 will not accept magical help from outsiders.",
+   "ua": "$C1 не приймає магічної допомоги від сторонніх."
+  },
+  "Ты не принимаешь магической помощи от посторонних.": {
+   "en": "You refuse magical help from outsiders.",
+   "ua": "Ти не приймаєш магічної допомоги від сторонніх."
   }
  },
  "plug-ins/skills_impl/defaultskillcommand.cpp": {


### PR DESCRIPTION
Companion to dreamland_code#768. Two trilingual ConfigElement options + EN/UA catalog for the 4 new refusal messages. lint-l10n 0 HARD. Same-reboot coupling (new add_comm bit).