### PR TITLE
catalog: gquest player command + progress + scenario flavor EN/UA (Trello 2594)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -9887,12 +9887,40 @@
   "Используй 'гквест безопыта да' или 'гквест безопыта нет'.": {
    "en": "Use 'gquest noexp yes' or 'gquest noexp no'.",
    "ua": "Використовуй 'гквест безопыта да' або 'гквест безопыта нет'."
+  },
+  "{yКвест {Y\"%1$s\"{y (для {Y%2$d-%3$d{y уровней)": {
+   "en": "{yQuest {Y\"%1$s\"{y (for levels {Y%2$d-%3$d{y)",
+   "ua": "{yКвест {Y\"%1$s\"{y (для {Y%2$d-%3$d{y рівнів)"
+  },
+  "{yКвест {Y\"%1$s\"{y (для всех уровней)": {
+   "en": "{yQuest {Y\"%1$s\"{y (for all levels)",
+   "ua": "{yКвест {Y\"%1$s\"{y (для всіх рівнів)"
+  },
+  "Твои победы в глобальных квестах:": {
+   "en": "Your victories in global quests:",
+   "ua": "Твої перемоги у глобальних квестах:"
+  },
+  "    ни одной, увы": {
+   "en": "    none yet, alas",
+   "ua": "    жодної, на жаль"
+  },
+  "Лучшие квестодеятели Мира Грез: ": {
+   "en": "Top questers of the World of Dreams: ",
+   "ua": "Найкращі квестороби Світу Мрій: "
   }
  },
  "plug-ins/gquest/command/gquestnotifyplugin.cpp": {
   "\r\nГлобальные квесты, в которых ты можешь принять участие: ": {
    "en": "\r\nGlobal quests you can take part in: ",
    "ua": "\r\nГлобальні квести, у яких ти можеш взяти участь: "
+  },
+  "         Квест {Y\"%1$s\"{y (для {Y%2$d-%3$d{y уровней)": {
+   "en": "         Quest {Y\"%1$s\"{y (for levels {Y%2$d-%3$d{y)",
+   "ua": "         Квест {Y\"%1$s\"{y (для {Y%2$d-%3$d{y рівнів)"
+  },
+  "         Квест {Y\"%1$s\"{y (для всех уровней)": {
+   "en": "         Quest {Y\"%1$s\"{y (for all levels)",
+   "ua": "         Квест {Y\"%1$s\"{y (для всіх рівнів)"
   }
  },
  "plug-ins/gquest/core/globalquest.cpp": {
@@ -9903,6 +9931,14 @@
   "Ты исчезаешь отсюда.": {
    "en": "You vanish from here.",
    "ua": "Ти зникаєш звідси."
+  },
+  "{Y%1$d{y минут%1$Iа|ы|": {
+   "en": "{Y%1$d{y minute%1$I|s|s",
+   "ua": "{Y%1$d{y хвилин%1$Iа|и|"
+  },
+  "меньше минуты": {
+   "en": "less than a minute",
+   "ua": "менше хвилини"
   }
  },
  "plug-ins/gquest/core/gqobjects.cpp": {
@@ -10033,6 +10069,18 @@
   "$c1 исчезает в клубе дыма.": {
    "en": "$c1 disappears in a puff of smoke.",
    "ua": "$c1 зникає в клубах диму."
+  },
+  "Число убитых тобой преступников: {Y%1$d{y": {
+   "en": "Criminals you have slain: {Y%1$d{y",
+   "ua": "Убито тобою злочинців: {Y%1$d{y"
+  },
+  "До конца охоты остается ": {
+   "en": "The hunt ends in ",
+   "ua": "До кінця полювання лишається "
+  },
+  "Шефа банды убила противоборствующая группировка.": {
+   "en": "The gang boss was killed by a rival faction.",
+   "ua": "Шефа банди вбило вороже угруповання."
   }
  },
  "plug-ins/gquest/invasion/invasion.cpp": {
@@ -10043,6 +10091,30 @@
   "$c1 лопается.": {
    "en": "$c1 bursts.",
    "ua": "$c1 лопається."
+  },
+  "Число уничтоженных тобой безобразий: {Y%1$d{y": {
+   "en": "Monstrosities you have destroyed: {Y%1$d{y",
+   "ua": "Знищено тобою неподобств: {Y%1$d{y"
+  },
+  "До конца охоты остается ": {
+   "en": "The hunt ends in ",
+   "ua": "До кінця полювання лишається "
+  },
+  "Разноцветные мыльные пузыри летят с небес. Не упусти свой шанс повеселиться! \nГероя, веселящегося, лопая пузыри активнее других, ожидает награда!": {
+   "en": "Multicolored soap bubbles drift down from the heavens. Don't miss your chance to have some fun! \nThe hero who pops bubbles more eagerly than the rest will earn a reward!",
+   "ua": "Різнокольорові мильні бульбашки летять з небес. Не проґав свій шанс повеселитися! \nГероя, що веселиться, лопаючи бульбашки завзятіше за інших, чекає нагорода!"
+  },
+  "Сегодня проходит самый интересный матч сезона! Сатиры против гигантов!\nНо гигантам как всегда не удается ничего поделать с ловкостью сатиров.\nИ они пошли ва-банк! Гиганты повыбивали все мячи с поля, куда подальше!\nИ теперь, если их не найдут - матч перенесут на следующий сезон.\nУничтожьте все мячи! Дайте шанс гигантам!": {
+   "en": "The most exciting match of the season is on today! Satyrs against giants!\nBut the giants, as always, can do nothing against the satyrs' agility.\nSo they went all in! The giants have kicked all the balls off the field, far away!\nAnd now, if the balls aren't found, the match will be postponed to next season.\nDestroy all the balls! Give the giants a chance!",
+   "ua": "Сьогодні проходить найцікавіший матч сезону! Сатири проти велетнів!\nАле велетням, як завжди, не вдається нічого вдіяти зі спритністю сатирів.\nІ вони пішли ва-банк! Велетні повибивали всі м'ячі з поля, куди подалі!\nІ тепер, якщо їх не знайдуть - матч перенесуть на наступний сезон.\nЗнищіть усі м'ячі! Дайте шанс велетням!"
+  },
+  "Черный злой колдун, с вершины своей черной башни, насылает на мир леденящие\nветры и ураганы. Все, к чему прикоснется такой ветер, застывает глыбой льда.\nКолдуну нужно дать отпор, иначе со временем все звери и люди превратятся\nв отморозков! Уничтожьте льдины, спасите теплокровных зверюшек.": {
+   "en": "A black evil sorcerer, from the top of his black tower, sends freezing\nwinds and hurricanes upon the world. Everything such a wind touches turns to a block of ice.\nThe sorcerer must be rebuffed, or in time all beasts and people will turn\ninto frostbitten wretches! Destroy the ice floes, save the warm-blooded critters.",
+   "ua": "Чорний злий чаклун, з вершини своєї чорної вежі, насилає на світ крижані\nвітри та урагани. Усе, до чого торкнеться такий вітер, застигає брилою льоду.\nЧаклунові треба дати відсіч, інакше з часом усі звірі й люди перетворяться\nна відморозків! Знищіть крижини, врятуйте теплокровних звіряток."
+  },
+  "Стаи огромной и очень прожорливой саранчи заполонили мир.\nНасекомое съедает все, что попадается ему на пути. Мирные и не очень жители \nпросят о помощи, так как самим им с такими полчищами не справится.\nСпешите. Самого лучшего борца ожидает награда!": {
+   "en": "Swarms of huge and very voracious locusts have overrun the world.\nThe insect devours everything in its path. Peaceful and not-so-peaceful folk \ncry out for help, for they cannot cope with such hordes on their own.\nHurry. A reward awaits the very best fighter!",
+   "ua": "Зграї величезної та дуже ненажерливої сарани заполонили світ.\nКомаха з'їдає все, що трапляється їй на шляху. Мирні й не дуже мешканці \nблагають про допомогу, бо самі з такими полчищами не впораються.\nПоспішайте. Найкращого борця чекає нагорода!"
   }
  },
  "plug-ins/gquest/invasion/mobiles.cpp": {
@@ -10119,6 +10191,30 @@
   "{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x": {
    "en": "{RYou can no longer take part in the quest, since you've stained your hands with murder.{x",
    "ua": "{RТи більше не зможеш брати участь у завданні, бо оскверни%Gло|в|ла свої руки вбивством.{x"
+  },
+  "Ярко вспыхнув, радуга разлетелась на множество осколков!": {
+   "en": "Flaring brightly, the rainbow shattered into a multitude of shards!",
+   "ua": "Яскраво спалахнувши, веселка розлетілася на безліч осколків!"
+  },
+  "В {1{rАду{2 открылась новая вакансия!": {
+   "en": "A new vacancy has opened in {1{rHell{2!",
+   "ua": "У {1{rПеклі{2 відкрилася нова вакансія!"
+  },
+  "Увы, никто из героев не сумел вновь зажечь радугу над миром.": {
+   "en": "Alas, none of the heroes managed to rekindle the rainbow over the world.",
+   "ua": "На жаль, ніхто з героїв не зумів знову запалити веселку над світом."
+  },
+  "Увы, на эту {1{rадскую должность{2 так и не нашлось достойного кандидата.": {
+   "en": "Alas, no worthy candidate was ever found for this {1{rinfernal post{2.",
+   "ua": "На жаль, на цю {1{rпекельну посаду{2 так і не знайшлося гідного кандидата."
+  },
+  "Семь больших разноцветных осколков разлетелись по всему миру и были найдены \nаборигенами. Для того, чтобы вновь зажечь радугу, надо собрать по кусочку от \nкаждого в одних руках. Осколки радуги подобрали:": {
+   "en": "Seven large multicolored shards scattered across the whole world and were found \nby the natives. To rekindle the rainbow, one must gather a piece of \neach into a single pair of hands. The rainbow shards were picked up by:",
+   "ua": "Сім великих різнокольорових осколків розлетілися по всьому світу й були знайдені \nаборигенами. Для того, щоб знову запалити веселку, треба зібрати по шматочку від \nкожного в одних руках. Осколки веселки підібрали:"
+  },
+  "Отдел кадров {1{rАда{2 объявляет набор на должность временного заместителя\nПогонятеля Младших Бесов. Если ты - злобный, инициативный и коммуникабельный,\nдокажи свою профпригодность, собрав семь смертных грехов!           \nЗнаменитые грешники, согласно адскому реестру:": {
+   "en": "The HR department of {1{rHell{2 announces an opening for the post of acting deputy\nDriver of Lesser Imps. If you are wicked, proactive and personable,\nprove your fitness by gathering the seven deadly sins!           \nRenowned sinners, per the infernal registry:",
+   "ua": "Відділ кадрів {1{rПекла{2 оголошує набір на посаду тимчасового заступника\nПоганяча Молодших Бісів. Якщо ти - злобний, ініціативний і комунікабельний,\nдоведи свою профпридатність, зібравши сім смертних гріхів!           \nВідомі грішники, згідно з пекельним реєстром:"
   }
  },
  "plug-ins/groups/class_antipaladin.cpp": {
@@ -17775,6 +17871,26 @@
   "\r\nТебя окружают {Yр{Rа{Mз{Gн{Bо{Cц{Rв{Mе{Gт{Cн{Yы{Rе{x вихри!": {
    "en": "\r\nYou're surrounded by {Ym{Ru{Ml{Gt{Bi{Cc{Ro{Ml{Go{Cr{Ye{Rd whirlwinds!{x",
    "ua": "\r\nТебе оточують {Yр{Rі{Mз{Gн{Bо{Cк{Rо{Mл{Gь{Cо{Yр{Rо{Yв{Rі вихори!{x"
+  },
+  "У тебя уже есть {Y%1$d{y разноцветн%1$Iый|ых|ых кусоч%1$Iек|ка|ков. ": {
+   "en": "You already have {Y%1$d{y colored piece%1$I|s|s. ",
+   "ua": "У тебе вже є {Y%1$d{y різнокольоров%1$Iий|их|их шматоч%1$Iок|ки|ків. "
+  },
+  "Остается ": {
+   "en": "You have ",
+   "ua": "Лишається "
+  },
+  ", чтобы собрать всю радугу.": {
+   "en": " left to gather the whole rainbow.",
+   "ua": ", щоб зібрати всю веселку."
+  },
+  "Тебе удалось собрать {Y%1$d{y смертн%1$Iый|ых|ых грех%1$I|а|ов. ": {
+   "en": "You have collected {Y%1$d{y deadly sin%1$I|s|s. ",
+   "ua": "Тобі вдалося зібрати {Y%1$d{y смертн%1$Iий|их|их гріх%1$I|и|ів. "
+  },
+  "До закрытия вакансии остается ": {
+   "en": "The vacancy closes in ",
+   "ua": "До закриття вакансії лишається "
   }
  },
  "plug-ins/groups/chance.cpp": {
@@ -18613,6 +18729,34 @@
   "{DКлючевые слова: ": {
    "en": "{DKeywords: ",
    "ua": "{DКлючові слова: "
+  }
+ },
+ "plug-ins/gquest/core/globalquestinfo.cpp": {
+  "Бандиты": {
+   "en": "Bandits",
+   "ua": "Бандити"
+  },
+  "Нашествие": {
+   "en": "Invasion",
+   "ua": "Навала"
+  },
+  "Радуга/Семь Смертных Грехов": {
+   "en": "Rainbow / Seven Deadly Sins",
+   "ua": "Веселка / Сім Смертних Гріхів"
+  }
+ },
+ "plug-ins/gquest/core/gqchannel.cpp": {
+  "Глобал": {
+   "en": "Global",
+   "ua": "Глобал"
+  },
+  "Радуга": {
+   "en": "Rainbow",
+   "ua": "Веселка"
+  },
+  "Семь Смертных Грехов": {
+   "en": "Seven Deadly Sins",
+   "ua": "Сім Смертних Гріхів"
   }
  }
 }


### PR DESCRIPTION
Pairs with dreamland_code #817. ~50 gquest catalog entries in plug-ins.json. lint-l10n 0 HARD. RU byte-identical.