### PR TITLE
l10n: catalog en/ua for clan shrine-lost infonet broadcast

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -1094,6 +1094,10 @@
    "en": "{WThe %w clan has lost its shrine.{x",
    "ua": "{W%w втратив свою святиню.{x"
   },
+  "{CЕхидный голос из $o2: {WКлан %w утратил свою святыню.{x": {
+   "en": "{CA sardonic voice from $o2: {WThe %w clan has lost its shrine.{x",
+   "ua": "{CЄхидний голос із $o2: {W%w втратив свою святиню.{x"
+  },
   "Ты видишь, как медленно появляется $o1.": {
    "en": "You see $o1 slowly appear.",
    "ua": "Ти бачиш, як повільно з'являється $o1."


### PR DESCRIPTION
clanobjects.cpp:193's per-viewer `infonet(_())` shrine-loss broadcast lacked en/ua for its full key, so EN/UA clan members saw Russian. Added, matching the cataloged bare variant. Catalog-only (C++ already live) → activates on next reload/reboot. Found by `lint-catalog-coverage.py` (#399).

🤖 Generated with [Claude Code](https://claude.com/claude-code)