### PR TITLE
launch: EN/UA for the per-viewer quit info-channel broadcast

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -6544,6 +6544,10 @@
    "en": "%1$#C1 has left the World of Dreams.",
    "ua": "%1$#C1 покину%1$#Gло|в|ла|ли Світ Мрій."
   },
+  "{CТихий голос из $o2: {W%1$#C1 покину%1$#Gло|л|ла Мир Мечты.{x": {
+   "en": "{CA quiet voice from $o2: {W%1$#C1 has left the World of Dreams.{x",
+   "ua": "{CТихий голос з $o2: {W%1$#C1 покину%1$#Gло|в|ла|ли Світ Мрій.{x"
+  },
   "Здесь нет ренты. Просто покинь мир.": {
    "en": "There's no rent here. Just leave the world.",
    "ua": "Тут немає ренти. Просто покинь світ."


### PR DESCRIPTION
Adds the infonet combined-string catalog entry (`plug-ins/comm/quit.cpp`) that the new per-viewer `infonet(MultiMessage)` overload resolves (dreamland_code #788). Additive; the paired Discord line was already cataloged. lint-l10n 0 HARD. RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)