### PR TITLE
gquest: fill EN/UA for invasion+rainbow reward-panel flavor (T11)

### DIFF
--- a/gquests/invasion.xml
+++ b/gquests/invasion.xml
@@ -9,9 +9,9 @@
       <infoMsg>Разноцветные мыльные пузыри летят с небес. Не упусти свой шанс повеселиться! 
 Героя, веселящегося, лопая пузыри активнее других, ожидает награда!</infoMsg>
       <noWinnerMsg>Ни один смертный так и не повеселился. А жаль.</noWinnerMsg>
-      <rewardMsg l="en"></rewardMsg>
+      <rewardMsg l="en">The bubble bursts, showering you with:</rewardMsg>
       <rewardMsg l="ru">Пузырь лопается, высыпав на тебя:</rewardMsg>
-      <rewardMsg l="ua"></rewardMsg>
+      <rewardMsg l="ua">Бульбашка лопається, висипавши на тебе:</rewardMsg>
       <startMsg>Опять кто-то из богов заполняет мир мыльными пузырями - давайте веселиться!</startMsg>
       <vnumMobs>
         <node>28017</node>
@@ -28,9 +28,9 @@
         <node>28028</node>
         <node>28029</node>
       </vnumMobs>
-      <winnerMsg l="en"></winnerMsg>
+      <winnerMsg l="en">You had the most fun of all, and on top of that you receive:</winnerMsg>
       <winnerMsg l="ru">Тебе было веселее всех, и в придачу ты получаешь:</winnerMsg>
-      <winnerMsg l="ua"></winnerMsg>
+      <winnerMsg l="ua">Тобі було найвеселіше за всіх, і на додачу ти отримуєш:</winnerMsg>
       <winnerMsgOther>Пузыри лопнули. Лучший лопух:</winnerMsgOther>
       <winnerMsgOtherMlt>Пузыри лопнули. Лучшие лопухи:</winnerMsgOtherMlt>
     </node>
@@ -41,17 +41,17 @@
 И теперь, если их не найдут - матч перенесут на следующий сезон.
 Уничтожьте все мячи! Дайте шанс гигантам!</infoMsg>
       <noWinnerMsg>Мячи найдены. Матч закончился со счетом 42:0 в пользу сатиров.</noWinnerMsg>
-      <rewardMsg l="en"></rewardMsg>
+      <rewardMsg l="en">Pop! And the prize that sprang from the burst ball is</rewardMsg>
       <rewardMsg l="ru">Хлоп! А приз, выскочивший из лопнувшего меча, составляет</rewardMsg>
-      <rewardMsg l="ua"></rewardMsg>
+      <rewardMsg l="ua">Хлоп! А приз, що вискочив із луснутого мʼяча, становить</rewardMsg>
       <startMsg>Начался футбольный матч сезона!</startMsg>
       <vnumMobs>
         <node>28036</node>
         <node>28037</node>
       </vnumMobs>
-      <winnerMsg l="en"></winnerMsg>
+      <winnerMsg l="en">The giants thank you and hail you the best footballer! And on top of that you receive:</winnerMsg>
       <winnerMsg l="ru">Гиганты благодарят тебя и считают лучшим футболистом! И впридачу ты получаешь:</winnerMsg>
-      <winnerMsg l="ua"></winnerMsg>
+      <winnerMsg l="ua">Велетні дякують тобі й вважають найкращим футболістом! І на додачу ти отримуєш:</winnerMsg>
       <winnerMsgOther>Мячи не найдены! Матч перенесен. Лучший футболист по версии гигантов:</winnerMsgOther>
       <winnerMsgOtherMlt>Мячи не найдены! Матч перенесен. Лучший футбольный коллектив по версии гигантов:</winnerMsgOtherMlt>
     </node>
@@ -61,18 +61,18 @@
 Колдуну нужно дать отпор, иначе со временем все звери и люди превратятся
 в отморозков! Уничтожьте льдины, спасите теплокровных зверюшек.</infoMsg>
       <noWinnerMsg>Температура понизилась на несколько градусов. Некоторые виды существ потеряны навсегда.</noWinnerMsg>
-      <rewardMsg l="en"></rewardMsg>
+      <rewardMsg l="en">It has grown a touch warmer beside you. You receive:</rewardMsg>
       <rewardMsg l="ru">Рядом с тобой стало чуточку теплее. Ты получаешь:</rewardMsg>
-      <rewardMsg l="ua"></rewardMsg>
+      <rewardMsg l="ua">Поряд із тобою стало трішки тепліше. Ти отримуєш:</rewardMsg>
       <startMsg>Откуда-то подул сильный холодный ветер..</startMsg>
       <vnumMobs>
         <node>28033</node>
         <node>28034</node>
         <node>28035</node>
       </vnumMobs>
-      <winnerMsg l="en"></winnerMsg>
+      <winnerMsg l="en">As a reward for saving the beasts from the cold you receive:</winnerMsg>
       <winnerMsg l="ru">В награду за спасение зверей от холода ты получаешь:</winnerMsg>
-      <winnerMsg l="ua"></winnerMsg>
+      <winnerMsg l="ua">У нагороду за порятунок звірів від холоду ти отримуєш:</winnerMsg>
       <winnerMsgOther>Ледяные ветры утихают. Звери благодарят за их спасение:</winnerMsgOther>
       <winnerMsgOtherMlt></winnerMsgOtherMlt>
     </node>
@@ -82,18 +82,18 @@
 просят о помощи, так как самим им с такими полчищами не справится.
 Спешите. Самого лучшего борца ожидает награда!</infoMsg>
       <noWinnerMsg>Увы.. никто не откликнулся на просьбу о помощи.</noWinnerMsg>
-      <rewardMsg l="en"></rewardMsg>
+      <rewardMsg l="en">One more foul creature gone! As a reward you receive:</rewardMsg>
       <rewardMsg l="ru">Еще одной тварью стало меньше! В награду ты получаешь:</rewardMsg>
-      <rewardMsg l="ua"></rewardMsg>
+      <rewardMsg l="ua">Ще однією твариною менше! У нагороду ти отримуєш:</rewardMsg>
       <startMsg>На города и села обрушились стаи саранчи!</startMsg>
       <vnumMobs>
         <node>28014</node>
         <node>28015</node>
         <node>28016</node>
       </vnumMobs>
-      <winnerMsg l="en"></winnerMsg>
+      <winnerMsg l="en">You destroyed so much locust that all the rest took fright and burst! As a reward you receive:</winnerMsg>
       <winnerMsg l="ru">Тобой уничтожено так много саранчи, что вся остальная испугалась и полопалась! В награду ты получаешь:</winnerMsg>
-      <winnerMsg l="ua"></winnerMsg>
+      <winnerMsg l="ua">Тобою знищено так багато сарани, що вся решта злякалася й полопалася! У нагороду ти отримуєш:</winnerMsg>
       <winnerMsgOther>Благодаря отважной борьбе, полчища саранчи были уничтожены или обращены в бегство! Лучший саранчеборец:</winnerMsgOther>
       <winnerMsgOtherMlt>Благодаря отважной борьбе, полчища саранчи были уничтожены или обращены в бегство! Лучшие саранчеборцы:</winnerMsgOtherMlt>
     </node>

--- a/gquests/rainbow.xml
+++ b/gquests/rainbow.xml
@@ -24,9 +24,9 @@
         <node>{Mфиолетов|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</node>
       </pieces>
       <startMsg>Ярко вспыхнув, радуга разлетелась на множество осколков!</startMsg>
-      <winnerMsg l="en"></winnerMsg>
+      <winnerMsg l="en">In gratitude, the Gods grant you:</winnerMsg>
       <winnerMsg l="ru">В благодарность от Богов ты получаешь:</winnerMsg>
-      <winnerMsg l="ua"></winnerMsg>
+      <winnerMsg l="ua">У подяку від Богів ти отримуєш:</winnerMsg>
     </node>
     <node name="sins" type="RainbowSinsScenario">
       <displayName>Семь Смертных Грехов</displayName>
@@ -48,9 +48,9 @@
         <node>желчн|ый|ого|ому|ый|ым|ом пузыр|ь|я|ю|ь|ем|е</node>
       </pieces>
       <startMsg>В {1{rАду{2 открылась новая вакансия!</startMsg>
-      <winnerMsg l="en"></winnerMsg>
+      <winnerMsg l="en">As a bonus to your salary you receive:</winnerMsg>
       <winnerMsg l="ru">В качестве бонуса к зарплате ты получаешь:</winnerMsg>
-      <winnerMsg l="ua"></winnerMsg>
+      <winnerMsg l="ua">Як бонус до зарплати ти отримуєш:</winnerMsg>
     </node>
   </scenarios>
   <shortDescr>Собрать части целого воедино</shortDescr>


### PR DESCRIPTION
Fills 10 empty winnerMsg/rewardMsg en/ua nodes (already XMLMultiString). RU byte-identical. Takes effect at next reboot (boot-loaded data).