### PR TITLE
l10n: catalog en/ua for kidnapquest NPC timer dialogue

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -14430,6 +14430,14 @@
   }
  },
  "plug-ins/quest/kidnapquest/scenario_bidon.cpp": {
+  "$c1 говорит тебе '{GИ учти, что через {Y%1$d{G минут%1$Iу|ы| мое терпение лопнет!{x'": {
+   "en": "$c1 tells you '{GAnd mind you, in {Y%1$d{G minute%1$I|s|s my patience runs out!{x'",
+   "ua": "$c1 говорить тобі '{GІ затям: за {Y%1$d{G хвилин%1$Iу|и| мій терпець урветься!{x'"
+  },
+  "$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, что если ты не приведешь ее ко мне через {Y%1$d{G минут%1$Iу|ы|, с ней случится что-то непоправимое.{x'": {
+   "en": "$c1 tells you '{GHurry! A mother's heart tells me that if you don't bring her to me within {Y%1$d{G minute%1$I|s|s, something irreparable will happen to her.{x'",
+   "ua": "$c1 говорить тобі '{GПоспішай! Материнське серце підказує мені, що коли ти не приведеш її до мене за {Y%1$d{G хвилин%1$Iу|и|, з нею станеться щось непоправне.{x'"
+  },
   "$c1 безо всякого интереса смотрит на $o4.": {
    "en": "$c1 looks at $o4 with no interest whatsoever.",
    "ua": "$c1 без жодного інтересу дивиться на $o4."
@@ -14572,6 +14580,14 @@
   }
  },
  "plug-ins/quest/kidnapquest/scenario_cyclop.cpp": {
+  "$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%1$d{G минут%1$Iу|ы| он мне уже не понадобится.{x": {
+   "en": "$c1 tells you '{GAnd be quick! I feel that in {Y%1$d{G minute%1$I|s|s I won't need him anymore.{x",
+   "ua": "$c1 говорить тобі '{GІ поспішай! Відчуваю, що за {Y%1$d{G хвилин%1$Iу|и| він мені вже не знадобиться.{x"
+  },
+  "$c1 говорит тебе '{GПоспеши! Через {Y%1$d{G минут%1$Iу|ы| он должен быть здесь!{x": {
+   "en": "$c1 tells you '{GHurry! In {Y%1$d{G minute%1$I|s|s he must be here!{x",
+   "ua": "$c1 говорить тобі '{GПоспішай! За {Y%1$d{G хвилин%1$Iу|и| він має бути тут!{x"
+  },
   "$c1 вручает $C3 $o4.": {
    "en": "$c1 hands $o4 to $C3.",
    "ua": "$c1 вручає $C3 $o4."
@@ -14786,6 +14802,10 @@
   }
  },
  "plug-ins/quest/kidnapquest/scenario_dragon.cpp": {
+  "$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%1$d{G минут%1$Iа|ы|, чтобы вернуть его в целости и сохранности.{x'": {
+   "en": "$c1 tells you '{GHurry! You'll have only {Y%1$d{G minute%1$I|s|s to bring him back safe and sound.{x'",
+   "ua": "$c1 говорить тобі '{GПоспішай! У тебе буде лише {Y%1$d{G хвилин%1$Iа|и|, щоб повернути його цілим і неушкодженим.{x'"
+  },
   "$c1 вручает $C3 $o4.": {
    "en": "$c1 hands $o4 to $C3.",
    "ua": "$c1 вручає $C3 $o4."
@@ -14932,6 +14952,10 @@
   }
  },
  "plug-ins/quest/kidnapquest/scenario_urchin.cpp": {
+  "$c1 говорит тебе '{GМатеринское сердце подсказывает мне, что, если ты не приведешь его ко мне через {Y%1$d{G минут%1$Iу|ы|, с ним случится что-то непоправимое.{x'": {
+   "en": "$c1 tells you '{GA mother's heart tells me that if you don't bring him to me within {Y%1$d{G minute%1$I|s|s, something irreparable will happen to him.{x'",
+   "ua": "$c1 говорить тобі '{GМатеринське серце підказує мені, що коли ти не приведеш його до мене за {Y%1$d{G хвилин%1$Iу|и|, з ним станеться щось непоправне.{x'"
+  },
   "$c1 вручает $C3 $o4.": {
    "en": "$c1 hands $o4 to $C3.",
    "ua": "$c1 вручає $C3 $o4."
@@ -15078,6 +15102,14 @@
   }
  },
  "plug-ins/quest/kidnapquest/scenario_urka.cpp": {
+  "$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%1$d{G минут%1$Iа|ы|, пока идут приготовления к казни. Приведи его сюда.{x'": {
+   "en": "$c1 tells you '{GBy my reckoning you have {Y%1$d{G minute%1$I|s|s while the execution is prepared. Bring him here.{x'",
+   "ua": "$c1 говорить тобі '{GЗа моїми підрахунками в тебе є {Y%1$d{G хвилин%1$Iа|и|, поки тривають приготування до страти. Приведи його сюди.{x'"
+  },
+  "$c1 говорит тебе '{GУ тебя есть примерно {W%1$d{G минут%1$Iа|ы|, пока идут приготовления к казни. Приведи его ко мне.{x'": {
+   "en": "$c1 tells you '{GYou have roughly {W%1$d{G minute%1$I|s|s while the execution is prepared. Bring him to me.{x'",
+   "ua": "$c1 говорить тобі '{GУ тебе є приблизно {W%1$d{G хвилин%1$Iа|и|, поки тривають приготування до страти. Приведи його до мене.{x'"
+  },
   "$C1 внимательно смотрит на $c4.": {
    "en": "$C1 looks closely at $c4.",
    "ua": "$C1 уважно дивиться на $c4."


### PR DESCRIPTION
Companion to dreamland_code #816. 8 en/ua entries for the kidnap-scenario timer-warning lines, keyed to the `fmt(hero)` numbered `%1$I` form. 0 HARD lint, placeholder-index parity, RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)