### PR TITLE
help 5088: index the Ukrainian name so 'help ім'я' finds it

### DIFF
--- a/commands/pcname.xml
+++ b/commands/pcname.xml
@@ -5,7 +5,7 @@
   <help id="5088" level="-1" type="CommandHelp">
     <extra l="en">names transliteration name forms latin cyrillic</extra>
     <extra l="ru">имена транслитерация формы имени латиница кириллица</extra>
-    <extra l="ua">імена транслітерація форми імені латиниця кирилиця</extra>
+    <extra l="ua">імя імена транслітерація форми імені латиниця кирилиця</extra>
     <text l="en">%FMT% *%CMD%*
 Shows how your name is written in each of the three languages. The line with a star beside it is the language you registered under: that form is your real name, and it cannot be changed.
 


### PR DESCRIPTION
Follow-up to #438. The new article answered to `name` and `имя` but not to `ім'я`: the help search normalises the apostrophe away, so a Ukrainian reader looks up `імя`, which appeared nowhere in the article. `help ім'я` therefore offered articles 11 and 31 instead — the same two wrong answers the article was written to fix.

Adds `імя` to the Ukrainian search terms.