### PR TITLE
help: remove obsolete node 205 ('[delete this]' chances article)

### DIFF
--- a/helps/help.xml
+++ b/helps/help.xml
@@ -6365,29 +6365,6 @@ You can also tell your {hh15pet{x to get healed at a healer -- the money will be
     <title l="ru">{CПлатные услуги: {xлекари, лечение, снятие проклятий</title>
     <title l="ua">{CПлатні послуги: {xлікарі, лікування, зняття проклять</title>
   </node>
-  <node id="205" labels="none" level="110" type="Help">
-    <text l="en">%FMT% *chances* _%CHAR%_ 
-
-This command lets you roughly estimate the difference in levels between you and a given creature, as well as its {hh33nature{x, some combat abilities (if any), and its available {hh62body parts{x.
-
-Naturally, engaging creatures that are incomparably or noticeably higher in level than you can be deadly -- especially when they have additional combat abilities!
-</text>
-    <text l="ru">%FMT% *шансы* _%CHAR%_ 
-
-Эта команда позволяет примерно оценить разницу в уровнях между тобой и данным существом, также его {hh33натуру{x, некоторые боевые способности (если есть), а также наявные {hh62части тела{x.
-
-Разумеется, что связываться с существами несравненно или заметно выше своего уровня может быть смертельно опасно -- особенно при наличии дополнительных боевых способностей!
-</text>
-    <text l="ua">%FMT% *шанси* _%CHAR%_ 
-
-Ця команда дозволяє приблизно оцінити різницю в рівнях між тобою і даною істотою, а також її {hh33натуру{x, деякі бойові здібності (якщо є), а також наявні {hh62частини тіла{x.
-
-Звісно ж, зачіпатися з істотами несумісно або помітно вище свого рівня може бути смертельно небезпечно -- особливо за наявності додаткових бойових здібностей!
-</text>
-    <title l="en"></title>
-    <title l="ru">[delete this]</title>
-    <title l="ua"></title>
-  </node>
   <node id="219" labels="learn" level="-1" type="Help">
     <extra l="en">&apos;area attack&apos; area_attack assist fast off_flags rescue</extra>
     <extra l="ru">быстрота &apos;круговая атака&apos; &apos;мощный удар&apos; спасает защищает</extra>


### PR DESCRIPTION
Node 205 (level 110, immortal-only) was titled `[delete this]` and describes the old `chances` command — confirmed obsolete (Kit). No inbound `{hh205` links. Removes the whole node. Bundles into the reboot.