### PR TITLE
Give every social a Ukrainian name

### DIFF
--- a/socials/aargh.xml
+++ b/socials/aargh.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хватает тебя за горло и беспорядочно мотает твоей головой!</msgVictimFound>
   <position>rest</position>
   <rusName>аргх</rusName>
+  <uaName>аргх</uaName>
   <shortDesc>просто порычать или придушить кого-нибудь</shortDesc>
 </Social>

--- a/socials/abat.xml
+++ b/socials/abat.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>луп-луп</rusName>
+  <uaName>луп-луп</uaName>
   <shortDesc>хлопать ресницами</shortDesc>
 </Social>

--- a/socials/abite.xml
+++ b/socials/abite.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 покусывает тебя за шейку.</msgVictimFound>
   <position>rest</position>
   <rusName>куснуть</rusName>
+  <uaName>куснути</uaName>
   <shortDesc>кусать.. себе локти или кого-нибудь за шейку</shortDesc>
 </Social>

--- a/socials/ablink.xml
+++ b/socials/ablink.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 строит тебе глазки. К чему бы это?</msgVictimFound>
   <position>rest</position>
   <rusName>глазки</rusName>
+  <uaName>оченята</uaName>
   <shortDesc>строить глазки</shortDesc>
 </Social>

--- a/socials/accept.xml
+++ b/socials/accept.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 милостиво принимает твои извинения.</msgVictimFound>
   <position>rest</position>
   <rusName>принять</rusName>
+  <uaName>прийняти</uaName>
   <shortDesc>принимать извинения</shortDesc>
 </Social>

--- a/socials/accuse.xml
+++ b/socials/accuse.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 обвиняюще глядит на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>винить</rusName>
+  <uaName>винуватити</uaName>
   <shortDesc>обвинять или совестливо смотреть на кого-либо</shortDesc>
 </Social>

--- a/socials/acomb.xml
+++ b/socials/acomb.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тянет тебя за волосы, желая расчесать их.</msgVictimFound>
   <position>rest</position>
   <rusName>расчесать</rusName>
+  <uaName>розчесати</uaName>
   <shortDesc>расчесывать волосы</shortDesc>
 </Social>

--- a/socials/adjust.xml
+++ b/socials/adjust.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>поправить</rusName>
+  <uaName>поправити</uaName>
   <shortDesc>поправить писюн, чтобы хорошо стоял</shortDesc>
 </Social>

--- a/socials/agree.xml
+++ b/socials/agree.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 кивает с энтузиазмом, соглашаясь с тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>соглашаться</rusName>
+  <uaName>погоджуватися</uaName>
   <shortDesc>согласиться с кем-либо</shortDesc>
 </Social>

--- a/socials/air.xml
+++ b/socials/air.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1, во главе группы воздушных музыкантов, наяривает для тебя на воздушной гитаре.</msgVictimFound>
   <position>rest</position>
   <rusName>гитара</rusName>
+  <uaName>гітара</uaName>
   <shortDesc>напевать себе под нос или петь для публики</shortDesc>
 </Social>

--- a/socials/ajudge.xml
+++ b/socials/ajudge.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 оценивает твои действия по десятибальной системе. Ты тянешь на ноль!!!</msgVictimFound>
   <position>rest</position>
   <rusName>заценить</rusName>
+  <uaName>оцінити</uaName>
   <shortDesc>унизительно отозваться о ближнем своем</shortDesc>
 </Social>

--- a/socials/alove.xml
+++ b/socials/alove.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 шепчет тебе сладкие слова любви.</msgVictimFound>
   <position>rest</position>
   <rusName>люблю</rusName>
+  <uaName>люблю</uaName>
   <shortDesc>признаться в любви себе, кому-то или всему миру</shortDesc>
 </Social>

--- a/socials/amake.xml
+++ b/socials/amake.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 отчего-то краснеет и тяжело дышит при виде тебя. Того и гляди накинется!</msgVictimFound>
   <position>rest</position>
   <rusName>пыхтеть</rusName>
+  <uaName>пихтіти</uaName>
   <shortDesc>разъяренно пыхтеть</shortDesc>
 </Social>

--- a/socials/anticipate.xml
+++ b/socials/anticipate.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>горлм</rusName>
+  <uaName>горлум</uaName>
   <shortDesc>выдать коронную фразу Горлума</shortDesc>
 </Social>

--- a/socials/apologize.xml
+++ b/socials/apologize.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 извиняется перед тобой и просит о прощении.</msgVictimFound>
   <position>rest</position>
   <rusName>извиняться</rusName>
+  <uaName>вибачатися</uaName>
   <shortDesc>приносить извинения</shortDesc>
 </Social>

--- a/socials/applaud.xml
+++ b/socials/applaud.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 аплодирует тебе. Наверно, ты сделал$Gо||а что-то очень хорошее!</msgVictimFound>
   <position>rest</position>
   <rusName>аплодисменты</rusName>
+  <uaName>оплески</uaName>
   <shortDesc>аплодировать</shortDesc>
 </Social>

--- a/socials/arun.xml
+++ b/socials/arun.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 убегает от тебя, опасаясь за свою жизнь!</msgVictimFound>
   <position>rest</position>
   <rusName>убегать</rusName>
+  <uaName>тікати</uaName>
   <shortDesc>убегать в смертельном ужасе</shortDesc>
 </Social>

--- a/socials/babble.xml
+++ b/socials/babble.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 что-то тебе гонит. Вот спамер!</msgVictimFound>
   <position>rest</position>
   <rusName>бла-бла</rusName>
+  <uaName>бла-бла</uaName>
   <shortDesc>много спамить</shortDesc>
 </Social>

--- a/socials/bark.xml
+++ b/socials/bark.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 гавкает громко на тебя, ты отбегаешь - как бы не укусили!!</msgVictimFound>
   <position>rest</position>
   <rusName>гав</rusName>
+  <uaName>гав</uaName>
   <shortDesc>гавкать от жизни собачьей</shortDesc>
 </Social>

--- a/socials/bcatch.xml
+++ b/socials/bcatch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>ловим</rusName>
+  <uaName>ловимо</uaName>
   <shortDesc>ловить бутылку пива</shortDesc>
 </Social>

--- a/socials/beam.xml
+++ b/socials/beam.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 от полноты чувств широко улыбается тебе!</msgVictimFound>
   <position>rest</position>
   <rusName>сиять</rusName>
+  <uaName>сяяти</uaName>
   <shortDesc>радостно и широко улыбаться</shortDesc>
 </Social>

--- a/socials/bearhug.xml
+++ b/socials/bearhug.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 грабастает и дружески жмакает тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>заграбастать</rusName>
+  <uaName>загребти</uaName>
   <shortDesc>очень крепко обнять</shortDesc>
 </Social>

--- a/socials/beckon.xml
+++ b/socials/beckon.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 зовет тебя с собой. FOLLOW !</msgVictimFound>
   <position>rest</position>
   <rusName>звать</rusName>
+  <uaName>кликати</uaName>
   <shortDesc>звать с собой</shortDesc>
 </Social>

--- a/socials/beer.xml
+++ b/socials/beer.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 бросает тебе пыво. Это был намек...</msgVictimFound>
   <position>rest</position>
   <rusName>пыво</rusName>
+  <uaName>пивко</uaName>
   <shortDesc>потреблять пиво и угощать им</shortDesc>
 </Social>

--- a/socials/beg.xml
+++ b/socials/beg.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 просит у тебя денег. Может и правда дать?</msgVictimFound>
   <position>rest</position>
   <rusName>умолять</rusName>
+  <uaName>благати</uaName>
   <shortDesc>клянчить и выпрашивать, просить прошения у богов</shortDesc>
 </Social>

--- a/socials/bird.xml
+++ b/socials/bird.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тычет тебе в нос что-то. Ах это дуля! Вот зараза!</msgVictimFound>
   <position>rest</position>
   <rusName>дуля</rusName>
+  <uaName>дуля</uaName>
   <shortDesc>показать комбинацию из трех пальцев</shortDesc>
 </Social>

--- a/socials/bkiss.xml
+++ b/socials/bkiss.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 посылает тебе воздушный поцелуй, надеясь на взаимность.</msgVictimFound>
   <position>rest</position>
   <rusName>впоцелуй</rusName>
+  <uaName>вцілунок</uaName>
   <shortDesc>посылать воздушный поцелуй</shortDesc>
 </Social>

--- a/socials/bleed.xml
+++ b/socials/bleed.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 кровоточит на тебя! Убегай!!</msgVictimFound>
   <position>rest</position>
   <rusName>кровить</rusName>
+  <uaName>кровити</uaName>
   <shortDesc>умирать от обильной кровопотери</shortDesc>
 </Social>

--- a/socials/blush.xml
+++ b/socials/blush.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 волнуется, видя тебя здесь. Гм, какой эффект на людей ты производишь!</msgVictimFound>
   <position>rest</position>
   <rusName>краснеть</rusName>
+  <uaName>червоніти</uaName>
   <shortDesc>краснеть от волнения</shortDesc>
 </Social>

--- a/socials/boast.xml
+++ b/socials/boast.xml
@@ -17,5 +17,6 @@
   <msgVictimObj>%1$^C1 хвастается перед тобой %3$O5.</msgVictimObj>
   <position>rest</position>
   <rusName>хвастать</rusName>
+  <uaName>хвалитися</uaName>
   <shortDesc>хвастаться собой или предметом</shortDesc>
 </Social>

--- a/socials/bonk.xml
+++ b/socials/bonk.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 стукает тебя по шлему, считая тебя идиот$Gиной|ом|кой.</msgVictimFound>
   <position>rest</position>
   <rusName>тук</rusName>
+  <uaName>тук</uaName>
   <shortDesc>стучать по голове, намекая на полный идиотизм</shortDesc>
 </Social>

--- a/socials/bounce.xml
+++ b/socials/bounce.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 прыгает тебе на колени и старается сесть поудобнее.</msgVictimFound>
   <position>rest</position>
   <rusName>попрыгать</rusName>
+  <uaName>пострибати</uaName>
   <shortDesc>биться головой, прыгать, запрыгнуть на колени</shortDesc>
 </Social>

--- a/socials/bow.xml
+++ b/socials/bow.xml
@@ -15,5 +15,6 @@
   <msgVictimFound>$c1 глубоко кланяется перед тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>поклон</rusName>
+  <uaName>уклін</uaName>
   <shortDesc>глубоко поклониться</shortDesc>
 </Social>

--- a/socials/brb.xml
+++ b/socials/brb.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>брб</rusName>
+  <uaName>брб</uaName>
   <shortDesc>сообщить, что ты уходишь, но скоро вернешься</shortDesc>
 </Social>

--- a/socials/buff.xml
+++ b/socials/buff.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>полировать</rusName>
+  <uaName>полірувати</uaName>
   <shortDesc>чистить ногти с наплевательским видом</shortDesc>
 </Social>

--- a/socials/burp.xml
+++ b/socials/burp.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 громко рыгает тебе в ответ.</msgVictimFound>
   <position>rest</position>
   <rusName>рыгать</rusName>
+  <uaName>ригати</uaName>
   <shortDesc>отрыжка</shortDesc>
 </Social>

--- a/socials/cackle.xml
+++ b/socials/cackle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 ликующе кудахчет над тобой. Лучше держись подальше от $x.</msgVictimFound>
   <position>rest</position>
   <rusName>кудахтать</rusName>
+  <uaName>кудкудакати</uaName>
   <shortDesc>громкое кудахтанье, символизируещее ликование</shortDesc>
 </Social>

--- a/socials/camel.xml
+++ b/socials/camel.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 поджигает сигарету &quot;Кэмел&quot; для тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>верблюд</rusName>
+  <uaName>верблюд</uaName>
   <shortDesc>притвориться верблюдом или курить</shortDesc>
 </Social>

--- a/socials/caress.xml
+++ b/socials/caress.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 нежно гладит тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>приласкать</rusName>
+  <uaName>приголубити</uaName>
   <shortDesc>погладить или приласкать</shortDesc>
 </Social>

--- a/socials/charge.xml
+++ b/socials/charge.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Аххх! $c1 врезается головой тебе в живот! Это больно.</msgVictimFound>
   <position>rest</position>
   <rusName>разборки</rusName>
+  <uaName>розбірки</uaName>
   <shortDesc>устроить разборки или боднуть кого-либо в живот</shortDesc>
 </Social>

--- a/socials/cheer.xml
+++ b/socials/cheer.xml
@@ -15,5 +15,6 @@
   <msgVictimFound2>%1$^C1 приветствует тебя и %3$C4... Тебе приятно!</msgVictimFound2>
   <position>rest</position>
   <rusName>радость</rusName>
+  <uaName>радість</uaName>
   <shortDesc>веселиться или радостно приветствовать кого-либо</shortDesc>
 </Social>

--- a/socials/chortle.xml
+++ b/socials/chortle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хрюкает над твоими действиями.</msgVictimFound>
   <position>rest</position>
   <rusName>хрюкать</rusName>
+  <uaName>хрюкати</uaName>
   <shortDesc>хрюкать от смеха</shortDesc>
 </Social>

--- a/socials/chuckle.xml
+++ b/socials/chuckle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смеется над твоей шуткой.</msgVictimFound>
   <position>rest</position>
   <rusName>смешно</rusName>
+  <uaName>смішно</uaName>
   <shortDesc>тихо и спокойно смеяться</shortDesc>
 </Social>

--- a/socials/clap.xml
+++ b/socials/clap.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хлопает в ладоши, радуясь твоим подвигам.</msgVictimFound>
   <position>rest</position>
   <rusName>хлоп</rusName>
+  <uaName>плесь</uaName>
   <shortDesc>радостно хлопать в ладоши. приветствовать</shortDesc>
 </Social>

--- a/socials/collapse.xml
+++ b/socials/collapse.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 не может устоять на ногах, и падает к тебе на руки.</msgVictimFound>
   <position>rest</position>
   <rusName>падать</rusName>
+  <uaName>падати</uaName>
   <shortDesc>валиться с ног от усталости</shortDesc>
 </Social>

--- a/socials/comfort.xml
+++ b/socials/comfort.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 утешает тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>утешить</rusName>
+  <uaName>втішити</uaName>
   <shortDesc>утешить убитого горем</shortDesc>
 </Social>

--- a/socials/confused.xml
+++ b/socials/confused.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 уставил$gось|ся|ась на тебя, недоуменно моргая.</msgVictimFound>
   <position>rest</position>
   <rusName>запутаться</rusName>
+  <uaName>заплутатися</uaName>
   <shortDesc>придти в замешательство, запутаться</shortDesc>
 </Social>

--- a/socials/conspire.xml
+++ b/socials/conspire.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 знакомит тебя со своими замыслами.</msgVictimFound>
   <position>rest</position>
   <rusName>заговор</rusName>
+  <uaName>змова</uaName>
   <shortDesc>заговорщически подмигивать</shortDesc>
 </Social>

--- a/socials/contemplate.xml
+++ b/socials/contemplate.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>задумчиво</rusName>
+  <uaName>задумливо</uaName>
   <shortDesc>задумчиво кусать губы</shortDesc>
 </Social>

--- a/socials/cough.xml
+++ b/socials/cough.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>кашель</rusName>
+  <uaName>кашель</uaName>
   <shortDesc>кашлять</shortDesc>
 </Social>

--- a/socials/cover.xml
+++ b/socials/cover.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 затыкает уши, потому что... ты слишком шумишь!</msgVictimFound>
   <position>rest</position>
   <rusName>затыкать</rusName>
+  <uaName>затикати</uaName>
   <shortDesc>затыкать уши, чтобы не слышать шума</shortDesc>
 </Social>

--- a/socials/cower.xml
+++ b/socials/cower.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Ты пугаешь $c4! $e садится в уголке, опасаясь за свою жизнь.</msgVictimFound>
   <position>rest</position>
   <rusName>съеживаться</rusName>
+  <uaName>щулитися</uaName>
   <shortDesc>испуганно съежиться в уголке</shortDesc>
 </Social>

--- a/socials/cramp.xml
+++ b/socials/cramp.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хватается за тебя и вопит &quot;AAAAA!! Рожаю! Это.. мальчик!!!&quot;</msgVictimFound>
   <position>rest</position>
   <rusName>схватки</rusName>
+  <uaName>судоми</uaName>
   <shortDesc>это когда живот прихватит..</shortDesc>
 </Social>

--- a/socials/cringe.xml
+++ b/socials/cringe.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 дрожит перед тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>метаться</rusName>
+  <uaName>метатися</uaName>
   <shortDesc>метаться в страхе</shortDesc>
 </Social>

--- a/socials/criticize.xml
+++ b/socials/criticize.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 критикует тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>критика</rusName>
+  <uaName>критика</uaName>
   <shortDesc>критиковать и самокритиковаться</shortDesc>
 </Social>

--- a/socials/cry.xml
+++ b/socials/cry.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 рыдает на твоем плече.</msgVictimFound>
   <position>rest</position>
   <rusName>плакать</rusName>
+  <uaName>плакати</uaName>
   <shortDesc>рыдать в три ручья</shortDesc>
 </Social>

--- a/socials/cuddle.xml
+++ b/socials/cuddle.xml
@@ -14,5 +14,6 @@
   <msgVictimFound>$c1 прижимает тебя к себе.</msgVictimFound>
   <position>rest</position>
   <rusName>прижать</rusName>
+  <uaName>пригорнути</uaName>
   <shortDesc>к сердцу прижмет...</shortDesc>
 </Social>

--- a/socials/curtsey.xml
+++ b/socials/curtsey.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 изящно делает реверанс тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>реверанс</rusName>
+  <uaName>реверанс</uaName>
   <shortDesc>делать реверанс</shortDesc>
 </Social>

--- a/socials/damn.xml
+++ b/socials/damn.xml
@@ -15,5 +15,6 @@
   <msgVictimFound2>%1$^C1 проклинает тебя и %3$C4!</msgVictimFound2>
   <position>rest</position>
   <rusName>обругать</rusName>
+  <uaName>облаяти</uaName>
   <shortDesc>громко или нецензурно ругаться</shortDesc>
 </Social>

--- a/socials/dance.xml
+++ b/socials/dance.xml
@@ -16,5 +16,6 @@
   <msgVictimFound>$c1 кружится с тобой в танце.</msgVictimFound>
   <position>rest</position>
   <rusName>танец</rusName>
+  <uaName>танець</uaName>
   <shortDesc>танцевать</shortDesc>
 </Social>

--- a/socials/daydream.xml
+++ b/socials/daydream.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>мечтать</rusName>
+  <uaName>мріяти</uaName>
   <shortDesc>мечтать об абстрактном</shortDesc>
 </Social>

--- a/socials/discodance.xml
+++ b/socials/discodance.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хватает тебя и лихо с тобой отплясывает!</msgVictimFound>
   <position>rest</position>
   <rusName>отплясывать</rusName>
+  <uaName>відпалювати</uaName>
   <shortDesc>буйно отплясывать</shortDesc>
 </Social>

--- a/socials/drool.xml
+++ b/socials/drool.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 похотливо сморит на тебя. Пускает слюни. Слюни двухметровые.</msgVictimFound>
   <position>rest</position>
   <rusName>нюни</rusName>
+  <uaName>шмарклі</uaName>
   <shortDesc>пускать простые или похотливые слюни</shortDesc>
 </Social>

--- a/socials/duck.xml
+++ b/socials/duck.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 уклоняется, пожалуйста, не бей $s!</msgVictimFound>
   <position>rest</position>
   <rusName>уклоняться</rusName>
+  <uaName>ухилятися</uaName>
   <shortDesc>трусливо уклоняться от предполагаемого избиения</shortDesc>
 </Social>

--- a/socials/embrace.xml
+++ b/socials/embrace.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 обвивает тебя руками в теплых любящих объятиях.</msgVictimFound>
   <position>rest</position>
   <rusName>обвить</rusName>
+  <uaName>обвити</uaName>
   <shortDesc>нежно, любяще обнять</shortDesc>
 </Social>

--- a/socials/eyebrow.xml
+++ b/socials/eyebrow.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 поднимает бровь, глядя на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>бровь</rusName>
+  <uaName>брова</uaName>
   <shortDesc>приподнять бровь, высказав свое удивление</shortDesc>
 </Social>

--- a/socials/faint.xml
+++ b/socials/faint.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 в обмороке падает тебе на руки.</msgVictimFound>
   <position>rest</position>
   <rusName>обморок</rusName>
+  <uaName>зомління</uaName>
   <shortDesc>упасть в обморок. можно-кому-нибудь на руки</shortDesc>
 </Social>

--- a/socials/fart.xml
+++ b/socials/fart.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 пукает в твоем направлении. Ты задыхаешься!</msgVictimFound>
   <position>rest</position>
   <rusName>пук</rusName>
+  <uaName>пук</uaName>
   <shortDesc>громкий намеренный пук!</shortDesc>
 </Social>

--- a/socials/fatality.xml
+++ b/socials/fatality.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 обреченно говорит: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgVictimFound>
   <position>rest</position>
   <rusName>обреченно</rusName>
+  <uaName>приречено</uaName>
   <shortDesc>выражение полной обреченности</shortDesc>
 </Social>

--- a/socials/flare.xml
+++ b/socials/flare.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 пренебрежительно раздувает ноздри, глядя на тебя...</msgVictimFound>
   <position>rest</position>
   <rusName>пренебрегать</rusName>
+  <uaName>зневажати</uaName>
   <shortDesc>высказывать пренебрежение</shortDesc>
 </Social>

--- a/socials/flash.xml
+++ b/socials/flash.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Ты опупеваешь! $c1 показывает свое &quot;equ&quot; тебе!</msgVictimFound>
   <position>rest</position>
   <rusName>оппа</rusName>
+  <uaName>опа</uaName>
   <shortDesc>заниматься эксгибиционизмом</shortDesc>
 </Social>

--- a/socials/flex.xml
+++ b/socials/flex.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 играет своими мускулами, пытаясь привлечь твой взгляд.</msgVictimFound>
   <position>rest</position>
   <rusName>мускулы</rusName>
+  <uaName>мускули</uaName>
   <shortDesc>играть мускулами, привлекая внимание</shortDesc>
 </Social>

--- a/socials/flinch.xml
+++ b/socials/flinch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 вздрагивает, слыша твои упреки.</msgVictimFound>
   <position>rest</position>
   <rusName>вздрагивать</rusName>
+  <uaName>сахатися</uaName>
   <shortDesc>вздрагивать от боли</shortDesc>
 </Social>

--- a/socials/flip.xml
+++ b/socials/flip.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 бросает тебя через бедро. Ты встаешь и отряхиваешься. Хммммм.</msgVictimFound>
   <position>rest</position>
   <rusName>кувырок</rusName>
+  <uaName>перекид</uaName>
   <shortDesc>кувыркаться либо бросить кого-нибудь через бедро</shortDesc>
 </Social>

--- a/socials/flirt.xml
+++ b/socials/flirt.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 флиртует с тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>флирт</rusName>
+  <uaName>флірт</uaName>
   <shortDesc>флиртовать или просто махать руками</shortDesc>
 </Social>

--- a/socials/flutter.xml
+++ b/socials/flutter.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 застенчиво хлопает своими ресницами, глядя на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>реснички</rusName>
+  <uaName>війки</uaName>
   <shortDesc>строить глазки, трепеща ресницами</shortDesc>
 </Social>

--- a/socials/fondle.xml
+++ b/socials/fondle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 ласково ласкает тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>ласкать</rusName>
+  <uaName>пестити</uaName>
   <shortDesc>эротично ласкать</shortDesc>
 </Social>

--- a/socials/french.xml
+++ b/socials/french.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 дарит тебе длинный и страстный поцелуй, кажется, это длится вечность...</msgVictimFound>
   <position>rest</position>
   <rusName>поцелуй</rusName>
+  <uaName>цілунок</uaName>
   <shortDesc>страстно целовать</shortDesc>
 </Social>

--- a/socials/frown.xml
+++ b/socials/frown.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 неодобрительно хмурится на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>хмуриться</rusName>
+  <uaName>хмуритися</uaName>
   <shortDesc>неодобрительно хмуриться</shortDesc>
 </Social>

--- a/socials/fume.xml
+++ b/socials/fume.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 в ярости смотрит на тебя!</msgVictimFound>
   <position>rest</position>
   <rusName>сердиться</rusName>
+  <uaName>сердитися</uaName>
   <shortDesc>яростно и от всей души ненавидеть кого-либо</shortDesc>
 </Social>

--- a/socials/gack.xml
+++ b/socials/gack.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 отчаянно крякает на тебя и ты отбегаешь - как бы не укусили.</msgVictimFound>
   <position>rest</position>
   <rusName>крякать</rusName>
+  <uaName>крякати</uaName>
   <shortDesc>крякать в глубоком отчаянии</shortDesc>
 </Social>

--- a/socials/gasp.xml
+++ b/socials/gasp.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 задыхается от удивления твоими действиями.</msgVictimFound>
   <position>rest</position>
   <rusName>задыхаться</rusName>
+  <uaName>задихатися</uaName>
   <shortDesc>задыхаться от удивления</shortDesc>
 </Social>

--- a/socials/giggle.xml
+++ b/socials/giggle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хихикает над тобой. Ты надеешься, что это не заразно.</msgVictimFound>
   <position>rest</position>
   <rusName>хихи</rusName>
+  <uaName>хіхі</uaName>
   <shortDesc>хихикать</shortDesc>
 </Social>

--- a/socials/glare.xml
+++ b/socials/glare.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 свирепо смотрит на тебя, и холод пронизывает тебя до костей.</msgVictimFound>
   <position>rest</position>
   <rusName>холодно</rusName>
+  <uaName>холодно</uaName>
   <shortDesc>смерять холодным взглядом</shortDesc>
 </Social>

--- a/socials/goose.xml
+++ b/socials/goose.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тебе молочный зуб выби$gло|л|ла! Хны! Хны!</msgVictimFound>
   <position>rest</position>
   <rusName>зуб</rusName>
+  <uaName>зуб</uaName>
   <shortDesc>выдрать зуб ближнему или себе лично</shortDesc>
 </Social>

--- a/socials/grimace.xml
+++ b/socials/grimace.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 кривится, глядя на тебя. Что, с мордой что-то не то?</msgVictimFound>
   <position>rest</position>
   <rusName>морда</rusName>
+  <uaName>морда</uaName>
   <shortDesc>кисло скривиться</shortDesc>
 </Social>

--- a/socials/grin.xml
+++ b/socials/grin.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 злобно тебе ухмыляется. Гм. Лучше держись на расстоянии.</msgVictimFound>
   <position>rest</position>
   <rusName>ухмыл</rusName>
+  <uaName>вишкір</uaName>
   <shortDesc>злобно ухмыляться</shortDesc>
 </Social>

--- a/socials/groan.xml
+++ b/socials/groan.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тяжело стонет, глядя на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>стонать</rusName>
+  <uaName>стогнати</uaName>
   <shortDesc>громко стонать - от раскаяния или просто так</shortDesc>
 </Social>

--- a/socials/grope.xml
+++ b/socials/grope.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 ощупывает тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>щупать</rusName>
+  <uaName>мацати</uaName>
   <shortDesc>ощупать себя или ослепнув, ощупать все вокруг</shortDesc>
 </Social>

--- a/socials/grovel.xml
+++ b/socials/grovel.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 падает ниц перед тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>ниц</rusName>
+  <uaName>ниць</uaName>
   <shortDesc>упасть ниц перед кем-либо</shortDesc>
 </Social>

--- a/socials/growl.xml
+++ b/socials/growl.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 рычит на тебя. Чего $e хочет?</msgVictimFound>
   <position>rest</position>
   <rusName>рык</rusName>
+  <uaName>рик</uaName>
   <shortDesc>рычать</shortDesc>
 </Social>

--- a/socials/grumble.xml
+++ b/socials/grumble.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 ворчит на тебя... Что ты такого сделал$Gо||а?</msgVictimFound>
   <position>rest</position>
   <rusName>ворчать</rusName>
+  <uaName>бурчати</uaName>
   <shortDesc>сварливо ворчать</shortDesc>
 </Social>

--- a/socials/hand.xml
+++ b/socials/hand.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 целует твою руку. Как благородно!</msgVictimFound>
   <position>rest</position>
   <rusName>цем</rusName>
+  <uaName>цем</uaName>
   <shortDesc>поцеловать руку</shortDesc>
 </Social>

--- a/socials/head.xml
+++ b/socials/head.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 надменно задирает голову, глядя на тебя... :(</msgVictimFound>
   <position>rest</position>
   <rusName>голову</rusName>
+  <uaName>голову</uaName>
   <shortDesc>надменно задирать голову</shortDesc>
 </Social>

--- a/socials/hiccup.xml
+++ b/socials/hiccup.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>икать</rusName>
+  <uaName>гикати</uaName>
   <shortDesc>икать</shortDesc>
 </Social>

--- a/socials/highfive.xml
+++ b/socials/highfive.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хлопает тебя по ладошке пятерней.</msgVictimFound>
   <position>rest</position>
   <rusName>пять</rusName>
+  <uaName>лапу</uaName>
   <shortDesc>пребывать в хорошем настроении или &quot;дать пять&quot;</shortDesc>
 </Social>

--- a/socials/homework.xml
+++ b/socials/homework.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>работа</rusName>
+  <uaName>робота</uaName>
   <shortDesc>резко вспомнить о существовании реала</shortDesc>
 </Social>

--- a/socials/hop.xml
+++ b/socials/hop.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>скакать</rusName>
+  <uaName>скакати</uaName>
   <shortDesc>прыгать от радости</shortDesc>
 </Social>

--- a/socials/howl.xml
+++ b/socials/howl.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 душевно завывает, глядя на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>выть</rusName>
+  <uaName>вити</uaName>
   <shortDesc>душевно выть на кого-то. выть на луну</shortDesc>
 </Social>

--- a/socials/hug.xml
+++ b/socials/hug.xml
@@ -15,5 +15,6 @@
   <msgVictimFound2>%1$^C1 обнимает тебя и %3$C4.</msgVictimFound2>
   <position>rest</position>
   <rusName>обнять</rusName>
+  <uaName>обійняти</uaName>
   <shortDesc>дружески обнять</shortDesc>
 </Social>

--- a/socials/hush.xml
+++ b/socials/hush.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 вежливо просит тебя помолчать.</msgVictimFound>
   <position>rest</position>
   <rusName>молчать</rusName>
+  <uaName>мовчати</uaName>
   <shortDesc>просить помолчать либо заткнуться самому</shortDesc>
 </Social>

--- a/socials/innocent.xml
+++ b/socials/innocent.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смотрит на тебя, невинно хлопая ресницами.</msgVictimFound>
   <position>rest</position>
   <rusName>невинно</rusName>
+  <uaName>невинно</uaName>
   <shortDesc>валять дурочку и невинно насвистывать</shortDesc>
 </Social>

--- a/socials/insane.xml
+++ b/socials/insane.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>псих</rusName>
+  <uaName>псих</uaName>
   <shortDesc>сходить с ума</shortDesc>
 </Social>

--- a/socials/itch.xml
+++ b/socials/itch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 чешет репу, глядя на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>репа</rusName>
+  <uaName>свербіж</uaName>
   <shortDesc>активно чухать репу в процессе размышлений</shortDesc>
 </Social>

--- a/socials/jump.xml
+++ b/socials/jump.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 прыгает на тебя!</msgVictimFound>
   <position>stand</position>
   <rusName>прыгать</rusName>
+  <uaName>стрибати</uaName>
   <shortDesc>прыгать на одном месте или на кого-то</shortDesc>
 </Social>

--- a/socials/kiss.xml
+++ b/socials/kiss.xml
@@ -14,5 +14,6 @@
   <msgVictimFound>$c1 целует тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>поцеловать</rusName>
+  <uaName>поцілувати</uaName>
   <shortDesc>целовать(ся)</shortDesc>
 </Social>

--- a/socials/knee.xml
+++ b/socials/knee.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 внезапно бьет тебя коленом в пах! Ты падаешь на землю в агонии.</msgVictimFound>
   <position>rest</position>
   <rusName>коленом</rusName>
+  <uaName>коліном</uaName>
   <shortDesc>ударить коленкой в пах или просто задрать ногу</shortDesc>
 </Social>

--- a/socials/laces.xml
+++ b/socials/laces.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Ты пытаешься встать, но падаешь! Кто-то связал тебе шнурки!</msgVictimFound>
   <position>rest</position>
   <rusName>шнурки</rusName>
+  <uaName>шнурки</uaName>
   <shortDesc>мелкая пакость: связать шнурки ботинок вместе</shortDesc>
 </Social>

--- a/socials/lag.xml
+++ b/socials/lag.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>завис</rusName>
+  <uaName>завис</uaName>
   <shortDesc>наглядно показать, КАКИЕ у тебя лаги</shortDesc>
 </Social>

--- a/socials/laugh.xml
+++ b/socials/laugh.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 добродушно смеется над тобой...</msgVictimFound>
   <position>rest</position>
   <rusName>смех</rusName>
+  <uaName>сміх</uaName>
   <shortDesc>добродушно посмеиваться</shortDesc>
 </Social>

--- a/socials/leer.xml
+++ b/socials/leer.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 плотоядно смотрит на тебя, не скрывая своих намерений.</msgVictimFound>
   <position>rest</position>
   <rusName>зыркать</rusName>
+  <uaName>зиркати</uaName>
   <shortDesc>плотоядно рассматривтаь кого-либо</shortDesc>
 </Social>

--- a/socials/lick.xml
+++ b/socials/lick.xml
@@ -17,5 +17,6 @@
   <msgVictimObj>%1$^C1 облизывает %3$O4, поглядывая на тебя.</msgVictimObj>
   <position>rest</position>
   <rusName>облизать</rusName>
+  <uaName>облизати</uaName>
   <shortDesc>лизнуть кого-либо в щеку либо облизнуться</shortDesc>
 </Social>

--- a/socials/life.xml
+++ b/socials/life.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Хоть немножко еще пожить дайте, сволочи!</msgVictimFound>
   <position>rest</position>
   <rusName>жизнь</rusName>
+  <uaName>життя</uaName>
   <shortDesc>отчаянно пытаться выжить</shortDesc>
 </Social>

--- a/socials/lightbulb.xml
+++ b/socials/lightbulb.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>осенило</rusName>
+  <uaName>осяяло</uaName>
   <shortDesc>демонстрация окружающим своей креативности</shortDesc>
 </Social>

--- a/socials/liver.xml
+++ b/socials/liver.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 вырывает у тебя печенку. Ты в шоке.</msgVictimFound>
   <position>rest</position>
   <rusName>потрошить</rusName>
+  <uaName>патрати</uaName>
   <shortDesc>самурский социал. Выдрать печень врага и съесть ее</shortDesc>
 </Social>

--- a/socials/lust.xml
+++ b/socials/lust.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 страстно желает твое аппетитное тело.</msgVictimFound>
   <position>rest</position>
   <rusName>похоть</rusName>
+  <uaName>хіть</uaName>
   <shortDesc>похотливо рассматривать окружающих... или себя</shortDesc>
 </Social>

--- a/socials/massage.xml
+++ b/socials/massage.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 нежно массирует твои плечи - Оух... как приятно!</msgVictimFound>
   <position>rest</position>
   <rusName>массаж</rusName>
+  <uaName>масаж</uaName>
   <shortDesc>делать массаж плеч</shortDesc>
 </Social>

--- a/socials/meditate.xml
+++ b/socials/meditate.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>медитировать</rusName>
+  <uaName>медитувати</uaName>
   <shortDesc>углубиться в медитацию</shortDesc>
 </Social>

--- a/socials/mischievous.xml
+++ b/socials/mischievous.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 ухмыляется тебе. Ты знаешь, что ни к чему хорошему это не приведет.</msgVictimFound>
   <position>rest</position>
   <rusName>озорно</rusName>
+  <uaName>пустотливо</uaName>
   <shortDesc>пакостно ухмыляться, задумав шкоду</shortDesc>
 </Social>

--- a/socials/moan.xml
+++ b/socials/moan.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 стонет, глядя на тебя. Эээ?</msgVictimFound>
   <position>rest</position>
   <rusName>стон</rusName>
+  <uaName>стогін</uaName>
   <shortDesc>тихо стонать. горестно стонать, потеряв кого-то</shortDesc>
 </Social>

--- a/socials/moo.xml
+++ b/socials/moo.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 мычит на тебя. Что бы это могло значить?</msgVictimFound>
   <position>rest</position>
   <rusName>муууу</rusName>
+  <uaName>муууу</uaName>
   <shortDesc>мычать, глядя на кого-то добрыми коровьими глазами</shortDesc>
 </Social>

--- a/socials/moon.xml
+++ b/socials/moon.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 с намеком показывает тебе свою попу!?</msgVictimFound>
   <position>rest</position>
   <rusName>попа</rusName>
+  <uaName>попа</uaName>
   <shortDesc>посветить голой попой</shortDesc>
 </Social>

--- a/socials/mosh.xml
+++ b/socials/mosh.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 врезается в тебя в творческом танцевальном порыве, и наступает на обе ноги и ухо! Это было действительно БОЛЬНО!</msgVictimFound>
   <position>rest</position>
   <rusName>плясать</rusName>
+  <uaName>витанцьовувати</uaName>
   <shortDesc>в экстатическом танце биться об пол или окружающих</shortDesc>
 </Social>

--- a/socials/muhaha.xml
+++ b/socials/muhaha.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 {rдемонически {xсмеется над тобой!</msgVictimFound>
   <position>rest</position>
   <rusName>мухаха</rusName>
+  <uaName>мухаха</uaName>
   <shortDesc>демонически смеяться</shortDesc>
 </Social>

--- a/socials/mull.xml
+++ b/socials/mull.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>раздумывать</rusName>
+  <uaName>розмірковувати</uaName>
   <shortDesc>не спеша обмозговывать проблему</shortDesc>
 </Social>

--- a/socials/mutter.xml
+++ b/socials/mutter.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 бормочет что-то тебе на ухо.</msgVictimFound>
   <position>rest</position>
   <rusName>бормотать</rusName>
+  <uaName>бурмотіти</uaName>
   <shortDesc>бормотать себе под нос или кому-то на ухо</shortDesc>
 </Social>

--- a/socials/nail.xml
+++ b/socials/nail.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 выцарапывает тебе глаза. Ты в$Gсё|есь|ся в крови!</msgVictimFound>
   <position>rest</position>
   <rusName>царап</rusName>
+  <uaName>дряп</uaName>
   <shortDesc>сжать до крови кулаки или выцарапать глаза</shortDesc>
 </Social>

--- a/socials/nibble.xml
+++ b/socials/nibble.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 покусывает тебя за ухо.</msgVictimFound>
   <position>rest</position>
   <rusName>кусь</rusName>
+  <uaName>кусь</uaName>
   <shortDesc>покусывать за ухо, грызть свое ухо</shortDesc>
 </Social>

--- a/socials/nod.xml
+++ b/socials/nod.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 кивает тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>кивать</rusName>
+  <uaName>кивати</uaName>
   <shortDesc>кивнуть в знак согласия</shortDesc>
 </Social>

--- a/socials/noogie.xml
+++ b/socials/noogie.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>О НЕТ, $c1 хватает тебя, зажимает твою голову и ЧЕШЕТ ее!</msgVictimFound>
   <position>rest</position>
   <rusName>чесать</rusName>
+  <uaName>чесати</uaName>
   <shortDesc>ЧЕСАТЬ голову (не репу. репу - это itch)</shortDesc>
 </Social>

--- a/socials/nudge.xml
+++ b/socials/nudge.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 толкает тебя локтем.</msgVictimFound>
   <position>rest</position>
   <rusName>толкать</rusName>
+  <uaName>штовхати</uaName>
   <shortDesc>пихнуть локтем</shortDesc>
 </Social>

--- a/socials/nuzzle.xml
+++ b/socials/nuzzle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 трется носом о твою шею.</msgVictimFound>
   <position>rest</position>
   <rusName>носики</rusName>
+  <uaName>носики</uaName>
   <shortDesc>потереться носом об чужую шею</shortDesc>
 </Social>

--- a/socials/oink.xml
+++ b/socials/oink.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хрюкает и водит пятачком в твоем направлении.</msgVictimFound>
   <position>rest</position>
   <rusName>хрю</rusName>
+  <uaName>хрю</uaName>
   <shortDesc>хрюкать и искать желуди</shortDesc>
 </Social>

--- a/socials/pant.xml
+++ b/socials/pant.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тоскливо смотрит на тебя. Видимо, любит.</msgVictimFound>
   <position>rest</position>
   <rusName>тосковать</rusName>
+  <uaName>сумувати</uaName>
   <shortDesc>тосковать по любимому(ой)</shortDesc>
 </Social>

--- a/socials/passout.xml
+++ b/socials/passout.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>отключка</rusName>
+  <uaName>відключка</uaName>
   <shortDesc>пьяный блевунчик и отключка</shortDesc>
 </Social>

--- a/socials/pat.xml
+++ b/socials/pat.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 шлепает тебя по голове.</msgVictimFound>
   <position>rest</position>
   <rusName>шлепать</rusName>
+  <uaName>плескати</uaName>
   <shortDesc>шлепнуть по голове. хлопнуть себя по лбу в озарении</shortDesc>
 </Social>

--- a/socials/peck.xml
+++ b/socials/peck.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 чмокает тебя в щеку - как мило!</msgVictimFound>
   <position>rest</position>
   <rusName>чмок</rusName>
+  <uaName>цьом</uaName>
   <shortDesc>чмокнуть в щечку</shortDesc>
 </Social>

--- a/socials/peer.xml
+++ b/socials/peer.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 внимательно всматривается в тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>разглядывать</rusName>
+  <uaName>роздивлятися</uaName>
   <shortDesc>внимательно разглядывать</shortDesc>
 </Social>

--- a/socials/pie.xml
+++ b/socials/pie.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 запускает торт тебе в лицо... Твое лицо теперь покрыто кремом!</msgVictimFound>
   <position>rest</position>
   <rusName>тортик</rusName>
+  <uaName>тортик</uaName>
   <shortDesc>упасть в торт лицом или запустить тортом в ближнего</shortDesc>
 </Social>

--- a/socials/pinch.xml
+++ b/socials/pinch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 щипает тебя за попку!</msgVictimFound>
   <position>rest</position>
   <rusName>щипать</rusName>
+  <uaName>щипати</uaName>
   <shortDesc>щипнуть себя или ущипнуть кого-либо за попу</shortDesc>
 </Social>

--- a/socials/pissed.xml
+++ b/socials/pissed.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 на тебя з$gол|ол|ла. И что теперь тебе делать?</msgVictimFound>
   <position>rest</position>
   <rusName>галимо</rusName>
+  <uaName>фігово</uaName>
   <shortDesc>злиться на кого-то. пребывать в полном упадке духа</shortDesc>
 </Social>

--- a/socials/plead.xml
+++ b/socials/plead.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>побираться</rusName>
+  <uaName>жебрати</uaName>
   <shortDesc>побираться</shortDesc>
 </Social>

--- a/socials/point.xml
+++ b/socials/point.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 указывает пальцем на тебя. Как невоспитанно!</msgVictimFound>
   <position>rest</position>
   <rusName>указать</rusName>
+  <uaName>вказати</uaName>
   <shortDesc>указывать пальцем, тыкать пальцами во все стороны</shortDesc>
 </Social>

--- a/socials/poke.xml
+++ b/socials/poke.xml
@@ -17,5 +17,6 @@
   <msgVictimObj>%1$^C1 тычет в тебя %3$O5.</msgVictimObj>
   <position>rest</position>
   <rusName>тыкать</rusName>
+  <uaName>тикати</uaName>
   <shortDesc>ткнуть под ребро (на всякий случай:)</shortDesc>
 </Social>

--- a/socials/polite.xml
+++ b/socials/polite.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 вежливо, но неодобрительно, хихикает над твоей шуткой.</msgVictimFound>
   <position>rest</position>
   <rusName>вежливо</rusName>
+  <uaName>ввічливо</uaName>
   <shortDesc>смеяться над шуткой исключительно из вежливости</shortDesc>
 </Social>

--- a/socials/ponder.xml
+++ b/socials/ponder.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>думать</rusName>
+  <uaName>думати</uaName>
   <shortDesc>обдумывать вопрос</shortDesc>
 </Social>

--- a/socials/pound.xml
+++ b/socials/pound.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 делает из тебя кровавый блин.</msgVictimFound>
   <position>rest</position>
   <rusName>бить</rusName>
+  <uaName>бити</uaName>
   <shortDesc>прибить кого-нибудь или демостративно размять кулак</shortDesc>
 </Social>

--- a/socials/pout.xml
+++ b/socials/pout.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>недовольство</rusName>
+  <uaName>невдоволення</uaName>
   <shortDesc>скорчить недовольную рожу</shortDesc>
 </Social>

--- a/socials/powertrip.xml
+++ b/socials/powertrip.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>поперло</rusName>
+  <uaName>поперло</uaName>
   <shortDesc>орать от счастья</shortDesc>
 </Social>

--- a/socials/pray.xml
+++ b/socials/pray.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 целует пыль у твоих ног.</msgVictimFound>
   <position>rest</position>
   <rusName>боготворить</rusName>
+  <uaName>боготворити</uaName>
   <shortDesc>ползать в пыли, доставая богов своими молитвами</shortDesc>
 </Social>

--- a/socials/propose.xml
+++ b/socials/propose.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 падает перед тобой на колени, достает обручальное кольцо из кармана и умоляет: &quot;Давай поженимся, а?!&quot;</msgVictimFound>
   <position>rest</position>
   <rusName>предлагать</rusName>
+  <uaName>пропонувати</uaName>
   <shortDesc>сделать предложение руки и сердца</shortDesc>
 </Social>

--- a/socials/puff.xml
+++ b/socials/puff.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>пуфф</rusName>
+  <uaName>пуфф</uaName>
   <shortDesc>тихонько вздыхать, сидя в уголке</shortDesc>
 </Social>

--- a/socials/puke.xml
+++ b/socials/puke.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 блюет прямо тебе на одежду!</msgVictimFound>
   <position>rest</position>
   <rusName>уээ</rusName>
+  <uaName>уее</uaName>
   <shortDesc>обблевать все кругом</shortDesc>
 </Social>

--- a/socials/punch.xml
+++ b/socials/punch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 шутливо бьет тебя кулаком. Вай!</msgVictimFound>
   <position>rest</position>
   <rusName>бамс</rusName>
+  <uaName>бамс</uaName>
   <shortDesc>тузить кулаком. шутливо</shortDesc>
 </Social>

--- a/socials/purr.xml
+++ b/socials/purr.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 трется о твои ноги и мурлыкает.</msgVictimFound>
   <position>rest</position>
   <rusName>мурчать</rusName>
+  <uaName>мурчати</uaName>
   <shortDesc>мурчать от удовольствия или тереться о чьи-то ноги</shortDesc>
 </Social>

--- a/socials/ramble.xml
+++ b/socials/ramble.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 шо-то говорит.. Непонятно, правда, что, но с большим энтузиазмом!</msgVictimFound>
   <position>rest</position>
   <rusName>поболтать</rusName>
+  <uaName>побалакати</uaName>
   <shortDesc>много и невнятно говорить</shortDesc>
 </Social>

--- a/socials/raspberry.xml
+++ b/socials/raspberry.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Тебя обплевали и показали язык! Это все $c1! Презирает $e тебя, подумайте только!</msgVictimFound>
   <position>rest</position>
   <rusName>презирать</rusName>
+  <uaName>бе</uaName>
   <shortDesc>наплевать на кого-либо и показать ему(ей) язык</shortDesc>
 </Social>

--- a/socials/rofl.xml
+++ b/socials/rofl.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 падает на землю, хохоча над твоей шуткой!</msgVictimFound>
   <position>rest</position>
   <rusName>рофл</rusName>
+  <uaName>рофл</uaName>
   <shortDesc>кататься по полу от смеха</shortDesc>
 </Social>

--- a/socials/roll.xml
+++ b/socials/roll.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смотрит на тебя и в отвращении возводит глаза.</msgVictimFound>
   <position>rest</position>
   <rusName>отврат</rusName>
+  <uaName>огида</uaName>
   <shortDesc>высказать полнейшее отвращение</shortDesc>
 </Social>

--- a/socials/romeo.xml
+++ b/socials/romeo.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>цыгарка</rusName>
+  <uaName>цигарка</uaName>
   <shortDesc>пыхнуть цыгаркой</shortDesc>
 </Social>

--- a/socials/rose.xml
+++ b/socials/rose.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 дарит тебе прекрасную {g---&apos;---,--{{{r@{x</msgVictimFound>
   <position>rest</position>
   <rusName>роза</rusName>
+  <uaName>троянда</uaName>
   <shortDesc>подарить розу</shortDesc>
 </Social>

--- a/socials/rub.xml
+++ b/socials/rub.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 потирает тебе спинку, спускаясь все ниже... А что, приятно!</msgVictimFound>
   <position>rest</position>
   <rusName>потирать</rusName>
+  <uaName>потирати</uaName>
   <shortDesc>чухаться, жадно потирать руки или чью-то спину</shortDesc>
 </Social>

--- a/socials/ruffle.xml
+++ b/socials/ruffle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 игриво ерошит твои волосы.</msgVictimFound>
   <position>rest</position>
   <rusName>ерошить</rusName>
+  <uaName>куйовдити</uaName>
   <shortDesc>ерошить шевелюру - свою или чужую</shortDesc>
 </Social>

--- a/socials/sage.xml
+++ b/socials/sage.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>мудро</rusName>
+  <uaName>мудро</uaName>
   <shortDesc>кивать с мудрым видом</shortDesc>
 </Social>

--- a/socials/scratch.xml
+++ b/socials/scratch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 старательно вычухивает из тебя блошек.</msgVictimFound>
   <position>rest</position>
   <rusName>чухать</rusName>
+  <uaName>чухати</uaName>
   <shortDesc>вычухивать мелких паразитов ака блох</shortDesc>
 </Social>

--- a/socials/scream.xml
+++ b/socials/scream.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 истошно ревет на тебя! Как некрасиво! *sniff*</msgVictimFound>
   <position>rest</position>
   <rusName>вопль</rusName>
+  <uaName>лемент</uaName>
   <shortDesc>истошно реветь в ярости</shortDesc>
 </Social>

--- a/socials/scuff.xml
+++ b/socials/scuff.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 колупает башмаком землю, избегая твоего взгляда.</msgVictimFound>
   <position>rest</position>
   <rusName>колупать</rusName>
+  <uaName>колупати</uaName>
   <shortDesc>застенчиво колупать носком ботинка в пыли</shortDesc>
 </Social>

--- a/socials/serenade.xml
+++ b/socials/serenade.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 исполняет тебе серенаду, ты потрясаешься силе $s голоса.</msgVictimFound>
   <position>rest</position>
   <rusName>серенада</rusName>
+  <uaName>серенада</uaName>
   <shortDesc>исполнить серенаду любви</shortDesc>
 </Social>

--- a/socials/sexplode.xml
+++ b/socials/sexplode.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 начинает злиться на тебя... Скорее прочь отсюда, а то щас каааак рванет!!!</msgVictimFound>
   <position>rest</position>
   <rusName>взрыв</rusName>
+  <uaName>вибух</uaName>
   <shortDesc>беситься или взорваться от ярости</shortDesc>
 </Social>

--- a/socials/shake.xml
+++ b/socials/shake.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 пожимает твою руку.</msgVictimFound>
   <position>rest</position>
   <rusName>пожать</rusName>
+  <uaName>потиснути</uaName>
   <shortDesc>пожать руку или схватиться за голову</shortDesc>
 </Social>

--- a/socials/shiver.xml
+++ b/socials/shiver.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 дрожит от страха перед тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>дрожать</rusName>
+  <uaName>тремтіти</uaName>
   <shortDesc>дрожать от страха</shortDesc>
 </Social>

--- a/socials/shrug.xml
+++ b/socials/shrug.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 пожимает плечами, глядя на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>плечи</rusName>
+  <uaName>плечі</uaName>
   <shortDesc>недоуменно пожать плечами</shortDesc>
 </Social>

--- a/socials/shudder.xml
+++ b/socials/shudder.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>дрожь</rusName>
+  <uaName>дрож</uaName>
   <shortDesc>проглатывать слезы и содрогаться в рыданиях</shortDesc>
 </Social>

--- a/socials/sigh.xml
+++ b/socials/sigh.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 вздыхает... думая о тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>вздох</rusName>
+  <uaName>зітхання</uaName>
   <shortDesc>вздохнуть или вздохнуть, думая о ком-либо</shortDesc>
 </Social>

--- a/socials/silly.xml
+++ b/socials/silly.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>глупо</rusName>
+  <uaName>безглуздо</uaName>
   <shortDesc>прогуливаться по комнате с глупым видом</shortDesc>
 </Social>

--- a/socials/sing.xml
+++ b/socials/sing.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 поет для тебя балладу! Как мило!</msgVictimFound>
   <position>rest</position>
   <rusName>спеть</rusName>
+  <uaName>заспівати</uaName>
   <shortDesc>напевать под нос или исполнить песню для кого-либо</shortDesc>
 </Social>

--- a/socials/slap.xml
+++ b/socials/slap.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 дарит тебе звонкую пощёчину.</msgVictimFound>
   <position>rest</position>
   <rusName>пощечина</rusName>
+  <uaName>ляпас</uaName>
   <shortDesc>дать пощечину</shortDesc>
 </Social>

--- a/socials/slobber.xml
+++ b/socials/slobber.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 слюнявит тебя. Как отвратительно!</msgVictimFound>
   <position>rest</position>
   <rusName>слюни</rusName>
+  <uaName>слина</uaName>
   <shortDesc>обслюнявить кого-либо</shortDesc>
 </Social>

--- a/socials/smile.xml
+++ b/socials/smile.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 улыбается тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>улыбка</rusName>
+  <uaName>усмішка</uaName>
   <shortDesc>просто улыбнуться</shortDesc>
 </Social>

--- a/socials/smirk.xml
+++ b/socials/smirk.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 самодовольно ухмыляется тебе в ответ.</msgVictimFound>
   <position>rest</position>
   <rusName>хы</rusName>
+  <uaName>хи</uaName>
   <shortDesc>самодовольно ухмыльнуться</shortDesc>
 </Social>

--- a/socials/snap.xml
+++ b/socials/snap.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хрустит пальцами, привлекая твое внимание!</msgVictimFound>
   <position>rest</position>
   <rusName>хрусть</rusName>
+  <uaName>хрусь</uaName>
   <shortDesc>разминать пальцы, громко хрустя суставами</shortDesc>
 </Social>

--- a/socials/snarl.xml
+++ b/socials/snarl.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 огрызается на тебя, непонятно почему.</msgVictimFound>
   <position>rest</position>
   <rusName>огрызаться</rusName>
+  <uaName>огризатися</uaName>
   <shortDesc>сердито огрызаться</shortDesc>
 </Social>

--- a/socials/sneeze.xml
+++ b/socials/sneeze.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>чих</rusName>
+  <uaName>чхання</uaName>
   <shortDesc>чихать</shortDesc>
 </Social>

--- a/socials/snicker.xml
+++ b/socials/snicker.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тихонько хихикает с тобой, секретничая.</msgVictimFound>
   <position>rest</position>
   <rusName>хихикать</rusName>
+  <uaName>хихотіти</uaName>
   <shortDesc>тихонько хихикать или секретничать</shortDesc>
 </Social>

--- a/socials/sniff.xml
+++ b/socials/sniff.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 тяжело сопит на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>сопеть</rusName>
+  <uaName>сопіти</uaName>
   <shortDesc>тяжело сопеть</shortDesc>
 </Social>

--- a/socials/snore.xml
+++ b/socials/snore.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>sleep</position>
   <rusName>храп</rusName>
+  <uaName>хропіння</uaName>
   <shortDesc>громко храпеть</shortDesc>
 </Social>

--- a/socials/snort.xml
+++ b/socials/snort.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 насмешливо фыркает на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>фыркать</rusName>
+  <uaName>пирхати</uaName>
   <shortDesc>насмешливо фыркнуть</shortDesc>
 </Social>

--- a/socials/snowball.xml
+++ b/socials/snowball.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 лепит из воздуха снежок и кидает его тебе в лицо.</msgVictimFound>
   <position>rest</position>
   <rusName>снежок</rusName>
+  <uaName>сніжка</uaName>
   <shortDesc>играть в снежки</shortDesc>
 </Social>

--- a/socials/snuggle.xml
+++ b/socials/snuggle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 нежно прижимается к тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>прижаться</rusName>
+  <uaName>пригорнутися</uaName>
   <shortDesc>сворачиваться калачиком. нежно прижиматься</shortDesc>
 </Social>

--- a/socials/sob.xml
+++ b/socials/sob.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Ты чувствуешь себя последним ничтожеством, так как из-за тебя рыдает $c1.</msgVictimFound>
   <position>rest</position>
   <rusName>рыдать</rusName>
+  <uaName>ридати</uaName>
   <shortDesc>рыдать или плакать из-за кого-либо</shortDesc>
 </Social>

--- a/socials/spam.xml
+++ b/socials/spam.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Тебя обспамил$gо||а $c1!</msgVictimFound>
   <position>rest</position>
   <rusName>спамить</rusName>
+  <uaName>спамити</uaName>
   <shortDesc>спамить</shortDesc>
 </Social>

--- a/socials/spank.xml
+++ b/socials/spank.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 игриво шлепает тебя. OUCH!</msgVictimFound>
   <position>rest</position>
   <rusName>шлеп</rusName>
+  <uaName>ляп</uaName>
   <shortDesc>игриво шлепнуть кого-либо</shortDesc>
 </Social>

--- a/socials/spit.xml
+++ b/socials/spit.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 плюет на тебя -- как невежливо!</msgVictimFound>
   <position>rest</position>
   <rusName>плевать</rusName>
+  <uaName>плювати</uaName>
   <shortDesc>плюнуть на кого-либо или просто на пол</shortDesc>
 </Social>

--- a/socials/squeal.xml
+++ b/socials/squeal.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смотрит на тебя и взвизгивает от восторга!</msgVictimFound>
   <position>rest</position>
   <rusName>взвизг</rusName>
+  <uaName>вереск</uaName>
   <shortDesc>визжать от восторга</shortDesc>
 </Social>

--- a/socials/squeeze.xml
+++ b/socials/squeeze.xml
@@ -14,5 +14,6 @@
   <msgVictimFound>$c1 нежно стискивает тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>тискать</rusName>
+  <uaName>стискати</uaName>
   <shortDesc>зажимать или тискать кого-либо</shortDesc>
 </Social>

--- a/socials/squirm.xml
+++ b/socials/squirm.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смотрит на тебя и извивается от восторга.</msgVictimFound>
   <position>rest</position>
   <rusName>извиваться</rusName>
+  <uaName>звиватися</uaName>
   <shortDesc>извиваться всем телом или корчиться от восторга</shortDesc>
 </Social>

--- a/socials/stagger.xml
+++ b/socials/stagger.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 уткнул$gось|ся|ась в тебя. И думает, что перед $y шведская стенка.</msgVictimFound>
   <position>rest</position>
   <rusName>шататься</rusName>
+  <uaName>хитатися</uaName>
   <shortDesc>бесконтролько ходить или уткнуться в кого-то</shortDesc>
 </Social>

--- a/socials/stare.xml
+++ b/socials/stare.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 мечтательно смотрит на тебя, теряясь в твоих глазах...</msgVictimFound>
   <position>rest</position>
   <rusName>пристально</rusName>
+  <uaName>пильно</uaName>
   <shortDesc>глазеть на небо. смотреть в чьи-то глаза:)</shortDesc>
 </Social>

--- a/socials/starve.xml
+++ b/socials/starve.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 умирает от голода прямо у тебя на глазах! Пожалей $s!</msgVictimFound>
   <position>rest</position>
   <rusName>голодать</rusName>
+  <uaName>голодувати</uaName>
   <shortDesc>умирать от голода</shortDesc>
 </Social>

--- a/socials/stretch.xml
+++ b/socials/stretch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 грациозно потягивается, поглядывая на тебя искоса. Ты хочешь $s, не так ли?</msgVictimFound>
   <position>rest</position>
   <rusName>потягиваться</rusName>
+  <uaName>потягуватися</uaName>
   <shortDesc>потянуться</shortDesc>
 </Social>

--- a/socials/strip.xml
+++ b/socials/strip.xml
@@ -15,5 +15,6 @@
   <msgVictimFound>$c1 начинает раздевать тебя...</msgVictimFound>
   <position>rest</position>
   <rusName>стриптиз</rusName>
+  <uaName>стриптиз</uaName>
   <shortDesc>исполнить стриптиз или раздеть кого-либо</shortDesc>
 </Social>

--- a/socials/stroke.xml
+++ b/socials/stroke.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 мягко гладит твое бедро. Ты взволнованно дышишь.</msgVictimFound>
   <position>rest</position>
   <rusName>гладить</rusName>
+  <uaName>гладити</uaName>
   <shortDesc>эротично гладить. себя или кого получится</shortDesc>
 </Social>

--- a/socials/strut.xml
+++ b/socials/strut.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 важно вышагивает, пытаясь привлечь твое внимание.</msgVictimFound>
   <position>rest</position>
   <rusName>вышагивать</rusName>
+  <uaName>крокувати</uaName>
   <shortDesc>важно вышагивать, привлекая внимание</shortDesc>
 </Social>

--- a/socials/sulk.xml
+++ b/socials/sulk.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>бу</rusName>
+  <uaName>бу</uaName>
   <shortDesc>обдуться и обидеться</shortDesc>
 </Social>

--- a/socials/support.xml
+++ b/socials/support.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 обнимает тебя и ободряюще улыбается.</msgVictimFound>
   <position>rest</position>
   <rusName>поддержка</rusName>
+  <uaName>підтримка</uaName>
   <shortDesc>выразить свою поддержку. пытаться не падать духом</shortDesc>
 </Social>

--- a/socials/sweep.xml
+++ b/socials/sweep.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 берет тебя на руки и целует долго и страстно.</msgVictimFound>
   <position>rest</position>
   <rusName>обхватить</rusName>
+  <uaName>обхопити</uaName>
   <shortDesc>взять на руки и страстно целовать</shortDesc>
 </Social>

--- a/socials/swoon.xml
+++ b/socials/swoon.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смотрит на тебя и замирает в абсолютном экстазе.</msgVictimFound>
   <position>rest</position>
   <rusName>замереть</rusName>
+  <uaName>завмерти</uaName>
   <shortDesc>замереть от восхищения</shortDesc>
 </Social>

--- a/socials/tackle.xml
+++ b/socials/tackle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 игриво валит тебя на землю... Продолжение следует!</msgVictimFound>
   <position>rest</position>
   <rusName>ловить</rusName>
+  <uaName>ловити</uaName>
   <shortDesc>игриво цапать или валить на землю</shortDesc>
 </Social>

--- a/socials/tag.xml
+++ b/socials/tag.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 передает тебе квача! Ты квач!</msgVictimFound>
   <position>rest</position>
   <rusName>квач</rusName>
+  <uaName>квач</uaName>
   <shortDesc>играть в квача</shortDesc>
 </Social>

--- a/socials/tank.xml
+++ b/socials/tank.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 предлагает танкануть, спасая тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>танковать</rusName>
+  <uaName>танкувати</uaName>
   <shortDesc>прикрыть кого-то широкой грудью</shortDesc>
 </Social>

--- a/socials/tease.xml
+++ b/socials/tease.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 показывает тебе язык!</msgVictimFound>
   <position>rest</position>
   <rusName>дразнить</rusName>
+  <uaName>дражнити</uaName>
   <shortDesc>дразнить и показывать язык</shortDesc>
 </Social>

--- a/socials/thank.xml
+++ b/socials/thank.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 сердечно благодарит тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>благодарить</rusName>
+  <uaName>дякувати</uaName>
   <shortDesc>сердечно благодарить</shortDesc>
 </Social>

--- a/socials/threaten.xml
+++ b/socials/threaten.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 запугивает тебя. Вот террорист, вот сукин сын(</msgVictimFound>
   <position>rest</position>
   <rusName>грозить</rusName>
+  <uaName>погрожувати</uaName>
   <shortDesc>запугивать кого-либо</shortDesc>
 </Social>

--- a/socials/tickle.xml
+++ b/socials/tickle.xml
@@ -15,5 +15,6 @@
   <msgVictimObj>%1$^C1 щекочет тебя %3$O5.</msgVictimObj>
   <position>rest</position>
   <rusName>щекотать</rusName>
+  <uaName>лоскотати</uaName>
   <shortDesc>щекотать</shortDesc>
 </Social>

--- a/socials/tie.xml
+++ b/socials/tie.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 хватает тебя и намертво приковывает наручниками к кровати.</msgVictimFound>
   <position>rest</position>
   <rusName>tie</rusName>
+  <uaName>tie</uaName>
   <shortDesc>приковать кого-либо наручниками к кровати</shortDesc>
 </Social>

--- a/socials/tight.xml
+++ b/socials/tight.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 крепко обвивает тебя руками.</msgVictimFound>
   <position>rest</position>
   <rusName>крепко</rusName>
+  <uaName>міцно</uaName>
   <shortDesc>крепко обнимать</shortDesc>
 </Social>

--- a/socials/tip.xml
+++ b/socials/tip.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 галантно приподнимает свою шляпу перед тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>шляпа</rusName>
+  <uaName>капелюх</uaName>
   <shortDesc>снять шляпу и приветствовать кого-либо</shortDesc>
 </Social>

--- a/socials/toast.xml
+++ b/socials/toast.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 пьет за твоё здоровье.</msgVictimFound>
   <position>rest</position>
   <rusName>тост</rusName>
+  <uaName>тост</uaName>
   <shortDesc>поднять бокал за кого-либо или пить</shortDesc>
 </Social>

--- a/socials/tongue.xml
+++ b/socials/tongue.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 медленно и страстно облизывает каждый уголок твоего тела...</msgVictimFound>
   <position>rest</position>
   <rusName>облизать</rusName>
+  <uaName>язик</uaName>
   <shortDesc>вылизываться, облизываться или облизать кого-нибудь</shortDesc>
 </Social>

--- a/socials/tweak.xml
+++ b/socials/tweak.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 нежно щипает твою щеку. Это напоминает тебе твою бабушку...</msgVictimFound>
   <position>rest</position>
   <rusName>щека</rusName>
+  <uaName>щока</uaName>
   <shortDesc>нежно ущипнуть кого-либо</shortDesc>
 </Social>

--- a/socials/twiddle.xml
+++ b/socials/twiddle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 вертит твои уши.</msgVictimFound>
   <position>rest</position>
   <rusName>вертеть</rusName>
+  <uaName>крутити</uaName>
   <shortDesc>перебирать пальцами или сворачивать уши в трубочку</shortDesc>
 </Social>

--- a/socials/twitch.xml
+++ b/socials/twitch.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 замечает тебя и начинает нервно дергаться.</msgVictimFound>
   <position>rest</position>
   <rusName>дергаться</rusName>
+  <uaName>смикатися</uaName>
   <shortDesc>нервно дергаться</shortDesc>
 </Social>

--- a/socials/undress.xml
+++ b/socials/undress.xml
@@ -15,5 +15,6 @@
   <msgVictimFound>Ты чувствуешь, как $c1 мысленно раздевает тебя своим взглядом...</msgVictimFound>
   <position>rest</position>
   <rusName>раздевание</rusName>
+  <uaName>роздягання</uaName>
   <shortDesc>раздеваться или раздевать кого-либо взглядом</shortDesc>
 </Social>

--- a/socials/view.xml
+++ b/socials/view.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>наблюдать</rusName>
+  <uaName>спостерігати</uaName>
   <shortDesc>отстраненно наблюдать за происходящим</shortDesc>
 </Social>

--- a/socials/voodoo.xml
+++ b/socials/voodoo.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>Твое сердце уходит в пятки и у тебя начинается жуткая мяугрень!</msgVictimFound>
   <position>rest</position>
   <rusName>вуду</rusName>
+  <uaName>вуду</uaName>
   <shortDesc>шаманить</shortDesc>
 </Social>

--- a/socials/wait.xml
+++ b/socials/wait.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>ждать</rusName>
+  <uaName>чекати</uaName>
   <shortDesc>терпеливо ждать</shortDesc>
 </Social>

--- a/socials/wave.xml
+++ b/socials/wave.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 машет рукой тебе. Счастливо оставаться!</msgVictimFound>
   <position>rest</position>
   <rusName>бай-бай</rusName>
+  <uaName>бай-бай</uaName>
   <shortDesc>прощально помахать рукой</shortDesc>
 </Social>

--- a/socials/whine.xml
+++ b/socials/whine.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 жалобно хнычет, глядя на тебя. Эка невидаль!</msgVictimFound>
   <position>rest</position>
   <rusName>хныкать</rusName>
+  <uaName>нити</uaName>
   <shortDesc>жалобно хныкать</shortDesc>
 </Social>

--- a/socials/whip.xml
+++ b/socials/whip.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 избивает тебя кнутом! О-о-о! Это может быть приятно!</msgVictimFound>
   <position>rest</position>
   <rusName>кнут</rusName>
+  <uaName>батіг</uaName>
   <shortDesc>щелкать кнутом или избивать кого-либо кнутом</shortDesc>
 </Social>

--- a/socials/whistle.xml
+++ b/socials/whistle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 свистит тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>свистеть</rusName>
+  <uaName>свистіти</uaName>
   <shortDesc>насвистывать или свистеть кому-то</shortDesc>
 </Social>

--- a/socials/wiggle.xml
+++ b/socials/wiggle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 виляет задом перед тобой.</msgVictimFound>
   <position>rest</position>
   <rusName>вилять</rusName>
+  <uaName>виляти</uaName>
   <shortDesc>вилять задом</shortDesc>
 </Social>

--- a/socials/wince.xml
+++ b/socials/wince.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 содрогается тебе в ответ.</msgVictimFound>
   <position>rest</position>
   <rusName>содрогаться</rusName>
+  <uaName>кривитися</uaName>
   <shortDesc>содрогаться в агонии</shortDesc>
 </Social>

--- a/socials/wink.xml
+++ b/socials/wink.xml
@@ -19,5 +19,6 @@
   <msgVictimFound>$c1 подмигивает с намеком тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>моргать</rusName>
+  <uaName>моргати</uaName>
   <shortDesc>моргать или подмигивать кому-либо</shortDesc>
 </Social>

--- a/socials/wonder.xml
+++ b/socials/wonder.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 смотрит на тебя с удивлением.</msgVictimFound>
   <position>rest</position>
   <rusName>удивляться</rusName>
+  <uaName>дивуватися</uaName>
   <shortDesc>удивляться или смотреть на кого-либо с удивлением</shortDesc>
 </Social>

--- a/socials/worry.xml
+++ b/socials/worry.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 взволнованно смотрит на тебя.</msgVictimFound>
   <position>rest</position>
   <rusName>волноваться</rusName>
+  <uaName>хвилюватися</uaName>
   <shortDesc>переживать за кого-то, волноваться</shortDesc>
 </Social>

--- a/socials/worship.xml
+++ b/socials/worship.xml
@@ -15,5 +15,6 @@
   <msgVictimFound>$c1 повергается на землю и кланяется тебе.</msgVictimFound>
   <position>rest</position>
   <rusName>челобитие</rusName>
+  <uaName>чолобитна</uaName>
   <shortDesc>поклоняться кому-либо или богам</shortDesc>
 </Social>

--- a/socials/wrestle.xml
+++ b/socials/wrestle.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 швыряет тебя на пол и ждет до 10.</msgVictimFound>
   <position>rest</position>
   <rusName>борьба</rusName>
+  <uaName>боротьба</uaName>
   <shortDesc>швырнуть кого-то на пол. бороться с собой</shortDesc>
 </Social>

--- a/socials/wrist.xml
+++ b/socials/wrist.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 бьет тебя по рукам линейкой.</msgVictimFound>
   <position>rest</position>
   <rusName>линейкой</rusName>
+  <uaName>лінійкою</uaName>
   <shortDesc>бить по рукам линейкой</shortDesc>
 </Social>

--- a/socials/yae.xml
+++ b/socials/yae.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 выразительно смотрит на тебя, полагая что ты полн$Gое|ый|ая кретин$Gко||ка.</msgVictimFound>
   <position>rest</position>
   <rusName>идиот</rusName>
+  <uaName>ідіот</uaName>
   <shortDesc>считать себя или кого-либо идиотом</shortDesc>
 </Social>

--- a/socials/yawn.xml
+++ b/socials/yawn.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>зевать</rusName>
+  <uaName>позіхати</uaName>
   <shortDesc>зевать</shortDesc>
 </Social>

--- a/socials/yeehaw.xml
+++ b/socials/yeehaw.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>ю-ху</rusName>
+  <uaName>ю-ху</uaName>
   <shortDesc>буйно радоваться</shortDesc>
 </Social>

--- a/socials/yodel.xml
+++ b/socials/yodel.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>$c1 орет тебе в ухо! Во дурило!</msgVictimFound>
   <position>rest</position>
   <rusName>распев</rusName>
+  <uaName>розспів</uaName>
   <shortDesc>громко и немелодично распеваться</shortDesc>
 </Social>

--- a/socials/yowl.xml
+++ b/socials/yowl.xml
@@ -12,5 +12,6 @@
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>вой</rusName>
+  <uaName>виття</uaName>
   <shortDesc>расстроено выть</shortDesc>
 </Social>

--- a/socials/zerbert.xml
+++ b/socials/zerbert.xml
@@ -12,5 +12,6 @@
   <msgVictimFound>АЙАЙАЙ! $c1 натяну$gло|л|ла тебе на голову рубашку и дует тебе в пуп! Щекотно!!!!</msgVictimFound>
   <position>rest</position>
   <rusName>дунуть</rusName>
+  <uaName>дмухнути</uaName>
   <shortDesc>это не то, что вы подумали, это означает дунуть в пупок:)</shortDesc>
 </Social>


### PR DESCRIPTION
Fills `<uaName>` for all 244 socials. Pairs with dreamland_code#844 (per-language help titles) — without this a Ukrainian viewer read `Социал хвастать, boast` as the article title and had nothing Ukrainian to type.

Register follows the Russian names: verbs where the Russian is a verb, onomatopoeia unchanged where both languages spell it the same (гав, хрю, муууу, брб, рофл).

**No apostrophes** — these are typed commands and the Ukrainian modifier-letter apostrophe is not enterable; where the natural form wanted one the wording went another way (`highfive` → `лапу`, `flex` → `мускули`).

Verified: no UA name collides with another social's Latin or Russian name, no mixed Latin/Cyrillic in a word, no Russian-only letters (ы/э/ъ/ё), all 244 files parse.