### PR TITLE
l10n: catalog entries for English gquest Discord notifications

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -10265,6 +10265,38 @@
   "Больше всего от руки бандитов пострадала местность {hh%1$s{hx.": {
    "en": "The land that suffered most at the bandits' hands is {hh%1$s{hx.",
    "ua": "Найбільше від рук бандитів постраждала місцевість {hh%1$s{hx."
+  },
+  "Шайка преступников атаковала мирных жителей. Ищутся храбрецы {Y%1$s{y уровней для уничтожения бандитов и их главаря.": {
+   "en": "A gang of criminals has attacked peaceful citizens. Brave souls of levels {Y%1$s{y are wanted to destroy the bandits and their leader.",
+   "ua": "Зграя злочинців напала на мирних жителів. Шукаються сміливці {Y%1$s{y рівнів для знищення бандитів та їхнього ватажка."
+  },
+  "Главаря шайки так никто и не убил.": {
+   "en": "No one ever managed to kill the gang leader.",
+   "ua": "Ватажка зграї так ніхто й не вбив."
+  },
+  "Более того, ни один бандит не пострадал.": {
+   "en": "What is more, not a single bandit was even harmed.",
+   "ua": "Ба більше, жоден бандит навіть не постраждав."
+  },
+  "Самый лучший охотник за бандитами:": {
+   "en": "The best bandit hunter:",
+   "ua": "Найкращий мисливець на бандитів:"
+  },
+  "Самые успешные охотники за бандитами:": {
+   "en": "The most successful bandit hunters:",
+   "ua": "Найуспішніші мисливці на бандитів:"
+  },
+  "{Y%1$s{y уничтожил%2$s главаря шайки!": {
+   "en": "{Y%1$s{y has slain the gang leader!",
+   "ua": "{Y%1$s{y вби%2$s ватажка зграї!"
+  },
+  "%1$s столкнул%2$s с гангстерами возле %3$s.": {
+   "en": "%1$s ran into the gangsters near %3$s.",
+   "ua": "%1$s зіткну%2$s з гангстерами біля %3$s."
+  },
+  "Гангстеры были также замечены неподалеку от %1$s.": {
+   "en": "The gangsters were also spotted not far from %1$s.",
+   "ua": "Гангстерів також помітили неподалік від %1$s."
   }
  },
  "plug-ins/gquest/invasion/invasion.cpp": {
@@ -10331,6 +10363,34 @@
   "Увы.. никто не откликнулся на просьбу о помощи.": {
    "en": "Alas.. no one answered the plea for help.",
    "ua": "На жаль.. ніхто не відгукнувся на прохання про допомогу."
+  },
+  "Благодаря отважной борьбе, полчища саранчи были уничтожены или обращены в бегство! Лучший саранчеборец:": {
+   "en": "Thanks to a valiant struggle, the locust hordes were destroyed or put to flight! Best locust-slayer:",
+   "ua": "Завдяки відважній боротьбі, полчища сарани були знищені або обернені на втечу! Найкращий саранчеборець:"
+  },
+  "Благодаря отважной борьбе, полчища саранчи были уничтожены или обращены в бегство! Лучшие саранчеборцы:": {
+   "en": "Thanks to a valiant struggle, the locust hordes were destroyed or put to flight! Best locust-slayers:",
+   "ua": "Завдяки відважній боротьбі, полчища сарани були знищені або обернені на втечу! Найкращі саранчеборці:"
+  },
+  "Ледяные ветры утихают. Звери благодарят за их спасение:": {
+   "en": "The icy winds subside. The beasts give thanks for their rescue:",
+   "ua": "Крижані вітри вщухають. Звірі дякують за свій порятунок:"
+  },
+  "Мячи не найдены! Матч перенесен. Лучший футболист по версии гигантов:": {
+   "en": "The balls were not found! The match is postponed. Best footballer according to the giants:",
+   "ua": "М'ячі не знайдено! Матч перенесено. Найкращий футболіст за версією велетнів:"
+  },
+  "Мячи не найдены! Матч перенесен. Лучший футбольный коллектив по версии гигантов:": {
+   "en": "The balls were not found! The match is postponed. Best football squad according to the giants:",
+   "ua": "М'ячі не знайдено! Матч перенесено. Найкращий футбольний колектив за версією велетнів:"
+  },
+  "Пузыри лопнули. Лучший лопух:": {
+   "en": "The bubbles have popped. Top popper:",
+   "ua": "Бульбашки луснули. Найкращий лопух:"
+  },
+  "Пузыри лопнули. Лучшие лопухи:": {
+   "en": "The bubbles have popped. Top poppers:",
+   "ua": "Бульбашки луснули. Найкращі лопухи:"
   }
  },
  "plug-ins/gquest/invasion/mobiles.cpp": {
@@ -18179,6 +18239,14 @@
   "До закрытия вакансии остается ": {
    "en": "The vacancy closes in ",
    "ua": "До закриття вакансії лишається "
+  },
+  "{Y%1$s{y зажигает {Yр{Rа{Mд{Gу{Bг{Cу{x {yнад Миром!": {
+   "en": "{Y%1$s{y lights a {Yr{Ra{Mi{Gn{Bb{Co{Rw{x {yover the World!",
+   "ua": "{Y%1$s{y запалює {Yв{Rе{Mс{Gе{Bл{Cк{Rу{x {yнад Світом!"
+  },
+  "{Y%1$s{y приняли на адскую должность!": {
+   "en": "{Y%1$s{y has been hired for the infernal post!",
+   "ua": "{Y%1$s{y прийняли на пекельну посаду!"
   }
  },
  "plug-ins/groups/chance.cpp": {
@@ -19073,6 +19141,18 @@
   "Семь Смертных Грехов": {
    "en": "Seven Deadly Sins",
    "ua": "Сім Смертних Гріхів"
+  },
+  "Бандиты": {
+   "en": "Bandits",
+   "ua": "Бандити"
+  },
+  "Нашествие": {
+   "en": "Invasion",
+   "ua": "Навала"
+  },
+  "Радуга/Семь Смертных Грехов": {
+   "en": "Rainbow / Seven Deadly Sins",
+   "ua": "Веселка / Сім Смертних Гріхів"
   }
  },
  "plug-ins/services/core/price.cpp": {


### PR DESCRIPTION
Catalog side of dreamland_code#861 (gquest Discord notifications in English).

20 entries:

| file key | entries |
|---|---|
| `plug-ins/gquest/core/gqchannel.cpp` | 3 quest profile names, so the raw-body `gecho` can label its Discord post (and its in-game frame) per language |
| `plug-ins/gquest/gangsters/gangsters.cpp` | quest start, both leader-roll-call headers, the "no one killed the leader" / "not a bandit was harmed" pair, the chef-killer line, both second-hint shapes |
| `plug-ins/gquest/rainbow/scenarios.cpp` | rainbow and seven-deadly-sins winner announcements |
| `plug-ins/gquest/invasion/invasion.cpp` | the 7 `winnerMsgOther`/`winnerMsgOtherMlt` strings from `gquests/invasion.xml` |

Applied with `l10n-catalog-add.py` (added=20, unchanged=0, overwritten=0) -- diff is purely additive, every pre-existing entry byte-identical.

`lint-l10n.py`: **0 HARD**. The only new warns are the two colour-code-count ones on the rainbow winner line, where EN `rainbow` / UA `веселку` are 7 letters against RU `радугу`'s 6 -- same benign class as the already-shipped rainbow entries.