### PR TITLE
cuisinart: fix help + description to match the actual mechanic

### DIFF
--- a/behaviors/cuisinart.xml
+++ b/behaviors/cuisinart.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
-  <description l="ru">{hh1023Используй{x {hh293кузинатру{x, чтобы раздробить вещь на {hh294компоненты{x.</description>
-  <description l="ua">{hh1023Використай{x {hh293кузинатру{x, щоб роздробити річ на {hh294компоненти{x.</description>
+  <description l="en">Load items into a {hh293cuisinart{x and run it to grind them into {hh294components{x.</description>
+  <description l="ru">Сложи вещи в {hh293кузинатру{x и запусти, чтобы раздробить их на {hh294компоненты{x.</description>
+  <description l="ua">Склади речі в {hh293кузинатру{x і запусти, щоб роздробити їх на {hh294компоненти{x.</description>
   <help id="293" level="-1" type="BehaviorHelp">
     <extra l="en">cuisinart grinder shredder disassemble</extra>
     <extra l="ru">кузинатра дробилка разобрать разбор</extra>
     <extra l="ua">кузинатра дробарка розібрати розбір</extra>
-    <text l="en">%FMT% *use* {Dcuisinart{x _%OBJ%_
+    <text l="en">%FMT% *use* {Dcuisinart{x
 
-Use a cuisinart on an item to shatter it into {hh294components{x -- raw material for crafting. Not every item can be broken down.</text>
-    <text l="ru">%FMT% *использовать* {Dкузинатра{x _%OBJ%_
+Put the items you want to scrap inside the cuisinart, close its lid, and use it. For a fee it grinds the contents into {hh294components{x -- raw material for crafting -- shredding objects into chunks and chunks into dust. Load it with five identical heaps of dust instead, and it presses them back into a single chunk. Not every item can be broken down.</text>
+    <text l="ru">%FMT% *использовать* {Dкузинатра{x
 
-Используй кузинатру на вещь, чтобы раздробить ее на {hh294компоненты{x -- сырье для крафта. Не всякая вещь поддается разбору.</text>
-    <text l="ua">%FMT% *використати* {Dкузинатра{x _%OBJ%_
+Сложи вещи, которые не жалко, внутрь кузинатры, закрой крышку и запусти. За плату она перемелет содержимое в {hh294компоненты{x -- сырье для крафта, -- дробя предметы в куски, а куски в пыль. А засыплешь вместо этого пять одинаковых горстей пыли -- спрессует их обратно в кусок. Не всякая вещь поддается разбору.</text>
+    <text l="ua">%FMT% *використати* {Dкузинатра{x
 
-Використай кузинатру на річ, щоб роздробити її на {hh294компоненти{x -- сировину для крафту. Не кожна річ піддається розбору.</text>
+Склади речі, яких не шкода, всередину кузинатри, зачини кришку і запусти. За плату вона перемеле вміст на {hh294компоненти{x -- сировину для крафту, -- дроблячи предмети на куски, а куски на пил. А всиплеш натомість пʼять однакових жмень пилу -- спресує їх назад у кусок. Не кожна річ піддається розбору.</text>
   </help>
   <id>58</id>
   <nameRus>кузинатра</nameRus>


### PR DESCRIPTION
The cuisinart help/description said "use cuisinart on an item" with a phantom `_%OBJ%_` target, but the handler works on container contents: load items inside, close the lid, `use` it (for a fee) to grind them into {hh294 components} or press 5 identical dust into a chunk. Rewrites help id 293 (EN/RU/UA) + the description to describe that, drops `_%OBJ%_` from the format line, adds the missing EN description.

Deploy: help 293 via `plug reload most` (no reboot); the XMLMultiString `<description>` lands on the next reboot.