### PR TITLE
Give the name command a help, and stop score pointing at a dead form

### DIFF
--- a/commands/pcname.xml
+++ b/commands/pcname.xml
@@ -2,6 +2,50 @@
 <Command>
   <cat>config</cat>
   <extra>keep_hide ghost</extra>
+  <help id="5088" level="-1" type="CommandHelp">
+    <extra l="en">names transliteration name forms latin cyrillic</extra>
+    <extra l="ru">имена транслитерация формы имени латиница кириллица</extra>
+    <extra l="ua">імена транслітерація форми імені латиниця кирилиця</extra>
+    <text l="en">%FMT% *%CMD%*
+Shows how your name is written in each of the three languages. The line with a star beside it is the language you registered under: that form is your real name, and it cannot be changed.
+
+%FMT% *%CMD%* _en|ru|ua_ _form_
+Sets how your name looks to everyone who reads the game in that language. The English form must be Latin letters, the Russian and Ukrainian forms Cyrillic, and no form may repeat a name another player already carries.
+
+None of this is required. The missing forms are filled in for you the first time you enter the game: a Cyrillic name is transliterated into Latin so that English readers can address you, and the Cyrillic forms are declined through the cases automatically, so that you read correctly in the middle of a sentence. Reach for this command when the automatic guess is not quite you.
+
+Available from level 10. A form that strays too far from the name you registered under has to be approved by an immortal -- ask one. Which language *you* read the game in is a separate setting (%H% {hh1087configuration{x).
+
+%SA% %H% {hh31roleplay{x
+</text>
+    <text l="ru">%FMT% *%CMD%*
+Покажет, как твое имя записано на каждом из трех языков. Строка со звездочкой -- это язык, под которым ты зарегистрирован: та форма и есть твое настоящее имя, менять ее нельзя.
+
+%FMT% *%CMD%* _en|ru|ua_ _форма_
+Задает, как твое имя выглядит для всех, кто читает игру на этом языке. Английская форма пишется латиницей, русская и украинская -- кириллицей, и ни одна из форм не должна повторять имя другого игрока.
+
+Делать это необязательно. Недостающие формы заполняются сами при первом входе в игру: имя с кириллицы переводится в латиницу, чтобы к тебе могли обратиться англоязычные, а кириллические формы автоматически склоняются по падежам, чтобы ты правильно читался посреди фразы. Команда нужна тогда, когда автоматика угадала не совсем тебя.
+
+Доступно с 10 уровня. Форму, которая слишком далеко ушла от имени при регистрации, должен подтвердить бессмертный -- обратись к нему. На каком языке читаешь игру ты сам -- отдельная настройка (%H% {hh1087режим{x).
+
+%SA% %H% {hh31отыгрыш{x
+</text>
+    <text l="ua">%FMT% *%CMD%*
+Покаже, як твоє імʼя записане кожною з трьох мов. Рядок із зірочкою -- це мова, під якою ти зареєстрований: та форма і є твоє справжнє імʼя, змінювати її не можна.
+
+%FMT% *%CMD%* _en|ru|ua_ _форма_
+Задає, як твоє імʼя виглядає для всіх, хто читає гру цією мовою. Англійська форма пишеться латиницею, російська й українська -- кирилицею, і жодна з форм не повинна повторювати імʼя іншого гравця.
+
+Робити це необовʼязково. Відсутні форми заповнюються самі під час першого входу в гру: імʼя з кирилиці переводиться в латиницю, щоб до тебе могли звернутися англомовні, а кириличні форми автоматично відмінюються за відмінками, щоб ти правильно читався посеред фрази. Команда потрібна тоді, коли автоматика вгадала не зовсім тебе.
+
+Доступно з 10 рівня. Форму, яка надто далеко відійшла від імені при реєстрації, має підтвердити безсмертний -- звернися до нього. Якою мовою читаєш гру ти сам -- окреме налаштування (%H% {hh1087режим{x).
+
+%SA% %H% {hh31рольова гра{x
+</text>
+    <title l="en">Your name in the other languages</title>
+    <title l="ru">Твое имя на других языках</title>
+    <title l="ua">Твоє імʼя іншими мовами</title>
+  </help>
   <hint l="en">set your name for other languages</hint>
   <hint l="ru">задать свое имя на других языках</hint>
   <hint l="ua">задати своє ім'я іншими мовами</hint>

--- a/commands/score.xml
+++ b/commands/score.xml
@@ -9,8 +9,8 @@
     <extra l="ru">добрых состояние статус убито злых</extra>
     <extra l="ua">добрих стан статус убито злих</extra>
     <text l="en">%FMT% *score*
-%FFF% *detailed score*
-Shows your current stats most comprehensively. The first command will display nicely and beautifully, the second one in more detail.
+%FFF% *oscore*
+Both show your current stats. The first is the compact, readable summary; the second is the classic detailed layout, kept for those who prefer it.
 
 %FMT% *score* _parameter_
 Will display information only for the specified parameter, among those mentioned in the full output of this command. Examples of parameters: health, mana, agility, race, weight, damage, silver, and so on.
@@ -22,7 +22,7 @@ Shows how much money you have, experience points, as well as how many creatures 
 </text>
     <text l="ru">%FMT% *счет*
 %FFF% *ссчет*
-Показывает твои текущие параметры в наиболее полном объеме. Первая команда отобразит удобно и красиво, вторая -- более подробно.
+Обе команды показывают твои текущие параметры. Первая -- краткая и удобная сводка, вторая -- классический подробный вид, оставленный для тех, кому он привычнее.
 
 %FMT% *счет* _параметр_
 Выведет только информацию по указанному параметру, из числа тех, что упоминаются в полном выводе этой команды. Примеры параметров: здоровье, мана, ловкость, раса, вес, урон, серебро и так далее.
@@ -33,8 +33,8 @@ Shows how much money you have, experience points, as well as how many creatures 
 Покажет, сколько у тебя денег, очков опыта, а также сколько существ твоей {hh33натуры{x и всех остальных было тобой убито до этих пор. {hh138Анти-паладинам{x важно знать, сколько существ именно противоположной натуры (то есть, добрых) они убили, но этого команда, к сожалению, пока не показывает.
 </text>
     <text l="ua">%FMT% *рахунок*
-%FFF% *детальний рахунок*
-Показує твої поточні параметри в найповнішому обсязі. Перша команда відобразить зручно і красиво, друга -- більш детально.
+%FFF% *срахунок*
+Обидві команди показують твої поточні параметри. Перша -- стислий і зручний підсумок, друга -- класичний детальний вигляд, залишений для тих, кому він звичніший.
 
 %FMT% *рахунок* _параметр_
 Виведе лише інформацію за вказаним параметром, з тих, що згадуються у повному виводі цієї команди. Приклади параметрів: здоров'я, мана, спритність, раса, вага, шкода, срібло і так далі.


### PR DESCRIPTION
Two help gaps found while preparing the changelog.

**`name` had no help node at all.** So `help name` fell through to article 11 (divine favours) and `help имя` to article 31 (roleplay) — both keywords already belonged to other articles, which made a brand-new command undiscoverable. New article **5088** covers both forms of the command, what is filled in automatically on first entry (Latin transliteration, case declension), the Latin/Cyrillic rule, the uniqueness check, the level-10 gate, and the immortal approval for a form that strays too far. Cross-links to config (1087) for the reader's own language and to roleplay (31).

Id taken **above the current max** rather than the gap `abc maxhelp` reported, per the CLAUDE.md rule — a gap can hold an unsynced live stub, and a duplicate help id crashes the server on reload.

**Article 999 named a command that no longer exists.** It offered `detailed score` in English and `детальний рахунок` in Ukrainian; that form became the separate `oscore` command. Russian already said `ссчет` and was correct. All three now name it and describe the split the same way: score is the compact summary, oscore the classic detailed layout.