### PR TITLE
launch: EN/UA for the clan promotion/petition/induct broadcasts

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -1118,6 +1118,46 @@
   }
  },
  "plug-ins/clan/command/cclan.cpp": {
+  "{CТихий голос из $o2: {W%C1 становится лидером %w.{x": {
+   "en": "{CA quiet voice from $o2: {W%C1 becomes the leader of %w.{x",
+   "ua": "{CТихий голос з $o2: {W%C1 стає лідером %w.{x"
+  },
+  "{W%C1 становится лидером %w.{x": {
+   "en": "{W%C1 becomes the leader of %w.{x",
+   "ua": "{W%C1 стає лідером %w.{x"
+  },
+  "{CТихий голос из $o2: {W%C1 становится рекрутером %w.{x": {
+   "en": "{CA quiet voice from $o2: {W%C1 becomes a recruiter of %w.{x",
+   "ua": "{CТихий голос з $o2: {W%C1 стає рекрутером %w.{x"
+  },
+  "{W%C1 становится рекрутером %w.{x": {
+   "en": "{W%C1 becomes a recruiter of %w.{x",
+   "ua": "{W%C1 стає рекрутером %w.{x"
+  },
+  "{CТихий голос из $o2: {W%1$^C1 подал%1$Gо||а петицию в %w.{x": {
+   "en": "{CA quiet voice from $o2: {W%1$^C1 has applied to join %w.{x",
+   "ua": "{CТихий голос з $o2: {W%1$^C1 пода%1$Gло|в|ла заявку до %w.{x"
+  },
+  "{W%1$^C1 подал%1$Gо||а петицию в %w.{x": {
+   "en": "{W%1$^C1 has applied to join %w.{x",
+   "ua": "{W%1$^C1 пода%1$Gло|в|ла заявку до %w.{x"
+  },
+  "{CТихий голос из $o2: {W%1$^C1 становится внекланов%1$Gым|ым|ой.{x": {
+   "en": "{CA quiet voice from $o2: {W%1$^C1 becomes clanless.{x",
+   "ua": "{CТихий голос з $o2: {W%1$^C1 стає позакланов%1$Gим|им|ою.{x"
+  },
+  "{W%1$^C1 становится внекланов%1$Gым|ым|ой.{x": {
+   "en": "{W%1$^C1 becomes clanless.{x",
+   "ua": "{W%1$^C1 стає позакланов%1$Gим|им|ою.{x"
+  },
+  "{CТихий голос из $o2: {W%1$^C1 вступает в %w.{x": {
+   "en": "{CA quiet voice from $o2: {W%1$^C1 joins %w.{x",
+   "ua": "{CТихий голос з $o2: {W%1$^C1 вступає до %w.{x"
+  },
+  "{W%1$^C1 вступает в %w.{x": {
+   "en": "{W%1$^C1 joins %w.{x",
+   "ua": "{W%1$^C1 вступає до %w.{x"
+  },
   "\n\r{BИмя         раса        класс         уровень{x": {
    "en": "\n\r{BName         race        class         level{x",
    "ua": "\n\r{BІм'я         раса        клас         рівень{x"


### PR DESCRIPTION
10 %w-clan-name entries (cclan.cpp) for dreamland_code clan Phase-2 final. lint 0 HARD. RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)