### PR TITLE
l10n: number intro race-name codes (crash-fix match) + Archant->Arhant

### DIFF
--- a/config/translations/areas2.json
+++ b/config/translations/areas2.json
@@ -1690,9 +1690,9 @@
             "en": "{cWhere am I?.. What's happening to me?..{x",
             "ua": "{cДе я?.. Що зі мною?..{x"
         },
-        "Ах да, ты смутно припоминаешь, что каким-то образом оказал%Gся|ся|ась в теле %N2!": {
-            "en": "Ah right, you dimly recall that somehow you ended up in the body of %N2!",
-            "ua": "Ах так, ти невиразно пригадуєш, що якимось чином опини%Gвся|вся|лася в тілі %N2!"
+        "Ах да, ты смутно припоминаешь, что каким-то образом оказал%1$Gся|ся|ась в теле %2$N2!": {
+            "en": "Ah right, you dimly recall that somehow you ended up in the body of %2$N2!",
+            "ua": "Ах так, ти невиразно пригадуєш, що якимось чином опини%1$Gвся|вся|лася в тілі %2$N2!"
         },
         "Вот это номер!": {
             "en": "Now that's something!",

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -3381,11 +3381,11 @@
    "ua": "Твого персонажа можуть видалити лише Боги."
   },
   "{1{C%1$^C1 идет по пути Арханта и совершает суицид, навсегда покидая этот мир.": {
-   "en": "{1{C%1$^C1 walks the path of the Archant and commits suicide, leaving this world forever.",
+   "en": "{1{C%1$^C1 walks the path of the Arhant and commits suicide, leaving this world forever.",
    "ua": "{1{C%1$^C1 йде шляхом Арханта і кінчає життя самогубством, назавжди покидаючи цей світ."
   },
   "{CТихий голос из $o2: {1{C%1$^C1 идет по пути Арханта и совершает суицид, навсегда покидая этот мир.": {
-   "en": "{CA quiet voice from $o2: {1{C%1$^C1 walks the path of the Archant and commits suicide, leaving this world forever.",
+   "en": "{CA quiet voice from $o2: {1{C%1$^C1 walks the path of the Arhant and commits suicide, leaving this world forever.",
    "ua": "{CТихий голос з $o2: {1{C%1$^C1 йде шляхом Арханта і кінчає життя самогубством, назавжди покидаючи цей світ."
   },
   "{RВНИМАНИЕ: {WЭТО НЕОБРАТИМОЕ ДЕЙСТВИЕ, ТВОЙ ПЕРСОНАЖ БУДЕТ УДАЛЕН НАСОВСЕМ!{x": {


### PR DESCRIPTION
**areas2.json**: intro 'body of %N2' key/en/ua → numbered `%1$G`/`%2$N2` so the `_()` lookup matches the dreamland_fenia crash fix #338. **plug-ins.json**: archont-suicide EN 'the Archant' → 'the Arhant' (×2), per Kit. RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)