### PR TITLE
launch: EN/UA for the marry ceremony broadcasts

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -13159,6 +13159,22 @@
   "Это еще как?": {
    "en": "How's that now?",
    "ua": "Це ще як?"
+  },
+  "Ты объявляешь %1$s и %2$s мужем и женой!\n": {
+   "en": "You declare %1$s and %2$s husband and wife!\n",
+   "ua": "Ти оголошуєш %1$s та %2$s чоловіком і дружиною!\n"
+  },
+  "%1$C1 объявляет вас мужем и женой!\n": {
+   "en": "%1$C1 declares you husband and wife!\n",
+   "ua": "%1$C1 оголошує вас чоловіком і дружиною!\n"
+  },
+  "%1$C1 объявляет %2$s и %3$s мужем и женой!\n": {
+   "en": "%1$C1 declares %2$s and %3$s husband and wife!\n",
+   "ua": "%1$C1 оголошує %2$s та %3$s чоловіком і дружиною!\n"
+  },
+  "{CВеселый голос из $o2: {Y%1$s{W и {Y%2$s{W теперь муж и жена!!!{x": {
+   "en": "{CA cheerful voice from $o2: {Y%1$s{W and {Y%2$s{W are now husband and wife!!!{x",
+   "ua": "{CВеселий голос із $o2: {Y%1$s{W та {Y%2$s{W тепер чоловік і дружина!!!{x"
   }
  },
  "plug-ins/mlove/mlove.cpp": {


### PR DESCRIPTION
4 catalog keys for code #795 (per-viewer marry announcement). lint-l10n 0 HARD, width clean, JSON valid. RU byte-identical (renders from key).