### PR TITLE
Drop RU-only %P1 from bash-door EN/UA (last 2 HARD lint)

### DIFF
--- a/config/translations/skillcommand.json
+++ b/config/translations/skillcommand.json
@@ -53,8 +53,8 @@
    "ua": "Знесилившись, %1$C1 пада%1$nє|ють навзнак!"
   },
   "%1$^C1 упа%1$Gло|л|ла|ли, %1$P1 не мо%1$nжет|гут ходить и выполнять некоторые команды.": {
-   "en": "%1$^C1 has fallen down; %1$P1 cannot walk or perform certain commands.",
-   "ua": "%1$^C1 впа%1$Gло|в|ла|ли, %1$P1 не мо%1$nже|жуть ходити й виконувати деякі команди."
+   "en": "%1$^C1 has fallen down and cannot walk or perform certain commands.",
+   "ua": "%1$^C1 впа%1$Gло|в|ла|ли і не мо%1$nже|жуть ходити й виконувати деякі команди."
   },
   "Напиши {y{hcприказать %1$N1 встать{x, если хочешь продолжить выбивать %3N4.": {
    "en": "Type {y{hcorder %1$N1 to stand{x if you want to keep bashing %3N4.",


### PR DESCRIPTION
The bash-door knock-down line rendered a Russian pronoun to EN/UA viewers via %1$P1. Rephrased to drop it; RU byte-identical. Catalog now 0 HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)