### PR TITLE
languages: trilingual word meanings (21 effects)

### DIFF
--- a/languages/ahenn.xml
+++ b/languages/ahenn.xml
@@ -72,35 +72,45 @@
     <node name="bad" type="BadSpellWE">
       <frequency>3</frequency>
       <global>true</global>
-      <meaning>проклять|е|я|ю|е|ьем|и</meaning>
+      <meaning l="en">a curse</meaning>
+      <meaning l="ru">проклять|е|я|ю|е|ьем|и</meaning>
+      <meaning l="ua">проклятт|я|я|ю|я|ям|і</meaning>
       <object>false</object>
       <offensive>true</offensive>
     </node>
     <node name="bless" type="BlessEquipWE">
       <frequency>3</frequency>
       <global>true</global>
-      <meaning>благословени|е|я|ю|е|ем|и</meaning>
+      <meaning l="en">a blessing</meaning>
+      <meaning l="ru">благословени|е|я|ю|е|ем|и</meaning>
+      <meaning l="ua">благословенн|я|я|ю|я|ям|і</meaning>
       <object>true</object>
       <offensive>false</offensive>
     </node>
     <node name="inspire" type="InspirationWE">
       <frequency>1</frequency>
       <global>true</global>
-      <meaning>вдохновени|е|я|ю|е|ем|и</meaning>
+      <meaning l="en">inspiration</meaning>
+      <meaning l="ru">вдохновени|е|я|ю|е|ем|и</meaning>
+      <meaning l="ua">натхненн|я|я|ю|я|ям|і</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="restore" type="RestoringWE">
       <frequency>4</frequency>
       <global>true</global>
-      <meaning>исцелени|е|я|ю|е|ем|и</meaning>
+      <meaning l="en">healing</meaning>
+      <meaning l="ru">исцелени|е|я|ю|е|ем|и</meaning>
+      <meaning l="ua">зціленн|я|я|ю|я|ям|і</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="sidhe_secret" type="ResistIronWE">
       <frequency>2</frequency>
       <global>false</global>
-      <meaning>тайн|ое|ого|ому|ое|ым|ом знани|е|я|ю|е|ем|и Сидхов</meaning>
+      <meaning l="en">the secret knowledge of the Sidhe</meaning>
+      <meaning l="ru">тайн|ое|ого|ому|ое|ым|ом знани|е|я|ю|е|ем|и Сидхов</meaning>
+      <meaning l="ua">таємн|е|ого|ому|е|им|ому знанн|я|я|ю|я|ям|і Сидхів</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>

--- a/languages/arcadian.xml
+++ b/languages/arcadian.xml
@@ -99,7 +99,9 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <node name="beer_armor" type="BeerArmorWE">
       <frequency>3</frequency>
       <global>true</global>
-      <meaning>толстокожест|ь|и|и|ь|ью|и</meaning>
+      <meaning l="en">toughness</meaning>
+      <meaning l="ru">толстокожест|ь|и|и|ь|ью|и</meaning>
+      <meaning l="ua">товстошкір|ість|ості|ості|ість|істю|ості</meaning>
       <minEffectiveVolume>75</minEffectiveVolume>
       <object>true</object>
       <offensive>false</offensive>
@@ -107,7 +109,9 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <node name="beer_elemental" type="BeerElementalWE">
       <frequency>2</frequency>
       <global>true</global>
-      <meaning>вызов||а|у||ом|е пивного элементаля</meaning>
+      <meaning l="en">summoning a beer elemental</meaning>
+      <meaning l="ru">вызов||а|у||ом|е пивного элементаля</meaning>
+      <meaning l="ua">виклик||у|у||ом|у пивного елементаля</meaning>
       <minEffectiveVolume>100</minEffectiveVolume>
       <object>true</object>
       <offensive>false</offensive>
@@ -115,21 +119,27 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <node name="water2beer" type="WaterToBeerWE">
       <frequency>2</frequency>
       <global>true</global>
-      <meaning>превращени|е|я|ю|е|ем|и воды в пиво</meaning>
+      <meaning l="en">turning water into beer</meaning>
+      <meaning l="ru">превращени|е|я|ю|е|ем|и воды в пиво</meaning>
+      <meaning l="ua">перетворенн|я|я|ю|я|ям|і води на пиво</meaning>
       <object>true</object>
       <offensive>false</offensive>
     </node>
     <node name="water2wine" type="WaterToWineWE">
       <frequency>2</frequency>
       <global>true</global>
-      <meaning>превращени|е|я|ю|е|ем|и воды в вино</meaning>
+      <meaning l="en">turning water into wine</meaning>
+      <meaning l="ru">превращени|е|я|ю|е|ем|и воды в вино</meaning>
+      <meaning l="ua">перетворенн|я|я|ю|я|ям|і води на вино</meaning>
       <object>true</object>
       <offensive>false</offensive>
     </node>
     <node name="wine_awake" type="WineAwakeWE">
       <frequency>1</frequency>
       <global>true</global>
-      <meaning>изготовлени|е|я|ю|е|ем|и бодрящего напитка</meaning>
+      <meaning l="en">brewing an invigorating drink</meaning>
+      <meaning l="ru">изготовлени|е|я|ю|е|ем|и бодрящего напитка</meaning>
+      <meaning l="ua">виготовленн|я|я|ю|я|ям|і бадьорого напою</meaning>
       <minEffectiveVolume>100</minEffectiveVolume>
       <object>true</object>
       <offensive>false</offensive>
@@ -137,7 +147,9 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <node name="wine_calm" type="WineCalmWE">
       <frequency>1</frequency>
       <global>true</global>
-      <meaning>изготовлени|е|я|ю|е|ем|и успокоительного напитка</meaning>
+      <meaning l="en">brewing a calming drink</meaning>
+      <meaning l="ru">изготовлени|е|я|ю|е|ем|и успокоительного напитка</meaning>
+      <meaning l="ua">виготовленн|я|я|ю|я|ям|і заспокійливого напою</meaning>
       <minEffectiveVolume>100</minEffectiveVolume>
       <object>true</object>
       <offensive>false</offensive>
@@ -145,7 +157,9 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <node name="wine_refresh" type="WineRefreshWE">
       <frequency>3</frequency>
       <global>true</global>
-      <meaning>изготовлени|е|я|ю|е|ем|и освежающего напитка</meaning>
+      <meaning l="en">brewing a refreshing drink</meaning>
+      <meaning l="ru">изготовлени|е|я|ю|е|ем|и освежающего напитка</meaning>
+      <meaning l="ua">виготовленн|я|я|ю|я|ям|і освіжного напою</meaning>
       <minEffectiveVolume>0</minEffectiveVolume>
       <object>true</object>
       <offensive>false</offensive>
@@ -153,7 +167,9 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <node name="wine_sleep" type="WineSleepWE">
       <frequency>1</frequency>
       <global>true</global>
-      <meaning>изготовлени|е|я|ю|е|ем|и снотворного</meaning>
+      <meaning l="en">brewing a sleeping draught</meaning>
+      <meaning l="ru">изготовлени|е|я|ю|е|ем|и снотворного</meaning>
+      <meaning l="ua">виготовленн|я|я|ю|я|ям|і снодійного</meaning>
       <minEffectiveVolume>100</minEffectiveVolume>
       <object>true</object>
       <offensive>false</offensive>

--- a/languages/khuzdul.xml
+++ b/languages/khuzdul.xml
@@ -67,21 +67,27 @@
     <node name="berserk" type="BerserkWE">
       <frequency>3</frequency>
       <global>true</global>
-      <meaning>древн|яя|ей|ей|юю|ей|ей ярост|ь|и|и|ь|ью|и</meaning>
+      <meaning l="en">ancient rage</meaning>
+      <meaning l="ru">древн|яя|ей|ей|юю|ей|ей ярост|ь|и|и|ь|ью|и</meaning>
+      <meaning l="ua">давн|я|ьої|ій|ю|ьою|ій лют|ь|і|і|ь|тю|і</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="enchant" type="EnchantWeaponWE">
       <frequency>1</frequency>
       <global>true</global>
-      <meaning>оружейн|ое|ого|ому|ое|ым|ом закляти|е|я|ю|е|ем|и</meaning>
+      <meaning l="en">a weapon enchantment</meaning>
+      <meaning l="ru">оружейн|ое|ого|ому|ое|ым|ом закляти|е|я|ю|е|ем|и</meaning>
+      <meaning l="ua">збройов|е|ого|ому|е|им|ому заклятт|я|я|ю|я|ям|і</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="mend" type="MendingWE">
       <frequency>4</frequency>
       <global>true</global>
-      <meaning>починк|а|и|е|у|ой|е доспехов</meaning>
+      <meaning l="en">armor repair</meaning>
+      <meaning l="ru">починк|а|и|е|у|ой|е доспехов</meaning>
+      <meaning l="ua">лагодженн|я|я|ю|я|ям|і обладунків</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>

--- a/languages/quenia.xml
+++ b/languages/quenia.xml
@@ -72,35 +72,45 @@
     <node name="accuracy" type="AccuracyWE">
       <frequency>2</frequency>
       <global>true</global>
-      <meaning>меткост|ь|и|и|ь|ью|и</meaning>
+      <meaning l="en">accuracy</meaning>
+      <meaning l="ru">меткост|ь|и|и|ь|ью|и</meaning>
+      <meaning l="ua">влучн|ість|ості|ості|ість|істю|ості</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="bless" type="BlessEquipWE">
       <frequency>2</frequency>
       <global>true</global>
-      <meaning>благословени|е|я|ю|е|ем|и</meaning>
+      <meaning l="en">a blessing</meaning>
+      <meaning l="ru">благословени|е|я|ю|е|ем|и</meaning>
+      <meaning l="ua">благословенн|я|я|ю|я|ям|і</meaning>
       <object>true</object>
       <offensive>false</offensive>
     </node>
     <node name="good" type="GoodSpellWE">
       <frequency>3</frequency>
       <global>true</global>
-      <meaning>благост|ь|и|и|ь|ью|и</meaning>
+      <meaning l="en">grace</meaning>
+      <meaning l="ru">благост|ь|и|и|ь|ью|и</meaning>
+      <meaning l="ua">благодат|ь|і|і|ь|тю|і</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="restore" type="RestoringWE">
       <frequency>4</frequency>
       <global>true</global>
-      <meaning>исцелени|е|я|ю|е|ем|и</meaning>
+      <meaning l="en">healing</meaning>
+      <meaning l="ru">исцелени|е|я|ю|е|ем|и</meaning>
+      <meaning l="ua">зціленн|я|я|ю|я|ям|і</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>
     <node name="sidhe_secret" type="ResistIronWE">
       <frequency>2</frequency>
       <global>false</global>
-      <meaning>тайн|ое|ого|ому|ое|ым|ом знани|е|я|ю|е|ем|и Сидхов</meaning>
+      <meaning l="en">the secret knowledge of the Sidhe</meaning>
+      <meaning l="ru">тайн|ое|ого|ому|ое|ым|ом знани|е|я|ю|е|ем|и Сидхов</meaning>
+      <meaning l="ua">таємн|е|ого|ому|е|им|ому знанн|я|я|ю|я|ям|і Сидхів</meaning>
       <object>false</object>
       <offensive>false</offensive>
     </node>


### PR DESCRIPTION
EN/UA <meaning> for all 21 word effects across 4 languages. RU byte-identical. Companion to dreamland_code#769. Same-reboot coupling (boot-loaded).