### PR TITLE
Catalog: skill-help header words + quest see-also

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -1,4 +1,22 @@
 {
+    "plug-ins/fight_core/skill_utils.cpp": {
+        "Заклинание": {
+            "en": "Spell",
+            "ua": "Закляття"
+        },
+        "Умение": {
+            "en": "Skill",
+            "ua": "Уміння"
+        },
+        ", входит в группу ": {
+            "en": ", group ",
+            "ua": ", входить до групи "
+        },
+        ", входит в группы ": {
+            "en": ", groups ",
+            "ua": ", входить до груп "
+        }
+    },
     "plug-ins/help/helpformatter.cpp": {
         "справка": {
             "en": "help",
@@ -14052,6 +14070,10 @@
         }
     },
     "plug-ins/quest/command/cquest.cpp": {
+        "Также смотри {W? квесты{x.": {
+            "en": "See also {W? quests{x.",
+            "ua": "Дивись також {W? квести{x."
+        },
         "%s: имя не найдено.": {
             "en": "%s: name not found.",
             "ua": "%s: ім'я не знайдено."


### PR DESCRIPTION
The en/ua side of dreamland_code#848.

- `plug-ins/fight_core/skill_utils.cpp` (new file-key): `Заклинание` → Spell / Закляття, `Умение` → Skill / Уміння, and the group frame in both numbers (`, group ` / `, groups `; `, входить до групи ` / `, входить до груп `).
- `plug-ins/quest/command/cquest.cpp`: the see-also line — EN `See also {W? quests{x.`, UA `Дивись також {W? квести{x.` (help 123 carries QUESTS / КВЕСТИ as keywords).

RU keys are the source text, so Russian output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)