### PR TITLE
launch: UA names for the 3 craft professions

### DIFF
--- a/craft-professions/blacksmith.xml
+++ b/craft-professions/blacksmith.xml
@@ -49,4 +49,5 @@ An old weaponsmaster can be found in the forge of {hh1838New Thalos{x. He runs t
   <mltName>кузнец|ы|ов|ам|ов|ами|ах</mltName>
   <name>blacksmith</name>
   <rusName>кузнец||а|у|а|ом|е</rusName>
+  <uaName>ковал|ь|я|ю|я|ем|і</uaName>
 </CraftProfession>

--- a/craft-professions/carpenter.xml
+++ b/craft-professions/carpenter.xml
@@ -43,4 +43,5 @@ Some of the most skilled carpenters and lumberjacks of Thera can be found in the
   <mltName>плотник|и|ов|ам|ов|ами|ах</mltName>
   <name>carpenter</name>
   <rusName>плотник||а|у|а|ом|е</rusName>
+  <uaName>тесл|я|і|і|ю|ею|і</uaName>
 </CraftProfession>

--- a/craft-professions/tattooist.xml
+++ b/craft-professions/tattooist.xml
@@ -70,4 +70,5 @@ To {hh245remove a tattoo{x, you need a special ointment, which can be bought fro
   <mltName>татуировщик|и|ов|ам|ов|ами|ах</mltName>
   <name>tattooist</name>
   <rusName>татуировщик||а|у|а|ом|е</rusName>
+  <uaName>татуювальник||а|у|а|ом|у</uaName>
 </CraftProfession>


### PR DESCRIPTION
uaName UA singular pads for blacksmith/carpenter/tattooist (code #800). Forms verified by construction (root + 6 case endings). Schema-coupled -> deploy with #800 in one reboot, no plug-reload. Live-verify UA declension in craft score owed post-reboot.