### PR TITLE
launch T1 data: fill EN/UA help-article titles (lore + voice batch)

### DIFF
--- a/helps/anatolia.xml
+++ b/helps/anatolia.xml
@@ -209,9 +209,9 @@ the punishment.
 на іх порушенні -- ти БУДЕШ покаран{Sfа{Sx. Доречність і міру покарання Безсмертні
 обирають самі.
 </text>
-    <title l="en"></title>
+    <title l="en">{CGame rules of Dreamland{x</title>
     <title l="ru">{CИгровые правила Мира Мечты{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CІгрові правила Дрімленду{x</title>
   </node>
   <node id="69" labels="system" level="-1" type="Help">
     <keyword l="en">greeting</keyword>
@@ -495,9 +495,9 @@ The choice of {hh81Path{x is yours!
 
 Вибір {hh81Шляху{x -- за тобою!
 </text>
-    <title l="en"></title>
+    <title l="en">{CDreamland:{x Introduction</title>
     <title l="ru">{CМир Мечты:{x Вступление</title>
-    <title l="ua"></title>
+    <title l="ua">{CДрімленд:{x Вступ</title>
   </node>
   <node id="80" labels="info" level="0" type="Help">
     <extra l="en">timeline</extra>
@@ -771,9 +771,9 @@ In the corner you notice a small, hasty signature:
 У кутку ти помічаєш маленький поспішний підпис:
 &apos;Незабаром допишу. Руфіна.&apos;{x
 </text>
-    <title l="en"></title>
+    <title l="en">{CHistorical epochs of Dreamland{x</title>
     <title l="ru">{CИсторические эпохи Мира Мечты{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CІсторичні епохи Дрімленду{x</title>
   </node>
   <node id="81" labels="info" level="-1" type="Help">
     <extra l="en">chaos &apos;eight paths&apos; evil good nature order rage reason society ways</extra>
@@ -854,9 +854,9 @@ To learn more about the so-called =Wheel of Paths= -- the friendly and hostile P
 
 Щоб дізнатися більше про так зване =Колесо Шляхів= -- дружні й ворожі Шляхи та їхні взаємини між собою -- почитай однойменну книгу в міській {hh2088Бібліотеці{x Мідгаарда.
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths{x of your character</title>
     <title l="ru">{CВосемь Путей{x твоего персонажа</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів{x твого персонажа</title>
   </node>
   <node id="83" labels="char item" level="-1" type="Help">
     <extra l="en">ac</extra>

--- a/helps/help.xml
+++ b/helps/help.xml
@@ -82,9 +82,9 @@ And read help often: just type {y?{x followed by any topic you're curious about.
                                                                           
 %SA% %H% {hh995довідка{x
 </text>
-    <title l="en"></title>
+    <title l="en">{CHelp{x and how to use it</title>
     <title l="ru">{CСправка{x и с чем ее едят</title>
-    <title l="ua"></title>
+    <title l="ua">{CДовідка{x і з чим її їдять</title>
   </node>
   <node id="11" labels="info" level="-1" type="Help">
     <extra l="en">buildprice change chests &apos;god prices&apos; immprice name</extra>
@@ -2997,9 +2997,9 @@ These commands toggle colour output mode on and off.
 
 Ці команди вмикають-вимикають режим виведення у кольорі.
 </text>
-    <title l="en"></title>
+    <title l="en">{RC{Yo{Gl{Co{Bu{Mr{Rs{x</title>
     <title l="ru">{RЦ{Yв{Gе{Cт{Bа{x</title>
-    <title l="ua"></title>
+    <title l="ua">{RК{Yо{Gл{Cь{Bо{Mр{Rи{x</title>
   </node>
   <node id="44" labels="class" level="-1" type="Help">
     <extra l="en">guildmaster</extra>
@@ -5643,9 +5643,9 @@ This path suits non-evil characters who specialise in blessings, healing skills 
 
 Цей шлях підійде незлим персонажам, що спеціалізуються на благословеннях, навичках зцілення хвороб і ран, які вірять у світлих богів або всім, хто готовий до самопожертви заради інших.
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {WLight{x</title>
     <title l="ru">{CВосемь Путей: {WСвет{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {WСвітло{x</title>
   </node>
   <node id="7" labels="info" level="-1" type="Help">
     <extra l="en">darkness</extra>
@@ -5720,9 +5720,9 @@ This path suits non-good characters who bring pain, curses, and sudden death, wh
 
 Цей шлях підійде незлим персонажам, що приносять біль, прокляття, раптову смерть, які вірять у темних богів або жадають влади за будь-яку ціну.
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {DDark{x</title>
     <title l="ru">{CВосемь Путей: {DТьма{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {DТемрява{x</title>
   </node>
   <node id="8" labels="info" level="-1" type="Help">
     <extra l="en">reason</extra>
@@ -5800,9 +5800,9 @@ This path suits those capable of casting spells (magic and prayers) -- and all w
 
 Цей шлях підійде здатним творити заклинання (магію і молитви) -- і всім, хто має раціональну тямущість, інтелект і тверезий розрахунок. Віра в богів Розуму для послідовників цього Шляху зовсім не обовʼязкова.
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {BReason{x</title>
     <title l="ru">{CВосемь Путей: {BРазум{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {BРозум{x</title>
   </node>
   <node id="10" labels="info" level="-1" type="Help">
     <extra l="en">fury passion &apos;path of passion&apos;</extra>
@@ -5865,9 +5865,9 @@ These gods and goddesses lead you into battle on the Path of Rage:
 %A% {hh1575Алала{x, богиня оглушливого бойового кличу
 %A% {hh976Гек Тенгрі{x, божество воїнської честі
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {RRage{x</title>
     <title l="ru">{CВосемь Путей: {RЯрость{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {RЛють{x</title>
   </node>
   <node id="23" labels="info" level="-1" type="Help">
     <extra l="en">order</extra>
@@ -5918,9 +5918,9 @@ On the Path of ORDER you will walk the thin bridge of eternal balance between go
 %A% {hh979Шамаш{x, бог справедливості й законів природи
 %A% {hh981Одін{x, бог сили закону й покровитель усіх, хто захищає закон у бою
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {wOrder{x</title>
     <title l="ru">{CВосемь Путей: {wПорядок{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {wПорядок{x</title>
   </node>
   <node id="25" labels="info" level="-1" type="Help">
     <extra l="en">chaos</extra>
@@ -5974,9 +5974,9 @@ If freedom is the thing you value above all else, and you despise laws and the a
 %A% {hh967Сет{x, бог-дракон, що сіє війну й руйнування
 %A% {hh978Фобос{x, бог страху й божевілля 
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {MChaos{x</title>
     <title l="ru">{CВосемь Путей: {MХаос{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {MХаос{x</title>
   </node>
   <node id="49" labels="info" level="-1" type="Help">
     <extra l="en">nature</extra>
@@ -6044,9 +6044,9 @@ These gods nurture the Path of Nature:
 %A% {hh983Сіебеле{x, богиня буйства природи та її грізної сили
 %A% {hh988Тешуб{x, бог бурі й блискавок
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {gNature{x</title>
     <title l="ru">{CВосемь Путей: {gПрирода{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {gПрирода{x</title>
   </node>
   <node id="52" labels="info" level="-1" type="Help">
     <extra l="en">progress society technology</extra>
@@ -6097,9 +6097,9 @@ On the Path of SOCIETY you will gain cynicism and clear-headed practical savvy. 
 %A% {hh977Еревен Ілесір{x, грайливе божество злодійства й хитрощів
 %A% {hh965Афіна{x, богиня військової хитрості, винахідництва й бойових технологій
 </text>
-    <title l="en"></title>
+    <title l="en">{CThe Eight Paths: {YSociety{x</title>
     <title l="ru">{CВосемь Путей: {YОбщество{x</title>
-    <title l="ua"></title>
+    <title l="ua">{CВісім Шляхів: {YСуспільство{x</title>
   </node>
   <node id="174" labels="clan" level="-1" type="Help">
     <keyword l="en">ordens</keyword>

--- a/helps/immort.xml
+++ b/helps/immort.xml
@@ -68,9 +68,9 @@
 %SA% %H% {hh66контакт{x, {hh1010благодарности{x
 </text>
     <text l="ua"></text>
-    <title l="en"></title>
+    <title l="en">{CImmortals{x (administrators) of Dreamland</title>
     <title l="ru">{CБессмертные{x (администраторы) Мира Мечты</title>
-    <title l="ua"></title>
+    <title l="ua">{CБезсмертні{x (адміністратори) Дрімленду</title>
   </node>
   <node id="94" labels="system" level="102" type="Help">
     <keyword l="en">commandments &apos;god rules&apos; gods laws</keyword>


### PR DESCRIPTION
The reviewed remainder of the T1 title fill (15 cells): Eight Paths (RELIGIONS.md canon, UA `Вісім Шляхів` locked), world name `Мир Мечты` → **Dreamland / Дрімленд** (Kit's pick), and 2 playful titles. Colour codes preserved, U+02BC, **RU byte-identical**. Only `help.xml` id 205 (`[delete this]`, a dead article) left. Reboot-gated (bundles with #778 + #371).