### PR TITLE
help 999: make the score article findable by its Ukrainian names

### DIFF
--- a/commands/score.xml
+++ b/commands/score.xml
@@ -7,7 +7,7 @@
   <help id="999" level="-1" ref="experience oscore worth" type="CommandHelp">
     <extra l="en">good state status killed evil</extra>
     <extra l="ru">добрых состояние статус убито злых</extra>
-    <extra l="ua">добрих стан статус убито злих</extra>
+    <extra l="ua">рахунок срахунок дохід добрих стан статус убито злих</extra>
     <text l="en">%FMT% *score*
 %FFF% *oscore*
 Both show your current stats. The first is the compact, readable summary; the second is the classic detailed layout, kept for those who prefer it.


### PR DESCRIPTION
Found while verifying #438. `help счет` lists article 999 among its matches; `help рахунок` does not — it returns only the three bank articles, because 999 carries `счет` in its Russian keywords and nothing equivalent in Ukrainian. So a Ukrainian player could not reach the help for their own `рахунок` command, nor for `срахунок` or `дохід`.

Adds all three to the Ukrainian search terms. `рахунок` legitimately also means a bank account, so it now returns a numbered list including 999 — which is the right answer, and what Russian already does.