### PR TITLE
Announce the 'skeleton' cooldown wearing off

### DIFF
--- a/config/translations/affect_wearoff.json
+++ b/config/translations/affect_wearoff.json
@@ -992,6 +992,10 @@
             "en": "You can once again put Evil to flight.",
             "ua": "Ти знову можеш обернути Зло на втечу."
         },
+        "Ты вновь можешь поднять скелета из могилы.": {
+            "en": "You can once again raise a skeleton from the grave.",
+            "ua": "Ти знову можеш підняти скелета з могили."
+        },
         "Ты вновь можешь призвать на помощь волка.": {
             "en": "You can once again summon a wolf for aid.",
             "ua": "Ти знову можеш прикликати вовка на допомогу."

--- a/generic-skills/skeleton.xml
+++ b/generic-skills/skeleton.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skill type="GenericSkill">
+  <affect type="DefaultAffectHandler">
+    <removeCharSelf>Ты вновь можешь поднять скелета из могилы.</removeCharSelf>
+  </affect>
   <align>evil</align>
   <beats>12</beats>
   <classes>


### PR DESCRIPTION
`skeleton` arms a "skeleton" affect as its summon cooldown (Fenia `spell/skeleton/runArg`), but `generic-skills/skeleton.xml` had no `<affect>` block, so `affect_remove` found no handler and the cooldown expired silently. `adamantite golem` and `ancestral spirits` already carry the same handler.

Adds `DefaultAffectHandler`/`removeCharSelf` and the EN/UA `affect_wearoff` catalog entry. Picked up by `plug reload most` -- both skill XML and `config/translations` are rescanned there.

Reported in-game by Kvoro.