### PR TITLE
behaviors: Ukrainian nameUa for 100 behaviors

### DIFF
--- a/behaviors/adept.xml
+++ b/behaviors/adept.xml
@@ -12,6 +12,7 @@
   </help>
   <id>30</id>
   <nameRus>адепт</nameRus>
+  <nameUa>адепт</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/amix.xml
+++ b/behaviors/amix.xml
@@ -5,6 +5,7 @@
   <description l="ua">Чудотворець: за квестові очки знищує речі з незнімним прокляттям, а також безкоштовно виводить надіті татуювання, які не є знаком віри персонажа.</description>
   <id>97</id>
   <nameRus>чудотворец</nameRus>
+  <nameUa>чудотворець</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/ashes.xml
+++ b/behaviors/ashes.xml
@@ -19,6 +19,7 @@ Use ashes to mournfully sprinkle them over your head -- an ancient gesture of gr
   </help>
   <id>46</id>
   <nameRus>пепел</nameRus>
+  <nameUa>попіл</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/assassin.xml
+++ b/behaviors/assassin.xml
@@ -5,6 +5,7 @@
   <description l="ua">Вбивця: вистежує здорову жертву відповідного рівня та нападає з погрозою.</description>
   <id>89</id>
   <nameRus>убийца</nameRus>
+  <nameUa>вбивця</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/atm.xml
+++ b/behaviors/atm.xml
@@ -19,6 +19,7 @@ At an atm you can deposit money into your account and withdraw it again. Money i
   </help>
   <id>40</id>
   <nameRus>банкомат</nameRus>
+  <nameUa>банкомат</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/axe lumberjack.xml
+++ b/behaviors/axe lumberjack.xml
@@ -25,6 +25,7 @@ With a suitable two-handed axe you can chop down a tree in the {hh86forest{x, fr
   </help>
   <id>48</id>
   <nameRus>топор лесоруба</nameRus>
+  <nameUa>сокира лісоруба</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/babayaga.xml
+++ b/behaviors/babayaga.xml
@@ -13,6 +13,7 @@
   </help>
   <id>80</id>
   <nameRus>Баба Яга</nameRus>
+  <nameUa>Баба Яга</nameUa>
   <props>null</props>
   <target>mob</target>
 </behavior>

--- a/behaviors/baker.xml
+++ b/behaviors/baker.xml
@@ -5,6 +5,7 @@
   <description l="ua">Пекар: підгодовує голодних новачків свіжим хлібом і зазиває покупців.</description>
   <id>94</id>
   <nameRus>пекарь</nameRus>
+  <nameUa>пекар</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/bank.xml
+++ b/behaviors/bank.xml
@@ -12,6 +12,7 @@
   </help>
   <id>41</id>
   <nameRus>банк</nameRus>
+  <nameUa>банк</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/beggar.xml
+++ b/behaviors/beggar.xml
@@ -5,6 +5,7 @@
   <description l="ua">Жебрак: випрошує монети, дякує за подаяння, кличе на допомогу в бійці.</description>
   <id>95</id>
   <nameRus>нищий</nameRus>
+  <nameUa>жебрак</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/bell.xml
+++ b/behaviors/bell.xml
@@ -19,6 +19,7 @@ Use a bell to ring it melodiously -- a soft, cheerful sound carries through the 
   </help>
   <id>60</id>
   <nameRus>колокольчик</nameRus>
+  <nameUa>дзвіночок</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/blacksmith.xml
+++ b/behaviors/blacksmith.xml
@@ -76,6 +76,7 @@ Blacksmiths also fit {hh151centaurs{x with new iron horseshoes, with stats scale
   </help>
   <id>42</id>
   <nameRus>кузнец</nameRus>
+  <nameUa>коваль</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/bloodthirst.xml
+++ b/behaviors/bloodthirst.xml
@@ -13,6 +13,7 @@
   </help>
   <id>53</id>
   <nameRus>кровожадность</nameRus>
+  <nameUa>кровожерність</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/blueprint.xml
+++ b/behaviors/blueprint.xml
@@ -19,6 +19,7 @@ From a blueprint a skilled craftsman can make the item it describes, given the r
   </help>
   <id>24</id>
   <nameRus>чертеж</nameRus>
+  <nameUa>креслення</nameUa>
   <props>{&quot;ingredients&quot;:&quot;&quot;,&quot;name&quot;:&quot;&quot;,&quot;product&quot;:0,&quot;skill&quot;:&quot;&quot;,&quot;tool&quot;:&quot;&quot;}
 </props>
   <target>obj</target>

--- a/behaviors/bottle.xml
+++ b/behaviors/bottle.xml
@@ -34,6 +34,7 @@ In peacetime a bottle tossed on the floor can be spun to play &quot;spin the bot
   </help>
   <id>11</id>
   <nameRus>бутылк|а|и|е|у|ой|е</nameRus>
+  <nameUa>пляшка</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/bouquet.xml
+++ b/behaviors/bouquet.xml
@@ -16,6 +16,7 @@
   </help>
   <id>101</id>
   <nameRus>букет||а|у||ом|е</nameRus>
+  <nameUa>букет</nameUa>
   <props>null</props>
   <target>obj</target>
 </behavior>

--- a/behaviors/caltraps.xml
+++ b/behaviors/caltraps.xml
@@ -31,6 +31,7 @@ A shard or spike underfoot may lodge in the flesh and keep gnawing at it. Tear t
   </help>
   <id>39</id>
   <nameRus>осколки</nameRus>
+  <nameUa>скалки</nameUa>
   <props>{&quot;quality&quot;:50}
 </props>
   <target>obj</target>

--- a/behaviors/captain.xml
+++ b/behaviors/captain.xml
@@ -5,6 +5,7 @@
   <description l="ua">Капітан варти Утіхи: на світанку відмикає двері та ворота міста, на заході замикає.</description>
   <id>93</id>
   <nameRus>капитан</nameRus>
+  <nameUa>капітан</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/cauldron.xml
+++ b/behaviors/cauldron.xml
@@ -28,6 +28,7 @@ Put the required components into the cauldron and use it -- then simply wait.
   </help>
   <id>57</id>
   <nameRus>котел для зельеварения</nameRus>
+  <nameUa>котел для варіння зілля</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/chessboard.xml
+++ b/behaviors/chessboard.xml
@@ -61,6 +61,7 @@ Beating a living opponent earns you 200 experience, but no more than once a day;
   </help>
   <id>76</id>
   <nameRus>шахматная доска</nameRus>
+  <nameUa>шахівниця</nameUa>
   <props>null</props>
   <target>obj</target>
 </behavior>

--- a/behaviors/cityguard.xml
+++ b/behaviors/cityguard.xml
@@ -16,6 +16,7 @@
   </help>
   <id>75</id>
   <nameRus>стражник</nameRus>
+  <nameUa>вартовий</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/clan guard.xml
+++ b/behaviors/clan guard.xml
@@ -12,6 +12,7 @@
   </help>
   <id>32</id>
   <nameRus>клановый охранник</nameRus>
+  <nameUa>клановий охоронець</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/coin.xml
+++ b/behaviors/coin.xml
@@ -28,6 +28,7 @@ Suitable coins can be {hh1024flipped{x on the floor to play heads-or-tails with 
   </help>
   <id>15</id>
   <nameRus>монет|а|ы|е|у|ой|е</nameRus>
+  <nameUa>монета</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/component.xml
+++ b/behaviors/component.xml
@@ -13,6 +13,7 @@
   </help>
   <id>59</id>
   <nameRus>крафтовый компонент</nameRus>
+  <nameUa>крафтовий компонент</nameUa>
   <props>{&quot;breaks_into&quot;:&quot;&quot;,&quot;combines_into&quot;:&quot;&quot;,&quot;main&quot;:&quot;&quot;,&quot;type&quot;:&quot;chunk&quot;}
 </props>
   <target>obj</target>

--- a/behaviors/conflagration.xml
+++ b/behaviors/conflagration.xml
@@ -37,6 +37,7 @@ Some areas in the world burn permanently.
   </help>
   <id>47</id>
   <nameRus>пожарище</nameRus>
+  <nameUa>згарище</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/cuisinart.xml
+++ b/behaviors/cuisinart.xml
@@ -20,6 +20,7 @@ Put the items you want to scrap inside the cuisinart, close its lid, and use it.
   </help>
   <id>58</id>
   <nameRus>кузинатра</nameRus>
+  <nameUa>кузінатра</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/cult adept.xml
+++ b/behaviors/cult adept.xml
@@ -12,6 +12,7 @@
   </help>
   <id>34</id>
   <nameRus>адепт культа</nameRus>
+  <nameUa>адепт культу</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/cutthroat.xml
+++ b/behaviors/cutthroat.xml
@@ -5,6 +5,7 @@
   <description l="ua">Головоріз: бʼє зі спини трохи сильнішу жертву, грабує в бою і тікає.</description>
   <id>85</id>
   <nameRus>головорез</nameRus>
+  <nameUa>головоріз</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/deathtrap.xml
+++ b/behaviors/deathtrap.xml
@@ -13,6 +13,7 @@
   </help>
   <id>81</id>
   <nameRus>смертельная ловушка</nameRus>
+  <nameUa>смертельна пастка</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/dice.xml
+++ b/behaviors/dice.xml
@@ -34,6 +34,7 @@ Incidentally, this is exactly how {hh122weapon{x damage is determined. For examp
   </help>
   <id>16</id>
   <nameRus>игральны|е|х|м|е|ми|х кост|и|ей|ям|и|ями|ях</nameRus>
+  <nameUa>гральні кістки</nameUa>
   <props>{&quot;dice&quot;:1,&quot;sides&quot;:6}
 </props>
   <target>obj</target>

--- a/behaviors/enchanter.xml
+++ b/behaviors/enchanter.xml
@@ -46,6 +46,7 @@ Enchanters who also offer smithing services can repair any items, not just armor
   </help>
   <id>43</id>
   <nameRus>чародей</nameRus>
+  <nameUa>чародій</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/executioner.xml
+++ b/behaviors/executioner.xml
@@ -5,6 +5,7 @@
   <description l="ua">Кат: переслідує оголошених у розшук злочинців і страчує їх.</description>
   <id>88</id>
   <nameRus>палач</nameRus>
+  <nameUa>кат</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/feather.xml
+++ b/behaviors/feather.xml
@@ -25,6 +25,7 @@ You can tickle someone with the feather. Hee-hee!
   </help>
   <id>21</id>
   <nameRus>перышк|о|а|у|о|ом|е</nameRus>
+  <nameUa>пірʼїнка</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/fido.xml
+++ b/behaviors/fido.xml
@@ -5,6 +5,7 @@
   <description l="ua">Падальник: пожирає трупи істот, що лежать на землі.</description>
   <id>82</id>
   <nameRus>падальщик</nameRus>
+  <nameUa>падальник</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/fire.xml
+++ b/behaviors/fire.xml
@@ -37,6 +37,7 @@ A fire can be put out by {hh177flooding{x, heavy {hh1028rain{x, certain ice spel
   </help>
   <id>22</id>
   <nameRus>пламя</nameRus>
+  <nameUa>полумʼя</nameUa>
   <props>{&quot;default_fire_time&quot;:2,&quot;fire_power&quot;:4,&quot;forge_quality&quot;:50}
 </props>
   <target>obj</target>

--- a/behaviors/fishka.xml
+++ b/behaviors/fishka.xml
@@ -13,6 +13,7 @@
   </help>
   <id>61</id>
   <nameRus>фишка</nameRus>
+  <nameUa>фішка</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/fountain.xml
+++ b/behaviors/fountain.xml
@@ -19,6 +19,7 @@ From a fountain you can drink whatever fills it -- water, wine, or something wor
   </help>
   <id>36</id>
   <nameRus>фонтан</nameRus>
+  <nameUa>фонтан</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/golem.xml
+++ b/behaviors/golem.xml
@@ -12,6 +12,7 @@
   </help>
   <id>27</id>
   <nameRus>голем</nameRus>
+  <nameUa>голем</nameUa>
   <props>{&quot;source_item&quot;:0}
 </props>
   <target>mob</target>

--- a/behaviors/hammer.xml
+++ b/behaviors/hammer.xml
@@ -19,6 +19,7 @@ The simplest hammer can be found at a merchant in the {hh2060Dwarf Kingdom{x. Hi
   </help>
   <id>18</id>
   <nameRus>кузнечн|ый|ого|ому|ый|ым|ом молот||а|у||ом|е</nameRus>
+  <nameUa>ковальський молот</nameUa>
   <props>{"quality":50}
 </props>
   <target>obj</target>

--- a/behaviors/healer.xml
+++ b/behaviors/healer.xml
@@ -12,6 +12,7 @@
   </help>
   <id>28</id>
   <nameRus>лекарь</nameRus>
+  <nameUa>лікар</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/jailer.xml
+++ b/behaviors/jailer.xml
@@ -12,6 +12,7 @@
   </help>
   <id>31</id>
   <nameRus>тюремщик</nameRus>
+  <nameUa>тюремник</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/janitor.xml
+++ b/behaviors/janitor.xml
@@ -5,6 +5,7 @@
   <description l="ua">Прибиральник: підбирає з підлоги сміття та порожні пляшки.</description>
   <id>83</id>
   <nameRus>уборщик</nameRus>
+  <nameUa>прибиральник</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/judge.xml
+++ b/behaviors/judge.xml
@@ -5,6 +5,7 @@
   <description l="ua">Суддя: у бою жбурляє фугасний заряд у того, хто на нього нападає.</description>
   <id>87</id>
   <nameRus>судья</nameRus>
+  <nameUa>суддя</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/katana.xml
+++ b/behaviors/katana.xml
@@ -13,6 +13,7 @@
   </help>
   <id>74</id>
   <nameRus>катана самурая</nameRus>
+  <nameUa>катана самурая</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/koschei.xml
+++ b/behaviors/koschei.xml
@@ -13,6 +13,7 @@
   </help>
   <id>79</id>
   <nameRus>Кощей</nameRus>
+  <nameUa>Кощій</nameUa>
   <props>null</props>
   <target>mob</target>
 </behavior>

--- a/behaviors/lust room.xml
+++ b/behaviors/lust room.xml
@@ -13,6 +13,7 @@
   </help>
   <id>49</id>
   <nameRus>ароматы весны</nameRus>
+  <nameUa>аромати весни</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/master samurai.xml
+++ b/behaviors/master samurai.xml
@@ -13,6 +13,7 @@
   </help>
   <id>72</id>
   <nameRus>мастер самурай</nameRus>
+  <nameUa>майстер самурай</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/master vampire.xml
+++ b/behaviors/master vampire.xml
@@ -13,6 +13,7 @@
   </help>
   <id>73</id>
   <nameRus>мастер вампир</nameRus>
+  <nameUa>майстер вампір</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/matches.xml
+++ b/behaviors/matches.xml
@@ -58,6 +58,7 @@ You can enter your captured "pet" in the races by using the box with the insect 
   </help>
   <id>20</id>
   <nameRus>спич|ки|ек|кам|ки|ками|ках</nameRus>
+  <nameUa>сірники</nameUa>
   <props>{&quot;fire_power&quot;:1,&quot;match_count&quot;:10}
 </props>
   <target>obj</target>

--- a/behaviors/mayor.xml
+++ b/behaviors/mayor.xml
@@ -5,6 +5,7 @@
   <description l="ua">Мер Мідгаарда: на світанку обходить місто до воріт і оголошує їх відчиненими, на заході сонця -- зачиненими.</description>
   <id>92</id>
   <nameRus>мэр</nameRus>
+  <nameUa>мер</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/mirror.xml
+++ b/behaviors/mirror.xml
@@ -28,6 +28,7 @@ Look into a mirror -- or use it -- to admire your otherworldly beauty, if you ar
   </help>
   <id>50</id>
   <nameRus>зеркало</nameRus>
+  <nameUa>дзеркало</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/money changer.xml
+++ b/behaviors/money changer.xml
@@ -12,6 +12,7 @@
   </help>
   <id>33</id>
   <nameRus>валютчик</nameRus>
+  <nameUa>міняйло</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/money.xml
+++ b/behaviors/money.xml
@@ -13,6 +13,7 @@
   </help>
   <id>37</id>
   <nameRus>деньги</nameRus>
+  <nameUa>гроші</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/municipality.xml
+++ b/behaviors/municipality.xml
@@ -34,6 +34,7 @@ Without a valid license your crafting will simply not work.
   </help>
   <id>98</id>
   <nameRus>ратуша</nameRus>
+  <nameUa>ратуша</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/needle.xml
+++ b/behaviors/needle.xml
@@ -25,6 +25,7 @@ Items made of {hh201cloth or leather{x (such as {hh65clothing{x) sometimes canno
   </help>
   <id>19</id>
   <nameRus>швейн|ая|ой|ой|ую|ой|ой игл|а|ы|е|у|ой|е</nameRus>
+  <nameUa>швейна голка</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/newbie weapon.xml
+++ b/behaviors/newbie weapon.xml
@@ -16,6 +16,7 @@
   </help>
   <id>23</id>
   <nameRus>оружие новичков</nameRus>
+  <nameUa>зброя новачків</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/ogre member.xml
+++ b/behaviors/ogre member.xml
@@ -5,6 +5,7 @@
   <description l="ua">Боєць клану огрів: задирається до тролів-суперників, якщо поруч немає патруля.</description>
   <id>91</id>
   <nameRus>боец огров</nameRus>
+  <nameUa>боєць огрів</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/perfume.xml
+++ b/behaviors/perfume.xml
@@ -25,6 +25,7 @@ Perfumery or cologne is used to give yourself or someone else you apply the bott
   </help>
   <id>12</id>
   <nameRus>парфюмери|я|и|и|ю|ей|и</nameRus>
+  <nameUa>парфумерія</nameUa>
   <props>{&quot;perfumeSmell&quot;:&quot;Прекрасный аромат, который, впрочем, сложно идентифицировать.&quot;}
 </props>
   <target>obj</target>

--- a/behaviors/poison.xml
+++ b/behaviors/poison.xml
@@ -5,6 +5,7 @@
   <description l="ua">Отруйний: у бою кусає/жалить жертву і насилає отруту (за формою тіла).</description>
   <id>86</id>
   <nameRus>ядовитый</nameRus>
+  <nameUa>отруйний</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/questreward.xml
+++ b/behaviors/questreward.xml
@@ -13,6 +13,7 @@
   </help>
   <id>56</id>
   <nameRus>квестовая награда героя</nameRus>
+  <nameUa>квестова нагорода героя</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/random weapon.xml
+++ b/behaviors/random weapon.xml
@@ -40,6 +40,7 @@ Good random weapons can be found in chests from {hh127the quest to help robbery 
   </help>
   <id>25</id>
   <nameRus>случайное оружие</nameRus>
+  <nameUa>випадкова зброя</nameUa>
   <props>{&quot;bestTier&quot;:3,&quot;random&quot;:true}
 </props>
   <target>obj</target>

--- a/behaviors/roulette croupier.xml
+++ b/behaviors/roulette croupier.xml
@@ -13,6 +13,7 @@
   </help>
   <id>77</id>
   <nameRus>крупье</nameRus>
+  <nameUa>крупʼє</nameUa>
   <props>null</props>
   <target>mob</target>
 </behavior>

--- a/behaviors/roulette table.xml
+++ b/behaviors/roulette table.xml
@@ -19,6 +19,7 @@ Use a roulette table to place a bet and spin the wheel. The {hh356croupier{x ann
   </help>
   <id>78</id>
   <nameRus>стол рулетки</nameRus>
+  <nameUa>стіл рулетки</nameUa>
   <props>null</props>
   <target>obj</target>
 </behavior>

--- a/behaviors/sage.xml
+++ b/behaviors/sage.xml
@@ -40,6 +40,7 @@ Same as the {hh707locator{x spell, shows the locations of all items that have th
   </help>
   <id>44</id>
   <nameRus>мудрец</nameRus>
+  <nameUa>мудрець</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/scales.xml
+++ b/behaviors/scales.xml
@@ -16,6 +16,7 @@
   </help>
   <id>99</id>
   <nameRus>вес|ы|ов|ам|ы|ами|ах</nameRus>
+  <nameUa>терези</nameUa>
   <props>null</props>
   <target>obj</target>
 </behavior>

--- a/behaviors/set amazon.xml
+++ b/behaviors/set amazon.xml
@@ -13,6 +13,7 @@
   </help>
   <id>70</id>
   <nameRus>набор амазонки</nameRus>
+  <nameUa>набір амазонки</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set ashigaru.xml
+++ b/behaviors/set ashigaru.xml
@@ -13,6 +13,7 @@
   </help>
   <id>62</id>
   <nameRus>набор асигару</nameRus>
+  <nameUa>набір асигару</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:80,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set berserker.xml
+++ b/behaviors/set berserker.xml
@@ -13,6 +13,7 @@
   </help>
   <id>69</id>
   <nameRus>набор берсерка</nameRus>
+  <nameUa>набір берсерка</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set davy jones.xml
+++ b/behaviors/set davy jones.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x нагороди Дейві Джонса.</description>
   <id>14</id>
   <nameRus>наград|а|ы|е|у|ой|е Дэви Джонса</nameRus>
+  <nameUa>нагорода Дейві Джонса</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:80,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set defender.xml
+++ b/behaviors/set defender.xml
@@ -13,6 +13,7 @@
   </help>
   <id>68</id>
   <nameRus>набор защитника</nameRus>
+  <nameUa>набір захисника</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set fathers.xml
+++ b/behaviors/set fathers.xml
@@ -13,6 +13,7 @@
   </help>
   <id>66</id>
   <nameRus>отцовское наследство</nameRus>
+  <nameUa>батьківська спадщина</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:true,&quot;max_level&quot;:35,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set gloomstalker.xml
+++ b/behaviors/set gloomstalker.xml
@@ -13,6 +13,7 @@
   </help>
   <id>71</id>
   <nameRus>набор охотника тьмы</nameRus>
+  <nameUa>набір мисливця тьми</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:4}
 </props>
   <target>obj</target>

--- a/behaviors/set hoplite.xml
+++ b/behaviors/set hoplite.xml
@@ -13,6 +13,7 @@
   </help>
   <id>63</id>
   <nameRus>набор гоплита</nameRus>
+  <nameUa>набір гопліта</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:110,&quot;total_count&quot;:2}
 </props>
   <target>obj</target>

--- a/behaviors/set master scout.xml
+++ b/behaviors/set master scout.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x майстра камуфляжу.</description>
   <id>17</id>
   <nameRus>мастер||а|у|а|ом|е камуфляжа</nameRus>
+  <nameUa>майстер камуфляжу</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:70,&quot;total_count&quot;:5}
 </props>
   <target>obj</target>

--- a/behaviors/set master thief.xml
+++ b/behaviors/set master thief.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x майстра крадійства.</description>
   <id>10</id>
   <nameRus>мастер||а|у|а|ом|е воровства</nameRus>
+  <nameUa>майстер крадійства</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:60,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set morris dancer.xml
+++ b/behaviors/set morris dancer.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x танцівника морріса.</description>
   <id>8</id>
   <nameRus>танцор||а|у|а|ом|е морриса</nameRus>
+  <nameUa>танцівник морріса</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;total_count&quot;:4}
 </props>
   <target>obj</target>

--- a/behaviors/set myrmidon.xml
+++ b/behaviors/set myrmidon.xml
@@ -13,6 +13,7 @@
   </help>
   <id>67</id>
   <nameRus>набор мирмидонянина</nameRus>
+  <nameUa>набір мірмідонянина</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:60,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/set myrvale noriva.xml
+++ b/behaviors/set myrvale noriva.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x мірвейл Норіва.</description>
   <id>1</id>
   <nameRus>мирвейл Норива</nameRus>
+  <nameUa>мірвейл Норива</nameUa>
   <props>{&quot;double_neck&quot;:true,&quot;double_wrist&quot;:true,&quot;total_count&quot;:12}
 </props>
   <target>obj</target>

--- a/behaviors/set pixie.xml
+++ b/behaviors/set pixie.xml
@@ -13,6 +13,7 @@
   </help>
   <id>55</id>
   <nameRus>доспехи пикси</nameRus>
+  <nameUa>обладунки піксі</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;max_level&quot;:65,&quot;total_count&quot;:5}
 </props>
   <target>obj</target>

--- a/behaviors/set secret of sidhe.xml
+++ b/behaviors/set secret of sidhe.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x секрет Сідхів.</description>
   <id>6</id>
   <nameRus>секрет||а|у||ом|е Сидхов</nameRus>
+  <nameUa>секрет Сідхів</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;total_count&quot;:5}
 </props>
   <target>obj</target>

--- a/behaviors/set shevale reykaris.xml
+++ b/behaviors/set shevale reykaris.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x шивейл Рейкарис.</description>
   <id>5</id>
   <nameRus>шивейл Рейкарис</nameRus>
+  <nameUa>шивейл Рейкарис</nameUa>
   <props>{&quot;double_neck&quot;:true,&quot;double_wrist&quot;:true,&quot;total_count&quot;:9}
 </props>
   <target>obj</target>

--- a/behaviors/set travellers joy.xml
+++ b/behaviors/set travellers joy.xml
@@ -5,6 +5,7 @@
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x розраду мандрівника.</description>
   <id>7</id>
   <nameRus>отрад|а|ы|е|у|ой|е путешественника</nameRus>
+  <nameUa>розрада мандрівника</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:false,&quot;total_count&quot;:4}
 </props>
   <target>obj</target>

--- a/behaviors/set wood nymph.xml
+++ b/behaviors/set wood nymph.xml
@@ -13,6 +13,7 @@
   </help>
   <id>65</id>
   <nameRus>оберег древесных нимф</nameRus>
+  <nameUa>оберіг деревних німф</nameUa>
   <props>{&quot;double_neck&quot;:false,&quot;double_wrist&quot;:true,&quot;max_level&quot;:110,&quot;total_count&quot;:3}
 </props>
   <target>obj</target>

--- a/behaviors/shovel.xml
+++ b/behaviors/shovel.xml
@@ -40,6 +40,7 @@ Rumour has it that {hh92Immortals{x have their own secret way of using shovels..
   </help>
   <id>2</id>
   <nameRus>лопат|а|ы|е|у|ой|е</nameRus>
+  <nameUa>лопата</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/snare.xml
+++ b/behaviors/snare.xml
@@ -37,6 +37,7 @@ You can release the prisoner -- simply by taking the poor thing out of the cage-
   </help>
   <id>4</id>
   <nameRus>капкан||а|у||ом|е</nameRus>
+  <nameUa>капкан</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/soap.xml
+++ b/behaviors/soap.xml
@@ -25,6 +25,7 @@ Soap lathers away unwanted scents -- a spilled liquid or a dab of perfume -- so 
   </help>
   <id>100</id>
   <nameRus>мыло</nameRus>
+  <nameUa>мило</nameUa>
   <props>null</props>
   <target>obj</target>
 </behavior>

--- a/behaviors/spyglass.xml
+++ b/behaviors/spyglass.xml
@@ -25,6 +25,7 @@ With a spyglass you peer in a chosen direction and make out the terrain a few ro
   </help>
   <id>51</id>
   <nameRus>подзорная труба</nameRus>
+  <nameUa>підзорна труба</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/suave moose.xml
+++ b/behaviors/suave moose.xml
@@ -12,6 +12,7 @@
   </help>
   <id>29</id>
   <nameRus>ввічливий лось</nameRus>
+  <nameUa>ввічливий лось</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/suicideroom.xml
+++ b/behaviors/suicideroom.xml
@@ -13,6 +13,7 @@
   </help>
   <id>52</id>
   <nameRus>суицидная</nameRus>
+  <nameUa>суїцидна</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/synesthesia.xml
+++ b/behaviors/synesthesia.xml
@@ -13,6 +13,7 @@
   </help>
   <id>54</id>
   <nameRus>синестезия</nameRus>
+  <nameUa>синестезія</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/tattoo picture.xml
+++ b/behaviors/tattoo picture.xml
@@ -19,6 +19,7 @@ Use a tattoo picture on a body part to apply a {hh242tattoo{x there. Different p
   </help>
   <id>26</id>
   <nameRus>рисунок татуировки</nameRus>
+  <nameUa>малюнок татуювання</nameUa>
   <props>{&quot;description&quot;:&quot;&quot;,&quot;div&quot;:1,&quot;levelAdaptive&quot;:false,&quot;long&quot;:&quot;&quot;,&quot;mult&quot;:1,&quot;name&quot;:&quot;&quot;,&quot;short&quot;:&quot;&quot;}
 </props>
   <target>obj</target>

--- a/behaviors/teacher.xml
+++ b/behaviors/teacher.xml
@@ -13,6 +13,7 @@
   </help>
   <id>45</id>
   <nameRus>учитель</nameRus>
+  <nameUa>вчитель</nameUa>
   <props>{&quot;groups&quot;:&quot;fightmaster illusion defensive transportation enhancement enchantment maladictions vampiric suddendeath detection nature necromancy combat weaponsmaster arcane adventure benedictions protective healing&quot;,&quot;max_level&quot;:&quot;101&quot;}
 </props>
   <target>mob</target>

--- a/behaviors/telescope.xml
+++ b/behaviors/telescope.xml
@@ -25,6 +25,7 @@ A telescope brings the far corners of the world to your eye. Put it to use and i
   </help>
   <id>103</id>
   <nameRus>телескоп</nameRus>
+  <nameUa>телескоп</nameUa>
   <props>null
 </props>
   <target>obj</target>

--- a/behaviors/templeperson.xml
+++ b/behaviors/templeperson.xml
@@ -12,6 +12,7 @@
   </help>
   <id>35</id>
   <nameRus>храмовник</nameRus>
+  <nameUa>храмовник</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/thief.xml
+++ b/behaviors/thief.xml
@@ -5,6 +5,7 @@
   <description l="ua">Кишеньковий злодій: непомітно краде монети у гравців, що стоять поруч.</description>
   <id>84</id>
   <nameRus>карманник</nameRus>
+  <nameUa>кишеньковий злодій</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/torch.xml
+++ b/behaviors/torch.xml
@@ -22,6 +22,7 @@ You can use a torch to set something flammable alight and start a {hh249campfire
   </help>
   <id>3</id>
   <nameRus>факел||а|у||ом|е</nameRus>
+  <nameUa>смолоскип</nameUa>
   <props>{&quot;fire_power&quot;:2}
 </props>
   <target>obj</target>

--- a/behaviors/trap.xml
+++ b/behaviors/trap.xml
@@ -13,6 +13,7 @@
   </help>
   <id>9</id>
   <nameRus>опасн|ая|ой|ой|ую|ой|ой местност|ь|и|и|ь|ью|и</nameRus>
+  <nameUa>небезпечна місцевість</nameUa>
   <props>{&quot;divingSpeed&quot;:2,&quot;flags&quot;:&quot;&quot;,&quot;flyingSafe&quot;:true,&quot;msgDiveOther&quot;:&quot;&quot;,&quot;msgDiveSelf&quot;:&quot;&quot;,&quot;msgMoveOther&quot;:&quot;&quot;,&quot;msgMoveSelf&quot;:&quot;&quot;,&quot;msgTargetOther&quot;:&quot;Внезапно появляется %C1.&quot;,&quot;msgTargetSelf&quot;:&quot;&quot;,&quot;msgTrapOther&quot;:&quot;&quot;,&quot;msgTrapSelf&quot;:&quot;&quot;,&quot;shortDescr&quot;:&quot;падает вниз&quot;,&quot;surfaceQuality&quot;:50,&quot;target&quot;:0}
 </props>
   <target>room</target>

--- a/behaviors/troll member.xml
+++ b/behaviors/troll member.xml
@@ -5,6 +5,7 @@
   <description l="ua">Боєць клану тролів: задирає огрів-суперників, якщо поруч немає патруля.</description>
   <id>90</id>
   <nameRus>боец троллей</nameRus>
+  <nameUa>боєць тролів</nameUa>
   <props>null
 </props>
   <target>mob</target>

--- a/behaviors/underwater.xml
+++ b/behaviors/underwater.xml
@@ -12,6 +12,7 @@
   </help>
   <id>38</id>
   <nameRus>под водой</nameRus>
+  <nameUa>під водою</nameUa>
   <props>null
 </props>
   <target>room</target>

--- a/behaviors/vagabond.xml
+++ b/behaviors/vagabond.xml
@@ -5,6 +5,7 @@
   <description l="ua">Бродяга-пʼяниця: пʼє, співає, жебракує і задирає перехожих.</description>
   <id>96</id>
   <nameRus>бродяга</nameRus>
+  <nameUa>волоцюга</nameUa>
   <props>null
 </props>
   <target>mob</target>


### PR DESCRIPTION
Adds a parallel `<nameUa>` (nominative) to every behavior with a `nameRus`, so the behavior help header shows the name in Ukrainian for UA viewers. Real UA nouns + transliterated lore proper nouns. Consumed by `getUkrainianName()`/`BehaviorHelp::getTitle` (dreamland_code #810) — deploy same reboot (new boot-loaded field; old binary ignores it).