### PR TITLE
Translate the practice section headings

### DIFF
--- a/config/flagmessages.json
+++ b/config/flagmessages.json
@@ -675,5 +675,17 @@
         "thief_only":  { "en": "only thieves",     "ua": "лише крадії" },
         "never":       { "en": "no one",           "ua": "ніхто" },
         "except_pk":   { "en": "only mobs",        "ua": "лише моби" }
+    },
+
+    // Section headings of the 'practice' list. The bit names are too terse to
+    // show a player as-is ("class:", "language:"), so every flag carries an "en".
+    "skill_category_flags": {
+        "other":    { "en": "miscellaneous",           "ua": "різне" },
+        "class":    { "en": "class skills",            "ua": "класові вміння" },
+        "race":     { "en": "unique abilities",        "ua": "унікальні здібності" },
+        "clan":     { "en": "clan skills",             "ua": "кланові вміння" },
+        "cards":    { "en": "deck skills",             "ua": "вміння колоди" },
+        "language": { "en": "ancient languages",       "ua": "давні мови" },
+        "craft":    { "en": "extra profession skills", "ua": "вміння додаткових професій" }
     }
 }


### PR DESCRIPTION
Seven EN/UA entries for `skill_category_flags`, which supplies the section headings of the `practice` list. Companion to dreamland_code#853, which makes `pracShow` pass the reader's language instead of falling to `LANG_DEFAULT`.

| flag | ru (in-binary) | en | ua |
|---|---|---|---|
| other | Разное | miscellaneous | різне |
| class | классовые умения | class skills | класові вміння |
| race | уникальные способности | unique abilities | унікальні здібності |
| clan | клановые умения | clan skills | кланові вміння |
| cards | умения колоды | deck skills | вміння колоди |
| language | древние языки | ancient languages | давні мови |
| craft | умения дополнительных профессий | extra profession skills | вміння додаткових професій |

Every flag in the table is filled, per the file's own rule that a partially translated table shows a viewer a mix of two languages and is worse than no table at all.

Each entry carries an explicit `"en"` rather than relying on the usual fallback to the bit name — those are internal identifiers and would print as `class:` and `language:`. The Ukrainian for the language group matches `<name l="ua">давні мови</name>` in `skill-groups/ancient languages.xml`.

Picked up by `plug reload most` (`CONFIGURABLE_LOADED(config, flagmessages)`).