### PR TITLE
launch: EN/UA for the clan defense-lost + territory-attacked broadcasts

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -1040,6 +1040,18 @@
   }
  },
  "plug-ins/clan/behavior/clanmobiles.cpp": {
+  "{CТихий голос из $o2: %w {Wне удалось удержать оборону.{x": {
+   "en": "{CA quiet voice from $o2: The %w clan {Wfailed to hold their defense.{x",
+   "ua": "{CТихий голос з $o2: %w {Wне вдалося утримати оборону.{x"
+  },
+  "%w {Wне удалось удержать оборону.{x": {
+   "en": "The %w clan {Wfailed to hold their defense.{x",
+   "ua": "%w {Wне вдалося утримати оборону.{x"
+  },
+  "Территория %w{x атакована!": {
+   "en": "The %w clan's territory{x is under attack!",
+   "ua": "Територія %w{x атакована!"
+  },
   "$C1 дает $o4 $c3.": {
    "en": "$C1 gives $o4 to $c3.",
    "ua": "$C1 дає $o4 $c3."


### PR DESCRIPTION
New %w-clan-name entries (clanmobiles.cpp) for dreamland_code clan Phase-2. lint 0 HARD. RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)