### PR TITLE
launch: EN/UA for the per-viewer craft mastery-level info broadcast

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -8540,6 +8540,10 @@
    "en": "%1$#C1 reached a new level of mastery in the %2$N2 profession.",
    "ua": "%1$#C1 дося%1$#Gгло|г|гла нового рівня майстерності в професії %2$N2."
   },
+  "{CРадостный голос из $o2: {W%1$#C1 дости%1$#Gгло|г|гла новой ступени мастерства.{x": {
+   "en": "{CA joyful voice from $o2: {W%1$#C1 has reached a new stage of mastery.{x",
+   "ua": "{CРадісний голос з $o2: {W%1$#C1 досяг%1$#Gло||ла нового ступеня майстерності.{x"
+  },
   "{CТы достигаешь {Y%1$dго{C уровня мастерства в профессии {Y%2$N2{C!{x": {
    "en": "{CYou reach mastery level {Y%1$d{C in the profession {Y%2$N2{C!{x",
    "ua": "{CТи досягаєш {Y%1$d{C рівня майстерності у професії {Y%2$N2{C!{x"


### PR DESCRIPTION
Infonet entry (subprofession.cpp) for dreamland_code #791. lint 0 HARD. RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)