### PR TITLE
Rewrite help 1079 and add the catalog for the new 'commands' table

### DIFF
--- a/commands/commands.xml
+++ b/commands/commands.xml
@@ -6,53 +6,44 @@
     <extra l="en">viewing 'command list'</extra>
     <extra l="ru">просмотра 'список команд'</extra>
     <extra l="ua">перегляд 'список команд'</extra>
-    <text l="en">Most actions in our world are performed using =commands=. There are a lot of commands, and to navigate them, there is a help and a general list.
+    <text l="en">Almost everything in our world is done with =commands=. There are a lot of them, so they are sorted into =help sections= -- the same ones you see in the menu on our site: {hlhttps://dreamland.rocks/help/{x.
 
 %FMT% *%CMD%*
-Displays a list of all currently available commands grouped by =categories=. Command categories correspond to menu items in the web help on our website: {hlhttps://dreamland.rocks/help/{x
-
-%FMT% *%CMD%* *show* _command name_
-Displays important parameters of any command: under what conditions it can be typed, whether it can be {hh1091ordered{x to followers, etc.
+The table of commands by section. It lists the commands that have a help article, so you can click any of them and read it right away.
 
 %FMT% *%CMD%* *list*
-Shows a list of Russian and English command names, as well as a short description of each.
+Every command in one list, with a short description and the aliases of each.
 
-%FMT% *%CMD%* *synonyms*
-The list will indicate all possible synonyms for each command.
+%FMT% *%CMD%* *show* _name_
+Everything about a single command: its aliases, its section, in what position you may type it, whether you can {hh1091order{x it to your followers.
 
-%SA% %H% {hh1095socials{x, %H% {hh1059channels{x
+%SA% %H% {hh995help{x, %H% {hh1095socials{x, %H% {hh1059channels{x
 </text>
-    <text l="ru">Большинство действий в нашем мире выполняются с помощью =команд=. Команд есть очень много, и чтобы ориентироваться в них есть справка и общий список.
+    <text l="ru">Почти все в нашем мире делается =командами=. Их очень много, поэтому они разложены по =разделам справки= -- тем же самым, что в меню на нашем сайте: {hlhttps://dreamland.rocks/help/{x.
 
 %FMT% *%CMD%*
-Показывает список всех доступных на данный момент команд, сгруппированных по =категориям=. Категории команд соответствуют пунктам меню в веб-справке на нашем сайте: {hlhttps://dreamland.rocks/help/{x
-
-%FMT% *%CMD%* *показать* _имя команды_
-Показывает важные параметры любой команды: при каких условиях ее можно писать, можно ли ее {hh1091приказать{x последователям и т.д.
+Таблица команд по разделам. В ней те команды, о которых есть справка, так что на любую можно нажать и сразу прочесть.
 
 %FMT% *%CMD%* *список*
-Показывает список русских и английских названий команд, а также краткое описание каждой из них.
+Все команды одним списком, с кратким описанием и синонимами каждой.
 
-%FMT% *%CMD%* *синонимы*
-В списке будут указаны все возможные синонимы каждой команды.
+%FMT% *%CMD%* *показать* _название_
+Все об одной команде: синонимы, раздел, в каком положении ее можно писать, можно ли {hh1091приказать{x ее последователям.
 
-%SA% %H% {hh1095социалы{x, %H% {hh1059каналы{x
+%SA% %H% {hh995помощь{x, %H% {hh1095социалы{x, %H% {hh1059каналы{x
 </text>
-    <text l="ua">Більшість дій у нашому світі виконуються за допомогою =команд=. Команд є дуже багато, і щоб орієнтуватися в них, є довідка та загальний список.
+    <text l="ua">Майже все в нашому світі робиться =командами=. Їх дуже багато, тому вони розкладені по =розділах довідки= -- тих самих, що в меню на нашому сайті: {hlhttps://dreamland.rocks/help/{x.
 
 %FMT% *%CMD%*
-Показує список всіх доступних на даний момент команд, згрупованих за =категоріями=. Категорії команд відповідають пунктам меню у веб-довідці на нашому сайті: {hlhttps://dreamland.rocks/help/{x
-
-%FMT% *%CMD%* *показати* _назва команди_
-Показує важливі параметри будь-якої команди: за яких умов її можна записувати, чи можна її {hh1091наказати{x послідовникам і т.д.
+Таблиця команд за розділами. У ній ті команди, про які є довідка, тож на будь-яку можна натиснути і одразу прочитати.
 
 %FMT% *%CMD%* *список*
-Показує список російських та англійських назв команд, а також короткий опис кожної з них.
+Усі команди одним списком, з коротким описом і синонімами кожної.
 
-%FMT% *%CMD%* *синоніми*
-У списку будуть вказані всі можливі синоніми кожної команди.
+%FMT% *%CMD%* *показати* _назва_
+Усе про одну команду: синоніми, розділ, у якому положенні її можна писати, чи можна її {hh1091наказати{x послідовникам.
 
-%SA% %H% {hh1095соціали{x, %H% {hh1059канали{x
+%SA% %H% {hh995допомога{x, %H% {hh1095соціали{x, %H% {hh1059канали{x
 </text>
     <title l="en">List of Commands</title>
     <title l="ru">Список команд</title>

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -7490,6 +7490,18 @@
   }
  },
  "plug-ins/comm/showtable.cpp": {
+  "{WКоманды{x по разделам справки:": {
+   "en": "{WCommands{x by help section:",
+   "ua": "{WКоманди{x за розділами довідки:"
+  },
+  "Полный список с описаниями: {y{hcкоманды список{x. Все разделы справки: {y{hcпомощь разделы{x.": {
+   "en": "Full list with descriptions: {y{hccommands list{x. All help sections: {y{hchelp index{x.",
+   "ua": "Повний список з описами: {y{hcкоманди список{x. Усі розділи довідки: {y{hcдопомога розділи{x."
+  },
+  "Таблица по разделам: {y{hcкоманды{x. Подробно об одной команде: {yкоманды показать {Dслово{x.": {
+   "en": "Table by section: {y{hccommands{x. One command in detail: {ycommands show {Dword{x.",
+   "ua": "Таблиця за розділами: {y{hcкоманди{x. Докладно про одну команду: {yкоманди показати {Dслово{x."
+  },
   "Найдены такие команды:": {
    "en": "Matching commands:",
    "ua": "Знайдено такі команди:"


### PR DESCRIPTION
Pairs with dreamland_code#862.

**Article 1079.** It documented a `commands synonyms` mode that has never existed — the command only ever handled `show` and `list` — and described its output as grouped by categories it no longer groups by. Rewritten shorter in all three languages around the 14 help sections, with `%SA%` now pointing at the articles for `help` (995), socials (1095) and channels (1059).

**Catalog.** Three strings for `plug-ins/comm/showtable.cpp`: the table header and the two footers. The footers carry the sub-command word inside the translation itself (`команды список` / `commands list` / `команди список`), so each `{hc}` link is a command the reader's own language actually resolves — `arg_is_list` takes `list` and `список`, `arg_is_show` takes `show`, `показать` and `показати`. `lint-l10n.py` reports 0 HARD.