### PR TITLE
EN/UA catalog: name the reader's own commands, not the Russian ones

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -4695,8 +4695,8 @@
             "ua": "Ти знову можеш говорити з будь-ким."
         },
         "Также смотри {hc{yпрослушать ?{x.": {
-            "en": "Also see {hc{yпрослушать ?{x.",
-            "ua": "Дивись також {hc{yпрослушать ?{x."
+            "en": "Also see {hc{yreplay ?{x.",
+            "ua": "Дивись також {hc{yпрослухати ?{x."
         }
     },
     "plug-ins/comm/compare.cpp": {
@@ -4787,8 +4787,8 @@
             "ua": "Вкажи мову: англ, укр або рос."
         },
         "  {%s%-14s {%s%5s {xнабери {y{hcрежим язык{x для установки": {
-            "en": "  {%s%-14s {%s%5s {xtype {y{hcрежим язык{x to set",
-            "ua": "  {%s%-14s {%s%5s {xнабери {y{hcрежим язык{x для встановлення"
+            "en": "  {%s%-14s {%s%5s {xtype {y{hcconfig lang{x to set",
+            "ua": "  {%s%-14s {%s%5s {xнабери {y{hcрежим мова{x для встановлення"
         },
         "Вывод установлен на %1$d лин%1$Iию|ии|ий.": {
             "en": "Output is set to %1$d line%1$I|s|s.",
@@ -4815,8 +4815,8 @@
             "ua": "\nВикористовуй команду {hc{yрежим %s %s{x, щоб змінити."
         },
         "\r\nПодробнее смотри по команде {yрежим {Dнастройка{w.": {
-            "en": "\r\nFor details see the {yрежим {Dнастройка{w command.",
-            "ua": "\r\nДетальніше дивись команду {yрежим {Dнастройка{w."
+            "en": "\r\nFor details see the {yconfig {Dsetting{w command.",
+            "ua": "\r\nДетальніше дивись команду {yрежим {Dналаштування{w."
         },
         "Тебе непрерывно выводится %1$d лин%1$Iия|ии|ий текста.": {
             "en": "You're constantly being shown %1$d line%1$I|s|s of text.",
@@ -4827,7 +4827,7 @@
             "ua": "Ти отримуєш довгі повідомлення без буферизації."
         },
         "Твой персонаж не связан с пользователями Telegram, набери {y{hcрежим телеграм{x.": {
-            "en": "Your character isn't linked to a Telegram user, type {y{hcрежим телеграм{x.",
+            "en": "Your character isn't linked to a Telegram user, type {y{hcconfig telegram{x.",
             "ua": "Твій персонаж не зв'язаний з користувачем Telegram, набери {y{hcрежим телеграм{x."
         },
         "Пользователь Discord {C%s{w ({C%s{w), статус %s": {
@@ -4835,12 +4835,12 @@
             "ua": "Користувач Discord {C%s{w ({C%s{w), статус %s"
         },
         "Твой персонаж не связан с пользователем Discord, набери {y{hcрежим дискорд{x": {
-            "en": "Your character isn't linked to a Discord user, type {y{hcрежим дискорд{x",
+            "en": "Your character isn't linked to a Discord user, type {y{hcconfig discord{x",
             "ua": "Твій персонаж не зв'язаний з користувачем Discord, набери {y{hcрежим дискорд{x"
         },
         "  {%s%-14s {%s%6s {xнабери {y{hcрежим цвет{x вкл, выкл или мягкий": {
-            "en": "  {%s%-14s {%s%6s {xtype {y{hcрежим цвет{x on, off or mild",
-            "ua": "  {%s%-14s {%s%6s {xнабери {y{hcрежим цвет{x увімк, вимк чи м'який"
+            "en": "  {%s%-14s {%s%6s {xtype {y{hcconfig color{x on, off or mild",
+            "ua": "  {%s%-14s {%s%6s {xнабери {y{hcрежим колір{x увімк, вимк чи м'який"
         },
         "язык": {
             "en": "lang",
@@ -4875,8 +4875,8 @@
             "ua": "м'який"
         },
         "Для изменения используй {yрежим строк{x число.": {
-            "en": "To change, type {yрежим строк{x number.",
-            "ua": "Щоб змінити, набери {yрежим строк{x число."
+            "en": "To change, type {yconfig lines{x number.",
+            "ua": "Щоб змінити, набери {yрежим рядки{x число."
         },
         "Ты используешь 'мягкую' цветовую схему.": {
             "en": "You're using the 'mild' color scheme.",
@@ -4907,8 +4907,8 @@
             "ua": "  {W*{x набери {W/link %s{x"
         },
         "Для смены секретного слова набери {hc{yрежим дискорд очистить{x.": {
-            "en": "To change the secret word, type {hc{yрежим дискорд очистить{x.",
-            "ua": "Щоб змінити секретне слово, набери {hc{yрежим дискорд очистить{x."
+            "en": "To change the secret word, type {hc{yconfig discord clear{x.",
+            "ua": "Щоб змінити секретне слово, набери {hc{yрежим дискорд очистити{x."
         },
         "Твой персонаж связан с пользователем {C%s{w ({C%s{w), статус %s": {
             "en": "Your character is linked to user {C%s{w ({C%s{w), status %s",
@@ -4919,8 +4919,8 @@
             "ua": "Для повторного зв'язку набери {W/link %s{x у приваті з ботом {WВалькирия{x"
         },
         "Для очистки и смены секретного слова набери {hc{yрежим дискорд очистить{x.": {
-            "en": "To clear and change the secret word, type {hc{yрежим дискорд очистить{x.",
-            "ua": "Щоб очистити та змінити секретне слово, набери {hc{yрежим дискорд очистить{x."
+            "en": "To clear and change the secret word, type {hc{yconfig discord clear{x.",
+            "ua": "Щоб очистити та змінити секретне слово, набери {hc{yрежим дискорд очистити{x."
         },
         "Укажи: вкл, выкл или мягкий.": {
             "en": "Specify: on, off or mild.",
@@ -11407,8 +11407,8 @@
             "ua": "$c1 прокинул$gося|вся|ася від жахіття, яке мучило його."
         },
         "Поклонись своему Гильдмастеру для вампирьей Инициации ({hc{yсправка инициация{x).": {
-            "en": "Bow to your Guildmaster for the vampiric Initiation ({hc{yhelp инициация{x).",
-            "ua": "Вклонись своєму Гільдмайстру для вампірської Ініціації ({hc{yдовідка инициация{x)."
+            "en": "Bow to your Guildmaster for the vampiric Initiation ({hc{yhelp initiation{x).",
+            "ua": "Вклонись своєму Гільдмайстру для вампірської Ініціації ({hc{yдовідка ініціація{x)."
         }
     },
     "plug-ins/groups/class_warrior.cpp": {
@@ -12853,8 +12853,8 @@
             "ua": "Такого вміння немає."
         },
         "Использование: {yумение{x <умение или заклинание>": {
-            "en": "Usage: {yумение{x <skill or spell>",
-            "ua": "Використання: {yумение{x <уміння чи заклинання>"
+            "en": "Usage: {yshowskill{x <skill or spell>",
+            "ua": "Використання: {yпоказатиуміння{x <уміння чи заклинання>"
         }
     },
     "plug-ins/learn/teach.cpp": {
@@ -13665,8 +13665,8 @@
             "ua": "Опублікован%1$Iо|о|о {W%1$d{x повідомлен%1$Iня|ня|ь про Кару Небесну ('{hc{yпокарання{x')."
         },
         "Тебя ожида%1$Iет|ют|ют {W%1$d{x сообщен%1$Iие|ия|ий о преступлени%1$Iи|ях|ях ('{hc{yпреступление{x').": {
-            "en": "You have {W%1$d{x message%1$I|s|s about crime%1$I|s|s awaiting you ('{hc{yпреступление{x').",
-            "ua": "На тебе чека%1$Iє|ють|ють {W%1$d{x повідомлен%1$Iня|ня|ь про злочин%1$I|и|ів ('{hc{yпреступление{x')."
+            "en": "You have {W%1$d{x message%1$I|s|s about crime%1$I|s|s awaiting you ('{hc{ycrime{x').",
+            "ua": "На тебе чека%1$Iє|ють|ють {W%1$d{x повідомлен%1$Iня|ня|ь про злочин%1$I|и|ів ('{hc{yзлочин{x')."
         },
         "У тебя {W%1$d{x непрочитан%1$Iное|ных|ных пис%1$Iьмо|ьма|ем ('{hc{yписьмо{x').": {
             "en": "You have {W%1$d{x unread letter%1$I|s|s ('{hc{ymail{x').",
@@ -14105,19 +14105,19 @@
             "ua": "          {W%4d{w %s (%d-е місце)\r\n"
         },
         "{wКоманды{x: {y{hcквест сдать{x, {y{hcквест сдать опыт{x, {y{hcквест найти{x, {y{hcквест отменить{x.": {
-            "en": "{wCommands{x: {y{hcквест сдать{x, {y{hcквест сдать опыт{x, {y{hcквест найти{x, {y{hcквест отменить{x.",
-            "ua": "{wКоманди{x: {y{hcквест сдать{x, {y{hcквест сдать опыт{x, {y{hcквест найти{x, {y{hcквест отменить{x."
+            "en": "{wCommands{x: {y{hcquest complete{x, {y{hcquest complete exp{x, {y{hcquest find{x, {y{hcquest cancel{x.",
+            "ua": "{wКоманди{x: {y{hcквест завершити{x, {y{hcквест завершити досвід{x, {y{hcквест знайти{x, {y{hcквест скасувати{x."
         },
         "Использование: quest set <player> <quest id> [+]<num. of victories>": {
             "en": "Usage: quest set <player> <quest id> [+]<num. of victories>",
             "ua": "Використання: quest set <player> <quest id> [+]<num. of victories>"
         },
         "Смотри также {y{hcквест ?{x для списка всех возможных действий.": {
-            "en": "See also {y{hcквест ?{x for a list of all possible actions.",
+            "en": "See also {y{hcquest ?{x for a list of all possible actions.",
             "ua": "Дивись також {y{hcквест ?{x для списку всіх можливих дій."
         },
         "У тебя сейчас нет задания от квестора. См. также команду {y{hcквест{x.": {
-            "en": "You don't currently have a task from a quest giver. See also the command {y{hcквест{x.",
+            "en": "You don't currently have a task from a quest giver. See also the command {y{hcquest{x.",
             "ua": "У тебе зараз немає завдання від квестора. Див. також команду {y{hcквест{x."
         },
         "У тебя сейчас нет задания. Подробности читай по команде {y{hcсправка квесты{x.": {


### PR DESCRIPTION
Follow-up to #433. Twelve catalog messages instructed an English or Ukrainian reader to type a **Russian** command — `режим цвет`, `квест сдать`, `умение`, `преступление`, `help инициация`. Typing what the message says does nothing in their client.

Each replacement was checked against the thing that actually parses it:

| message | EN | UA | source of truth |
|---|---|---|---|
| `режим <opt>` | `config lang/color/lines` | `режим мова/колір/рядки` | `commands/config.xml` name + `<extra l=en/ua>` |
| `режим телеграм/дискорд [очистить]` | `config telegram/discord [clear]` | `режим …/очистити` | `print_line()` option names + `synonyms.json` clear |
| `квест сдать/сдать опыт/найти/отменить` | `quest complete/complete exp/find/cancel` | `квест завершити/…досвід/знайти/скасувати` | `quest.xml` + `synonyms.json` |
| `прослушать ?` | `replay ?` | `прослухати ?` | `commands/replay.xml` |
| `умение` | `showskill` | `показатиуміння` | `commands/showskill.xml` |
| `преступление` | `crime` | `злочин` | `notes/crime.xml` |
| `справка инициация` | `help initiation` | `довідка ініціація` | help 836 keywords |

**Deliberately left Russian:** `#дрим-чат` and `Валькирия` — a Discord channel and a bot, proper names rather than commands.

RU source strings untouched, so Russian output is byte-identical.

**Not in this PR:** the same defect exists in 57 more EN values in the other catalog files (areas quest prompts, spells, public utils). Most of those are `сказать <RU phrase>` answer prompts whose phrase is matched by a Fenia `onSpeech` handler — translating the instruction without teaching the matcher would break the quest, so they need code, not just data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)