### PR TITLE
Catalog: skill-name connector

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -1,5 +1,9 @@
 {
     "plug-ins/fight_core/skill_utils.cpp": {
+        "или": {
+            "en": "or",
+            "ua": "або"
+        },
         "Заклинание": {
             "en": "Spell",
             "ua": "Закляття"


### PR DESCRIPTION
One string for dreamland_code#849: the `или` between the two names in a skill-help header → `or` / `або`, the same pair `defaultprofession.cpp` and `defaultrace.cpp` already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)