### PR TITLE
Socials in English and Ukrainian

### DIFF
--- a/socials/aargh.xml
+++ b/socials/aargh.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1633" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты орешь от осознания своего идиотизма!</msgCharAuto>
-  <msgCharFound>Ты в отчаяньи рычишь и начинаешь душить $C4!</msgCharFound>
-  <msgCharNoArgument>AAAAAARRRRRRGGGGGGHHHHHH!!!!!!</msgCharNoArgument>
-  <msgCharNotFound>Ты приходишь в полное отчаянье, понимая, что тут некого душить!</msgCharNotFound>
-  <msgOthersAuto>$c1 подвывает, осознав весь трагизм $s положения!</msgOthersAuto>
-  <msgOthersFound>$c1 с леденящим душу завываньем пытается удушить $C4!</msgOthersFound>
-  <msgOthersNoArgument>$c1 набычивается и в отчаяньи рычит!</msgOthersNoArgument>
-  <msgVictimFound>$c1 хватает тебя за горло и беспорядочно мотает твоей головой!</msgVictimFound>
+  <msgCharAuto l="ru">Ты орешь от осознания своего идиотизма!</msgCharAuto>
+  <msgCharAuto l="ua">Ти волаєш від усвідомлення власного ідіотизму!</msgCharAuto>
+  <msgCharAuto l="en">You scream in frustration at your own stupidity!</msgCharAuto>
+  <msgCharFound l="ru">Ты в отчаяньи рычишь и начинаешь душить $C4!</msgCharFound>
+  <msgCharFound l="ua">Ти у відчаї гарчиш і починаєш душити $C4!</msgCharFound>
+  <msgCharFound l="en">You howl in despair and lunge to throttle $C1!</msgCharFound>
+  <msgCharNoArgument l="ru">AAAAAARRRRRRGGGGGGHHHHHH!!!!!!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">AAAAAARRRRRRGGGGGGHHHHHH!!!!!!</msgCharNoArgument>
+  <msgCharNoArgument l="en">AAAAAARRRRRRGGGGGGHHHHHH!!!!!!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты приходишь в полное отчаянье, понимая, что тут некого душить!</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти впадаєш у цілковитий відчай, розуміючи, що тут нема кого душити!</msgCharNotFound>
+  <msgCharNotFound l="en">You despair completely, realising there is nobody here to throttle!</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 подвывает, осознав весь трагизм $s положения!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 підвиває, усвідомивши весь трагізм становища!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 howls, having grasped the full tragedy of the situation!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 с леденящим душу завываньем пытается удушить $C4!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 з крижаним завиванням намагається задушити $C4!</msgOthersFound>
+  <msgOthersFound l="en">$c1 lets out a blood-chilling howl and tries to throttle $C1!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 набычивается и в отчаяньи рычит!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 набичується і у відчаї гарчить!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 hunches up and growls in despair!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 хватает тебя за горло и беспорядочно мотает твоей головой!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 хапає тебе за горло і безладно мотає твоєю головою!</msgVictimFound>
+  <msgVictimFound l="en">$c1 grabs you by the throat and shakes your head about wildly!</msgVictimFound>
   <position>rest</position>
   <rusName>аргх</rusName>
   <uaName>аргх</uaName>
-  <shortDesc>просто порычать или придушить кого-нибудь</shortDesc>
+  <shortDesc l="ru">просто порычать или придушить кого-нибудь</shortDesc>
+  <shortDesc l="ua">просто погарчати або придушити когось</shortDesc>
+  <shortDesc l="en">just growl, or throttle somebody</shortDesc>
 </Social>

--- a/socials/abat.xml
+++ b/socials/abat.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты трепещешь ресницами невинно и соблазнительно.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты трепещешь ресницами невинно и соблазнительно.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти тріпочеш віями невинно і звабливо.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You flutter your eyelashes, innocent and seductive.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 трепещет своими длинными и красивыми ресницами.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 трепещет своими длинными и красивыми ресницами.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 тріпоче своїми довгими і красивими віями.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 flutters those long, beautiful eyelashes.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>луп-луп</rusName>
   <uaName>луп-луп</uaName>
-  <shortDesc>хлопать ресницами</shortDesc>
+  <shortDesc l="ru">хлопать ресницами</shortDesc>
+  <shortDesc l="ua">кліпати віями</shortDesc>
+  <shortDesc l="en">flutter your eyelashes</shortDesc>
 </Social>

--- a/socials/abite.xml
+++ b/socials/abite.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1659" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты кусаешь локти.</msgCharAuto>
-  <msgCharFound>Ты покусываешь $S за шейку.</msgCharFound>
-  <msgCharNoArgument>Ты эротично шепчешь: &quot;{1{gНу? Кто меня куснет?..{2&quot;.</msgCharNoArgument>
-  <msgCharNotFound>Голод напал? А укусить-то некого.</msgCharNotFound>
-  <msgOthersAuto>$c1 кусает локти! Какая трагедия!</msgOthersAuto>
-  <msgOthersFound>$c1 покусывает $C4 за шейку!</msgOthersFound>
-  <msgOthersNoArgument>$c1 эротично шепчет: &quot;{gКусните меня...{x&quot;.</msgOthersNoArgument>
-  <msgVictimFound>$c1 покусывает тебя за шейку.</msgVictimFound>
+  <msgCharAuto l="ru">Ты кусаешь локти.</msgCharAuto>
+  <msgCharAuto l="ua">Ти кусаєш лікті.</msgCharAuto>
+  <msgCharAuto l="en">You bite your elbows.</msgCharAuto>
+  <msgCharFound l="ru">Ты покусываешь $S за шейку.</msgCharFound>
+  <msgCharFound l="ua">Ти покусуєш $C4 за шийку.</msgCharFound>
+  <msgCharFound l="en">You nibble $C1 on the neck.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты эротично шепчешь: &quot;{1{gНу? Кто меня куснет?..{2&quot;.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти еротично шепочеш: "{1{gНу? Хто мене кусне?..{2".</msgCharNoArgument>
+  <msgCharNoArgument l="en">You whisper erotically: "{1{gWell? Who is going to bite me?..{2".</msgCharNoArgument>
+  <msgCharNotFound l="ru">Голод напал? А укусить-то некого.</msgCharNotFound>
+  <msgCharNotFound l="ua">Голод напав? А кусати нема кого.</msgCharNotFound>
+  <msgCharNotFound l="en">Feeling peckish? Nobody here to bite, though.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 кусает локти! Какая трагедия!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 кусає лікті! Яка трагедія!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 bites those elbows! What a tragedy!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 покусывает $C4 за шейку!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 покусує $C4 за шийку!</msgOthersFound>
+  <msgOthersFound l="en">$c1 nibbles $C1 on the neck!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 эротично шепчет: &quot;{gКусните меня...{x&quot;.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 еротично шепоче: "{gКусніть мене...{x".</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 whispers erotically: "{gBite me...{x".</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 покусывает тебя за шейку.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 покусує тебе за шийку.</msgVictimFound>
+  <msgVictimFound l="en">$c1 nibbles you on the neck.</msgVictimFound>
   <position>rest</position>
   <rusName>куснуть</rusName>
   <uaName>куснути</uaName>
-  <shortDesc>кусать.. себе локти или кого-нибудь за шейку</shortDesc>
+  <shortDesc l="ru">кусать.. себе локти или кого-нибудь за шейку</shortDesc>
+  <shortDesc l="ua">кусати.. собі лікті або когось за шийку</shortDesc>
+  <shortDesc l="en">bite.. your own elbows, or somebody's neck</shortDesc>
 </Social>

--- a/socials/ablink.xml
+++ b/socials/ablink.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1721" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Пытаешься себе состроить глазки? Зря. Так можно окосеть.</msgCharAuto>
-  <msgCharFound>Ты стреляешь глазками в $C4.</msgCharFound>
-  <msgCharNoArgument>Ты делаешь ЛУП - ЛУП своими длинными накрашенными ресницами.</msgCharNoArgument>
-  <msgCharNotFound>Кому будем глазки строить?</msgCharNotFound>
+  <msgCharAuto l="ru">Пытаешься себе состроить глазки? Зря. Так можно окосеть.</msgCharAuto>
+  <msgCharAuto l="ua">Намагаєшся будувати очка собі? Дарма. Так і косооким стати можна.</msgCharAuto>
+  <msgCharAuto l="en">Making eyes at yourself? Bad idea. You will end up cross-eyed.</msgCharAuto>
+  <msgCharFound l="ru">Ты стреляешь глазками в $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти стріляєш очками в $C4.</msgCharFound>
+  <msgCharFound l="en">You make eyes at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты делаешь ЛУП - ЛУП своими длинными накрашенными ресницами.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти робиш ЛУП -- ЛУП своїми довгими нафарбованими віями.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You go BLINK -- BLINK with those long painted eyelashes.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Кому будем глазки строить?</msgCharNotFound>
+  <msgCharNotFound l="ua">Кому будемо очка будувати?</msgCharNotFound>
+  <msgCharNotFound l="en">Who are we making eyes at?</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 стреляет глазками в $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 таращит зенки.</msgOthersNoArgument>
-  <msgVictimFound>$c1 строит тебе глазки. К чему бы это?</msgVictimFound>
+  <msgOthersFound l="ru">$c1 стреляет глазками в $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 стріляє очками в $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 makes eyes at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 таращит зенки.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 витріщає баньки.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 goggles.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 строит тебе глазки. К чему бы это?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 будує тобі очка. До чого б це?</msgVictimFound>
+  <msgVictimFound l="en">$c1 makes eyes at you. Now what could that mean?</msgVictimFound>
   <position>rest</position>
   <rusName>глазки</rusName>
   <uaName>оченята</uaName>
-  <shortDesc>строить глазки</shortDesc>
+  <shortDesc l="ru">строить глазки</shortDesc>
+  <shortDesc l="ua">будувати очка</shortDesc>
+  <shortDesc l="en">make eyes at somebody</shortDesc>
 </Social>

--- a/socials/accept.xml
+++ b/socials/accept.xml
@@ -3,15 +3,27 @@
   <help id="1799" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты милостиво принимаешь извинения $C2.</msgCharFound>
-  <msgCharNoArgument>Ты принимаешь извинения.</msgCharNoArgument>
+  <msgCharFound l="ru">Ты милостиво принимаешь извинения $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти милостиво приймаєш вибачення $C2.</msgCharFound>
+  <msgCharFound l="en">You graciously accept $C1's apology.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты принимаешь извинения.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти приймаєш вибачення.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You accept the proffered apology graciously.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 милостиво принимает извинения $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 милостиво принимает извинения.</msgOthersNoArgument>
-  <msgVictimFound>$c1 милостиво принимает твои извинения.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 милостиво принимает извинения $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 милостиво приймає вибачення $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 graciously accepts $C1's apology.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 милостиво принимает извинения.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 милостиво приймає вибачення.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 graciously accepts the proffered apology.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 милостиво принимает твои извинения.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 милостиво приймає твої вибачення.</msgVictimFound>
+  <msgVictimFound l="en">$c1 graciously accepts your apology.</msgVictimFound>
   <position>rest</position>
   <rusName>принять</rusName>
   <uaName>прийняти</uaName>
-  <shortDesc>принимать извинения</shortDesc>
+  <shortDesc l="ru">принимать извинения</shortDesc>
+  <shortDesc l="ua">приймати вибачення</shortDesc>
+  <shortDesc l="en">accept an apology</shortDesc>
 </Social>

--- a/socials/accuse.xml
+++ b/socials/accuse.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1609" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты во всем винишь себя, даже не Клаву К.</msgCharAuto>
-  <msgCharFound>Ты обвиняюще глядишь на $X.</msgCharFound>
-  <msgCharNoArgument>Обвинить кого??</msgCharNoArgument>
-  <msgCharNotFound>Обвинить кого-то, кого даже нет здесь?</msgCharNotFound>
-  <msgOthersAuto>$c4, кажется, заела собственная совесть.</msgOthersAuto>
-  <msgOthersFound>$c1 обвиняюще глядит на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 сейчас начнет кого-то обвинять.</msgOthersNoArgument>
-  <msgVictimFound>$c1 обвиняюще глядит на тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты во всем винишь себя, даже не Клаву К.</msgCharAuto>
+  <msgCharAuto l="ua">Ти в усьому винуватиш себе, навіть не Клаву К.</msgCharAuto>
+  <msgCharAuto l="en">You blame yourself for everything, and nobody else.</msgCharAuto>
+  <msgCharFound l="ru">Ты обвиняюще глядишь на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти звинувачувально дивишся на $C4.</msgCharFound>
+  <msgCharFound l="en">You look accusingly at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Обвинить кого??</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Звинуватити кого??</msgCharNoArgument>
+  <msgCharNoArgument l="en">Accuse who??</msgCharNoArgument>
+  <msgCharNotFound l="ru">Обвинить кого-то, кого даже нет здесь?</msgCharNotFound>
+  <msgCharNotFound l="ua">Звинуватити когось, кого тут навіть немає?</msgCharNotFound>
+  <msgCharNotFound l="en">Accuse somebody who is not even there?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c4, кажется, заела собственная совесть.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c4, здається, заїла власна совість.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 seems to have a bad conscience.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 обвиняюще глядит на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 звинувачувально дивиться на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 looks accusingly at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 сейчас начнет кого-то обвинять.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 зараз почне когось звинувачувати.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 is in an accusing mood.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 обвиняюще глядит на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 звинувачувально дивиться на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 looks accusingly at you.</msgVictimFound>
   <position>rest</position>
   <rusName>винить</rusName>
   <uaName>винуватити</uaName>
-  <shortDesc>обвинять или совестливо смотреть на кого-либо</shortDesc>
+  <shortDesc l="ru">обвинять или совестливо смотреть на кого-либо</shortDesc>
+  <shortDesc l="ua">звинувачувати або докірливо дивитися на когось</shortDesc>
+  <shortDesc l="en">accuse somebody, or give them a reproachful look</shortDesc>
 </Social>

--- a/socials/acomb.xml
+++ b/socials/acomb.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1650" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тянешь себя за волосы, но они не расчесываются.</msgCharAuto>
-  <msgCharFound>Ты терпеливо распутываешь волосы $C2.</msgCharFound>
-  <msgCharNoArgument>Ты расчесываешь свои волосы.</msgCharNoArgument>
-  <msgCharNotFound>Таких здесь нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 пытается прочесать свои патлы.</msgOthersAuto>
-  <msgOthersFound>$c1 пытается прочесать спутанные волосы $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 расчесывает свои волосы.</msgOthersNoArgument>
-  <msgVictimFound>$c1 тянет тебя за волосы, желая расчесать их.</msgVictimFound>
+  <msgCharAuto l="ru">Ты тянешь себя за волосы, но они не расчесываются.</msgCharAuto>
+  <msgCharAuto l="ua">Ти тягнеш себе за волосся, але воно не розчісується.</msgCharAuto>
+  <msgCharAuto l="en">You tug at your own hair, but it refuses to be combed.</msgCharAuto>
+  <msgCharFound l="ru">Ты терпеливо распутываешь волосы $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти терпляче розплутуєш волосся $C2.</msgCharFound>
+  <msgCharFound l="en">You patiently untangle $C1's hair.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты расчесываешь свои волосы.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти розчісуєш своє волосся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You comb your hair.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Таких здесь нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody like that here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 пытается прочесать свои патлы.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 намагається прочесати свої патли.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 tries to drag a comb through that mop.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 пытается прочесать спутанные волосы $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 намагається прочесати сплутане волосся $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 tries to comb out $C1's tangled hair.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 расчесывает свои волосы.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 розчісує своє волосся.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 combs $gits|his|her|their hair.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 тянет тебя за волосы, желая расчесать их.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 тягне тебе за волосся, бажаючи його розчесати.</msgVictimFound>
+  <msgVictimFound l="en">$c1 tugs at your hair, meaning to comb it out.</msgVictimFound>
   <position>rest</position>
   <rusName>расчесать</rusName>
   <uaName>розчесати</uaName>
-  <shortDesc>расчесывать волосы</shortDesc>
+  <shortDesc l="ru">расчесывать волосы</shortDesc>
+  <shortDesc l="ua">розчісувати волосся</shortDesc>
+  <shortDesc l="en">comb hair</shortDesc>
 </Social>

--- a/socials/adjust.xml
+++ b/socials/adjust.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты оглядываешься, и убедившись, что никто не смотрит, поправляешь свой &quot;Инструмент&quot;.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты оглядываешься, и убедившись, что никто не смотрит, поправляешь свой &quot;Инструмент&quot;.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти озираєшся і, переконавшись, що ніхто не дивиться, поправляєш свій "Інструмент".</msgCharNoArgument>
+  <msgCharNoArgument l="en">You look around, make sure nobody is watching, and adjust your "Tool".</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 оглядывается, и поправляет свой &quot;Инструмент&quot;...</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 оглядывается, и поправляет свой &quot;Инструмент&quot;...</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 озирається і поправляє свій "Інструмент"...</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 looks around slyly, then reaches down and adjusts that "Tool"...</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>поправить</rusName>
   <uaName>поправити</uaName>
-  <shortDesc>поправить писюн, чтобы хорошо стоял</shortDesc>
+  <shortDesc l="ru">поправить писюн, чтобы хорошо стоял</shortDesc>
+  <shortDesc l="ua">поправити пісюн, щоб добре стояв</shortDesc>
+  <shortDesc l="en">adjust your dick so it sits right</shortDesc>
 </Social>

--- a/socials/agree.xml
+++ b/socials/agree.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1775" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Лучше всего - соглашаться с собой.</msgCharAuto>
-  <msgCharFound>Ты киваешь с энтузиазмом, соглашаясь с $C5.</msgCharFound>
-  <msgCharNoArgument>Ты абсолютно соглас$gно|ен|на.</msgCharNoArgument>
-  <msgCharNotFound>Не с кем согласиться.</msgCharNotFound>
-  <msgOthersAuto>$c1 считает, что согласится не с кем, кроме себя.</msgOthersAuto>
-  <msgOthersFound>$c1 кивает с энтузиазмом, соглашаясь с $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 абсолютно соглас$gно|ен|на.</msgOthersNoArgument>
-  <msgVictimFound>$c1 кивает с энтузиазмом, соглашаясь с тобой.</msgVictimFound>
+  <msgCharAuto l="ru">Лучше всего - соглашаться с собой.</msgCharAuto>
+  <msgCharAuto l="ua">Найкраще -- погоджуватися із собою.</msgCharAuto>
+  <msgCharAuto l="en">The best company to agree with is yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты киваешь с энтузиазмом, соглашаясь с $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти киваєш з ентузіазмом, погоджуючись з $C5.</msgCharFound>
+  <msgCharFound l="en">You nod in enthusiastic agreement with $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты абсолютно соглас$gно|ен|на.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти абсолютно згод$gне|ен|на.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You agree absolutely.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Не с кем согласиться.</msgCharNotFound>
+  <msgCharNotFound l="ua">Немає з ким погодитися.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here to agree with.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 считает, что согласится не с кем, кроме себя.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 вважає, що погодитися нема з ким, окрім себе.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 finds nobody worth agreeing with, except $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 кивает с энтузиазмом, соглашаясь с $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 киває з ентузіазмом, погоджуючись з $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 nods in enthusiastic agreement with $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 абсолютно соглас$gно|ен|на.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 абсолютно згод$gне|ен|на.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 agrees absolutely.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 кивает с энтузиазмом, соглашаясь с тобой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 киває з ентузіазмом, погоджуючись з тобою.</msgVictimFound>
+  <msgVictimFound l="en">$c1 nods in enthusiastic agreement with you.</msgVictimFound>
   <position>rest</position>
   <rusName>соглашаться</rusName>
   <uaName>погоджуватися</uaName>
-  <shortDesc>согласиться с кем-либо</shortDesc>
+  <shortDesc l="ru">согласиться с кем-либо</shortDesc>
+  <shortDesc l="ua">погодитися з кимось</shortDesc>
+  <shortDesc l="en">agree with somebody</shortDesc>
 </Social>

--- a/socials/air.xml
+++ b/socials/air.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1705" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты напеваешь песенку себе под нос.</msgCharAuto>
-  <msgCharFound>Ты надеешься, что $E оценит твои таланты (?) по достоинству.</msgCharFound>
-  <msgCharNoArgument>Ты берешь воображаемую гитару и поешь изо всех сил!</msgCharNoArgument>
-  <msgCharNotFound>Нету слушателей!</msgCharNotFound>
+  <msgCharAuto l="ru">Ты напеваешь песенку себе под нос.</msgCharAuto>
+  <msgCharAuto l="ua">Ти наспівуєш пісеньку собі під ніс.</msgCharAuto>
+  <msgCharAuto l="en">You hum a tune under your breath.</msgCharAuto>
+  <msgCharFound l="ru">Ты надеешься, что $E оценит твои таланты (?) по достоинству.</msgCharFound>
+  <msgCharFound l="ua">Ти сподіваєшся, що $C1 оцінить твої таланти (?) по достоїнству.</msgCharFound>
+  <msgCharFound l="en">You hope $C1 appreciates your talent (?) at its true worth.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты берешь воображаемую гитару и поешь изо всех сил!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти береш уявну гітару і граєш щосили!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You grab your air guitar and play for all you are worth!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нету слушателей!</msgCharNotFound>
+  <msgCharNotFound l="ua">Немає слухачів!</msgCharNotFound>
+  <msgCharNotFound l="en">No audience!</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1, во главе группы воздушных музыкантов, наяривает для $C2 на воздушной гитаре.</msgOthersFound>
-  <msgOthersNoArgument>$c1 берет воображаемую гитару и наяривает изо всех сил!</msgOthersNoArgument>
-  <msgVictimFound>$c1, во главе группы воздушных музыкантов, наяривает для тебя на воздушной гитаре.</msgVictimFound>
+  <msgOthersFound l="ru">$c1, во главе группы воздушных музыкантов, наяривает для $C2 на воздушной гитаре.</msgOthersFound>
+  <msgOthersFound l="ua">$c1, на чолі гурту повітряних музикантів, шкварить для $C2 на повітряній гітарі.</msgOthersFound>
+  <msgOthersFound l="en">$c1, at the head of a band of air musicians, wails away on an air guitar for $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 берет воображаемую гитару и наяривает изо всех сил!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 бере уявну гітару і шкварить щосили!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 grabs an air guitar and wails away for all it is worth!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1, во главе группы воздушных музыкантов, наяривает для тебя на воздушной гитаре.</msgVictimFound>
+  <msgVictimFound l="ua">$c1, на чолі гурту повітряних музикантів, шкварить для тебе на повітряній гітарі.</msgVictimFound>
+  <msgVictimFound l="en">$c1, at the head of a band of air musicians, wails away on an air guitar just for you.</msgVictimFound>
   <position>rest</position>
   <rusName>гитара</rusName>
   <uaName>гітара</uaName>
-  <shortDesc>напевать себе под нос или петь для публики</shortDesc>
+  <shortDesc l="ru">напевать себе под нос или петь для публики</shortDesc>
+  <shortDesc l="ua">наспівувати собі під ніс або грати для публіки</shortDesc>
+  <shortDesc l="en">hum to yourself, or play for an audience</shortDesc>
 </Social>

--- a/socials/anticipate.xml
+++ b/socials/anticipate.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты мурлычешь &apos;СССкоро, моя прелессссть...&apos;</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты мурлычешь &apos;СССкоро, моя прелессссть...&apos;</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти муркочеш 'СССкоро, мій дорогессенький...'</msgCharNoArgument>
+  <msgCharNoArgument l="en">You murmur 'Sssssoonnn, my presssssciousssss...'</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 мурлычет &apos;СССкоро, моя прелессссть...&apos;</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 мурлычет &apos;СССкоро, моя прелессссть...&apos;</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 муркоче 'СССкоро, мій дорогессенький...'</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 murmurs 'Sssssoonnn, my presssssciousssss...'</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>горлм</rusName>
   <uaName>горлум</uaName>
-  <shortDesc>выдать коронную фразу Горлума</shortDesc>
+  <shortDesc l="ru">выдать коронную фразу Горлума</shortDesc>
+  <shortDesc l="ua">видати коронну фразу Горлума</shortDesc>
+  <shortDesc l="en">deliver Gollum's signature line</shortDesc>
 </Social>

--- a/socials/applaud.xml
+++ b/socials/applaud.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1684" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты аплодируешь себе - какое самодовольство!</msgCharAuto>
-  <msgCharFound>Ты аплодируешь действиям $C2.</msgCharFound>
-  <msgCharNoArgument>Хлоп, хлоп, хлоп.</msgCharNoArgument>
-  <msgCharNotFound>Ты мысленно аплодируешь своему далекому другу.</msgCharNotFound>
-  <msgOthersAuto>$c1 аплодирует себе. Что за самодовольство?</msgOthersAuto>
-  <msgOthersFound>$c1 аплодирует действиям $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 хлопает в ладоши.</msgOthersNoArgument>
-  <msgVictimFound>$c1 аплодирует тебе. Наверно, ты сделал$Gо||а что-то очень хорошее!</msgVictimFound>
+  <msgCharAuto l="ru">Ты аплодируешь себе - какое самодовольство!</msgCharAuto>
+  <msgCharAuto l="ua">Ти аплодуєш собі -- яке самовдоволення!</msgCharAuto>
+  <msgCharAuto l="en">You applaud yourself. Boy, are we conceited!</msgCharAuto>
+  <msgCharFound l="ru">Ты аплодируешь действиям $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти аплодуєш діям $C2.</msgCharFound>
+  <msgCharFound l="en">You clap at $C1's actions.</msgCharFound>
+  <msgCharNoArgument l="ru">Хлоп, хлоп, хлоп.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Плесь, плесь, плесь.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Clap, clap, clap.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты мысленно аплодируешь своему далекому другу.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти подумки аплодуєш своєму далекому другові.</msgCharNotFound>
+  <msgCharNotFound l="en">You give an imaginary round of applause to your imaginary friend.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 аплодирует себе. Что за самодовольство?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 аплодує собі. Що за самовдоволення?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 applauds $gitself|himself|herself|themselves. Boy, are we conceited!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 аплодирует действиям $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 аплодує діям $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 claps at $C1's actions.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 хлопает в ладоши.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 плескає в долоні.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 gives a round of applause.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 аплодирует тебе. Наверно, ты сделал$Gо||а что-то очень хорошее!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 аплодує тобі. Мабуть, ти $Gзробило|зробив|зробила|зробили щось дуже добре!</msgVictimFound>
+  <msgVictimFound l="en">$c1 gives you a round of applause. You MUST have done something good!</msgVictimFound>
   <position>rest</position>
   <rusName>аплодисменты</rusName>
   <uaName>оплески</uaName>
-  <shortDesc>аплодировать</shortDesc>
+  <shortDesc l="ru">аплодировать</shortDesc>
+  <shortDesc l="ua">аплодувати</shortDesc>
+  <shortDesc l="en">applaud</shortDesc>
 </Social>

--- a/socials/bark.xml
+++ b/socials/bark.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1618" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты гавкаешь на себя, и подпрыгиваешь от страха.</msgCharAuto>
-  <msgCharFound>Ты гавкаешь на $C4, пугая.</msgCharFound>
-  <msgCharNoArgument>Ты громко гавкаешь.</msgCharNoArgument>
-  <msgCharNotFound>Гавкнуть на кого?</msgCharNotFound>
-  <msgOthersAuto>$c1 гавкает на себя и ежится от страха.</msgOthersAuto>
-  <msgOthersFound>$c1 гавкает на $C4, пугая.</msgOthersFound>
-  <msgOthersNoArgument>$c1 гавкает, как собака.</msgOthersNoArgument>
-  <msgVictimFound>$c1 гавкает громко на тебя, ты отбегаешь - как бы не укусили!!</msgVictimFound>
+  <msgCharAuto l="ru">Ты гавкаешь на себя, и подпрыгиваешь от страха.</msgCharAuto>
+  <msgCharAuto l="ua">Ти гавкаєш на себе і підстрибуєш зі страху.</msgCharAuto>
+  <msgCharAuto l="en">You bark at yourself and jump back in fear.</msgCharAuto>
+  <msgCharFound l="ru">Ты гавкаешь на $C4, пугая.</msgCharFound>
+  <msgCharFound l="ua">Ти гавкаєш на $C4, лякаючи.</msgCharFound>
+  <msgCharFound l="en">You bark at $C1, scaring $Git|him|her|them silly.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты громко гавкаешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти голосно гавкаєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You bark loudly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Гавкнуть на кого?</msgCharNotFound>
+  <msgCharNotFound l="ua">Гавкнути на кого?</msgCharNotFound>
+  <msgCharNotFound l="en">Bark at whom?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 гавкает на себя и ежится от страха.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 гавкає на себе і щулиться від страху.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 barks at $gitself|himself|herself|themselves and cowers in fear.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 гавкает на $C4, пугая.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 гавкає на $C4, лякаючи.</msgOthersFound>
+  <msgOthersFound l="en">$c1 barks at $C1, scaring $Git|him|her|them senseless.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 гавкает, как собака.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 гавкає, як собака.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 barks like a dog. WOOF! WOOF!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 гавкает громко на тебя, ты отбегаешь - как бы не укусили!!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 голосно гавкає на тебе, ти відбігаєш -- а раптом вкусить?!</msgVictimFound>
+  <msgVictimFound l="en">$c1 barks loudly at you and you back away -- what if $git|he|she|they bites?!</msgVictimFound>
   <position>rest</position>
   <rusName>гав</rusName>
   <uaName>гав</uaName>
-  <shortDesc>гавкать от жизни собачьей</shortDesc>
+  <shortDesc l="ru">гавкать от жизни собачьей</shortDesc>
+  <shortDesc l="ua">гавкати від собачого життя</shortDesc>
+  <shortDesc l="en">bark, such is a dog's life</shortDesc>
 </Social>

--- a/socials/beam.xml
+++ b/socials/beam.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1673" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Улыбнись себе, ах какой ты пупсик!!!</msgCharAuto>
-  <msgCharFound>От полноты чувств ты широко улыбаешься $C3!</msgCharFound>
-  <msgCharNoArgument>Ты цветешь и радуешься.</msgCharNoArgument>
-  <msgCharNotFound>На кого лыбишься?...</msgCharNotFound>
-  <msgOthersAuto>$c1 улыбается своим мыслям.</msgOthersAuto>
-  <msgOthersFound>$c1 от полноты чувств к $C3 широко улыбается $M!</msgOthersFound>
-  <msgOthersNoArgument>$c1 прямо-таки сияет!</msgOthersNoArgument>
-  <msgVictimFound>$c1 от полноты чувств широко улыбается тебе!</msgVictimFound>
+  <msgCharAuto l="ru">Улыбнись себе, ах какой ты пупсик!!!</msgCharAuto>
+  <msgCharAuto l="ua">Усміхнися собі, ах який же ти пупсик!!!</msgCharAuto>
+  <msgCharAuto l="en">Smile at yourself, aren't you just adorable!!!</msgCharAuto>
+  <msgCharFound l="ru">От полноты чувств ты широко улыбаешься $C3!</msgCharFound>
+  <msgCharFound l="ua">Від повноти почуттів ти широко усміхаєшся $C3!</msgCharFound>
+  <msgCharFound l="en">You dazzle $C1 with a smile of pure feeling!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты цветешь и радуешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти цвітеш і радієш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You beam delightedly at nothing in particular.</msgCharNoArgument>
+  <msgCharNotFound l="ru">На кого лыбишься?...</msgCharNotFound>
+  <msgCharNotFound l="ua">На кого шкіришся?...</msgCharNotFound>
+  <msgCharNotFound l="en">Who are you grinning at?...</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 улыбается своим мыслям.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 усміхається своїм думкам.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 beams at some private thought.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 от полноты чувств к $C3 широко улыбается $M!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 від повноти почуттів до $C2 широко усміхається!</msgOthersFound>
+  <msgOthersFound l="en">$c1 must like $C1 a great deal to beam so broadly!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 прямо-таки сияет!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 просто-таки сяє!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 is positively beaming!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 от полноты чувств широко улыбается тебе!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 від повноти почуттів широко усміхається тобі!</msgVictimFound>
+  <msgVictimFound l="en">$c1 must like you a great deal to beam at you so broadly!</msgVictimFound>
   <position>rest</position>
   <rusName>сиять</rusName>
   <uaName>сяяти</uaName>
-  <shortDesc>радостно и широко улыбаться</shortDesc>
+  <shortDesc l="ru">радостно и широко улыбаться</shortDesc>
+  <shortDesc l="ua">радісно і широко усміхатися</shortDesc>
+  <shortDesc l="en">beam a wide, happy smile</shortDesc>
 </Social>

--- a/socials/beckon.xml
+++ b/socials/beckon.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1644" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты зовешь свою тень с собой.</msgCharAuto>
-  <msgCharFound>Ты зовешь $C4 с собой. Может пойдет?!</msgCharFound>
-  <msgCharNoArgument>Ты зовешь всех за собой.</msgCharNoArgument>
-  <msgCharNotFound>Извини, нет таких здесь.</msgCharNotFound>
-  <msgOthersAuto>$c1 зовет свою тень с собой.</msgOthersAuto>
-  <msgOthersFound>$c1 зовет $C4 с собой... Гм, а что, собственно, происходит?</msgOthersFound>
-  <msgOthersNoArgument>$c1 зовет всех за собой. FOLLOW !</msgOthersNoArgument>
-  <msgVictimFound>$c1 зовет тебя с собой. FOLLOW !</msgVictimFound>
+  <msgCharAuto l="ru">Ты зовешь свою тень с собой.</msgCharAuto>
+  <msgCharAuto l="ua">Ти кличеш свою тінь за собою.</msgCharAuto>
+  <msgCharAuto l="en">You beckon to your shadow to follow.</msgCharAuto>
+  <msgCharFound l="ru">Ты зовешь $C4 с собой. Может пойдет?!</msgCharFound>
+  <msgCharFound l="ua">Ти кличеш $C4 за собою. Може, піде?!</msgCharFound>
+  <msgCharFound l="en">You beckon for $C1 to follow -- sure hope they do!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты зовешь всех за собой.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти кличеш усіх за собою.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You beckon for everyone to follow.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Извини, нет таких здесь.</msgCharNotFound>
+  <msgCharNotFound l="ua">Вибач, таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">So sorry, that person has already left.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 зовет свою тень с собой.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 кличе свою тінь за собою.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 beckons to $gits|his|her|their shadow to follow.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 зовет $C4 с собой... Гм, а что, собственно, происходит?</msgOthersFound>
+  <msgOthersFound l="ua">$c1 кличе $C4 за собою... Гм, а що, власне, відбувається?</msgOthersFound>
+  <msgOthersFound l="en">$c1 beckons $C1 to follow... hmmm, what is going on?</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 зовет всех за собой. FOLLOW !</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 кличе всіх за собою. FOLLOW !</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 beckons for everyone to follow. FOLLOW !</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 зовет тебя с собой. FOLLOW !</msgVictimFound>
+  <msgVictimFound l="ua">$c1 кличе тебе за собою. FOLLOW !</msgVictimFound>
+  <msgVictimFound l="en">$c1 beckons for you to follow. FOLLOW !</msgVictimFound>
   <position>rest</position>
   <rusName>звать</rusName>
   <uaName>кликати</uaName>
-  <shortDesc>звать с собой</shortDesc>
+  <shortDesc l="ru">звать с собой</shortDesc>
+  <shortDesc l="ua">кликати за собою</shortDesc>
+  <shortDesc l="en">beckon others to follow</shortDesc>
 </Social>

--- a/socials/bkiss.xml
+++ b/socials/bkiss.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1763" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты посылаешь себе поцелуйчик. Жизнь прекрасна!</msgCharAuto>
-  <msgCharFound>Ты посылаешь воздушный поцелуй $C3.</msgCharFound>
-  <msgCharNoArgument>Ты посылаешь воздушный поцелуй.</msgCharNoArgument>
-  <msgCharNotFound>Поцелуй ушел мимо цели :(</msgCharNotFound>
-  <msgOthersAuto>$c1 дарит сам себе поцелуйчик, видимо влюбил$gось|ся|ась.</msgOthersAuto>
-  <msgOthersFound>$c1 посылает поцелуйчик $C3 ... лапуся!</msgOthersFound>
-  <msgOthersNoArgument>$c1 посылает поцелуй по ветру вдаль.</msgOthersNoArgument>
-  <msgVictimFound>$c1 посылает тебе воздушный поцелуй, надеясь на взаимность.</msgVictimFound>
+  <msgCharAuto l="ru">Ты посылаешь себе поцелуйчик. Жизнь прекрасна!</msgCharAuto>
+  <msgCharAuto l="ua">Ти шлеш поцілуночок собі. Життя прекрасне!</msgCharAuto>
+  <msgCharAuto l="en">You blow a kiss to yourself... isn't the world beautiful?</msgCharAuto>
+  <msgCharFound l="ru">Ты посылаешь воздушный поцелуй $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти шлеш повітряний поцілунок $C3.</msgCharFound>
+  <msgCharFound l="en">You blow a kiss at $C1 and wonder if it will be caught.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты посылаешь воздушный поцелуй.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти шлеш повітряний поцілунок.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You blow kisses to the air.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Поцелуй ушел мимо цели :(</msgCharNotFound>
+  <msgCharNotFound l="ua">Поцілунок пішов повз ціль :(</msgCharNotFound>
+  <msgCharNotFound l="en">Your kiss falls to the ground with no one to catch it.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 дарит сам себе поцелуйчик, видимо влюбил$gось|ся|ась.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 дарує сам собі поцілуночок, видно, закоха$gлося|вся|лася.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 blows a kiss to $gitself|himself|herself|themselves, obviously very in love.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 посылает поцелуйчик $C3 ... лапуся!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 шле поцілуночок $C3 ... лапуся!</msgOthersFound>
+  <msgOthersFound l="en">$c1 blows a kiss at $C1 ... isn't that just CUTE?</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 посылает поцелуй по ветру вдаль.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 шле поцілунок за вітром удалечінь.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 blows kisses at no one in particular.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 посылает тебе воздушный поцелуй, надеясь на взаимность.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 шле тобі повітряний поцілунок, сподіваючись на взаємність.</msgVictimFound>
+  <msgVictimFound l="en">$c1 blows a kiss at you and hopes you will blow one back.</msgVictimFound>
   <position>rest</position>
   <rusName>впоцелуй</rusName>
   <uaName>вцілунок</uaName>
-  <shortDesc>посылать воздушный поцелуй</shortDesc>
+  <shortDesc l="ru">посылать воздушный поцелуй</shortDesc>
+  <shortDesc l="ua">слати повітряний поцілунок</shortDesc>
+  <shortDesc l="en">blow a kiss</shortDesc>
 </Social>

--- a/socials/blush.xml
+++ b/socials/blush.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1617" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты краснеешь от собственной глупости.</msgCharAuto>
-  <msgCharFound>Ты волнуешься, видя $C4.</msgCharFound>
-  <msgCharNoArgument>Твои щеки наливаются румянцем.</msgCharNoArgument>
-  <msgCharNotFound>Ты краснеешь, не видя таких людей тут.</msgCharNotFound>
-  <msgOthersAuto>$c1 краснеет, понимая, что делает глупости.</msgOthersAuto>
-  <msgOthersFound>$c1 волнуется, видя $C4 здесь.</msgOthersFound>
-  <msgOthersNoArgument>$c1 краснеет.</msgOthersNoArgument>
-  <msgVictimFound>$c1 волнуется, видя тебя здесь. Гм, какой эффект на людей ты производишь!</msgVictimFound>
+  <msgCharAuto l="ru">Ты краснеешь от собственной глупости.</msgCharAuto>
+  <msgCharAuto l="ua">Ти червонієш від власної дурості.</msgCharAuto>
+  <msgCharAuto l="en">You blush at your own folly.</msgCharAuto>
+  <msgCharFound l="ru">Ты волнуешься, видя $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти хвилюєшся, бачачи $C4.</msgCharFound>
+  <msgCharFound l="en">You get all flustered at the sight of $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Твои щеки наливаются румянцем.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Твої щоки наливаються рум'янцем.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Your cheeks are burning.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты краснеешь, не видя таких людей тут.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти червонієш, не бачачи тут таких людей.</msgCharNotFound>
+  <msgCharNotFound l="en">You blush as you notice that person isn't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 краснеет, понимая, что делает глупости.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 червоніє, розуміючи, що робить дурниці.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 blushes, realising what a silly thing that was.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 волнуется, видя $C4 здесь.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 хвилюється, бачачи тут $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 blushes at the sight of $C1 here.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 краснеет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 червоніє.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 blushes.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 волнуется, видя тебя здесь. Гм, какой эффект на людей ты производишь!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 хвилюється, бачачи тебе тут. Гм, який же ефект ти справляєш на людей!</msgVictimFound>
+  <msgVictimFound l="en">$c1 blushes at the sight of you. Such an effect you have on people!</msgVictimFound>
   <position>rest</position>
   <rusName>краснеть</rusName>
   <uaName>червоніти</uaName>
-  <shortDesc>краснеть от волнения</shortDesc>
+  <shortDesc l="ru">краснеть от волнения</shortDesc>
+  <shortDesc l="ua">червоніти від хвилювання</shortDesc>
+  <shortDesc l="en">blush with excitement</shortDesc>
 </Social>

--- a/socials/bonk.xml
+++ b/socials/bonk.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1712" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты стукаешь себя по шлему, дур$gилло|ачок|очка.</msgCharAuto>
-  <msgCharFound>Ты стукаешь $C4 по шлему за то, что $E так$Gое|ой|ая идио$Gтичное|т|тка.</msgCharFound>
-  <msgCharNoArgument>{W***ТРАХ!!!***{x</msgCharNoArgument>
-  <msgCharNotFound>{W***ТРАХ***{x Они ушли...</msgCharNotFound>
-  <msgOthersAuto>$c1 стукает себя по шлему и морщится от боли.</msgOthersAuto>
-  <msgOthersFound>$c1 стукает $C4 по шлему, считая $S ПОЛН$GЫМ|ЫМ|ОЙ идиот$Gизмом|ом|кой.</msgOthersFound>
+  <msgCharAuto l="ru">Ты стукаешь себя по шлему, дур$gилло|ачок|очка.</msgCharAuto>
+  <msgCharAuto l="ua">Ти стукаєш себе по шолому, дур$gнило|ник|епа.</msgCharAuto>
+  <msgCharAuto l="en">You bonk yourself, fool that you are.</msgCharAuto>
+  <msgCharFound l="ru">Ты стукаешь $C4 по шлему за то, что $E так$Gое|ой|ая идио$Gтичное|т|тка.</msgCharFound>
+  <msgCharFound l="ua">Ти стукаєш $C4 по шолому за те, що $Gвоно|він|вона|вони так$Gе|ий|а ідіо$Gтичне|т|тка.</msgCharFound>
+  <msgCharFound l="en">You bonk $C1 on the head for being such a moron.</msgCharFound>
+  <msgCharNoArgument l="ru">{W***ТРАХ!!!***{x</msgCharNoArgument>
+  <msgCharNoArgument l="ua">{W***БАЦ!!!***{x</msgCharNoArgument>
+  <msgCharNoArgument l="en">{W***BONK!!!***{x</msgCharNoArgument>
+  <msgCharNotFound l="ru">{W***ТРАХ***{x Они ушли...</msgCharNotFound>
+  <msgCharNotFound l="ua">{W***БАЦ***{x Вони пішли...</msgCharNotFound>
+  <msgCharNotFound l="en">{W***BONK***{x They left...</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 стукает себя по шлему и морщится от боли.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 стукає себе по шолому і кривиться від болю.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 bonks $gitself|himself|herself|themselves and grimaces in pain.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 стукает $C4 по шлему, считая $S ПОЛН$GЫМ|ЫМ|ОЙ идиот$Gизмом|ом|кой.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 стукає $C4 по шолому, вважаючи $Gйого|його|її|їх ПОВН$Gим|им|ою ідіот$Gом|ом|кою.</msgOthersFound>
+  <msgOthersFound l="en">$c1 bonks $C1 on the head for being such an UTTER moron.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 стукает тебя по шлему, считая тебя идиот$Gиной|ом|кой.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 стукает тебя по шлему, считая тебя идиот$Gиной|ом|кой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 стукає тебе по шолому, вважаючи тебе ідіот$Gиною|ом|кою.</msgVictimFound>
+  <msgVictimFound l="en">$c1 bonks you on the head for being so foolish.</msgVictimFound>
   <position>rest</position>
   <rusName>тук</rusName>
   <uaName>тук</uaName>
-  <shortDesc>стучать по голове, намекая на полный идиотизм</shortDesc>
+  <shortDesc l="ru">стучать по голове, намекая на полный идиотизм</shortDesc>
+  <shortDesc l="ua">стукати по голові, натякаючи на цілковитий ідіотизм</shortDesc>
+  <shortDesc l="en">bonk somebody on the head, hinting at utter idiocy</shortDesc>
 </Social>

--- a/socials/bow.xml
+++ b/socials/bow.xml
@@ -5,16 +5,34 @@
     <keyword l="ru">кланяться поклониться</keyword>
     <keyword l="ua"></keyword>
   </help>
-  <msgCharAuto>Ты целуешь большие пальцы своих ног!</msgCharAuto>
-  <msgCharFound>Ты глубоко кланяешься перед $Y.</msgCharFound>
-  <msgCharNoArgument>Ты глубоко кланяешься.</msgCharNoArgument>
-  <msgCharNotFound>А кто это?</msgCharNotFound>
-  <msgOthersAuto>$c1 целует большие пальцы своих ног! Вот это растяжка!</msgOthersAuto>
-  <msgOthersFound>$c1 кланяется перед $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 глубоко кланяется.</msgOthersNoArgument>
-  <msgVictimFound>$c1 глубоко кланяется перед тобой.</msgVictimFound>
+  <msgCharAuto l="ru">Ты целуешь большие пальцы своих ног!</msgCharAuto>
+  <msgCharAuto l="ua">Ти цілуєш великі пальці своїх ніг!</msgCharAuto>
+  <msgCharAuto l="en">You kiss your own toes.</msgCharAuto>
+  <msgCharFound l="ru">Ты глубоко кланяешься перед $Y.</msgCharFound>
+  <msgCharFound l="ua">Ти глибоко вклоняєшся перед $C5.</msgCharFound>
+  <msgCharFound l="en">You bow deeply before $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты глубоко кланяешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти глибоко вклоняєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You bow deeply.</msgCharNoArgument>
+  <msgCharNotFound l="ru">А кто это?</msgCharNotFound>
+  <msgCharNotFound l="ua">А хто це?</msgCharNotFound>
+  <msgCharNotFound l="en">And who might that be?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 целует большие пальцы своих ног! Вот это растяжка!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 цілує великі пальці своїх ніг! Оце розтяжка!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 folds up like a jackknife and kisses those own toes. What a stretch!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 кланяется перед $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 вклоняється перед $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 bows before $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 глубоко кланяется.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 глибоко вклоняється.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 bows deeply.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 глубоко кланяется перед тобой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 глибоко вклоняється перед тобою.</msgVictimFound>
+  <msgVictimFound l="en">$c1 bows deeply before you.</msgVictimFound>
   <position>rest</position>
   <rusName>поклон</rusName>
   <uaName>уклін</uaName>
-  <shortDesc>глубоко поклониться</shortDesc>
+  <shortDesc l="ru">глубоко поклониться</shortDesc>
+  <shortDesc l="ua">глибоко вклонитися</shortDesc>
+  <shortDesc l="en">bow deeply</shortDesc>
 </Social>

--- a/socials/buff.xml
+++ b/socials/buff.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты полируешь ногти с отсутствующим видом.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты полируешь ногти с отсутствующим видом.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти поліруєш нігті з відсутнім виглядом.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You buff your nails with an absent look.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 полирует свои ногти с наплевательской мордой!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 полирует свои ногти с наплевательской мордой!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 полірує свої нігті з наплювацькою мордою!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 buffs $gits|his|her|their nails, looking like nothing matters at all!</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>полировать</rusName>
   <uaName>полірувати</uaName>
-  <shortDesc>чистить ногти с наплевательским видом</shortDesc>
+  <shortDesc l="ru">чистить ногти с наплевательским видом</shortDesc>
+  <shortDesc l="ua">чистити нігті з наплювацьким виглядом</shortDesc>
+  <shortDesc l="en">buff your nails, looking thoroughly unbothered</shortDesc>
 </Social>

--- a/socials/burp.xml
+++ b/socials/burp.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1777" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты рыгаешь, чтоб доставить себе удовольствие.</msgCharAuto>
-  <msgCharFound>Ты громко рыгаешь $M в ответ.</msgCharFound>
-  <msgCharNoArgument>Ты громко рыгаешь.</msgCharNoArgument>
-  <msgCharNotFound>Похоже, у тебя не хватает горючего для этого.</msgCharNotFound>
-  <msgOthersAuto>$c1 рыгает, чтобы не пучило живот. Неприятное зрелище.</msgOthersAuto>
-  <msgOthersFound>$c1 громко рыгает в ответ $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 громко рыгает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 громко рыгает тебе в ответ.</msgVictimFound>
+  <msgCharAuto l="ru">Ты рыгаешь, чтоб доставить себе удовольствие.</msgCharAuto>
+  <msgCharAuto l="ua">Ти ригаєш, щоб потішити себе.</msgCharAuto>
+  <msgCharAuto l="en">You burp for your own pleasure.</msgCharAuto>
+  <msgCharFound l="ru">Ты громко рыгаешь $M в ответ.</msgCharFound>
+  <msgCharFound l="ua">Ти голосно ригаєш $C3 у відповідь.</msgCharFound>
+  <msgCharFound l="en">You burp loudly at $C1 in response.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты громко рыгаешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти голосно ригаєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You burp loudly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Похоже, у тебя не хватает горючего для этого.</msgCharNotFound>
+  <msgCharNotFound l="ua">Схоже, тобі бракує пального для цього.</msgCharNotFound>
+  <msgCharNotFound l="en">Looks like you are short on fuel for that.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 рыгает, чтобы не пучило живот. Неприятное зрелище.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 ригає, щоб не пучило живіт. Неприємне видовище.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 burps to keep the belly from swelling. What a sight.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 громко рыгает в ответ $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 голосно ригає у відповідь $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 burps loudly in response to $C1's remark.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 громко рыгает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 голосно ригає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 burps loudly.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 громко рыгает тебе в ответ.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 голосно ригає тобі у відповідь.</msgVictimFound>
+  <msgVictimFound l="en">$c1 burps loudly in response to your remark.</msgVictimFound>
   <position>rest</position>
   <rusName>рыгать</rusName>
   <uaName>ригати</uaName>
-  <shortDesc>отрыжка</shortDesc>
+  <shortDesc l="ru">отрыжка</shortDesc>
+  <shortDesc l="ua">відрижка</shortDesc>
+  <shortDesc l="en">a burp</shortDesc>
 </Social>

--- a/socials/cackle.xml
+++ b/socials/cackle.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1733" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты кудахчешь над собой. Это весьма странно!</msgCharAuto>
-  <msgCharFound>Ты ликующе кудахчешь над $C5</msgCharFound>
-  <msgCharNoArgument>Ты ликующе кудахчешь.</msgCharNoArgument>
-  <msgCharNotFound>Ты не находишь, над кем покудахтать.</msgCharNotFound>
-  <msgOthersAuto>Шизуха покосила наши стройные ряды! $c1 кудахчет над собой.</msgOthersAuto>
-  <msgOthersFound>$c1 ликующе кудахчет над $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 запрокидывает $s голову и кудахчет в безумном веселье!</msgOthersNoArgument>
-  <msgVictimFound>$c1 ликующе кудахчет над тобой. Лучше держись подальше от $x.</msgVictimFound>
+  <msgCharAuto l="ru">Ты кудахчешь над собой. Это весьма странно!</msgCharAuto>
+  <msgCharAuto l="ua">Ти кудкудакаєш над собою. Це вельми дивно!</msgCharAuto>
+  <msgCharAuto l="en">You cackle at yourself. Now, THAT'S strange!</msgCharAuto>
+  <msgCharFound l="ru">Ты ликующе кудахчешь над $C5</msgCharFound>
+  <msgCharFound l="ua">Ти радісно кудкудакаєш над $C5</msgCharFound>
+  <msgCharFound l="en">You cackle gleefully at $C1</msgCharFound>
+  <msgCharNoArgument l="ru">Ты ликующе кудахчешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти радісно кудкудакаєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You cackle gleefully.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты не находишь, над кем покудахтать.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти не знаходиш, над ким покудкудакати.</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot find anyone to cackle with.</msgCharNotFound>
+  <msgOthersAuto l="ru">Шизуха покосила наши стройные ряды! $c1 кудахчет над собой.</msgOthersAuto>
+  <msgOthersAuto l="ua">Шизуха скосила наші стрункі ряди! $c1 кудкудакає над собою.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 has really lost it now, cackling at $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 ликующе кудахчет над $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 радісно кудкудакає над $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 cackles gleefully at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 запрокидывает $s голову и кудахчет в безумном веселье!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 закидає голову і кудкудакає в шаленій радості!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 throws back $gits|his|her|their head and cackles with insane glee!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 ликующе кудахчет над тобой. Лучше держись подальше от $x.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 радісно кудкудакає над тобою. Краще тримайся подалі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 cackles gleefully at you. Better keep your distance.</msgVictimFound>
   <position>rest</position>
   <rusName>кудахтать</rusName>
   <uaName>кудкудакати</uaName>
-  <shortDesc>громкое кудахтанье, символизируещее ликование</shortDesc>
+  <shortDesc l="ru">громкое кудахтанье, символизируещее ликование</shortDesc>
+  <shortDesc l="ua">гучне кудкудакання на знак радості</shortDesc>
+  <shortDesc l="en">a loud cackle of glee</shortDesc>
 </Social>

--- a/socials/camel.xml
+++ b/socials/camel.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1615" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты поджигаешь сигарету &quot;Кэмел&quot; и глубоко затягиваешься.</msgCharAuto>
-  <msgCharFound>Ты поджигаешь сигарету &quot;Кэмел&quot; для $X.</msgCharFound>
-  <msgCharNoArgument>Ты притворяешься верблюдом.</msgCharNoArgument>
-  <msgCharNotFound>Никто не курит тут.</msgCharNotFound>
-  <msgOthersAuto>$c1 поджигает сигарету &quot;Кэмел&quot; и глубоко затягивается.</msgOthersAuto>
-  <msgOthersFound>$c1 поджигает сигарету &quot;Кэмел&quot; для $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 притворяется верблюдом.</msgOthersNoArgument>
-  <msgVictimFound>$c1 поджигает сигарету &quot;Кэмел&quot; для тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты поджигаешь сигарету &quot;Кэмел&quot; и глубоко затягиваешься.</msgCharAuto>
+  <msgCharAuto l="ua">Ти підпалюєш цигарку "Кемел" і глибоко затягуєшся.</msgCharAuto>
+  <msgCharAuto l="en">You light a Camel cigarette and inhale sharply.</msgCharAuto>
+  <msgCharFound l="ru">Ты поджигаешь сигарету &quot;Кэмел&quot; для $X.</msgCharFound>
+  <msgCharFound l="ua">Ти підпалюєш цигарку "Кемел" для $C2.</msgCharFound>
+  <msgCharFound l="en">You light a Camel cigarette for $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты притворяешься верблюдом.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти вдаєш із себе верблюда.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You pretend you are a camel.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Никто не курит тут.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ніхто тут не курить.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody is smoking here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 поджигает сигарету &quot;Кэмел&quot; и глубоко затягивается.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 підпалює цигарку "Кемел" і глибоко затягується.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 lights a Camel cigarette and inhales sharply.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 поджигает сигарету &quot;Кэмел&quot; для $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 підпалює цигарку "Кемел" для $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 lights a Camel cigarette for $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 притворяется верблюдом.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 вдає із себе верблюда.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 pretends to be a camel.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 поджигает сигарету &quot;Кэмел&quot; для тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 підпалює цигарку "Кемел" для тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 lights a Camel cigarette for you.</msgVictimFound>
   <position>rest</position>
   <rusName>верблюд</rusName>
   <uaName>верблюд</uaName>
-  <shortDesc>притвориться верблюдом или курить</shortDesc>
+  <shortDesc l="ru">притвориться верблюдом или курить</shortDesc>
+  <shortDesc l="ua">вдати верблюда або курити</shortDesc>
+  <shortDesc l="en">pretend to be a camel, or have a smoke</shortDesc>
 </Social>

--- a/socials/caress.xml
+++ b/socials/caress.xml
@@ -3,15 +3,29 @@
   <help id="1626" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты нежно гладишь $S.</msgCharFound>
-  <msgCharNoArgument>Поласкать? Кого?</msgCharNoArgument>
-  <msgCharNotFound>Гм...</msgCharNotFound>
+  <msgCharFound l="ru">Ты нежно гладишь $S.</msgCharFound>
+  <msgCharFound l="ua">Ти ніжно гладиш $C4.</msgCharFound>
+  <msgCharFound l="en">You tenderly caress $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Поласкать? Кого?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Приголубити? Кого?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Caress? Whom?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Гм...</msgCharNotFound>
+  <msgCharNotFound l="ua">Гм...</msgCharNotFound>
+  <msgCharNotFound l="en">Hmm...</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 нежно гладит $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 ищет, кого бы приласкать.</msgOthersNoArgument>
-  <msgVictimFound>$c1 нежно гладит тебя.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 нежно гладит $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 ніжно гладить $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 tenderly caresses $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 ищет, кого бы приласкать.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 шукає, кого б приголубити.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 looks for someone to caress.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 нежно гладит тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 ніжно гладить тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 tenderly caresses you.</msgVictimFound>
   <position>rest</position>
   <rusName>приласкать</rusName>
   <uaName>приголубити</uaName>
-  <shortDesc>погладить или приласкать</shortDesc>
+  <shortDesc l="ru">погладить или приласкать</shortDesc>
+  <shortDesc l="ua">погладити або приголубити</shortDesc>
+  <shortDesc l="en">stroke or caress somebody</shortDesc>
 </Social>

--- a/socials/cheer.xml
+++ b/socials/cheer.xml
@@ -2,19 +2,43 @@
 <Social type="Social">
   <help id="1805" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Поскольку никто больше тебя не приветствует, ты делаешь это самостоятельно.</msgCharAuto>
-  <msgCharFound>Ты приветствуешь $C4 и желаешь $M удачи!</msgCharFound>
-  <msgCharFound2>Ты приветствуешь %2$C4 и %3$C4 и желаешь им удачи!</msgCharFound2>
-  <msgCharNoArgument>Ты радостно приплясываешь... Веселье из тебя так и прет :)</msgCharNoArgument>
-  <msgCharNotFound>Кого?</msgCharNotFound>
-  <msgOthersAuto>$c1 приветствует себя... как это печально.</msgOthersAuto>
-  <msgOthersFound>$C1!!! $c1 приветствует $S.</msgOthersFound>
-  <msgOthersFound2>%1$^C1 приветствует %2$C4 и %3$C4!</msgOthersFound2>
-  <msgOthersNoArgument>$c1 радостно приплясывает... $s переполняет радость!</msgOthersNoArgument>
-  <msgVictimFound>Тебя приветствует $c1... Тебе приятно!</msgVictimFound>
-  <msgVictimFound2>%1$^C1 приветствует тебя и %3$C4... Тебе приятно!</msgVictimFound2>
+  <msgCharAuto l="ru">Поскольку никто больше тебя не приветствует, ты делаешь это самостоятельно.</msgCharAuto>
+  <msgCharAuto l="ua">Оскільки більше ніхто тебе не вітає, ти робиш це самотужки.</msgCharAuto>
+  <msgCharAuto l="en">Since nobody else will cheer for you, you do it yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты приветствуешь $C4 и желаешь $M удачи!</msgCharFound>
+  <msgCharFound l="ua">Ти вітаєш $C4 і бажаєш удачі!</msgCharFound>
+  <msgCharFound l="en">You cheer $C1 on and wish $Git|him|her|them good luck!</msgCharFound>
+  <msgCharFound2 l="ru">Ты приветствуешь %2$C4 и %3$C4 и желаешь им удачи!</msgCharFound2>
+  <msgCharFound2 l="ua">Ти вітаєш %2$C4 і %3$C4 та бажаєш їм удачі!</msgCharFound2>
+  <msgCharFound2 l="en">You cheer %2$C4 and %3$C4 on and wish them both good luck!</msgCharFound2>
+  <msgCharNoArgument l="ru">Ты радостно приплясываешь... Веселье из тебя так и прет :)</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти радісно пританцьовуєш... Веселість із тебе так і пре :)</msgCharNoArgument>
+  <msgCharNoArgument l="en">You cheer and dance as the joy within you bursts forth!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Кого?</msgCharNotFound>
+  <msgCharNotFound l="ua">Кого?</msgCharNotFound>
+  <msgCharNotFound l="en">Who? Huh? Where? Not here, that much is certain.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 приветствует себя... как это печально.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 вітає себе... як це сумно.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 resorts to cheering for $gitself|himself|herself|themselves... how sad.</msgOthersAuto>
+  <msgOthersFound l="ru">$C1!!! $c1 приветствует $S.</msgOthersFound>
+  <msgOthersFound l="ua">$C1!!! $c1 вітає $C4.</msgOthersFound>
+  <msgOthersFound l="en">*Yay!* Go $C1!!! $c1 cheers away.</msgOthersFound>
+  <msgOthersFound2 l="ru">%1$^C1 приветствует %2$C4 и %3$C4!</msgOthersFound2>
+  <msgOthersFound2 l="ua">%1$^C1 вітає %2$C4 і %3$C4!</msgOthersFound2>
+  <msgOthersFound2 l="en">%1$^C1 cheers %2$C4 and %3$C4 on!</msgOthersFound2>
+  <msgOthersNoArgument l="ru">$c1 радостно приплясывает... $s переполняет радость!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 радісно пританцьовує... його переповнює радість!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 cheers and sings, just BURSTING with joy!</msgOthersNoArgument>
+  <msgVictimFound l="ru">Тебя приветствует $c1... Тебе приятно!</msgVictimFound>
+  <msgVictimFound l="ua">Тебе вітає $c1... Тобі приємно!</msgVictimFound>
+  <msgVictimFound l="en">You are cheered on by $c1... you feel so loved!</msgVictimFound>
+  <msgVictimFound2 l="ru">%1$^C1 приветствует тебя и %3$C4... Тебе приятно!</msgVictimFound2>
+  <msgVictimFound2 l="ua">%1$^C1 вітає тебе і %3$C4... Тобі приємно!</msgVictimFound2>
+  <msgVictimFound2 l="en">%1$^C1 cheers you and %3$C4 on... you feel so loved!</msgVictimFound2>
   <position>rest</position>
   <rusName>радость</rusName>
   <uaName>радість</uaName>
-  <shortDesc>веселиться или радостно приветствовать кого-либо</shortDesc>
+  <shortDesc l="ru">веселиться или радостно приветствовать кого-либо</shortDesc>
+  <shortDesc l="ua">веселитися або радісно вітати когось</shortDesc>
+  <shortDesc l="en">celebrate, or cheer somebody on</shortDesc>
 </Social>

--- a/socials/chuckle.xml
+++ b/socials/chuckle.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1665" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты смеешься над собственной шуткой, так как больше некому.</msgCharAuto>
-  <msgCharFound>Ты смеешься над шуткой $C2.</msgCharFound>
-  <msgCharNoArgument>Ты вежливо смеешься.</msgCharNoArgument>
-  <msgCharNotFound>Ты не можешь найти, с кем посмеяться.</msgCharNotFound>
-  <msgOthersAuto>$c1 смеется над своей шуткой, хотя вы и не смеетесь.</msgOthersAuto>
-  <msgOthersFound>$c1 смеется над шуткой $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 вежливо смеется.</msgOthersNoArgument>
-  <msgVictimFound>$c1 смеется над твоей шуткой.</msgVictimFound>
+  <msgCharAuto l="ru">Ты смеешься над собственной шуткой, так как больше некому.</msgCharAuto>
+  <msgCharAuto l="ua">Ти смієшся з власного жарту, бо більше нема кому.</msgCharAuto>
+  <msgCharAuto l="en">You chuckle at your own joke, since no one else would.</msgCharAuto>
+  <msgCharFound l="ru">Ты смеешься над шуткой $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти смієшся з жарту $C2.</msgCharFound>
+  <msgCharFound l="en">You chuckle at $C1's joke.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты вежливо смеешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти ввічливо смієшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You chuckle politely.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты не можешь найти, с кем посмеяться.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти не можеш знайти, з ким посміятися.</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot find anyone to chuckle with.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 смеется над своей шуткой, хотя вы и не смеетесь.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 сміється з власного жарту, хоча ви й не смієтеся.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 chuckles at $gits|his|her|their own joke, since none of you would.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 смеется над шуткой $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 сміється з жарту $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 chuckles at $C1's joke.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вежливо смеется.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 ввічливо сміється.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 chuckles politely.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 смеется над твоей шуткой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 сміється з твого жарту.</msgVictimFound>
+  <msgVictimFound l="en">$c1 chuckles at your joke.</msgVictimFound>
   <position>rest</position>
   <rusName>смешно</rusName>
   <uaName>смішно</uaName>
-  <shortDesc>тихо и спокойно смеяться</shortDesc>
+  <shortDesc l="ru">тихо и спокойно смеяться</shortDesc>
+  <shortDesc l="ua">тихо і спокійно сміятися</shortDesc>
+  <shortDesc l="en">a quiet, easy laugh</shortDesc>
 </Social>

--- a/socials/clap.xml
+++ b/socials/clap.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1664" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты хлопаешь в ладоши, радуясь своим подвигам.</msgCharAuto>
-  <msgCharFound>Ты хлопаешь в ладоши, радуясь подвигам $C2.</msgCharFound>
-  <msgCharNoArgument>Ты поднимаешь руки, сомкнутые вместе, в приветствии.</msgCharNoArgument>
-  <msgCharNotFound>Нечему хлопать...</msgCharNotFound>
-  <msgOthersAuto>$c1 хлопает в ладоши, радуясь своим подвигам.</msgOthersAuto>
-  <msgOthersFound>$c1 хлопает в ладоши, радуясь подвигам $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 поднимает руки, сомкнутые вместе, в приветствии.</msgOthersNoArgument>
-  <msgVictimFound>$c1 хлопает в ладоши, радуясь твоим подвигам.</msgVictimFound>
+  <msgCharAuto l="ru">Ты хлопаешь в ладоши, радуясь своим подвигам.</msgCharAuto>
+  <msgCharAuto l="ua">Ти плескаєш у долоні, радіючи власним подвигам.</msgCharAuto>
+  <msgCharAuto l="en">You clap at your own performance.</msgCharAuto>
+  <msgCharFound l="ru">Ты хлопаешь в ладоши, радуясь подвигам $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти плескаєш у долоні, радіючи подвигам $C2.</msgCharFound>
+  <msgCharFound l="en">You clap at $C1's performance.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты поднимаешь руки, сомкнутые вместе, в приветствии.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти піднімаєш зімкнуті руки у вітанні.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You clap your hands together.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нечему хлопать...</msgCharNotFound>
+  <msgCharNotFound l="ua">Нема чому плескати...</msgCharNotFound>
+  <msgCharNotFound l="en">You clap for nothing.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 хлопает в ладоши, радуясь своим подвигам.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 плескає в долоні, радіючи власним подвигам.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 claps at $gits|his|her|their own performance.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 хлопает в ладоши, радуясь подвигам $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 плескає в долоні, радіючи подвигам $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 claps at $C1's performance.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 поднимает руки, сомкнутые вместе, в приветствии.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 піднімає зімкнуті руки у вітанні.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 shows approval by clapping $gits|his|her|their hands together.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 хлопает в ладоши, радуясь твоим подвигам.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 плескає в долоні, радіючи твоїм подвигам.</msgVictimFound>
+  <msgVictimFound l="en">$c1 claps at your performance.</msgVictimFound>
   <position>rest</position>
   <rusName>хлоп</rusName>
   <uaName>плесь</uaName>
-  <shortDesc>радостно хлопать в ладоши. приветствовать</shortDesc>
+  <shortDesc l="ru">радостно хлопать в ладоши. приветствовать</shortDesc>
+  <shortDesc l="ua">радісно плескати в долоні, вітати</shortDesc>
+  <shortDesc l="en">clap your hands, applaud, greet</shortDesc>
 </Social>

--- a/socials/collapse.xml
+++ b/socials/collapse.xml
@@ -3,15 +3,29 @@
   <help id="1674" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты не можешь больше стоять и падаешь на руки $C3.</msgCharFound>
-  <msgCharNoArgument>Ты валишься с ног от усталости.</msgCharNoArgument>
-  <msgCharNotFound>Они только что ушли, только что - можешь догнать - если есть силы :)</msgCharNotFound>
+  <msgCharFound l="ru">Ты не можешь больше стоять и падаешь на руки $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти вже не можеш стояти і падаєш на руки $C3.</msgCharFound>
+  <msgCharFound l="en">You collapse right into $C1's arms.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты валишься с ног от усталости.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти валишся з ніг від утоми.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You collapse on the floor from exhaustion.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Они только что ушли, только что - можешь догнать - если есть силы :)</msgCharNotFound>
+  <msgCharNotFound l="ua">Вони щойно пішли, щойно -- можеш наздогнати, якщо є сили :)</msgCharNotFound>
+  <msgCharNotFound l="en">They have only just left -- you could still catch up, if you had the strength :)</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 падает на руки $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 валится с ног от усталости.</msgOthersNoArgument>
-  <msgVictimFound>$c1 не может устоять на ногах, и падает к тебе на руки.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 падает на руки $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 падає на руки $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 collapses right into $C1's arms.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 валится с ног от усталости.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 валиться з ніг від утоми.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 dramatically collapses to the floor from exhaustion.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 не может устоять на ногах, и падает к тебе на руки.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 не може встояти на ногах і падає тобі на руки.</msgVictimFound>
+  <msgVictimFound l="en">Suddenly, $c1 collapses into your arms from exhaustion.</msgVictimFound>
   <position>rest</position>
   <rusName>падать</rusName>
   <uaName>падати</uaName>
-  <shortDesc>валиться с ног от усталости</shortDesc>
+  <shortDesc l="ru">валиться с ног от усталости</shortDesc>
+  <shortDesc l="ua">валитися з ніг від утоми</shortDesc>
+  <shortDesc l="en">collapse from exhaustion</shortDesc>
 </Social>

--- a/socials/comfort.xml
+++ b/socials/comfort.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1694" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тщетно пытаешься утешиться.</msgCharAuto>
-  <msgCharFound>Ты утешаешь $C4.</msgCharFound>
-  <msgCharNoArgument>Тебе неудобно?</msgCharNoArgument>
-  <msgCharNotFound>Утешить кого?</msgCharNotFound>
-  <msgOthersAuto>$c1 утешает себя... Больше, похоже, некому.</msgOthersAuto>
-  <msgOthersFound>$c1 утешает $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Ты тщетно пытаешься утешиться.</msgCharAuto>
+  <msgCharAuto l="ua">Ти марно намагаєшся втішитися.</msgCharAuto>
+  <msgCharAuto l="en">You make a vain attempt to comfort yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты утешаешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти втішаєш $C4.</msgCharFound>
+  <msgCharFound l="en">You comfort $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Тебе неудобно?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Тобі незручно?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Do you feel uncomfortable?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Утешить кого?</msgCharNotFound>
+  <msgCharNotFound l="ua">Втішити кого?</msgCharNotFound>
+  <msgCharNotFound l="en">Comfort who?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 утешает себя... Больше, похоже, некому.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 втішає себе... Більше, схоже, нема кому.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 has no one to offer any comfort, and settles for self.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 утешает $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 втішає $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 comforts $C1.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 утешает тебя.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 утешает тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 втішає тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 comforts you.</msgVictimFound>
   <position>rest</position>
   <rusName>утешить</rusName>
   <uaName>втішити</uaName>
-  <shortDesc>утешить убитого горем</shortDesc>
+  <shortDesc l="ru">утешить убитого горем</shortDesc>
+  <shortDesc l="ua">втішити вбитого горем</shortDesc>
+  <shortDesc l="en">comfort the grief-stricken</shortDesc>
 </Social>

--- a/socials/contemplate.xml
+++ b/socials/contemplate.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты задумчиво кусаешь губы.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты задумчиво кусаешь губы.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти задумливо кусаєш губи.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You bite your lip contemplatively.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 задумчиво кусает губы.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 задумчиво кусает губы.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 задумливо кусає губи.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 bites $gits|his|her|their lip contemplatively.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>задумчиво</rusName>
   <uaName>задумливо</uaName>
-  <shortDesc>задумчиво кусать губы</shortDesc>
+  <shortDesc l="ru">задумчиво кусать губы</shortDesc>
+  <shortDesc l="ua">задумливо кусати губи</shortDesc>
+  <shortDesc l="en">bite your lip in thought</shortDesc>
 </Social>

--- a/socials/cramp.xml
+++ b/socials/cramp.xml
@@ -3,15 +3,29 @@
   <help id="1720" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты хватаешься за $X и орешь &quot;AAAAA!! Воды отходят!!!&quot;</msgCharFound>
-  <msgCharNoArgument>Ты хватаешься за живот. Тебя сводит судоргой.</msgCharNoArgument>
-  <msgCharNotFound>Тебе даже помочь некому.</msgCharNotFound>
+  <msgCharFound l="ru">Ты хватаешься за $X и орешь &quot;AAAAA!! Воды отходят!!!&quot;</msgCharFound>
+  <msgCharFound l="ua">Ти хапаєшся за $C4 і волаєш "АААА!! Води відійшли!!!"</msgCharFound>
+  <msgCharFound l="en">You grab hold of $C1, screaming "AAAAA!! My water just broke!!!"</msgCharFound>
+  <msgCharNoArgument l="ru">Ты хватаешься за живот. Тебя сводит судоргой.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти хапаєшся за живіт. Тебе зводить судомою.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You clutch your belly. A cramp doubles you over.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Тебе даже помочь некому.</msgCharNotFound>
+  <msgCharNotFound l="ua">Тобі навіть допомогти нема кому.</msgCharNotFound>
+  <msgCharNotFound l="en">Suffering as you are, there is nobody even to help you.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 хватается за $C4, крича &quot;AAAAA!! Сейчас рожу!!!&quot;.</msgOthersFound>
-  <msgOthersNoArgument>$c1 хватается за живот и натужно орет.</msgOthersNoArgument>
-  <msgVictimFound>$c1 хватается за тебя и вопит &quot;AAAAA!! Рожаю! Это.. мальчик!!!&quot;</msgVictimFound>
+  <msgOthersFound l="ru">$c1 хватается за $C4, крича &quot;AAAAA!! Сейчас рожу!!!&quot;.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 хапається за $C4, кричачи "АААА!! Зараз народжу!!!".</msgOthersFound>
+  <msgOthersFound l="en">$c1 grabs hold of $C1, screaming "AAAAA!! It's coming!!!".</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 хватается за живот и натужно орет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 хапається за живіт і надсадно волає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 clutches that belly and howls with the strain.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 хватается за тебя и вопит &quot;AAAAA!! Рожаю! Это.. мальчик!!!&quot;</msgVictimFound>
+  <msgVictimFound l="ua">$c1 хапається за тебе і репетує "АААА!! Народжую! Це.. хлопчик!!!"</msgVictimFound>
+  <msgVictimFound l="en">$c1 grabs hold of you and shrieks "AAAAA!! It's coming! It's.. a boy!!!"</msgVictimFound>
   <position>rest</position>
   <rusName>схватки</rusName>
   <uaName>судоми</uaName>
-  <shortDesc>это когда живот прихватит..</shortDesc>
+  <shortDesc l="ru">это когда живот прихватит..</shortDesc>
+  <shortDesc l="ua">це коли живіт прихопить..</shortDesc>
+  <shortDesc l="en">that moment when your belly seizes up..</shortDesc>
 </Social>

--- a/socials/cry.xml
+++ b/socials/cry.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1620" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты рыдаешь в свою жилетку.</msgCharAuto>
-  <msgCharFound>Ты рыдаешь у $X на плече.</msgCharFound>
-  <msgCharNoArgument>Ы-ы-ы-ы-ы-ы..</msgCharNoArgument>
-  <msgCharNotFound>Это еще кто?</msgCharNotFound>
-  <msgOthersAuto>Жилетка $c2 внезапно намокает... от собственных слез.</msgOthersAuto>
-  <msgOthersFound>$c1 рыдает на плече у $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 горько плачет.</msgOthersNoArgument>
-  <msgVictimFound>$c1 рыдает на твоем плече.</msgVictimFound>
+  <msgCharAuto l="ru">Ты рыдаешь в свою жилетку.</msgCharAuto>
+  <msgCharAuto l="ua">Ти ридаєш у власну жилетку.</msgCharAuto>
+  <msgCharAuto l="en">You cry into your own waistcoat.</msgCharAuto>
+  <msgCharFound l="ru">Ты рыдаешь у $X на плече.</msgCharFound>
+  <msgCharFound l="ua">Ти ридаєш на плечі в $C2.</msgCharFound>
+  <msgCharFound l="en">You cry on $C1's shoulder.</msgCharFound>
+  <msgCharNoArgument l="ru">Ы-ы-ы-ы-ы-ы..</msgCharNoArgument>
+  <msgCharNoArgument l="ua">И-и-и-и-и-и..</msgCharNoArgument>
+  <msgCharNoArgument l="en">Waaaaah..</msgCharNoArgument>
+  <msgCharNotFound l="ru">Это еще кто?</msgCharNotFound>
+  <msgCharNotFound l="ua">Це ще хто?</msgCharNotFound>
+  <msgCharNotFound l="en">And who might that be?</msgCharNotFound>
+  <msgOthersAuto l="ru">Жилетка $c2 внезапно намокает... от собственных слез.</msgOthersAuto>
+  <msgOthersAuto l="ua">Жилетка $c2 раптом намокає... від власних сліз.</msgOthersAuto>
+  <msgOthersAuto l="en">$c2 waistcoat is suddenly soaked... with its owner's own tears.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 рыдает на плече у $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 ридає на плечі в $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 cries on $C1's shoulder.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 горько плачет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 гірко плаче.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 bursts into tears.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 рыдает на твоем плече.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 ридає на твоєму плечі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 cries on your shoulder.</msgVictimFound>
   <position>rest</position>
   <rusName>плакать</rusName>
   <uaName>плакати</uaName>
-  <shortDesc>рыдать в три ручья</shortDesc>
+  <shortDesc l="ru">рыдать в три ручья</shortDesc>
+  <shortDesc l="ua">ридати в три струмки</shortDesc>
+  <shortDesc l="en">weep buckets</shortDesc>
 </Social>

--- a/socials/cuddle.xml
+++ b/socials/cuddle.xml
@@ -2,18 +2,38 @@
 <Social type="Social">
   <help id="1784" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>На самом деле ты уже и так прижат$gо||а сам$gо||а к себе :)</msgCharAuto>
-  <msgCharFound>Ты прижимаешь к себе $S.</msgCharFound>
-  <msgCharNoArgument>Кого ты хочешь сегодня прижать к себе?</msgCharNoArgument>
-  <msgCharNotFound>Таких тут нет.</msgCharNotFound>
-  <msgCharObj>Ты жадно прижимаешь к себе %2$O4.</msgCharObj>
-  <msgOthersAuto>$c1 прижимает к себе собственную тень. Ну и зрелище!</msgOthersAuto>
-  <msgOthersFound>$c1 прижимает к себе $C4.</msgOthersFound>
+  <msgCharAuto l="ru">На самом деле ты уже и так прижат$gо||а сам$gо||а к себе :)</msgCharAuto>
+  <msgCharAuto l="ua">Насправді ти вже й так притисну$gте|тий|та сам$gе|ий|а до себе :)</msgCharAuto>
+  <msgCharAuto l="en">You must feel very cuddly indeed ... :)</msgCharAuto>
+  <msgCharFound l="ru">Ты прижимаешь к себе $S.</msgCharFound>
+  <msgCharFound l="ua">Ти пригортаєш до себе $C4.</msgCharFound>
+  <msgCharFound l="en">You cuddle $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Кого ты хочешь сегодня прижать к себе?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кого ти хочеш сьогодні пригорнути?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Who do you feel like cuddling today?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Таких тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">They aren't here.</msgCharNotFound>
+  <msgCharObj l="ru">Ты жадно прижимаешь к себе %2$O4.</msgCharObj>
+  <msgCharObj l="ua">Ти жадібно пригортаєш до себе %2$O4.</msgCharObj>
+  <msgCharObj l="en">You greedily hug %2$O4 to your chest.</msgCharObj>
+  <msgOthersAuto l="ru">$c1 прижимает к себе собственную тень. Ну и зрелище!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 пригортає до себе власну тінь. Ото видовище!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 cuddles up to $gits|his|her|their own shadow. What a sorry sight.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 прижимает к себе $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 пригортає до себе $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 cuddles $C1.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgOthersObj>%1$^C1 жадно прижимает к себе %2$O4.</msgOthersObj>
-  <msgVictimFound>$c1 прижимает тебя к себе.</msgVictimFound>
+  <msgOthersObj l="ru">%1$^C1 жадно прижимает к себе %2$O4.</msgOthersObj>
+  <msgOthersObj l="ua">%1$^C1 жадібно пригортає до себе %2$O4.</msgOthersObj>
+  <msgOthersObj l="en">%1$^C1 greedily hugs %2$O4 close.</msgOthersObj>
+  <msgVictimFound l="ru">$c1 прижимает тебя к себе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 пригортає тебе до себе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 cuddles you.</msgVictimFound>
   <position>rest</position>
   <rusName>прижать</rusName>
   <uaName>пригорнути</uaName>
-  <shortDesc>к сердцу прижмет...</shortDesc>
+  <shortDesc l="ru">к сердцу прижмет...</shortDesc>
+  <shortDesc l="ua">до серця пригорне...</shortDesc>
+  <shortDesc l="en">hold somebody close to your heart...</shortDesc>
 </Social>

--- a/socials/curtsey.xml
+++ b/socials/curtsey.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1729" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты делаешь реверанс себе.</msgCharAuto>
-  <msgCharFound>Ты делаешь реверанс перед $C5.</msgCharFound>
-  <msgCharNoArgument>Ты делаешь реверанс.</msgCharNoArgument>
-  <msgCharNotFound>Ты делаешь реверанс непонятно кому, мысленно.</msgCharNotFound>
-  <msgOthersAuto>$c1 делает себе реверанс, пытаясь привлечь хоть чьё-нибудь внимание.</msgOthersAuto>
-  <msgOthersFound>$c1 изящно делает реверанс $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 изящно делает реверанс.</msgOthersNoArgument>
-  <msgVictimFound>$c1 изящно делает реверанс тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты делаешь реверанс себе.</msgCharAuto>
+  <msgCharAuto l="ua">Ти робиш реверанс собі.</msgCharAuto>
+  <msgCharAuto l="en">You curtsey to your audience (yourself).</msgCharAuto>
+  <msgCharFound l="ru">Ты делаешь реверанс перед $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти робиш реверанс перед $C5.</msgCharFound>
+  <msgCharFound l="en">You curtsey to $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты делаешь реверанс.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти робиш реверанс.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You curtsey to your audience.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты делаешь реверанс непонятно кому, мысленно.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти робиш реверанс невідомо кому, подумки.</msgCharNotFound>
+  <msgCharNotFound l="en">You curtsey to no one in particular.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 делает себе реверанс, пытаясь привлечь хоть чьё-нибудь внимание.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 робить собі реверанс, намагаючись привернути хоч чиюсь увагу.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 curtseys to $gitself|himself|herself|themselves, since nobody else is paying attention.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 изящно делает реверанс $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 витончено робить реверанс $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 curtseys gracefully to $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 изящно делает реверанс.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 витончено робить реверанс.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 curtseys gracefully.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 изящно делает реверанс тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 витончено робить реверанс тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 curtseys gracefully for you.</msgVictimFound>
   <position>rest</position>
   <rusName>реверанс</rusName>
   <uaName>реверанс</uaName>
-  <shortDesc>делать реверанс</shortDesc>
+  <shortDesc l="ru">делать реверанс</shortDesc>
+  <shortDesc l="ua">робити реверанс</shortDesc>
+  <shortDesc l="en">drop a curtsey</shortDesc>
 </Social>

--- a/socials/dance.xml
+++ b/socials/dance.xml
@@ -6,16 +6,34 @@
   </aliases>
   <help id="1622" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты подпрыгиваешь, и танцуешь, держа себя за бока.</msgCharAuto>
-  <msgCharFound>Ты кружишься в танце с $C5.</msgCharFound>
-  <msgCharNoArgument>Ты извиваешься в танце.</msgCharNoArgument>
-  <msgCharNotFound>Эх, а с кем?</msgCharNotFound>
-  <msgOthersAuto>$c1 подпрыгивает и танцует, держа себя за бока.</msgOthersAuto>
-  <msgOthersFound>$c1 кружится в танце с $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 извивается в диком танце перед тобой!</msgOthersNoArgument>
-  <msgVictimFound>$c1 кружится с тобой в танце.</msgVictimFound>
+  <msgCharAuto l="ru">Ты подпрыгиваешь, и танцуешь, держа себя за бока.</msgCharAuto>
+  <msgCharAuto l="ua">Ти підстрибуєш і танцюєш, тримаючи себе за боки.</msgCharAuto>
+  <msgCharAuto l="en">You skip and dance around by yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты кружишься в танце с $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти кружляєш у танці з $C5.</msgCharFound>
+  <msgCharFound l="en">You lead $C1 to the dancefloor.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты извиваешься в танце.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти звиваєшся в танці.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Feels silly, doesn't it?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Эх, а с кем?</msgCharNotFound>
+  <msgCharNotFound l="ua">Ех, а з ким?</msgCharNotFound>
+  <msgCharNotFound l="en">Eh, WHO?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 подпрыгивает и танцует, держа себя за бока.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 підстрибує і танцює, тримаючи себе за боки.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 skips a light Fandango.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 кружится в танце с $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 кружляє у танці з $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sends $C1 across the dancefloor.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 извивается в диком танце перед тобой!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 звивається в шаленому танці перед тобою!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 dances wildly before you!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 кружится с тобой в танце.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 кружляє з тобою в танці.</msgVictimFound>
+  <msgVictimFound l="en">$c1 sends you across the dancefloor.</msgVictimFound>
   <position>rest</position>
   <rusName>танец</rusName>
   <uaName>танець</uaName>
-  <shortDesc>танцевать</shortDesc>
+  <shortDesc l="ru">танцевать</shortDesc>
+  <shortDesc l="ua">танцювати</shortDesc>
+  <shortDesc l="en">dance</shortDesc>
 </Social>

--- a/socials/daydream.xml
+++ b/socials/daydream.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты мечтаешь о лучших днях.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты мечтаешь о лучших днях.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти мрієш про кращі дні.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You dream of better times.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 думает о чем-то, уставившись в одну точку.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 думает о чем-то, уставившись в одну точку.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 думає про щось, утупившись в одну точку.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 looks absent-minded, eyes staring into space.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>мечтать</rusName>
   <uaName>мріяти</uaName>
-  <shortDesc>мечтать об абстрактном</shortDesc>
+  <shortDesc l="ru">мечтать об абстрактном</shortDesc>
+  <shortDesc l="ua">мріяти про абстрактне</shortDesc>
+  <shortDesc l="en">dream of nothing in particular</shortDesc>
 </Social>

--- a/socials/discodance.xml
+++ b/socials/discodance.xml
@@ -3,15 +3,29 @@
   <help id="1785" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты хватаешь $C4 и лихо отплясываешь с $Y! Гоп-гоп!</msgCharFound>
-  <msgCharNoArgument>Ты вытанцовываешь кренделя!</msgCharNoArgument>
-  <msgCharNotFound>Все в порядке! Клево танцуешь сам.</msgCharNotFound>
+  <msgCharFound l="ru">Ты хватаешь $C4 и лихо отплясываешь с $Y! Гоп-гоп!</msgCharFound>
+  <msgCharFound l="ua">Ти хапаєш $C4 і хвацько витанцьовуєш! Гоп-гоп!</msgCharFound>
+  <msgCharFound l="en">You grab $C1 and disco wildly! Groovy!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты вытанцовываешь кренделя!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти витанцьовуєш кренделі!</msgCharNoArgument>
+  <msgCharNoArgument l="en">Groovy!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Все в порядке! Клево танцуешь сам.</msgCharNotFound>
+  <msgCharNotFound l="ua">Усе гаразд! Класно танцюєш і сам$gе|ий|а.</msgCharNotFound>
+  <msgCharNotFound l="en">It's okay, you can disco solo too.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 хватает $C4 и отплясывает гопачок!</msgOthersFound>
-  <msgOthersNoArgument>$c1 вытанцовывает кренделя!</msgOthersNoArgument>
-  <msgVictimFound>$c1 хватает тебя и лихо с тобой отплясывает!</msgVictimFound>
+  <msgOthersFound l="ru">$c1 хватает $C4 и отплясывает гопачок!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 хапає $C4 і витанцьовує гопачок!</msgOthersFound>
+  <msgOthersFound l="en">$c1 grabs $C1 and does the best Travolta you have ever seen!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вытанцовывает кренделя!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 витанцьовує кренделі!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 discos wildly!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 хватает тебя и лихо с тобой отплясывает!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 хапає тебе і хвацько з тобою витанцьовує!</msgVictimFound>
+  <msgVictimFound l="en">$c1 grabs you and dances up a storm!</msgVictimFound>
   <position>rest</position>
   <rusName>отплясывать</rusName>
   <uaName>відпалювати</uaName>
-  <shortDesc>буйно отплясывать</shortDesc>
+  <shortDesc l="ru">буйно отплясывать</shortDesc>
+  <shortDesc l="ua">буйно витанцьовувати</shortDesc>
+  <shortDesc l="en">dance up a storm</shortDesc>
 </Social>

--- a/socials/embrace.xml
+++ b/socials/embrace.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1689" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты пытаешься, любя, обхватить себя.</msgCharAuto>
-  <msgCharFound>Ты обвиваешь руками $C4 в теплых любящих объятиях.</msgCharFound>
-  <msgCharNoArgument>Кого обнять?</msgCharNoArgument>
-  <msgCharNotFound>Твое сердце разбивается на мелкие кусочки - их тут нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 пытается обхватить себя.</msgOthersAuto>
-  <msgOthersFound>$c1 обвивает руками $C4 в теплых любящих объятиях.</msgOthersFound>
+  <msgCharAuto l="ru">Ты пытаешься, любя, обхватить себя.</msgCharAuto>
+  <msgCharAuto l="ua">Ти намагаєшся, люблячи, обхопити себе.</msgCharAuto>
+  <msgCharAuto l="en">You try to console yourself with a loving embrace.</msgCharAuto>
+  <msgCharFound l="ru">Ты обвиваешь руками $C4 в теплых любящих объятиях.</msgCharFound>
+  <msgCharFound l="ua">Ти обвиваєш руками $C4 у теплих люблячих обіймах.</msgCharFound>
+  <msgCharFound l="en">You wrap your arms around $C1 in a warm and loving embrace.</msgCharFound>
+  <msgCharNoArgument l="ru">Кого обнять?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кого обійняти?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Who would you like to embrace?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Твое сердце разбивается на мелкие кусочки - их тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Твоє серце розбивається на дрібні шматочки -- їх тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Your heart breaks into little pieces -- they are not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 пытается обхватить себя.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 намагається обхопити себе.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 tries to console $gitself|himself|herself|themselves with a self-embrace.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 обвивает руками $C4 в теплых любящих объятиях.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 обвиває руками $C4 у теплих люблячих обіймах.</msgOthersFound>
+  <msgOthersFound l="en">$c1 wraps $gits|his|her|their arms around $C1 in a warm and loving embrace.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 обвивает тебя руками в теплых любящих объятиях.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 обвивает тебя руками в теплых любящих объятиях.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 обвиває тебе руками у теплих люблячих обіймах.</msgVictimFound>
+  <msgVictimFound l="en">$c1 takes you in a warm and loving embrace.</msgVictimFound>
   <position>rest</position>
   <rusName>обвить</rusName>
   <uaName>обвити</uaName>
-  <shortDesc>нежно, любяще обнять</shortDesc>
+  <shortDesc l="ru">нежно, любяще обнять</shortDesc>
+  <shortDesc l="ua">ніжно, люблячи обійняти</shortDesc>
+  <shortDesc l="en">a tender, loving embrace</shortDesc>
 </Social>

--- a/socials/eyebrow.xml
+++ b/socials/eyebrow.xml
@@ -3,15 +3,29 @@
   <help id="1641" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты поднимаешь бровь, глядя на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты поднимаешь бровь.</msgCharNoArgument>
-  <msgCharNotFound>Забудь. Их здесь все равно нет.</msgCharNotFound>
+  <msgCharFound l="ru">Ты поднимаешь бровь, глядя на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти піднімаєш брову, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You raise your eyebrow at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты поднимаешь бровь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти піднімаєш брову.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You raise an eyebrow at the notion.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Забудь. Их здесь все равно нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Забудь. Їх тут усе одно немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Forget it. They aren't here anyway.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 поднимает бровь, глядя на странные действия $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 поднимает бровь.</msgOthersNoArgument>
-  <msgVictimFound>$c1 поднимает бровь, глядя на тебя.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 поднимает бровь, глядя на странные действия $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 піднімає брову, дивлячись на дивні дії $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 raises an eyebrow at $C1's weird actions.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 поднимает бровь.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 піднімає брову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 raises an eyebrow.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 поднимает бровь, глядя на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 піднімає брову, дивлячись на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 raises an eyebrow at you.</msgVictimFound>
   <position>rest</position>
   <rusName>бровь</rusName>
   <uaName>брова</uaName>
-  <shortDesc>приподнять бровь, высказав свое удивление</shortDesc>
+  <shortDesc l="ru">приподнять бровь, высказав свое удивление</shortDesc>
+  <shortDesc l="ua">звести брову, висловивши свій подив</shortDesc>
+  <shortDesc l="en">raise an eyebrow to show your surprise</shortDesc>
 </Social>

--- a/socials/faint.xml
+++ b/socials/faint.xml
@@ -3,15 +3,29 @@
   <help id="1592" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты в обмороке падаешь $M на руки.</msgCharFound>
-  <msgCharNoArgument>Ты падаешь в обморок.</msgCharNoArgument>
-  <msgCharNotFound>Ты падаешь на землю, и цепенеешь.</msgCharNotFound>
+  <msgCharFound l="ru">Ты в обмороке падаешь $M на руки.</msgCharFound>
+  <msgCharFound l="ua">Ти зомліваєш і падаєш $C3 на руки.</msgCharFound>
+  <msgCharFound l="en">You faint into $C1's arms.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты падаешь в обморок.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти зомліваєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You faint.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты падаешь на землю, и цепенеешь.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти падаєш на землю і ціпенієш.</msgCharNotFound>
+  <msgCharNotFound l="en">You fall on the floor and lie there, stiff as a board.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 в обмороке падает на руки $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 падает в обморок.</msgOthersNoArgument>
-  <msgVictimFound>$c1 в обмороке падает тебе на руки.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 в обмороке падает на руки $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 зомліває і падає на руки $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 faints into $C1's open arms.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 падает в обморок.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 зомліває.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 faints.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 в обмороке падает тебе на руки.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 зомліває і падає тобі на руки.</msgVictimFound>
+  <msgVictimFound l="en">$c1 just fainted into YOUR arms.</msgVictimFound>
   <position>rest</position>
   <rusName>обморок</rusName>
   <uaName>зомління</uaName>
-  <shortDesc>упасть в обморок. можно-кому-нибудь на руки</shortDesc>
+  <shortDesc l="ru">упасть в обморок. можно-кому-нибудь на руки</shortDesc>
+  <shortDesc l="ua">зомліти. можна комусь на руки</shortDesc>
+  <shortDesc l="en">faint, possibly into somebody's arms</shortDesc>
 </Social>

--- a/socials/fart.xml
+++ b/socials/fart.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1822" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты пукаешь на себя. Для снятия стресса.</msgCharAuto>
-  <msgCharFound>Ты пукаешь на $X. Ты явно болеешь.</msgCharFound>
-  <msgCharNoArgument>Где твои манеры?</msgCharNoArgument>
-  <msgCharNotFound>Ты не можешь держать это так долго! Ты лопнешь!</msgCharNotFound>
-  <msgOthersAuto>$c1 пукает на себя. Видимо, опять на завтрак были паучьи кишки!</msgOthersAuto>
-  <msgOthersFound>$c1 пукает в направлении $C2. Беги отсюда, пока вонь не сбила тебя с ног!</msgOthersFound>
-  <msgOthersNoArgument>$c1 издает оглушительный пук... $c1 окутывается зеленоватым облаком!</msgOthersNoArgument>
-  <msgVictimFound>$c1 пукает в твоем направлении. Ты задыхаешься!</msgVictimFound>
+  <msgCharAuto l="ru">Ты пукаешь на себя. Для снятия стресса.</msgCharAuto>
+  <msgCharAuto l="ua">Ти пердиш на себе. Для зняття стресу.</msgCharAuto>
+  <msgCharAuto l="en">You fart at yourself. Stress relief.</msgCharAuto>
+  <msgCharFound l="ru">Ты пукаешь на $X. Ты явно болеешь.</msgCharFound>
+  <msgCharFound l="ua">Ти пердиш на $C4. Ти явно хвор$gе|ий|а.</msgCharFound>
+  <msgCharFound l="en">You fart at $C1. Boy, you are sick.</msgCharFound>
+  <msgCharNoArgument l="ru">Где твои манеры?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Де твої манери?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Where are your manners?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты не можешь держать это так долго! Ты лопнешь!</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти не можеш тримати це так довго! Ти лусне$gш|ш|ш!</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot hold it that long! You will burst!</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 пукает на себя. Видимо, опять на завтрак были паучьи кишки!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 пердить на себе. Видно, знову на сніданок були павучі кишки!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 farts at $gitself|himself|herself|themselves. Spider guts for breakfast again, evidently!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 пукает в направлении $C2. Беги отсюда, пока вонь не сбила тебя с ног!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 пердить у напрямку $C2. Тікай звідси, поки сморід не збив тебе з ніг!</msgOthersFound>
+  <msgOthersFound l="en">$c1 farts in the direction of $C1. Flee before the stink knocks you off your feet!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 издает оглушительный пук... $c1 окутывается зеленоватым облаком!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 видає оглушливий перд... $c1 огортається зеленуватою хмарою!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 lets off a real rip-roarer ... a greenish cloud envelops $c1!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 пукает в твоем направлении. Ты задыхаешься!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 пердить у твоєму напрямку. Ти задихаєшся!</msgVictimFound>
+  <msgVictimFound l="en">$c1 farts in your direction. You gasp for air!</msgVictimFound>
   <position>rest</position>
   <rusName>пук</rusName>
   <uaName>пук</uaName>
-  <shortDesc>громкий намеренный пук!</shortDesc>
+  <shortDesc l="ru">громкий намеренный пук!</shortDesc>
+  <shortDesc l="ua">гучний навмисний перд!</shortDesc>
+  <shortDesc l="en">a loud, deliberate fart!</shortDesc>
 </Social>

--- a/socials/fatality.xml
+++ b/socials/fatality.xml
@@ -3,15 +3,23 @@
   <help id="1767" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты обреченно говоришь: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgCharFound>
+  <msgCharFound l="ru">Ты обреченно говоришь: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgCharFound>
+  <msgCharFound l="ua">Ти приречено кажеш: '$C1 $Gвиграло|виграв|виграла|виграли. Начисто.'</msgCharFound>
+  <msgCharFound l="en">You intone, '$C1 wins. Fatality.'</msgCharFound>
   <msgCharNoArgument></msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 обреченно говорит: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgOthersFound>
+  <msgOthersFound l="ru">$c1 обреченно говорит: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgOthersFound>
+  <msgOthersFound l="ua">$c1 приречено каже: '$C1 $Gвиграло|виграв|виграла|виграли. Начисто.'</msgOthersFound>
+  <msgOthersFound l="en">$c1 intones, '$C1 wins. Fatality.'</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 обреченно говорит: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgVictimFound>
+  <msgVictimFound l="ru">$c1 обреченно говорит: &apos;$C1 выигра$Gло|л|ла. Вчистую.&apos;</msgVictimFound>
+  <msgVictimFound l="ua">$c1 приречено каже: '$C1 $Gвиграло|виграв|виграла|виграли. Начисто.'</msgVictimFound>
+  <msgVictimFound l="en">$c1 intones, '$C1 wins. Fatality.'</msgVictimFound>
   <position>rest</position>
   <rusName>обреченно</rusName>
   <uaName>приречено</uaName>
-  <shortDesc>выражение полной обреченности</shortDesc>
+  <shortDesc l="ru">выражение полной обреченности</shortDesc>
+  <shortDesc l="ua">вираз цілковитої приреченості</shortDesc>
+  <shortDesc l="en">an expression of utter doom</shortDesc>
 </Social>

--- a/socials/flare.xml
+++ b/socials/flare.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1765" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>*Фи!* Перестань!</msgCharAuto>
-  <msgCharFound>Ты пренебрежительно раздуваешь ноздри, глядя на $C4...</msgCharFound>
-  <msgCharNoArgument>Ты пренебрежительно раздуваешь ноздри.</msgCharNoArgument>
-  <msgCharNotFound>Можешь своим носом делать все что хочешь, но тут таких нет.</msgCharNotFound>
+  <msgCharAuto l="ru">*Фи!* Перестань!</msgCharAuto>
+  <msgCharAuto l="ua">*Фі!* Припини!</msgCharAuto>
+  <msgCharAuto l="en">*Sniff* Oh, stop it!</msgCharAuto>
+  <msgCharFound l="ru">Ты пренебрежительно раздуваешь ноздри, глядя на $C4...</msgCharFound>
+  <msgCharFound l="ua">Ти зневажливо роздуваєш ніздрі, дивлячись на $C4...</msgCharFound>
+  <msgCharFound l="en">You flare your nostrils disdainfully at $C1... HOW RUDE!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты пренебрежительно раздуваешь ноздри.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти зневажливо роздуваєш ніздрі.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You flare your nostrils disdainfully.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Можешь своим носом делать все что хочешь, но тут таких нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Можеш своїм носом робити що завгодно, але таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Flare all you wish, but that person isn't here to see it.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 пренебрежительно раздувает ноздри, глядя на $C4, и отворачивается.</msgOthersFound>
-  <msgOthersNoArgument>$c1 пренебрежительно раздувает ноздри.</msgOthersNoArgument>
-  <msgVictimFound>$c1 пренебрежительно раздувает ноздри, глядя на тебя...</msgVictimFound>
+  <msgOthersFound l="ru">$c1 пренебрежительно раздувает ноздри, глядя на $C4, и отворачивается.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 зневажливо роздуває ніздрі, дивлячись на $C4, і відвертається.</msgOthersFound>
+  <msgOthersFound l="en">$c1 flares $gits|his|her|their nostrils disdainfully at $C1 and turns away.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 пренебрежительно раздувает ноздри.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 зневажливо роздуває ніздрі.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 flares $gits|his|her|their nostrils disdainfully.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 пренебрежительно раздувает ноздри, глядя на тебя...</msgVictimFound>
+  <msgVictimFound l="ua">$c1 зневажливо роздуває ніздрі, дивлячись на тебе...</msgVictimFound>
+  <msgVictimFound l="en">$c1 flares those nostrils disdainfully at you... what did you DO???</msgVictimFound>
   <position>rest</position>
   <rusName>пренебрегать</rusName>
   <uaName>зневажати</uaName>
-  <shortDesc>высказывать пренебрежение</shortDesc>
+  <shortDesc l="ru">высказывать пренебрежение</shortDesc>
+  <shortDesc l="ua">висловлювати зневагу</shortDesc>
+  <shortDesc l="en">show your disdain</shortDesc>
 </Social>

--- a/socials/flex.xml
+++ b/socials/flex.xml
@@ -3,15 +3,27 @@
   <help id="1724" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты поворачиваешься к $C3, гордо играя своими мускулами.</msgCharFound>
-  <msgCharNoArgument>Ты гордо играешь своими мускулами!</msgCharNoArgument>
+  <msgCharFound l="ru">Ты поворачиваешься к $C3, гордо играя своими мускулами.</msgCharFound>
+  <msgCharFound l="ua">Ти повертаєшся до $C2, гордо граючи своїми м'язами.</msgCharFound>
+  <msgCharFound l="en">You show off to $C1, flexing your muscles proudly.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты гордо играешь своими мускулами!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти гордо граєш своїми м'язами!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You flex your muscles proudly!</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 играет своими мускулами, в попытке произвести впечатление на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 играет мускулами... Прямо вышибала из &quot;Хрюкающего кабана&quot;!</msgOthersNoArgument>
-  <msgVictimFound>$c1 играет своими мускулами, пытаясь привлечь твой взгляд.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 играет своими мускулами, в попытке произвести впечатление на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 грає своїми м'язами, намагаючись справити враження на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 flexes $gits|his|her|their muscles in a vain attempt to impress $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 играет мускулами... Прямо вышибала из &quot;Хрюкающего кабана&quot;!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 грає м'язами... Прямо викидайло з "Рохкаючого кабана"!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 flexes those muscles... a proper bouncer from the Grunting Boar!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 играет своими мускулами, пытаясь привлечь твой взгляд.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 грає своїми м'язами, намагаючись привабити твій погляд.</msgVictimFound>
+  <msgVictimFound l="en">$c1 flexes those muscles in a vain attempt to catch your eye.</msgVictimFound>
   <position>rest</position>
   <rusName>мускулы</rusName>
   <uaName>мускули</uaName>
-  <shortDesc>играть мускулами, привлекая внимание</shortDesc>
+  <shortDesc l="ru">играть мускулами, привлекая внимание</shortDesc>
+  <shortDesc l="ua">грати м'язами, привертаючи увагу</shortDesc>
+  <shortDesc l="en">flex your muscles for attention</shortDesc>
 </Social>

--- a/socials/flinch.xml
+++ b/socials/flinch.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1666" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты не можешь поверить, в то, что сделано тобой...</msgCharAuto>
-  <msgCharFound>Может, тебе проще просто прилечь и тихонько УМЕРЕТЬ?</msgCharFound>
-  <msgCharNoArgument>Ты вздрагиваешь от боли.</msgCharNoArgument>
-  <msgCharNotFound>Расслабься, все уже ушли.</msgCharNotFound>
-  <msgOthersAuto>$c1 вздрагивает, оценив свое поведение.</msgOthersAuto>
-  <msgOthersFound>$c1 смотрит на $C4 и вздрагивает.</msgOthersFound>
-  <msgOthersNoArgument>$c1 вздрагивает от боли.</msgOthersNoArgument>
-  <msgVictimFound>$c1 вздрагивает, слыша твои упреки.</msgVictimFound>
+  <msgCharAuto l="ru">Ты не можешь поверить, в то, что сделано тобой...</msgCharAuto>
+  <msgCharAuto l="ua">Ти не можеш повірити в те, що тобою зроблено...</msgCharAuto>
+  <msgCharAuto l="en">You cannot believe what you have done...</msgCharAuto>
+  <msgCharFound l="ru">Может, тебе проще просто прилечь и тихонько УМЕРЕТЬ?</msgCharFound>
+  <msgCharFound l="ua">Може, тобі простіше просто лягти і тихенько ПОМЕРТИ?</msgCharFound>
+  <msgCharFound l="en">Wouldn't it be easier to just lie down and DIE?</msgCharFound>
+  <msgCharNoArgument l="ru">Ты вздрагиваешь от боли.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти здригаєшся від болю.</msgCharNoArgument>
+  <msgCharNoArgument l="en">EEEK... You flinch in obvious pain.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Расслабься, все уже ушли.</msgCharNotFound>
+  <msgCharNotFound l="ua">Розслабся, усі вже пішли.</msgCharNotFound>
+  <msgCharNotFound l="en">Relax, everyone has already left.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 вздрагивает, оценив свое поведение.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 здригається, оцінивши свою поведінку.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 twitches violently, shocked at $gits|his|her|their own behaviour.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 смотрит на $C4 и вздрагивает.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дивиться на $C4 і здригається.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sneaks a glance at $C1 and flinches.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вздрагивает от боли.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 здригається від болю.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 flinches in obvious pain.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 вздрагивает, слыша твои упреки.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 здригається, чуючи твої докори.</msgVictimFound>
+  <msgVictimFound l="en">$c1 flinches in response to your cold rebuke.</msgVictimFound>
   <position>rest</position>
   <rusName>вздрагивать</rusName>
   <uaName>сахатися</uaName>
-  <shortDesc>вздрагивать от боли</shortDesc>
+  <shortDesc l="ru">вздрагивать от боли</shortDesc>
+  <shortDesc l="ua">здригатися від болю</shortDesc>
+  <shortDesc l="en">flinch in pain</shortDesc>
 </Social>

--- a/socials/flip.xml
+++ b/socials/flip.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1711" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты кувыркаешься по комнате.</msgCharAuto>
-  <msgCharFound>Ты делаешь $M бросок через бедро.</msgCharFound>
-  <msgCharNoArgument>Ты кувыркаешься.</msgCharNoArgument>
-  <msgCharNotFound>Не находишь!</msgCharNotFound>
-  <msgOthersAuto>$c1 делает несколько кувырков, прыжков и других смешных ужимок.</msgOthersAuto>
-  <msgOthersFound>$c1 делает бросок $C2 через бедро.</msgOthersFound>
-  <msgOthersNoArgument>$c1 кувыркается.</msgOthersNoArgument>
-  <msgVictimFound>$c1 бросает тебя через бедро. Ты встаешь и отряхиваешься. Хммммм.</msgVictimFound>
+  <msgCharAuto l="ru">Ты кувыркаешься по комнате.</msgCharAuto>
+  <msgCharAuto l="ua">Ти перекидаєшся по кімнаті.</msgCharAuto>
+  <msgCharAuto l="en">You tumble all over the room.</msgCharAuto>
+  <msgCharFound l="ru">Ты делаешь $M бросок через бедро.</msgCharFound>
+  <msgCharFound l="ua">Ти робиш $C3 кидок через стегно.</msgCharFound>
+  <msgCharFound l="en">You flip $C1 over your shoulder.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты кувыркаешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти перекидаєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You flip head over heels.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Не находишь!</msgCharNotFound>
+  <msgCharNotFound l="ua">Не знаходиш!</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot find the person!</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 делает несколько кувырков, прыжков и других смешных ужимок.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 робить кілька перекидів, стрибків та інших смішних вихилясів.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 does some nice tumbling and gymnastics.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 делает бросок $C2 через бедро.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 робить кидок $C2 через стегно.</msgOthersFound>
+  <msgOthersFound l="en">$c1 flips $C1 over $gits|his|her|their shoulder.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 кувыркается.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 перекидається.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 flips head over heels.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 бросает тебя через бедро. Ты встаешь и отряхиваешься. Хммммм.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 кидає тебе через стегно. Ти встаєш і обтрушуєшся. Хмммм.</msgVictimFound>
+  <msgVictimFound l="en">$c1 flips you over one shoulder. You get up and dust yourself off. Hmmmm.</msgVictimFound>
   <position>rest</position>
   <rusName>кувырок</rusName>
   <uaName>перекид</uaName>
-  <shortDesc>кувыркаться либо бросить кого-нибудь через бедро</shortDesc>
+  <shortDesc l="ru">кувыркаться либо бросить кого-нибудь через бедро</shortDesc>
+  <shortDesc l="ua">перекидатися або кинути когось через стегно</shortDesc>
+  <shortDesc l="en">tumble, or flip somebody over your shoulder</shortDesc>
 </Social>

--- a/socials/flirt.xml
+++ b/socials/flirt.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1787" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Флиртуешь с собой? И чего хочешь достичь?</msgCharAuto>
-  <msgCharFound>Ты флиртуешь с $C5, пытаясь привлечь $S внимание.</msgCharFound>
-  <msgCharNoArgument>Ты машешь руками, как орел.</msgCharNoArgument>
-  <msgCharNotFound>Не с кем :(</msgCharNotFound>
-  <msgOthersAuto>$c1 флиртует с собой, интересно, чего добивается?</msgOthersAuto>
-  <msgOthersFound>$c1 флиртует с $C5, хммм, интересно, что $e хочет?</msgOthersFound>
-  <msgOthersNoArgument>$c1 машет руками, как орел.</msgOthersNoArgument>
-  <msgVictimFound>$c1 флиртует с тобой.</msgVictimFound>
+  <msgCharAuto l="ru">Флиртуешь с собой? И чего хочешь достичь?</msgCharAuto>
+  <msgCharAuto l="ua">Фліртуєш із собою? І чого хочеш досягти?</msgCharAuto>
+  <msgCharAuto l="en">You flirt with yourself -- what ARE you trying to gain!?!?!?</msgCharAuto>
+  <msgCharFound l="ru">Ты флиртуешь с $C5, пытаясь привлечь $S внимание.</msgCharFound>
+  <msgCharFound l="ua">Ти фліртуєш з $C5, намагаючись привернути увагу.</msgCharFound>
+  <msgCharFound l="en">You flirt with $C1, trying to get some attention.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты машешь руками, как орел.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти махаєш руками, як орел.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You flirt outrageously.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Не с кем :(</msgCharNotFound>
+  <msgCharNotFound l="ua">Немає з ким :(</msgCharNotFound>
+  <msgCharNotFound l="en">Sorry, no one here to flirt with. :(</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 флиртует с собой, интересно, чего добивается?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 фліртує із собою, цікаво, чого домагається?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 flirts with $gitself|himself|herself|themselves. Wonder what that is meant to accomplish?</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 флиртует с $C5, хммм, интересно, что $e хочет?</msgOthersFound>
+  <msgOthersFound l="ua">$c1 фліртує з $C5, хмммм, цікаво, чого хоче?</msgOthersFound>
+  <msgOthersFound l="en">$c1 flirts with $C1, hmmm, wonder what that is about? *wink*</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 машет руками, как орел.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 махає руками, як орел.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 is an outrageous flirt.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 флиртует с тобой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 фліртує з тобою.</msgVictimFound>
+  <msgVictimFound l="en">$c1 flirts with you.</msgVictimFound>
   <position>rest</position>
   <rusName>флирт</rusName>
   <uaName>флірт</uaName>
-  <shortDesc>флиртовать или просто махать руками</shortDesc>
+  <shortDesc l="ru">флиртовать или просто махать руками</shortDesc>
+  <shortDesc l="ua">фліртувати або просто махати руками</shortDesc>
+  <shortDesc l="en">flirt, or just flap your arms</shortDesc>
 </Social>

--- a/socials/flutter.xml
+++ b/socials/flutter.xml
@@ -3,15 +3,29 @@
   <help id="1824" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты хлопаешь ресницами, глядя на $C4, пытаясь выглядеть соблазнительно.</msgCharFound>
-  <msgCharNoArgument>Ты соблазнительно хлопаешь своими ресницами.</msgCharNoArgument>
-  <msgCharNotFound>Эх... нет таких.</msgCharNotFound>
+  <msgCharFound l="ru">Ты хлопаешь ресницами, глядя на $C4, пытаясь выглядеть соблазнительно.</msgCharFound>
+  <msgCharFound l="ua">Ти кліпаєш віями, дивлячись на $C4, намагаючись мати звабливий вигляд.</msgCharFound>
+  <msgCharFound l="en">You flutter your eyelashes at $C1, trying to be seductive.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты соблазнительно хлопаешь своими ресницами.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти звабливо кліпаєш своїми віями.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You flutter your eyelashes seductively.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Эх... нет таких.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ех... немає таких.</msgCharNotFound>
+  <msgCharNotFound l="en">EH? Cannot see them here.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 соблазняет $C4, хлопая ресницами.</msgOthersFound>
-  <msgOthersNoArgument>$c1 соблазнительно хлопает своими ресницами.</msgOthersNoArgument>
-  <msgVictimFound>$c1 застенчиво хлопает своими ресницами, глядя на тебя.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 соблазняет $C4, хлопая ресницами.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 зваблює $C4, кліпаючи віями.</msgOthersFound>
+  <msgOthersFound l="en">$c1 flirts with $C1, fluttering those eyelashes.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 соблазнительно хлопает своими ресницами.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 звабливо кліпає своїми віями.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 flutters $gits|his|her|their eyelashes seductively.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 застенчиво хлопает своими ресницами, глядя на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 сором'язливо кліпає своїми віями, дивлячись на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 flutters those eyelashes at you coyly.</msgVictimFound>
   <position>rest</position>
   <rusName>реснички</rusName>
   <uaName>війки</uaName>
-  <shortDesc>строить глазки, трепеща ресницами</shortDesc>
+  <shortDesc l="ru">строить глазки, трепеща ресницами</shortDesc>
+  <shortDesc l="ua">будувати очка, тріпочучи віями</shortDesc>
+  <shortDesc l="en">make eyes with a flutter of eyelashes</shortDesc>
 </Social>

--- a/socials/french.xml
+++ b/socials/french.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1797" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты достаешь зеркало и начинаешь целовать свое отражение.</msgCharAuto>
-  <msgCharFound>Ты даришь $C3 длинный и страстный поцелуй, кажется, это длится вечность...</msgCharFound>
-  <msgCharNoArgument>Целовать кого?</msgCharNoArgument>
-  <msgCharNotFound>Твое сердце в печали - здесь таких нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 покрывает свое тело поцелуями, где может дотянуться.</msgOthersAuto>
-  <msgOthersFound>$c1 страстно целует $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Ты достаешь зеркало и начинаешь целовать свое отражение.</msgCharAuto>
+  <msgCharAuto l="ua">Ти дістаєш дзеркало і починаєш цілувати своє відображення.</msgCharAuto>
+  <msgCharAuto l="en">You take out a mirror and start kissing your own reflection.</msgCharAuto>
+  <msgCharFound l="ru">Ты даришь $C3 длинный и страстный поцелуй, кажется, это длится вечность...</msgCharFound>
+  <msgCharFound l="ua">Ти даруєш $C3 довгий і пристрасний поцілунок, здається, це триває вічно...</msgCharFound>
+  <msgCharFound l="en">You give $C1 a long and passionate kiss, it seems to last forever...</msgCharFound>
+  <msgCharNoArgument l="ru">Целовать кого?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Цілувати кого?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Kiss whom?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Твое сердце в печали - здесь таких нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Твоє серце в печалі -- тут таких немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Your heart fills with sorrow -- that person is not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 покрывает свое тело поцелуями, где может дотянуться.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 вкриває своє тіло поцілунками, де може дотягтися.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 covers every reachable inch of self in kisses.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 страстно целует $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 пристрасно цілує $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 kisses $C1 passionately.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 дарит тебе длинный и страстный поцелуй, кажется, это длится вечность...</msgVictimFound>
+  <msgVictimFound l="ru">$c1 дарит тебе длинный и страстный поцелуй, кажется, это длится вечность...</msgVictimFound>
+  <msgVictimFound l="ua">$c1 дарує тобі довгий і пристрасний поцілунок, здається, це триває вічно...</msgVictimFound>
+  <msgVictimFound l="en">$c1 gives you a long and passionate kiss, it seems to last forever...</msgVictimFound>
   <position>rest</position>
   <rusName>поцелуй</rusName>
   <uaName>цілунок</uaName>
-  <shortDesc>страстно целовать</shortDesc>
+  <shortDesc l="ru">страстно целовать</shortDesc>
+  <shortDesc l="ua">пристрасно цілувати</shortDesc>
+  <shortDesc l="en">a passionate kiss</shortDesc>
 </Social>

--- a/socials/frown.xml
+++ b/socials/frown.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1794" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты хмуришься на себя.</msgCharAuto>
-  <msgCharFound>Ты неодобрительно хмуришься на $X.</msgCharFound>
-  <msgCharNoArgument>Ты неодобрительно хмуришься.</msgCharNoArgument>
-  <msgCharNotFound>Тут не на кого хмуриться.</msgCharNotFound>
-  <msgOthersAuto>$c1 хмурится на себя.</msgOthersAuto>
-  <msgOthersFound>$c1 неодобрительно хмурится на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 хмурит брови.</msgOthersNoArgument>
-  <msgVictimFound>$c1 неодобрительно хмурится на тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты хмуришься на себя.</msgCharAuto>
+  <msgCharAuto l="ua">Ти хмуришся на себе.</msgCharAuto>
+  <msgCharAuto l="en">You frown at yourself. Poor baby.</msgCharAuto>
+  <msgCharFound l="ru">Ты неодобрительно хмуришься на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти несхвально хмуришся на $C4.</msgCharFound>
+  <msgCharFound l="en">You frown disapprovingly at what $C1 did.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты неодобрительно хмуришься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти несхвально хмуришся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You frown disapprovingly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Тут не на кого хмуриться.</msgCharNotFound>
+  <msgCharNotFound l="ua">Тут нема на кого хмуритися.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here to frown at.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 хмурится на себя.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 хмуриться на себе.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 frowns at $gitself|himself|herself|themselves. What a sad puppy...</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 неодобрительно хмурится на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 несхвально хмуриться на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 frowns at what $C1 did.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 хмурит брови.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 хмурить брови.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 frowns.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 неодобрительно хмурится на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 несхвально хмуриться на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 frowns at what you did.</msgVictimFound>
   <position>rest</position>
   <rusName>хмуриться</rusName>
   <uaName>хмуритися</uaName>
-  <shortDesc>неодобрительно хмуриться</shortDesc>
+  <shortDesc l="ru">неодобрительно хмуриться</shortDesc>
+  <shortDesc l="ua">несхвально хмуритися</shortDesc>
+  <shortDesc l="en">frown disapprovingly</shortDesc>
 </Social>

--- a/socials/fume.xml
+++ b/socials/fume.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1821" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Правильно! Себя надо ненавидеть!</msgCharAuto>
-  <msgCharFound>Ты в ярости смотришь на $X.</msgCharFound>
-  <msgCharNoArgument>Эй-эй, полегче! Посчитай до десяти, и помедленнее.</msgCharNoArgument>
-  <msgCharNotFound>Не волнуйся так, тут таких нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 сжимает кулаки, скрипит зубами, роет землю копытом.</msgOthersAuto>
-  <msgOthersFound>$c1 в ярости смотрит на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 скрипит зубами, зеленея от ярости.</msgOthersNoArgument>
-  <msgVictimFound>$c1 в ярости смотрит на тебя!</msgVictimFound>
+  <msgCharAuto l="ru">Правильно! Себя надо ненавидеть!</msgCharAuto>
+  <msgCharAuto l="ua">Правильно! Себе треба ненавидіти!</msgCharAuto>
+  <msgCharAuto l="en">That's right -- hate yourself!</msgCharAuto>
+  <msgCharFound l="ru">Ты в ярости смотришь на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти люто дивишся на $C4.</msgCharFound>
+  <msgCharFound l="en">You stare at $C1, fuming.</msgCharFound>
+  <msgCharNoArgument l="ru">Эй-эй, полегче! Посчитай до десяти, и помедленнее.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Гей-гей, легше! Порахуй до десяти, і повільніше.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Hey, hey, easy now! Count to ten, very slowly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Не волнуйся так, тут таких нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Не хвилюйся так, тут таких немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Fume away... they ain't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 сжимает кулаки, скрипит зубами, роет землю копытом.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 стискає кулаки, скрегоче зубами, риє землю копитом.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 clenches those fists, grinds those teeth and paws the ground.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 в ярости смотрит на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 люто дивиться на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 stares at $C1, fuming with rage.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 скрипит зубами, зеленея от ярости.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 скрегоче зубами, зеленіючи від люті.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 grits those teeth, going green with rage.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 в ярости смотрит на тебя!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 люто дивиться на тебе!</msgVictimFound>
+  <msgVictimFound l="en">$c1 stares at you, fuming with rage!</msgVictimFound>
   <position>rest</position>
   <rusName>сердиться</rusName>
   <uaName>сердитися</uaName>
-  <shortDesc>яростно и от всей души ненавидеть кого-либо</shortDesc>
+  <shortDesc l="ru">яростно и от всей души ненавидеть кого-либо</shortDesc>
+  <shortDesc l="ua">люто і від усієї душі ненавидіти когось</shortDesc>
+  <shortDesc l="en">hate somebody furiously and wholeheartedly</shortDesc>
 </Social>

--- a/socials/giggle.xml
+++ b/socials/giggle.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1728" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты хихикаешь над собой.</msgCharAuto>
-  <msgCharFound>Ты хихикаешь над $Y.</msgCharFound>
-  <msgCharNoArgument>Ты хихикаешь.</msgCharNoArgument>
-  <msgCharNotFound>Не находя, над кем похихикать, тебе приходится хихикать над собой.</msgCharNotFound>
-  <msgOthersAuto>$c1 хихикает над собой. Наверное, нервничает...</msgOthersAuto>
-  <msgOthersFound>$c1 хихикает над $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 хихикает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 хихикает над тобой. Ты надеешься, что это не заразно.</msgVictimFound>
+  <msgCharAuto l="ru">Ты хихикаешь над собой.</msgCharAuto>
+  <msgCharAuto l="ua">Ти хихочеш над собою.</msgCharAuto>
+  <msgCharAuto l="en">You giggle at yourself, which makes you giggle at yourself, which makes you ...</msgCharAuto>
+  <msgCharFound l="ru">Ты хихикаешь над $Y.</msgCharFound>
+  <msgCharFound l="ua">Ти хихочеш над $C5.</msgCharFound>
+  <msgCharFound l="en">You giggle in $C1's presence.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты хихикаешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти хихочеш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You giggle.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Не находя, над кем похихикать, тебе приходится хихикать над собой.</msgCharNotFound>
+  <msgCharNotFound l="ua">Не знаходячи, над ким похихотіти, тобі доводиться хихотіти над собою.</msgCharNotFound>
+  <msgCharNotFound l="en">Finding nobody to giggle with, you have to giggle at yourself.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 хихикает над собой. Наверное, нервничает...</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 хихоче над собою. Мабуть, нервує...</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 giggles at $gitself|himself|herself|themselves. Nerves, probably...</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 хихикает над $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 хихоче над $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 giggles at $C1's actions.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 хихикает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 хихоче.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 giggles.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 хихикает над тобой. Ты надеешься, что это не заразно.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 хихоче над тобою. Сподіваєшся, що це не заразно.</msgVictimFound>
+  <msgVictimFound l="en">$c1 giggles at you. Hope it's not contagious!</msgVictimFound>
   <position>rest</position>
   <rusName>хихи</rusName>
   <uaName>хіхі</uaName>
-  <shortDesc>хихикать</shortDesc>
+  <shortDesc l="ru">хихикать</shortDesc>
+  <shortDesc l="ua">хихотіти</shortDesc>
+  <shortDesc l="en">giggle</shortDesc>
 </Social>

--- a/socials/glare.xml
+++ b/socials/glare.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1594" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты свирепо смотришь на свои ноги... как они замерзли!</msgCharAuto>
-  <msgCharFound>Ты даришь $M холодный взгляд.</msgCharFound>
-  <msgCharNoArgument>Ты свирепо озираешься.</msgCharNoArgument>
-  <msgCharNotFound>Не на кого тут злиться.</msgCharNotFound>
-  <msgOthersAuto>$c1 свирепо смотрит на свои ноги... На дворе зима, а на ногах сандалии :)</msgOthersAuto>
-  <msgOthersFound>$c1 дарит холодный взгляд $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 свирепо озирается вокруг.</msgOthersNoArgument>
-  <msgVictimFound>$c1 свирепо смотрит на тебя, и холод пронизывает тебя до костей.</msgVictimFound>
+  <msgCharAuto l="ru">Ты свирепо смотришь на свои ноги... как они замерзли!</msgCharAuto>
+  <msgCharAuto l="ua">Ти люто дивишся на свої ноги... як вони змерзли!</msgCharAuto>
+  <msgCharAuto l="en">You glare icily at your feet, they are suddenly very cold.</msgCharAuto>
+  <msgCharFound l="ru">Ты даришь $M холодный взгляд.</msgCharFound>
+  <msgCharFound l="ua">Ти даруєш $C3 холодний погляд.</msgCharFound>
+  <msgCharFound l="en">You glare icily at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты свирепо озираешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти люто озираєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You glare at nothing in particular.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Не на кого тут злиться.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нема на кого тут злитися.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here to be angry at.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 свирепо смотрит на свои ноги... На дворе зима, а на ногах сандалии :)</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 люто дивиться на свої ноги... Надворі зима, а на ногах сандалі :)</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 glares at those feet -- winter outside, and sandals on!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 дарит холодный взгляд $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дарує холодний погляд $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 glares at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 свирепо озирается вокруг.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 люто озирається навколо.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 glares around the room.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 свирепо смотрит на тебя, и холод пронизывает тебя до костей.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 люто дивиться на тебе, і холод пронизує тебе до кісток.</msgVictimFound>
+  <msgVictimFound l="en">$c1 glares icily at you, and the cold goes right to your bones.</msgVictimFound>
   <position>rest</position>
   <rusName>холодно</rusName>
   <uaName>холодно</uaName>
-  <shortDesc>смерять холодным взглядом</shortDesc>
+  <shortDesc l="ru">смерять холодным взглядом</shortDesc>
+  <shortDesc l="ua">зміряти холодним поглядом</shortDesc>
+  <shortDesc l="en">measure somebody with an icy stare</shortDesc>
 </Social>

--- a/socials/goose.xml
+++ b/socials/goose.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1747" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Пытаешься себе зуб вырвать. Это тяжело.</msgCharAuto>
-  <msgCharFound>Ты тихонько выбиваешь клыки $C3.</msgCharFound>
-  <msgCharNoArgument>Кому зубы выбить?</msgCharNoArgument>
-  <msgCharNotFound>Мда, подожди чуть, может к тебе еще придут как к стоматологу.</msgCharNotFound>
-  <msgOthersAuto>$c1 рвет себе зубы!</msgOthersAuto>
-  <msgOthersFound>$c1 подкрадывается к $C3 сзади и аккуратно рвет $M зуб.</msgOthersFound>
+  <msgCharAuto l="ru">Пытаешься себе зуб вырвать. Это тяжело.</msgCharAuto>
+  <msgCharAuto l="ua">Намагаєшся собі зуб вирвати. Це важко.</msgCharAuto>
+  <msgCharAuto l="en">Trying to pull out your own tooth. That is hard work.</msgCharAuto>
+  <msgCharFound l="ru">Ты тихонько выбиваешь клыки $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти тихенько вибиваєш ікла $C3.</msgCharFound>
+  <msgCharFound l="en">You gently knock out $C1's fangs.</msgCharFound>
+  <msgCharNoArgument l="ru">Кому зубы выбить?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кому зуби вибити?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Whose teeth would you like to knock out?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Мда, подожди чуть, может к тебе еще придут как к стоматологу.</msgCharNotFound>
+  <msgCharNotFound l="ua">Мда, зачекай трохи, може, до тебе ще прийдуть як до стоматолога.</msgCharNotFound>
+  <msgCharNotFound l="en">Well, wait a bit -- somebody may yet come to you as to a dentist.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 рвет себе зубы!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 рве собі зуби!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 is pulling out $gits|his|her|their own teeth!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 подкрадывается к $C3 сзади и аккуратно рвет $M зуб.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 підкрадається до $C2 ззаду й акуратно рве зуб.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sneaks up behind $C1 and carefully pulls out a tooth.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 тебе молочный зуб выби$gло|л|ла! Хны! Хны!</msgVictimFound>
+  <msgVictimFound l="ru">$c1 тебе молочный зуб выби$gло|л|ла! Хны! Хны!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 тобі молочний зуб виби$gло|в|ла! Хни! Хни!</msgVictimFound>
+  <msgVictimFound l="en">$c1 knocked out your milk tooth! Waah! Waah!</msgVictimFound>
   <position>rest</position>
   <rusName>зуб</rusName>
   <uaName>зуб</uaName>
-  <shortDesc>выдрать зуб ближнему или себе лично</shortDesc>
+  <shortDesc l="ru">выдрать зуб ближнему или себе лично</shortDesc>
+  <shortDesc l="ua">видерти зуб ближньому або собі особисто</shortDesc>
+  <shortDesc l="en">pull a tooth, your neighbour's or your own</shortDesc>
 </Social>

--- a/socials/grimace.xml
+++ b/socials/grimace.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1679" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты хмуришься на мрачную мысль.</msgCharAuto>
-  <msgCharFound>Ты кривишься, глядя на $C4.</msgCharFound>
-  <msgCharNoArgument>Мысль тебе не понравилась и ты скривил$gось|ся|ась.</msgCharNoArgument>
-  <msgCharNotFound>Ты кривишься в пустоту.</msgCharNotFound>
-  <msgOthersAuto>$c1 хмурится.</msgOthersAuto>
-  <msgOthersFound>$c1 кривится на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 болезненно кривится.</msgOthersNoArgument>
-  <msgVictimFound>$c1 кривится, глядя на тебя. Что, с мордой что-то не то?</msgVictimFound>
+  <msgCharAuto l="ru">Ты хмуришься на мрачную мысль.</msgCharAuto>
+  <msgCharAuto l="ua">Ти хмуришся від похмурої думки.</msgCharAuto>
+  <msgCharAuto l="en">You grimace at a gloomy thought.</msgCharAuto>
+  <msgCharFound l="ru">Ты кривишься, глядя на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти кривишся, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You grimace at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Мысль тебе не понравилась и ты скривил$gось|ся|ась.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Думка тобі не сподобалася, і ти скриви$gлося|вся|лася.</msgCharNoArgument>
+  <msgCharNoArgument l="en">The thought did not please you, and you grimace.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты кривишься в пустоту.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти кривишся в порожнечу.</msgCharNotFound>
+  <msgCharNotFound l="en">You grimace at no one in particular.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 хмурится.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 хмуриться.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 grimaces painfully.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 кривится на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 кривиться на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 grimaces at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 болезненно кривится.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 болісно кривиться.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 grimaces painfully at the thought.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 кривится, глядя на тебя. Что, с мордой что-то не то?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 кривиться, дивлячись на тебе. Що, з мордою щось не те?</msgVictimFound>
+  <msgVictimFound l="en">$c1 grimaces at you. Something wrong with your face?</msgVictimFound>
   <position>rest</position>
   <rusName>морда</rusName>
   <uaName>морда</uaName>
-  <shortDesc>кисло скривиться</shortDesc>
+  <shortDesc l="ru">кисло скривиться</shortDesc>
+  <shortDesc l="ua">кисло скривитися</shortDesc>
+  <shortDesc l="en">pull a sour face</shortDesc>
 </Social>

--- a/socials/grin.xml
+++ b/socials/grin.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1603" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты злобно смеешься своим мыслям. Видимо, задумал какую-то гадость.</msgCharAuto>
-  <msgCharFound>Ты злобно ухмыляешься, глядя на $X.</msgCharFound>
-  <msgCharNoArgument>Ты злобно ухмыляешься.</msgCharNoArgument>
-  <msgCharNotFound>Должно быть, ты бредишь.</msgCharNotFound>
-  <msgOthersAuto>$c1 злобно ухмыляется себе. Ты думаешь, что у $x что-то не так с мозгами.</msgOthersAuto>
-  <msgOthersFound>$c1 злобно ухмыляется, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 злобно ухмыляется.</msgOthersNoArgument>
-  <msgVictimFound>$c1 злобно тебе ухмыляется. Гм. Лучше держись на расстоянии.</msgVictimFound>
+  <msgCharAuto l="ru">Ты злобно смеешься своим мыслям. Видимо, задумал какую-то гадость.</msgCharAuto>
+  <msgCharAuto l="ua">Ти злобно смієшся своїм думкам. Видно, задума$gло|в|ла якусь капость.</msgCharAuto>
+  <msgCharAuto l="en">You grin at your own thoughts. Plotting something nasty, evidently.</msgCharAuto>
+  <msgCharFound l="ru">Ты злобно ухмыляешься, глядя на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти злобно посміхаєшся, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You grin evilly at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты злобно ухмыляешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти злобно посміхаєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You grin evilly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Должно быть, ты бредишь.</msgCharNotFound>
+  <msgCharNotFound l="ua">Мабуть, ти мариш.</msgCharNotFound>
+  <msgCharNotFound l="en">You must be delirious.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 злобно ухмыляется себе. Ты думаешь, что у $x что-то не так с мозгами.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 злобно посміхається собі. Ти думаєш, що там щось не так із мізками.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 grins evilly at nothing. You wonder what is going on in that head.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 злобно ухмыляется, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 злобно посміхається, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 grins evilly at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 злобно ухмыляется.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 злобно посміхається.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 grins evilly.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 злобно тебе ухмыляется. Гм. Лучше держись на расстоянии.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 злобно тобі посміхається. Гм. Краще тримайся на відстані.</msgVictimFound>
+  <msgVictimFound l="en">$c1 grins evilly at you. Hmmm. Better keep your distance.</msgVictimFound>
   <position>rest</position>
   <rusName>ухмыл</rusName>
   <uaName>вишкір</uaName>
-  <shortDesc>злобно ухмыляться</shortDesc>
+  <shortDesc l="ru">злобно ухмыляться</shortDesc>
+  <shortDesc l="ua">злобно посміхатися</shortDesc>
+  <shortDesc l="en">grin evilly</shortDesc>
 </Social>

--- a/socials/grope.xml
+++ b/socials/grope.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1736" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты ощупываешь себя - все на месте!</msgCharAuto>
-  <msgCharFound>Савсэм слэпой, да?</msgCharFound>
-  <msgCharNoArgument>Кого-кого ощупать ??</msgCharNoArgument>
-  <msgCharNotFound>Попробуй ощупать тех, кто рядом.</msgCharNotFound>
-  <msgOthersAuto>$c1 ощупывает себя - на месте ли кошелек.</msgOthersAuto>
-  <msgOthersFound>$c1 ощупывает $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Ты ощупываешь себя - все на месте!</msgCharAuto>
+  <msgCharAuto l="ua">Ти обмацуєш себе -- усе на місці!</msgCharAuto>
+  <msgCharAuto l="en">You grope yourself -- everything is where it should be!</msgCharAuto>
+  <msgCharFound l="ru">Савсэм слэпой, да?</msgCharFound>
+  <msgCharFound l="ua">Зовсім сліпий, га?</msgCharFound>
+  <msgCharFound l="en">Blind as a bat, are we?</msgCharFound>
+  <msgCharNoArgument l="ru">Кого-кого ощупать ??</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кого-кого обмацати ??</msgCharNoArgument>
+  <msgCharNoArgument l="en">Grope whom, exactly??</msgCharNoArgument>
+  <msgCharNotFound l="ru">Попробуй ощупать тех, кто рядом.</msgCharNotFound>
+  <msgCharNotFound l="ua">Спробуй обмацати тих, хто поруч.</msgCharNotFound>
+  <msgCharNotFound l="en">Try groping somebody who is actually here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 ощупывает себя - на месте ли кошелек.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 обмацує себе -- чи на місці гаманець.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 gropes $gitself|himself|herself|themselves -- checking the purse is still there.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 ощупывает $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 обмацує $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 gropes $C1.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 ощупывает тебя.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 ощупывает тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 обмацує тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 gropes you.</msgVictimFound>
   <position>rest</position>
   <rusName>щупать</rusName>
   <uaName>мацати</uaName>
-  <shortDesc>ощупать себя или ослепнув, ощупать все вокруг</shortDesc>
+  <shortDesc l="ru">ощупать себя или ослепнув, ощупать все вокруг</shortDesc>
+  <shortDesc l="ua">обмацати себе або, осліпнувши, обмацати все навколо</shortDesc>
+  <shortDesc l="en">grope yourself, or grope around blind</shortDesc>
 </Social>

--- a/socials/grovel.xml
+++ b/socials/grovel.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1727" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Это довольно будет глупо.</msgCharAuto>
-  <msgCharFound>Ты падаешь перед $Y ниц.</msgCharFound>
-  <msgCharNoArgument>Ты падаешь ниц.</msgCharNoArgument>
-  <msgCharNotFound>Это кто?</msgCharNotFound>
+  <msgCharAuto l="ru">Это довольно будет глупо.</msgCharAuto>
+  <msgCharAuto l="ua">Це буде досить безглуздо.</msgCharAuto>
+  <msgCharAuto l="en">That would look rather silly.</msgCharAuto>
+  <msgCharFound l="ru">Ты падаешь перед $Y ниц.</msgCharFound>
+  <msgCharFound l="ua">Ти падаєш перед $C5 ниць.</msgCharFound>
+  <msgCharFound l="en">You grovel before $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты падаешь ниц.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти падаєш ниць.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You grovel in the dirt.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Это кто?</msgCharNotFound>
+  <msgCharNotFound l="ua">Це хто?</msgCharNotFound>
+  <msgCharNotFound l="en">Who is that?</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 падает ниц перед $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 падает ниц.</msgOthersNoArgument>
-  <msgVictimFound>$c1 падает ниц перед тобой.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 падает ниц перед $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 падає ниць перед $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 grovels in the dirt before $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 падает ниц.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 падає ниць.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 grovels in the dirt.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 падает ниц перед тобой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 падає ниць перед тобою.</msgVictimFound>
+  <msgVictimFound l="en">$c1 grovels in the dirt before you.</msgVictimFound>
   <position>rest</position>
   <rusName>ниц</rusName>
   <uaName>ниць</uaName>
-  <shortDesc>упасть ниц перед кем-либо</shortDesc>
+  <shortDesc l="ru">упасть ниц перед кем-либо</shortDesc>
+  <shortDesc l="ua">упасти ниць перед кимось</shortDesc>
+  <shortDesc l="en">grovel before somebody</shortDesc>
 </Social>

--- a/socials/growl.xml
+++ b/socials/growl.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1813" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты рычишь на себя. Тебе совсем паршиво!</msgCharAuto>
-  <msgCharFound>Гррррррррррр.... ты рычишь на $C4!!!</msgCharFound>
-  <msgCharNoArgument>Гррррррррррр...</msgCharNoArgument>
-  <msgCharNotFound>Порычать-то и не на кого.</msgCharNotFound>
-  <msgOthersAuto>$c1 рычит на себя. Э-то ста-но-вится оч-чень ин-те-ре-сно...</msgOthersAuto>
-  <msgOthersFound>$c1 рычит на $C4. Лучше уйти, пока драка еще не началась.</msgOthersFound>
-  <msgOthersNoArgument>$c1 рычит.</msgOthersNoArgument>
-  <msgVictimFound>$c1 рычит на тебя. Чего $e хочет?</msgVictimFound>
+  <msgCharAuto l="ru">Ты рычишь на себя. Тебе совсем паршиво!</msgCharAuto>
+  <msgCharAuto l="ua">Ти гарчиш на себе. Тобі геть кепсько!</msgCharAuto>
+  <msgCharAuto l="en">You growl at yourself. Boy, do you feel bitter!</msgCharAuto>
+  <msgCharFound l="ru">Гррррррррррр.... ты рычишь на $C4!!!</msgCharFound>
+  <msgCharFound l="ua">Гррррррррррр.... ти гарчиш на $C4!!!</msgCharFound>
+  <msgCharFound l="en">Grrrrrrrrrr.... take that, $C1!!!</msgCharFound>
+  <msgCharNoArgument l="ru">Гррррррррррр...</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Гррррррррррр...</msgCharNoArgument>
+  <msgCharNoArgument l="en">Grrrrrrrrrr...</msgCharNoArgument>
+  <msgCharNotFound l="ru">Порычать-то и не на кого.</msgCharNotFound>
+  <msgCharNotFound l="ua">Погарчати й нема на кого.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here to growl at.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 рычит на себя. Э-то ста-но-вится оч-чень ин-те-ре-сно...</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 гарчить на себе. Це ста-є ду-же ці-ка-во...</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 growls at $gitself|himself|herself|themselves. This co-uld get in-te-res-ting...</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 рычит на $C4. Лучше уйти, пока драка еще не началась.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 гарчить на $C4. Краще піти, поки бійка ще не почалася.</msgOthersFound>
+  <msgOthersFound l="en">$c1 growls at $C1. Better leave the room before the fighting starts.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 рычит.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 гарчить.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 growls.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 рычит на тебя. Чего $e хочет?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 гарчить на тебе. Чого хоче?</msgVictimFound>
+  <msgVictimFound l="en">$c1 growls at you. Now what does that mean?</msgVictimFound>
   <position>rest</position>
   <rusName>рык</rusName>
   <uaName>рик</uaName>
-  <shortDesc>рычать</shortDesc>
+  <shortDesc l="ru">рычать</shortDesc>
+  <shortDesc l="ua">гарчати</shortDesc>
+  <shortDesc l="en">growl</shortDesc>
 </Social>

--- a/socials/grumble.xml
+++ b/socials/grumble.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1627" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Что-то беспокоит?</msgCharAuto>
-  <msgCharFound>Ты ворчишь на $C4, морщась.</msgCharFound>
-  <msgCharNoArgument>Ты расстроено ворчишь на себя.</msgCharNoArgument>
-  <msgCharNotFound>Нет этой противной личности.</msgCharNotFound>
+  <msgCharAuto l="ru">Что-то беспокоит?</msgCharAuto>
+  <msgCharAuto l="ua">Щось непокоїть?</msgCharAuto>
+  <msgCharAuto l="en">Something bothering you?</msgCharAuto>
+  <msgCharFound l="ru">Ты ворчишь на $C4, морщась.</msgCharFound>
+  <msgCharFound l="ua">Ти буркочеш на $C4, морщачись.</msgCharFound>
+  <msgCharFound l="en">You grumble at $C1, wincing.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты расстроено ворчишь на себя.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти засмучено буркочеш сам$gе|ий|а до себе.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You grumble distractedly to yourself.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нет этой противной личности.</msgCharNotFound>
+  <msgCharNotFound l="ua">Немає цієї бридкої особи.</msgCharNotFound>
+  <msgCharNotFound l="en">That objectionable person is not around.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 как сварлив$gое|ый|ая медвед$gко|ь|ица, ворчит на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 ворчит и жалуется.</msgOthersNoArgument>
-  <msgVictimFound>$c1 ворчит на тебя... Что ты такого сделал$Gо||а?</msgVictimFound>
+  <msgOthersFound l="ru">$c1 как сварлив$gое|ый|ая медвед$gко|ь|ица, ворчит на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1, як сварлив$gе|ий|а ведмед$gеня|ідь|иця, буркоче на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 grumbles at poor $C1 like a grumpy old bear.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 ворчит и жалуется.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 буркоче і скаржиться.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 grumbles and complains. You wonder what is wrong...</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 ворчит на тебя... Что ты такого сделал$Gо||а?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 буркоче на тебе... Що ти такого $Gзробило|зробив|зробила|зробили?</msgVictimFound>
+  <msgVictimFound l="en">$c1 is grumbling at you... what did you do?</msgVictimFound>
   <position>rest</position>
   <rusName>ворчать</rusName>
   <uaName>бурчати</uaName>
-  <shortDesc>сварливо ворчать</shortDesc>
+  <shortDesc l="ru">сварливо ворчать</shortDesc>
+  <shortDesc l="ua">сварливо буркотіти</shortDesc>
+  <shortDesc l="en">grumble peevishly</shortDesc>
 </Social>

--- a/socials/hand.xml
+++ b/socials/hand.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1588" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты чмокаешь себя в ладошку!</msgCharAuto>
-  <msgCharFound>Ты целуешь руку $C2.</msgCharFound>
-  <msgCharNoArgument>Поцеловать чью-то ручку?</msgCharNoArgument>
-  <msgCharNotFound>Ты не можешь найти Леди своей мечты.</msgCharNotFound>
-  <msgOthersAuto>$c1 чмокает себя в ладошку.</msgOthersAuto>
-  <msgOthersFound>$c1 целует руку $C2. Как благородно!</msgOthersFound>
+  <msgCharAuto l="ru">Ты чмокаешь себя в ладошку!</msgCharAuto>
+  <msgCharAuto l="ua">Ти цмокаєш себе в долоньку!</msgCharAuto>
+  <msgCharAuto l="en">You kiss your own hand!</msgCharAuto>
+  <msgCharFound l="ru">Ты целуешь руку $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти цілуєш руку $C2.</msgCharFound>
+  <msgCharFound l="en">You kiss $C1's hand.</msgCharFound>
+  <msgCharNoArgument l="ru">Поцеловать чью-то ручку?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Поцілувати чиюсь ручку?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Kiss whose hand?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты не можешь найти Леди своей мечты.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти не можеш знайти Леді своєї мрії.</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot find the Lady of your dreams.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 чмокает себя в ладошку.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 цмокає себе в долоньку.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 kisses $gits|his|her|their own hand.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 целует руку $C2. Как благородно!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 цілує руку $C2. Як шляхетно!</msgOthersFound>
+  <msgOthersFound l="en">$c1 kisses $C1's hand. How continental!</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 целует твою руку. Как благородно!</msgVictimFound>
+  <msgVictimFound l="ru">$c1 целует твою руку. Как благородно!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 цілує твою руку. Як шляхетно!</msgVictimFound>
+  <msgVictimFound l="en">$c1 kisses your hand. How continental!</msgVictimFound>
   <position>rest</position>
   <rusName>цем</rusName>
   <uaName>цем</uaName>
-  <shortDesc>поцеловать руку</shortDesc>
+  <shortDesc l="ru">поцеловать руку</shortDesc>
+  <shortDesc l="ua">поцілувати руку</shortDesc>
+  <shortDesc l="en">kiss a hand</shortDesc>
 </Social>

--- a/socials/head.xml
+++ b/socials/head.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1750" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Почему ты хочешь этого?</msgCharAuto>
-  <msgCharFound>Ты надменно задираешь голову, глядя на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты надменно задираешь голову.</msgCharNoArgument>
-  <msgCharNotFound>Таких уже давно нет рядом.</msgCharNotFound>
+  <msgCharAuto l="ru">Почему ты хочешь этого?</msgCharAuto>
+  <msgCharAuto l="ua">Чому ти цього хочеш?</msgCharAuto>
+  <msgCharAuto l="en">Why would you do that?</msgCharAuto>
+  <msgCharFound l="ru">Ты надменно задираешь голову, глядя на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти пихато задираєш голову, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You toss your head haughtily at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты надменно задираешь голову.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти пихато задираєш голову.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You toss your head haughtily.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Таких уже давно нет рядом.</msgCharNotFound>
+  <msgCharNotFound l="ua">Таких уже давно немає поруч.</msgCharNotFound>
+  <msgCharNotFound l="en">That person has been gone a long while.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 надменно задирает голову, глядя на $C4...</msgOthersFound>
-  <msgOthersNoArgument>$c1 надменно задирает голову.</msgOthersNoArgument>
-  <msgVictimFound>$c1 надменно задирает голову, глядя на тебя... :(</msgVictimFound>
+  <msgOthersFound l="ru">$c1 надменно задирает голову, глядя на $C4...</msgOthersFound>
+  <msgOthersFound l="ua">$c1 пихато задирає голову, дивлячись на $C4...</msgOthersFound>
+  <msgOthersFound l="en">$c1 tosses that head haughtily at $C1... what an ATTITUDE!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 надменно задирает голову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 пихато задирає голову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 tosses $gits|his|her|their head haughtily.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 надменно задирает голову, глядя на тебя... :(</msgVictimFound>
+  <msgVictimFound l="ua">$c1 пихато задирає голову, дивлячись на тебе... :(</msgVictimFound>
+  <msgVictimFound l="en">$c1 tossed that head haughtily at you... :(</msgVictimFound>
   <position>rest</position>
   <rusName>голову</rusName>
   <uaName>голову</uaName>
-  <shortDesc>надменно задирать голову</shortDesc>
+  <shortDesc l="ru">надменно задирать голову</shortDesc>
+  <shortDesc l="ua">пихато задирати голову</shortDesc>
+  <shortDesc l="en">toss your head haughtily</shortDesc>
 </Social>

--- a/socials/hiccup.xml
+++ b/socials/hiccup.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>{c*ИК-к*{x</msgCharNoArgument>
+  <msgCharNoArgument l="ru">{c*ИК-к*{x</msgCharNoArgument>
+  <msgCharNoArgument l="ua">{c*Ік-к*{x</msgCharNoArgument>
+  <msgCharNoArgument l="en">{c*HIC-c*{x</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 икает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 икает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 гикає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 hiccups.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>икать</rusName>
   <uaName>гикати</uaName>
-  <shortDesc>икать</shortDesc>
+  <shortDesc l="ru">икать</shortDesc>
+  <shortDesc l="ua">гикати</shortDesc>
+  <shortDesc l="en">hiccup</shortDesc>
 </Social>

--- a/socials/highfive.xml
+++ b/socials/highfive.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1811" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты пытаешься поделиться с собой хорошим настроением.</msgCharAuto>
-  <msgCharFound>Ты даешь пять $C3!</msgCharFound>
-  <msgCharNoArgument>Ты подпрыгиваешь от избытка чувств, с надеждой кому-нибудь по ладошке хлопнуть.</msgCharNoArgument>
-  <msgCharNotFound>Упс.. они ушли.</msgCharNotFound>
-  <msgOthersAuto>$c1 пытается пожать себе руку от избытка чувств!</msgOthersAuto>
-  <msgOthersFound>$c1 дает пятерню $C3!</msgOthersFound>
-  <msgOthersNoArgument>$c1 чего-то прыгает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 хлопает тебя по ладошке пятерней.</msgVictimFound>
+  <msgCharAuto l="ru">Ты пытаешься поделиться с собой хорошим настроением.</msgCharAuto>
+  <msgCharAuto l="ua">Ти намагаєшся поділитися із собою гарним настроєм.</msgCharAuto>
+  <msgCharAuto l="en">You try to give yourself a high five. What ARE you thinking?</msgCharAuto>
+  <msgCharFound l="ru">Ты даешь пять $C3!</msgCharFound>
+  <msgCharFound l="ua">Ти даєш п'ять $C3!</msgCharFound>
+  <msgCharFound l="en">You jump in the air and give a BIG high five to $C1!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты подпрыгиваешь от избытка чувств, с надеждой кому-нибудь по ладошке хлопнуть.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти підстрибуєш від надлишку почуттів, сподіваючись комусь по долоньці плеснути.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You jump in the air and give a BIG high five to... umm... absolutely nothing.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Упс.. они ушли.</msgCharNotFound>
+  <msgCharNotFound l="ua">Упс.. вони пішли.</msgCharNotFound>
+  <msgCharNotFound l="en">Oops.. they left.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 пытается пожать себе руку от избытка чувств!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 намагається потиснути собі руку від надлишку почуттів!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 tries to high five $gitself|himself|herself|themselves, and ends up looking foolish instead.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 дает пятерню $C3!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дає п'ятірню $C3!</msgOthersFound>
+  <msgOthersFound l="en">$c1 enthusiastically high-fives $C1!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 чего-то прыгает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 чогось стрибає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 high fives the air, looking very foolish indeed.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 хлопает тебя по ладошке пятерней.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 плескає тебе по долоньці п'ятірнею.</msgVictimFound>
+  <msgVictimFound l="en">$c1 gives you a BIG high five! Way to go!!</msgVictimFound>
   <position>rest</position>
   <rusName>пять</rusName>
   <uaName>лапу</uaName>
-  <shortDesc>пребывать в хорошем настроении или &quot;дать пять&quot;</shortDesc>
+  <shortDesc l="ru">пребывать в хорошем настроении или &quot;дать пять&quot;</shortDesc>
+  <shortDesc l="ua">перебувати в гарному настрої або "дати п'ять"</shortDesc>
+  <shortDesc l="en">be in a great mood, or give a high five</shortDesc>
 </Social>

--- a/socials/hop.xml
+++ b/socials/hop.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты скачешь от радости, как ребенок.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты скачешь от радости, как ребенок.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти скачеш від радості, як дитина.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You hop around like a little kid.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 скачет от радости, как ребенок.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 скачет от радости, как ребенок.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 скаче від радості, як дитина.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 hops around like a little kid.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>скакать</rusName>
   <uaName>скакати</uaName>
-  <shortDesc>прыгать от радости</shortDesc>
+  <shortDesc l="ru">прыгать от радости</shortDesc>
+  <shortDesc l="ua">стрибати від радості</shortDesc>
+  <shortDesc l="en">hop about with joy</shortDesc>
 </Social>

--- a/socials/howl.xml
+++ b/socials/howl.xml
@@ -3,15 +3,29 @@
   <help id="1610" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты душевно завываешь, глядя на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты воешь на луну.</msgCharNoArgument>
-  <msgCharNotFound>Что? На кого? Или на что?</msgCharNotFound>
+  <msgCharFound l="ru">Ты душевно завываешь, глядя на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти душевно завиваєш, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You howl soulfully at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты воешь на луну.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти виєш на місяць.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You howl at the moon.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Что? На кого? Или на что?</msgCharNotFound>
+  <msgCharNotFound l="ua">Що? На кого? Чи на що?</msgCharNotFound>
+  <msgCharNotFound l="en">What? At whom? Or at what?</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 душевно завывает, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 воет на луну.</msgOthersNoArgument>
-  <msgVictimFound>$c1 душевно завывает, глядя на тебя.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 душевно завывает, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 душевно завиває, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 howls at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 воет на луну.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 виє на місяць.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 howls at the moon.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 душевно завывает, глядя на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 душевно завиває, дивлячись на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 howls soulfully at you.</msgVictimFound>
   <position>rest</position>
   <rusName>выть</rusName>
   <uaName>вити</uaName>
-  <shortDesc>душевно выть на кого-то. выть на луну</shortDesc>
+  <shortDesc l="ru">душевно выть на кого-то. выть на луну</shortDesc>
+  <shortDesc l="ua">душевно вити на когось. вити на місяць</shortDesc>
+  <shortDesc l="en">howl soulfully at somebody, or at the moon</shortDesc>
 </Social>

--- a/socials/hug.xml
+++ b/socials/hug.xml
@@ -2,19 +2,41 @@
 <Social type="Social">
   <help id="1826" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты обнимаешь себя.</msgCharAuto>
-  <msgCharFound>Ты обнимаешь $C4.</msgCharFound>
-  <msgCharFound2>Ты обнимаешь %2$C4 и %3$C4.</msgCharFound2>
-  <msgCharNoArgument>Кого обнять?</msgCharNoArgument>
-  <msgCharNotFound>Извини, не видно таких здесь.</msgCharNotFound>
-  <msgOthersAuto>$c1 обнимает себя, пытаясь помириться с собой, но тщетно.</msgOthersAuto>
-  <msgOthersFound>$c1 обнимает $C4.</msgOthersFound>
-  <msgOthersFound2>%1$^C1 обнимает %2$C4 и %3$C4.</msgOthersFound2>
+  <msgCharAuto l="ru">Ты обнимаешь себя.</msgCharAuto>
+  <msgCharAuto l="ua">Ти обіймаєш себе.</msgCharAuto>
+  <msgCharAuto l="en">You hug yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты обнимаешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти обіймаєш $C4.</msgCharFound>
+  <msgCharFound l="en">You hug $C1.</msgCharFound>
+  <msgCharFound2 l="ru">Ты обнимаешь %2$C4 и %3$C4.</msgCharFound2>
+  <msgCharFound2 l="ua">Ти обіймаєш %2$C4 і %3$C4.</msgCharFound2>
+  <msgCharFound2 l="en">You hug %2$C4 and %3$C4.</msgCharFound2>
+  <msgCharNoArgument l="ru">Кого обнять?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кого обійняти?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Hug who?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Извини, не видно таких здесь.</msgCharNotFound>
+  <msgCharNotFound l="ua">Вибач, не видно таких тут.</msgCharNotFound>
+  <msgCharNotFound l="en">Sorry, friend, that person is not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 обнимает себя, пытаясь помириться с собой, но тщетно.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 обіймає себе, намагаючись помиритися із собою, але марно.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 hugs $gitself|himself|herself|themselves in a vain attempt at making friends.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 обнимает $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 обіймає $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 hugs $C1.</msgOthersFound>
+  <msgOthersFound2 l="ru">%1$^C1 обнимает %2$C4 и %3$C4.</msgOthersFound2>
+  <msgOthersFound2 l="ua">%1$^C1 обіймає %2$C4 і %3$C4.</msgOthersFound2>
+  <msgOthersFound2 l="en">%1$^C1 hugs %2$C4 and %3$C4.</msgOthersFound2>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 обнимает тебя.</msgVictimFound>
-  <msgVictimFound2>%1$^C1 обнимает тебя и %3$C4.</msgVictimFound2>
+  <msgVictimFound l="ru">$c1 обнимает тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 обіймає тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 hugs you.</msgVictimFound>
+  <msgVictimFound2 l="ru">%1$^C1 обнимает тебя и %3$C4.</msgVictimFound2>
+  <msgVictimFound2 l="ua">%1$^C1 обіймає тебе і %3$C4.</msgVictimFound2>
+  <msgVictimFound2 l="en">%1$^C1 hugs you and %3$C4.</msgVictimFound2>
   <position>rest</position>
   <rusName>обнять</rusName>
   <uaName>обійняти</uaName>
-  <shortDesc>дружески обнять</shortDesc>
+  <shortDesc l="ru">дружески обнять</shortDesc>
+  <shortDesc l="ua">дружньо обійняти</shortDesc>
+  <shortDesc l="en">a friendly hug</shortDesc>
 </Social>

--- a/socials/hush.xml
+++ b/socials/hush.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1613" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты понимаешь, что ты очень шумишь, и пытаешься заткнуться.</msgCharAuto>
-  <msgCharFound>Ты вежливо просишь $C4 помолчать.</msgCharFound>
-  <msgCharNoArgument>Шшшшшшшшшшшшшшшшшшш!</msgCharNoArgument>
-  <msgCharNotFound>Кому надо заткнуться?</msgCharNotFound>
-  <msgOthersAuto>$c1 закрывает свой рот. Звуки стихают.</msgOthersAuto>
-  <msgOthersFound>$c1 вежливо просит $C4 помолчать.</msgOthersFound>
-  <msgOthersNoArgument>$c1 просит всех помолчать. Чшшшшшшш!</msgOthersNoArgument>
-  <msgVictimFound>$c1 вежливо просит тебя помолчать.</msgVictimFound>
+  <msgCharAuto l="ru">Ты понимаешь, что ты очень шумишь, и пытаешься заткнуться.</msgCharAuto>
+  <msgCharAuto l="ua">Ти розумієш, що дуже шумиш, і намагаєшся заткнутися.</msgCharAuto>
+  <msgCharAuto l="en">You realise you are loud and obnoxious, and try to silence yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты вежливо просишь $C4 помолчать.</msgCharFound>
+  <msgCharFound l="ua">Ти ввічливо просиш $C4 помовчати.</msgCharFound>
+  <msgCharFound l="en">You nicely ask $C1 to be more quiet.</msgCharFound>
+  <msgCharNoArgument l="ru">Шшшшшшшшшшшшшшшшшшш!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Шшшшшшшшшшшшшшшшшшш!</msgCharNoArgument>
+  <msgCharNoArgument l="en">SHHHHHHHHHHHHHHHHHHHHHH!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Кому надо заткнуться?</msgCharNotFound>
+  <msgCharNotFound l="ua">Кому треба заткнутися?</msgCharNotFound>
+  <msgCharNotFound l="en">Who needs to be silenced?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 закрывает свой рот. Звуки стихают.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 закриває свій рот. Звуки стихають.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 covers that mouth in an attempt at self-silencing.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 вежливо просит $C4 помолчать.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 ввічливо просить $C4 помовчати.</msgOthersFound>
+  <msgOthersFound l="en">$c1 nicely asks $C1 to be more quiet.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 просит всех помолчать. Чшшшшшшш!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 просить усіх помовчати. Чшшшшшшш!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 requests everyone quiet down. Shhhhhhhhhhh...</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 вежливо просит тебя помолчать.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 ввічливо просить тебе помовчати.</msgVictimFound>
+  <msgVictimFound l="en">$c1 kindly requests that you please quiet down.</msgVictimFound>
   <position>rest</position>
   <rusName>молчать</rusName>
   <uaName>мовчати</uaName>
-  <shortDesc>просить помолчать либо заткнуться самому</shortDesc>
+  <shortDesc l="ru">просить помолчать либо заткнуться самому</shortDesc>
+  <shortDesc l="ua">просити помовчати або заткнутися самому</shortDesc>
+  <shortDesc l="en">ask for quiet, or hush yourself</shortDesc>
 </Social>

--- a/socials/innocent.xml
+++ b/socials/innocent.xml
@@ -3,15 +3,29 @@
   <help id="1808" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты смотришь на $C4 и моргаешь ресницами -- сама невинность!</msgCharFound>
-  <msgCharNoArgument>Ты невинно насвистываешь.</msgCharNoArgument>
-  <msgCharNotFound>Даже не пытайся - не перед кем прикидываться.</msgCharNotFound>
+  <msgCharFound l="ru">Ты смотришь на $C4 и моргаешь ресницами -- сама невинность!</msgCharFound>
+  <msgCharFound l="ua">Ти дивишся на $C4 і кліпаєш віями -- сама невинність!</msgCharFound>
+  <msgCharFound l="en">You look at $C1 and bat your eyelashes -- the picture of innocence!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты невинно насвистываешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти невинно насвистуєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You innocently whistle a tune.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Даже не пытайся - не перед кем прикидываться.</msgCharNotFound>
+  <msgCharNotFound l="ua">Навіть не намагайся -- нема перед ким прикидатися.</msgCharNotFound>
+  <msgCharNotFound l="en">Don't even TRY -- they've already left.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 невинно хлопает ресницами, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 оглядывается по сторонам и невинно насвистывает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 смотрит на тебя, невинно хлопая ресницами.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 невинно хлопает ресницами, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 невинно кліпає віями, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 bats $gits|his|her|their eyelashes innocently at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 оглядывается по сторонам и невинно насвистывает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 озирається навсібіч і невинно насвистує.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 looks around and whistles innocently.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 смотрит на тебя, невинно хлопая ресницами.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 дивиться на тебе, невинно кліпаючи віями.</msgVictimFound>
+  <msgVictimFound l="en">$c1 looks at you, innocently batting those eyelashes.</msgVictimFound>
   <position>rest</position>
   <rusName>невинно</rusName>
   <uaName>невинно</uaName>
-  <shortDesc>валять дурочку и невинно насвистывать</shortDesc>
+  <shortDesc l="ru">валять дурочку и невинно насвистывать</shortDesc>
+  <shortDesc l="ua">вдавати дурника і невинно насвистувати</shortDesc>
+  <shortDesc l="en">play the innocent and whistle a tune</shortDesc>
 </Social>

--- a/socials/itch.xml
+++ b/socials/itch.xml
@@ -3,15 +3,29 @@
   <help id="1804" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты чешешь репу, глядя на $X.</msgCharFound>
-  <msgCharNoArgument>Ты чешешь репу.</msgCharNoArgument>
-  <msgCharNotFound>Никого нету.</msgCharNotFound>
+  <msgCharFound l="ru">Ты чешешь репу, глядя на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти чухаєш ріпу, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You scratch your head, looking at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты чешешь репу.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти чухаєш ріпу.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You scratch your head.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Никого нету.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нікого немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 чешет репу, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 чешет репу в растерянности.</msgOthersNoArgument>
-  <msgVictimFound>$c1 чешет репу, глядя на тебя.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 чешет репу, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 чухає ріпу, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 scratches $gits|his|her|their head, looking at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 чешет репу в растерянности.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 чухає ріпу в розгубленості.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 scratches $gits|his|her|their head in confusion.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 чешет репу, глядя на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 чухає ріпу, дивлячись на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 scratches $gits|his|her|their head, looking at you.</msgVictimFound>
   <position>rest</position>
   <rusName>репа</rusName>
   <uaName>свербіж</uaName>
-  <shortDesc>активно чухать репу в процессе размышлений</shortDesc>
+  <shortDesc l="ru">активно чухать репу в процессе размышлений</shortDesc>
+  <shortDesc l="ua">активно чухати ріпу в процесі роздумів</shortDesc>
+  <shortDesc l="en">scratch your head hard while thinking</shortDesc>
 </Social>

--- a/socials/jump.xml
+++ b/socials/jump.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1745" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты скачешь на одной ножке.</msgCharAuto>
-  <msgCharFound>Ты прыгаешь на $C4!</msgCharFound>
-  <msgCharNoArgument>Ты подпрыгиваешь.</msgCharNoArgument>
+  <msgCharAuto l="ru">Ты скачешь на одной ножке.</msgCharAuto>
+  <msgCharAuto l="ua">Ти скачеш на одній ніжці.</msgCharAuto>
+  <msgCharAuto l="en">You hop on one leg.</msgCharAuto>
+  <msgCharFound l="ru">Ты прыгаешь на $C4!</msgCharFound>
+  <msgCharFound l="ua">Ти стрибаєш на $C4!</msgCharFound>
+  <msgCharFound l="en">You jump at $C1!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты подпрыгиваешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти підстрибуєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You jump up.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
-  <msgOthersAuto>$c1 скачет на одной ножке.</msgOthersAuto>
-  <msgOthersFound>$c1 прыгает на $C4!</msgOthersFound>
-  <msgOthersNoArgument>$c1 подпрыгивает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 прыгает на тебя!</msgVictimFound>
+  <msgOthersAuto l="ru">$c1 скачет на одной ножке.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 скаче на одній ніжці.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 hops on one leg.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 прыгает на $C4!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 стрибає на $C4!</msgOthersFound>
+  <msgOthersFound l="en">$c1 jumps at $C1!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 подпрыгивает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 підстрибує.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 jumps up.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 прыгает на тебя!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 стрибає на тебе!</msgVictimFound>
+  <msgVictimFound l="en">$c1 jumps at you!</msgVictimFound>
   <position>stand</position>
   <rusName>прыгать</rusName>
   <uaName>стрибати</uaName>
-  <shortDesc>прыгать на одном месте или на кого-то</shortDesc>
+  <shortDesc l="ru">прыгать на одном месте или на кого-то</shortDesc>
+  <shortDesc l="ua">стрибати на одному місці або на когось</shortDesc>
+  <shortDesc l="en">jump on the spot, or at somebody</shortDesc>
 </Social>

--- a/socials/kiss.xml
+++ b/socials/kiss.xml
@@ -2,18 +2,36 @@
 <Social type="Social">
   <help id="1687" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>У всех жена ушла... :(</msgCharAuto>
-  <msgCharFound>Ты целуешь $C4.</msgCharFound>
-  <msgCharNoArgument>Поцеловать, а кого??</msgCharNoArgument>
-  <msgCharNotFound>Никогда нет рядом, когда надо.</msgCharNotFound>
-  <msgCharObj>Ты осыпаешь поцелуями %2$O4.</msgCharObj>
+  <msgCharAuto l="ru">У всех жена ушла... :(</msgCharAuto>
+  <msgCharAuto l="ua">У всіх дружина пішла... :(</msgCharAuto>
+  <msgCharAuto l="en">All the lonely people :(</msgCharAuto>
+  <msgCharFound l="ru">Ты целуешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти цілуєш $C4.</msgCharFound>
+  <msgCharFound l="en">You kiss $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Поцеловать, а кого??</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Поцілувати, а кого??</msgCharNoArgument>
+  <msgCharNoArgument l="en">Kiss, but whom??</msgCharNoArgument>
+  <msgCharNotFound l="ru">Никогда нет рядом, когда надо.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ніколи немає поруч, коли треба.</msgCharNotFound>
+  <msgCharNotFound l="en">Never around when required.</msgCharNotFound>
+  <msgCharObj l="ru">Ты осыпаешь поцелуями %2$O4.</msgCharObj>
+  <msgCharObj l="ua">Ти обсипаєш поцілунками %2$O4.</msgCharObj>
+  <msgCharObj l="en">You shower %2$O4 with kisses.</msgCharObj>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 целует $C4.</msgOthersFound>
+  <msgOthersFound l="ru">$c1 целует $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 цілує $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 kisses $C1.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgOthersObj>%1$^C1 осыпает поцелуями %2$O4.</msgOthersObj>
-  <msgVictimFound>$c1 целует тебя.</msgVictimFound>
+  <msgOthersObj l="ru">%1$^C1 осыпает поцелуями %2$O4.</msgOthersObj>
+  <msgOthersObj l="ua">%1$^C1 обсипає поцілунками %2$O4.</msgOthersObj>
+  <msgOthersObj l="en">%1$^C1 showers %2$O4 with kisses.</msgOthersObj>
+  <msgVictimFound l="ru">$c1 целует тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 цілує тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 kisses you.</msgVictimFound>
   <position>rest</position>
   <rusName>поцеловать</rusName>
   <uaName>поцілувати</uaName>
-  <shortDesc>целовать(ся)</shortDesc>
+  <shortDesc l="ru">целовать(ся)</shortDesc>
+  <shortDesc l="ua">цілувати(ся)</shortDesc>
+  <shortDesc l="en">kiss somebody</shortDesc>
 </Social>

--- a/socials/laces.xml
+++ b/socials/laces.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1621" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты связываешь себе шнурки, пытаешься встать и роешь носом землю!</msgCharAuto>
-  <msgCharFound>Бесшумно подкравшись, ты таки связал$gо||а вместе шнурки $C2!</msgCharFound>
-  <msgCharNoArgument>Чьи шнурки?</msgCharNoArgument>
-  <msgCharNotFound>Так чьи шнурки?</msgCharNotFound>
-  <msgOthersAuto>$c1 связывает вместе свои шнурки и долго любуется ими.</msgOthersAuto>
-  <msgOthersFound>$c1 подползает на пузе к $C3 и связывает $S шнурки красивым бантиком.</msgOthersFound>
+  <msgCharAuto l="ru">Ты связываешь себе шнурки, пытаешься встать и роешь носом землю!</msgCharAuto>
+  <msgCharAuto l="ua">Ти зв'язуєш собі шнурки, намагаєшся встати і риєш носом землю!</msgCharAuto>
+  <msgCharAuto l="en">You tie your own shoelaces together, try to stand up, and plough the ground with your nose!</msgCharAuto>
+  <msgCharFound l="ru">Бесшумно подкравшись, ты таки связал$gо||а вместе шнурки $C2!</msgCharFound>
+  <msgCharFound l="ua">Безшумно підкравшись, ти таки зв'яза$gло|в|ла разом шнурки $C2!</msgCharFound>
+  <msgCharFound l="en">With the greatest of stealth, you tie $C1's shoelaces together!</msgCharFound>
+  <msgCharNoArgument l="ru">Чьи шнурки?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Чиї шнурки?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Whose laces?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Так чьи шнурки?</msgCharNotFound>
+  <msgCharNotFound l="ua">Так чиї шнурки?</msgCharNotFound>
+  <msgCharNotFound l="en">So whose laces, then?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 связывает вместе свои шнурки и долго любуется ими.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 зв'язує разом свої шнурки і довго ними милується.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 cleverly ties those own shoelaces together and admires the knot at length.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 подползает на пузе к $C3 и связывает $S шнурки красивым бантиком.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 підповзає на пузі до $C2 і зв'язує шнурки гарним бантиком.</msgOthersFound>
+  <msgOthersFound l="en">$c1 crawls up to $C1 on the belly and ties those shoelaces into a pretty bow.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>Ты пытаешься встать, но падаешь! Кто-то связал тебе шнурки!</msgVictimFound>
+  <msgVictimFound l="ru">Ты пытаешься встать, но падаешь! Кто-то связал тебе шнурки!</msgVictimFound>
+  <msgVictimFound l="ua">Ти намагаєшся встати, але падаєш! Хтось зв'язав тобі шнурки!</msgVictimFound>
+  <msgVictimFound l="en">You try to stand up and fall flat! Somebody tied your shoelaces together!</msgVictimFound>
   <position>rest</position>
   <rusName>шнурки</rusName>
   <uaName>шнурки</uaName>
-  <shortDesc>мелкая пакость: связать шнурки ботинок вместе</shortDesc>
+  <shortDesc l="ru">мелкая пакость: связать шнурки ботинок вместе</shortDesc>
+  <shortDesc l="ua">дрібна капость: зв'язати шнурки черевиків разом</shortDesc>
+  <shortDesc l="en">a small piece of mischief: tie somebody's shoelaces together</shortDesc>
 </Social>

--- a/socials/laugh.xml
+++ b/socials/laugh.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1628" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты смеешься над собой.</msgCharAuto>
-  <msgCharFound>Ты добродушно смеешься над $C5.</msgCharFound>
-  <msgCharNoArgument>Ты падаешь на землю от смеха.</msgCharNoArgument>
-  <msgCharNotFound>Ты не можешь найти мишень для твоих насмешек.</msgCharNotFound>
-  <msgOthersAuto>$c1 смеется над собой. Присоединяйтесь все!!!</msgOthersAuto>
-  <msgOthersFound>$c1 добродушно смеется над $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 падает на землю от смеха.</msgOthersNoArgument>
-  <msgVictimFound>$c1 добродушно смеется над тобой...</msgVictimFound>
+  <msgCharAuto l="ru">Ты смеешься над собой.</msgCharAuto>
+  <msgCharAuto l="ua">Ти смієшся з себе.</msgCharAuto>
+  <msgCharAuto l="en">You laugh at yourself. So would I.</msgCharAuto>
+  <msgCharFound l="ru">Ты добродушно смеешься над $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти добродушно смієшся з $C2.</msgCharFound>
+  <msgCharFound l="en">You laugh good-naturedly at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты падаешь на землю от смеха.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти падаєш на землю від сміху.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You fall down laughing.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты не можешь найти мишень для твоих насмешек.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти не можеш знайти мішень для своїх насмішок.</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot find the butt of your joke.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 смеется над собой. Присоединяйтесь все!!!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 сміється з себе. Приєднуйтеся всі!!!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 laughs at $gitself|himself|herself|themselves. Let us all join in!!!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 добродушно смеется над $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 добродушно сміється з $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 laughs good-naturedly at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 падает на землю от смеха.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 падає на землю від сміху.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 falls down laughing.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 добродушно смеется над тобой...</msgVictimFound>
+  <msgVictimFound l="ua">$c1 добродушно сміється з тебе...</msgVictimFound>
+  <msgVictimFound l="en">$c1 laughs good-naturedly at you...</msgVictimFound>
   <position>rest</position>
   <rusName>смех</rusName>
   <uaName>сміх</uaName>
-  <shortDesc>добродушно посмеиваться</shortDesc>
+  <shortDesc l="ru">добродушно посмеиваться</shortDesc>
+  <shortDesc l="ua">добродушно посміюватися</shortDesc>
+  <shortDesc l="en">a good-natured laugh</shortDesc>
 </Social>

--- a/socials/leer.xml
+++ b/socials/leer.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1758" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты в отчаянии смотришь на себя?</msgCharAuto>
-  <msgCharFound>Ты плотоядно смотришь на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты плотоядно смотришь на всех, как последн$gее|ий|яя поган$gко|ец|ка!</msgCharNoArgument>
-  <msgCharNotFound>Тут никого нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 рассматривает свое тело.</msgOthersAuto>
-  <msgOthersFound>$c1 плотоядно смотрит на $C4. Вот извращен$gец|ец|ка!</msgOthersFound>
-  <msgOthersNoArgument>$c1 плотоядно смотрит на присутствующих! Любвеобильн$gое|ый|ая, однако!</msgOthersNoArgument>
-  <msgVictimFound>$c1 плотоядно смотрит на тебя, не скрывая своих намерений.</msgVictimFound>
+  <msgCharAuto l="ru">Ты в отчаянии смотришь на себя?</msgCharAuto>
+  <msgCharAuto l="ua">Ти у відчаї дивишся на себе?</msgCharAuto>
+  <msgCharAuto l="en">Desperation has reached new heights, hasn't it?</msgCharAuto>
+  <msgCharFound l="ru">Ты плотоядно смотришь на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти хтиво дивишся на $C4.</msgCharFound>
+  <msgCharFound l="en">You leer at $C1 like the pervert you are.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты плотоядно смотришь на всех, как последн$gее|ий|яя поган$gко|ец|ка!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти хтиво дивишся на всіх, як останн$gє|ій|я поган$gеня|ець|ка!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You peer around the room, leering like the pervert you are!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Тут никого нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Тут нікого немає.</msgCharNotFound>
+  <msgCharNotFound l="en">You will have to settle for memories -- that person isn't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 рассматривает свое тело.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 розглядає своє тіло.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 leers at $gitself|himself|herself|themselves shamelessly.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 плотоядно смотрит на $C4. Вот извращен$gец|ец|ка!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 хтиво дивиться на $C4. Ото збочен$gеня|ець|ка!</msgOthersFound>
+  <msgOthersFound l="en">$c1 eyes $C1 up and down, leering like a filthy pervert!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 плотоядно смотрит на присутствующих! Любвеобильн$gое|ый|ая, однако!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 хтиво дивиться на присутніх! Любвеобільн$gе|ий|а, однак!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 peers about, leering like a filthy pervert!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 плотоядно смотрит на тебя, не скрывая своих намерений.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 хтиво дивиться на тебе, не приховуючи своїх намірів.</msgVictimFound>
+  <msgVictimFound l="en">$c1 eyes you up and down, making no secret of the intent.</msgVictimFound>
   <position>rest</position>
   <rusName>зыркать</rusName>
   <uaName>зиркати</uaName>
-  <shortDesc>плотоядно рассматривтаь кого-либо</shortDesc>
+  <shortDesc l="ru">плотоядно рассматривтаь кого-либо</shortDesc>
+  <shortDesc l="ua">хтиво розглядати когось</shortDesc>
+  <shortDesc l="en">leer at somebody hungrily</shortDesc>
 </Social>

--- a/socials/lick.xml
+++ b/socials/lick.xml
@@ -2,21 +2,49 @@
 <Social type="Social">
   <help id="1591" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты лижешь собственную бровь.</msgCharAuto>
-  <msgCharFound>Ты лижешь $C4 в щеку.</msgCharFound>
-  <msgCharNoArgument>Ты облизываешься и пытаешься улыбнуться.</msgCharNoArgument>
-  <msgCharNotFound>Полижи себя, таких тут нет.</msgCharNotFound>
-  <msgCharObj>Ты облизываешь %2$O4.</msgCharObj>
-  <msgCharVictimObj>Ты облизываешь %3$O4, поглядывая на %2$C4.</msgCharVictimObj>
-  <msgOthersAuto>$c1 лижет свою бровь.</msgOthersAuto>
-  <msgOthersFound>$c1 лижет $C4 в щеку.</msgOthersFound>
-  <msgOthersNoArgument>$c1 облизнувшись, улыбается.</msgOthersNoArgument>
-  <msgOthersObj>%1$^C1 облизывает %2$O4.</msgOthersObj>
-  <msgOthersVictimObj>%1$^C1 облизывает %3$O4, поглядывая на %2$C4.</msgOthersVictimObj>
-  <msgVictimFound>$c1 лижет тебя в щеку.</msgVictimFound>
-  <msgVictimObj>%1$^C1 облизывает %3$O4, поглядывая на тебя.</msgVictimObj>
+  <msgCharAuto l="ru">Ты лижешь собственную бровь.</msgCharAuto>
+  <msgCharAuto l="ua">Ти лижеш власну брову.</msgCharAuto>
+  <msgCharAuto l="en">You lick your own eyebrow.</msgCharAuto>
+  <msgCharFound l="ru">Ты лижешь $C4 в щеку.</msgCharFound>
+  <msgCharFound l="ua">Ти лижеш $C4 у щоку.</msgCharFound>
+  <msgCharFound l="en">You lick $C1's cheek.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты облизываешься и пытаешься улыбнуться.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти облизуєшся і намагаєшся всміхнутися.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You lick your lips and try to smile.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Полижи себя, таких тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Полижи себе, таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Lick yourself, there is nobody like that here.</msgCharNotFound>
+  <msgCharObj l="ru">Ты облизываешь %2$O4.</msgCharObj>
+  <msgCharObj l="ua">Ти облизуєш %2$O4.</msgCharObj>
+  <msgCharObj l="en">You lick %2$O4.</msgCharObj>
+  <msgCharVictimObj l="ru">Ты облизываешь %3$O4, поглядывая на %2$C4.</msgCharVictimObj>
+  <msgCharVictimObj l="ua">Ти облизуєш %3$O4, поглядаючи на %2$C4.</msgCharVictimObj>
+  <msgCharVictimObj l="en">You lick %3$O4, glancing at %2$C4.</msgCharVictimObj>
+  <msgOthersAuto l="ru">$c1 лижет свою бровь.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 лиже свою брову.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 licks $gits|his|her|their own eyebrow.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 лижет $C4 в щеку.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 лиже $C4 у щоку.</msgOthersFound>
+  <msgOthersFound l="en">$c1 licks $C1's cheek.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 облизнувшись, улыбается.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1, облизнувшись, усміхається.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 licks those lips and smiles.</msgOthersNoArgument>
+  <msgOthersObj l="ru">%1$^C1 облизывает %2$O4.</msgOthersObj>
+  <msgOthersObj l="ua">%1$^C1 облизує %2$O4.</msgOthersObj>
+  <msgOthersObj l="en">%1$^C1 licks %2$O4.</msgOthersObj>
+  <msgOthersVictimObj l="ru">%1$^C1 облизывает %3$O4, поглядывая на %2$C4.</msgOthersVictimObj>
+  <msgOthersVictimObj l="ua">%1$^C1 облизує %3$O4, поглядаючи на %2$C4.</msgOthersVictimObj>
+  <msgOthersVictimObj l="en">%1$^C1 licks %3$O4, glancing at %2$C4.</msgOthersVictimObj>
+  <msgVictimFound l="ru">$c1 лижет тебя в щеку.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 лиже тебе у щоку.</msgVictimFound>
+  <msgVictimFound l="en">$c1 licks your cheek.</msgVictimFound>
+  <msgVictimObj l="ru">%1$^C1 облизывает %3$O4, поглядывая на тебя.</msgVictimObj>
+  <msgVictimObj l="ua">%1$^C1 облизує %3$O4, поглядаючи на тебе.</msgVictimObj>
+  <msgVictimObj l="en">%1$^C1 licks %3$O4, glancing at you.</msgVictimObj>
   <position>rest</position>
   <rusName>облизать</rusName>
   <uaName>облизати</uaName>
-  <shortDesc>лизнуть кого-либо в щеку либо облизнуться</shortDesc>
+  <shortDesc l="ru">лизнуть кого-либо в щеку либо облизнуться</shortDesc>
+  <shortDesc l="ua">лизнути когось у щоку або облизнутися</shortDesc>
+  <shortDesc l="en">lick somebody's cheek, or lick your lips</shortDesc>
 </Social>

--- a/socials/life.xml
+++ b/socials/life.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1781" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Некому</msgCharAuto>
-  <msgCharFound>Мы теряем $C4!</msgCharFound>
-  <msgCharNoArgument>Ты отчаянно цепляешься за жизнь.</msgCharNoArgument>
-  <msgCharNotFound>Кому тут пожить?</msgCharNotFound>
-  <msgOthersAuto>$c1 пытаеться ожить, но тщетно.</msgOthersAuto>
-  <msgOthersFound>Мы теряем $C4!</msgOthersFound>
-  <msgOthersNoArgument>$c1 пытается выжить. Не получается.</msgOthersNoArgument>
-  <msgVictimFound>Хоть немножко еще пожить дайте, сволочи!</msgVictimFound>
+  <msgCharAuto l="ru">Некому</msgCharAuto>
+  <msgCharAuto l="ua">Нема кому</msgCharAuto>
+  <msgCharAuto l="en">Nobody to give it to.</msgCharAuto>
+  <msgCharFound l="ru">Мы теряем $C4!</msgCharFound>
+  <msgCharFound l="ua">Ми втрачаємо $C4!</msgCharFound>
+  <msgCharFound l="en">We are losing $C1!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты отчаянно цепляешься за жизнь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти відчайдушно чіпляєшся за життя.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You cling to life in desperation.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Кому тут пожить?</msgCharNotFound>
+  <msgCharNotFound l="ua">Кому тут пожити?</msgCharNotFound>
+  <msgCharNotFound l="en">Who here needs a life?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 пытаеться ожить, но тщетно.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 намагається ожити, але марно.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 tries to come back to life, in vain.</msgOthersAuto>
+  <msgOthersFound l="ru">Мы теряем $C4!</msgOthersFound>
+  <msgOthersFound l="ua">Ми втрачаємо $C4!</msgOthersFound>
+  <msgOthersFound l="en">We are losing $C1!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 пытается выжить. Не получается.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 намагається вижити. Не виходить.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 tries to survive. It is not working.</msgOthersNoArgument>
+  <msgVictimFound l="ru">Хоть немножко еще пожить дайте, сволочи!</msgVictimFound>
+  <msgVictimFound l="ua">Хоч трошки ще пожити дайте, сволото!</msgVictimFound>
+  <msgVictimFound l="en">Let me live a little longer, you swine!</msgVictimFound>
   <position>rest</position>
   <rusName>жизнь</rusName>
   <uaName>життя</uaName>
-  <shortDesc>отчаянно пытаться выжить</shortDesc>
+  <shortDesc l="ru">отчаянно пытаться выжить</shortDesc>
+  <shortDesc l="ua">відчайдушно намагатися вижити</shortDesc>
+  <shortDesc l="en">cling desperately to life</shortDesc>
 </Social>

--- a/socials/liver.xml
+++ b/socials/liver.xml
@@ -3,15 +3,29 @@
   <help id="1768" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты вырываешь у $X печенку и жадно пожираешь ее.</msgCharFound>
-  <msgCharNoArgument>Ты ищещь, кого бы выпотрошить.</msgCharNoArgument>
-  <msgCharNotFound>Объект вне зоны досягаемости.</msgCharNotFound>
+  <msgCharFound l="ru">Ты вырываешь у $X печенку и жадно пожираешь ее.</msgCharFound>
+  <msgCharFound l="ua">Ти вириваєш у $C2 печінку і жадібно пожираєш її.</msgCharFound>
+  <msgCharFound l="en">You rip out $C1's liver and devour it greedily.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты ищещь, кого бы выпотрошить.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти шукаєш, кого б випатрати.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You look for someone to disembowel.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Объект вне зоны досягаемости.</msgCharNotFound>
+  <msgCharNotFound l="ua">Об'єкт поза зоною досяжності.</msgCharNotFound>
+  <msgCharNotFound l="en">The object of your wrath is out of reach.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 вырывает печень у $C2 и пожирает ее, разбрасывая кровавые брызги.</msgOthersFound>
-  <msgOthersNoArgument>$c1 ищет жертву для потрошения.</msgOthersNoArgument>
-  <msgVictimFound>$c1 вырывает у тебя печенку. Ты в шоке.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 вырывает печень у $C2 и пожирает ее, разбрасывая кровавые брызги.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 вириває печінку в $C2 і пожирає її, розкидаючи криваві бризки.</msgOthersFound>
+  <msgOthersFound l="en">$c1 rips out $C1's liver and devours it, scattering bloody spray.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 ищет жертву для потрошения.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 шукає жертву для патрання.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 looks for a victim to disembowel.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 вырывает у тебя печенку. Ты в шоке.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 вириває в тебе печінку. Ти в шоці.</msgVictimFound>
+  <msgVictimFound l="en">$c1 rips out your liver. You are in shock.</msgVictimFound>
   <position>rest</position>
   <rusName>потрошить</rusName>
   <uaName>патрати</uaName>
-  <shortDesc>самурский социал. Выдрать печень врага и съесть ее</shortDesc>
+  <shortDesc l="ru">самурский социал. Выдрать печень врага и съесть ее</shortDesc>
+  <shortDesc l="ua">самурайський соціал. Видерти печінку ворога і з'їсти її</shortDesc>
+  <shortDesc l="en">a samurai social. Tear out your enemy's liver and eat it</shortDesc>
 </Social>

--- a/socials/lust.xml
+++ b/socials/lust.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1788" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>О, пожалуйста! Это уже совсем нехорошо...</msgCharAuto>
-  <msgCharFound>Ты страстно желаешь $C4.</msgCharFound>
-  <msgCharNoArgument>Твои гормоны начинают играть.</msgCharNoArgument>
-  <msgCharNotFound>Кого бы еще вам возжелать?</msgCharNotFound>
-  <msgOthersAuto>Видно, что $c1 хочет себя. Псих-одиночка!</msgOthersAuto>
-  <msgOthersFound>$c1 смотрит на $C4 с вожделением.</msgOthersFound>
-  <msgOthersNoArgument>В глазах $c2 появляется похотливый блеск --- быстро беги отсюда!</msgOthersNoArgument>
-  <msgVictimFound>$c1 страстно желает твое аппетитное тело.</msgVictimFound>
+  <msgCharAuto l="ru">О, пожалуйста! Это уже совсем нехорошо...</msgCharAuto>
+  <msgCharAuto l="ua">О, будь ласка! Це вже зовсім негарно...</msgCharAuto>
+  <msgCharAuto l="en">Oh, please! This is getting out of hand...</msgCharAuto>
+  <msgCharFound l="ru">Ты страстно желаешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти пристрасно бажаєш $C4.</msgCharFound>
+  <msgCharFound l="en">You lust after $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Твои гормоны начинают играть.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Твої гормони починають грати.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Your hormones begin to rage.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Кого бы еще вам возжелать?</msgCharNotFound>
+  <msgCharNotFound l="ua">Кого б іще тобі забажати?</msgCharNotFound>
+  <msgCharNotFound l="en">Whom are you trying to lust after?</msgCharNotFound>
+  <msgOthersAuto l="ru">Видно, что $c1 хочет себя. Псих-одиночка!</msgOthersAuto>
+  <msgOthersAuto l="ua">Видно, що $c1 хоче себе. Псих-одинак!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 quite obviously lusts after $gitself|himself|herself|themselves. A lonely madness!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 смотрит на $C4 с вожделением.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дивиться на $C4 із хтивістю.</msgOthersFound>
+  <msgOthersFound l="en">$c1 looks lustily at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">В глазах $c2 появляется похотливый блеск --- быстро беги отсюда!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">В очах $c2 з'являється хтивий блиск --- швидко тікай звідси!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">That look of lust appears in $c2 eyes --- get away QUICK!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 страстно желает твое аппетитное тело.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 пристрасно бажає твоє апетитне тіло.</msgVictimFound>
+  <msgVictimFound l="en">$c1 lusts after your delectable body.</msgVictimFound>
   <position>rest</position>
   <rusName>похоть</rusName>
   <uaName>хіть</uaName>
-  <shortDesc>похотливо рассматривать окружающих... или себя</shortDesc>
+  <shortDesc l="ru">похотливо рассматривать окружающих... или себя</shortDesc>
+  <shortDesc l="ua">хтиво розглядати оточення... або себе</shortDesc>
+  <shortDesc l="en">look over the company lustfully... or yourself</shortDesc>
 </Social>

--- a/socials/massage.xml
+++ b/socials/massage.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1608" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты массируешь свои онемевшие члены.</msgCharAuto>
-  <msgCharFound>Ты нежно массируешь плечи $C2.</msgCharFound>
-  <msgCharNoArgument>Массажировать кого? Воздух?</msgCharNoArgument>
-  <msgCharNotFound>Твои руки не дотягиваются до персонажей в других комнатах.</msgCharNotFound>
-  <msgOthersAuto>$c1 массирует свои затекшие конечности.</msgOthersAuto>
-  <msgOthersFound>$c1 массажирует плечи $C2.</msgOthersFound>
+  <msgCharAuto l="ru">Ты массируешь свои онемевшие члены.</msgCharAuto>
+  <msgCharAuto l="ua">Ти масуєш свої затерплі члени.</msgCharAuto>
+  <msgCharAuto l="en">You practice yoga as you try to massage yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты нежно массируешь плечи $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти ніжно масуєш плечі $C2.</msgCharFound>
+  <msgCharFound l="en">You gently massage $C1's shoulders.</msgCharFound>
+  <msgCharNoArgument l="ru">Массажировать кого? Воздух?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Масажувати кого? Повітря?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Massage what? Thin air?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Твои руки не дотягиваются до персонажей в других комнатах.</msgCharNotFound>
+  <msgCharNotFound l="ua">Твої руки не дотягуються до персонажів в інших кімнатах.</msgCharNotFound>
+  <msgCharNotFound l="en">Your hands do not reach into other rooms.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 массирует свои затекшие конечности.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 масує свої затерплі кінцівки.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 puts on a display of yoga positions, trying to self-massage.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 массажирует плечи $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 масажує плечі $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 massages $C1's shoulders.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 нежно массирует твои плечи - Оух... как приятно!</msgVictimFound>
+  <msgVictimFound l="ru">$c1 нежно массирует твои плечи - Оух... как приятно!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 ніжно масує твої плечі -- оух... як приємно!</msgVictimFound>
+  <msgVictimFound l="en">$c1 gently massages your shoulders -- ahhhhhh, that is good!</msgVictimFound>
   <position>rest</position>
   <rusName>массаж</rusName>
   <uaName>масаж</uaName>
-  <shortDesc>делать массаж плеч</shortDesc>
+  <shortDesc l="ru">делать массаж плеч</shortDesc>
+  <shortDesc l="ua">робити масаж плечей</shortDesc>
+  <shortDesc l="en">give a shoulder massage</shortDesc>
 </Social>

--- a/socials/meditate.xml
+++ b/socials/meditate.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты принимаешь удобную позу и начинаешь медитировать.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты принимаешь удобную позу и начинаешь медитировать.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти займаєш зручну позу і починаєш медитувати.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You assume a very comfortable position and begin to meditate.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 устраивается поудобнее и начинает медитировать.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 устраивается поудобнее и начинает медитировать.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 влаштовується зручніше і починає медитувати.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 settles in comfortably and begins to meditate.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>медитировать</rusName>
   <uaName>медитувати</uaName>
-  <shortDesc>углубиться в медитацию</shortDesc>
+  <shortDesc l="ru">углубиться в медитацию</shortDesc>
+  <shortDesc l="ua">заглибитися в медитацію</shortDesc>
+  <shortDesc l="en">sink into meditation</shortDesc>
 </Social>

--- a/socials/moo.xml
+++ b/socials/moo.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1601" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты мычишь на себя... Как все надоело!</msgCharAuto>
-  <msgCharFound>Ты высказываешь свои жалобы $C3 - Муу-у-у!</msgCharFound>
-  <msgCharNoArgument>Ты жуешь жвачку и жалобно мычишь. Муу-у-у!</msgCharNoArgument>
-  <msgCharNotFound>Найди кого-нибудь еще, чтобы ему помычать.</msgCharNotFound>
-  <msgOthersAuto>$c1 мычит на себя... Ты ищешь, куда бы уйти...</msgOthersAuto>
-  <msgOthersFound>$c1 смотрит на $C4, жует жвачку, и произносит: {gМуууу-уу-уу-у-у!{x</msgOthersFound>
-  <msgOthersNoArgument>$c1 поворачивает к тебе свои коровьи глаза и, жуя жвачку, жалобно мычит.</msgOthersNoArgument>
-  <msgVictimFound>$c1 мычит на тебя. Что бы это могло значить?</msgVictimFound>
+  <msgCharAuto l="ru">Ты мычишь на себя... Как все надоело!</msgCharAuto>
+  <msgCharAuto l="ua">Ти мукаєш на себе... Як усе набридло!</msgCharAuto>
+  <msgCharAuto l="en">You moo at yourself... everything is so very tiresome!</msgCharAuto>
+  <msgCharFound l="ru">Ты высказываешь свои жалобы $C3 - Муу-у-у!</msgCharFound>
+  <msgCharFound l="ua">Ти висловлюєш свої скарги $C3 -- Муу-у-у!</msgCharFound>
+  <msgCharFound l="en">You air your complaints to $C1 -- Moo-oo-oo!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты жуешь жвачку и жалобно мычишь. Муу-у-у!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти жуєш жуйку і жалібно мукаєш. Муу-у-у!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You chew your cud and moo plaintively. Muh-OOOOO!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Найди кого-нибудь еще, чтобы ему помычать.</msgCharNotFound>
+  <msgCharNotFound l="ua">Знайди когось іншого, щоб йому помукати.</msgCharNotFound>
+  <msgCharNotFound l="en">You had better find somebody else to moo at.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 мычит на себя... Ты ищешь, куда бы уйти...</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 мукає на себе... Ти шукаєш, куди б піти...</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 is mooing at $gitself|himself|herself|themselves again... You look for an exit...</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 смотрит на $C4, жует жвачку, и произносит: {gМуууу-уу-уу-у-у!{x</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дивиться на $C4, жує жуйку і промовляє: {gМуууу-уу-уу-у-у!{x</msgOthersFound>
+  <msgOthersFound l="en">Slowly, $c1 looks at $C1, chews that cud, and goes: {gMoooo-oo-oo-o-o!{x</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 поворачивает к тебе свои коровьи глаза и, жуя жвачку, жалобно мычит.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 повертає до тебе свої коров'ячі очі і, жуючи жуйку, жалібно мукає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 turns cowlike eyes on you, chews that cud, and moos plaintively.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 мычит на тебя. Что бы это могло значить?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 мукає на тебе. Що б це могло означати?</msgVictimFound>
+  <msgVictimFound l="en">$c1 moos at you. What could that possibly mean?</msgVictimFound>
   <position>rest</position>
   <rusName>муууу</rusName>
   <uaName>муууу</uaName>
-  <shortDesc>мычать, глядя на кого-то добрыми коровьими глазами</shortDesc>
+  <shortDesc l="ru">мычать, глядя на кого-то добрыми коровьими глазами</shortDesc>
+  <shortDesc l="ua">мукати, дивлячись на когось добрими коров'ячими очима</shortDesc>
+  <shortDesc l="en">moo at somebody with kind, cowlike eyes</shortDesc>
 </Social>

--- a/socials/mosh.xml
+++ b/socials/mosh.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1704" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Мазохист!!!</msgCharAuto>
-  <msgCharFound>Со всей дури ты врезаешься в $C4 ... Думаешь, тебе это сойдет с рук?</msgCharFound>
-  <msgCharNoArgument>Ты гламурно корчишься в танце!</msgCharNoArgument>
-  <msgCharNotFound>... похоже никто не хочет танцевать с таким психом</msgCharNotFound>
-  <msgOthersAuto>$c1 бьется об пол в панковском порыве поразить всех своим танцем. Уже поразил$gо||а.</msgOthersAuto>
-  <msgOthersFound>$c1 бьется об $C4, исполняя брачный танец голозадой макаки...У макак и панков это получается не в пример лучше!</msgOthersFound>
-  <msgOthersNoArgument>$c1 корчится в танце, ударяясь в экстазе об пол головой и другими частями тела!</msgOthersNoArgument>
-  <msgVictimFound>$c1 врезается в тебя в творческом танцевальном порыве, и наступает на обе ноги и ухо! Это было действительно БОЛЬНО!</msgVictimFound>
+  <msgCharAuto l="ru">Мазохист!!!</msgCharAuto>
+  <msgCharAuto l="ua">Мазохіст!!!</msgCharAuto>
+  <msgCharAuto l="en">Masochist!!!</msgCharAuto>
+  <msgCharFound l="ru">Со всей дури ты врезаешься в $C4 ... Думаешь, тебе это сойдет с рук?</msgCharFound>
+  <msgCharFound l="ua">З усієї дурі ти врізаєшся в $C4 ... Думаєш, тобі це зійде з рук?</msgCharFound>
+  <msgCharFound l="en">You slam into $C1 with everything you have ... you think that will go unpunished?</msgCharFound>
+  <msgCharNoArgument l="ru">Ты гламурно корчишься в танце!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти гламурно корчишся в танці!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You writhe about in a glamorous dance!</msgCharNoArgument>
+  <msgCharNotFound l="ru">... похоже никто не хочет танцевать с таким психом</msgCharNotFound>
+  <msgCharNotFound l="ua">... схоже, ніхто не хоче танцювати з таким психом</msgCharNotFound>
+  <msgCharNotFound l="en">... looks like nobody wants to dance with a lunatic like that</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 бьется об пол в панковском порыве поразить всех своим танцем. Уже поразил$gо||а.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 б'ється об підлогу в панківському пориві вразити всіх своїм танцем. Уже врази$gло|в|ла.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 slams into the floor in a punk urge to impress everyone. Impressed, all right.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 бьется об $C4, исполняя брачный танец голозадой макаки...У макак и панков это получается не в пример лучше!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 б'ється об $C4, виконуючи шлюбний танець голозадої макаки... У макак і панків це виходить незрівнянно краще!</msgOthersFound>
+  <msgOthersFound l="en">$c1 bounces off $C1, performing the mating dance of a bare-arsed macaque... macaques and punks do it far better!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 корчится в танце, ударяясь в экстазе об пол головой и другими частями тела!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 корчиться в танці, б'ючись в екстазі об підлогу головою та іншими частинами тіла!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 writhes about, hitting the floor in ecstasy with a head and various other body parts!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 врезается в тебя в творческом танцевальном порыве, и наступает на обе ноги и ухо! Это было действительно БОЛЬНО!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 врізається в тебе у творчому танцювальному пориві і наступає на обидві ноги і вухо! Це було справді БОЛЯЧЕ!</msgVictimFound>
+  <msgVictimFound l="en">$c1 slams into you in a creative dance urge, and treads on both your feet and one ear! That REALLY hurt!</msgVictimFound>
   <position>rest</position>
   <rusName>плясать</rusName>
   <uaName>витанцьовувати</uaName>
-  <shortDesc>в экстатическом танце биться об пол или окружающих</shortDesc>
+  <shortDesc l="ru">в экстатическом танце биться об пол или окружающих</shortDesc>
+  <shortDesc l="ua">в екстатичному танці битися об підлогу або оточення</shortDesc>
+  <shortDesc l="en">slam into the floor, and everyone around, in an ecstatic dance</shortDesc>
 </Social>

--- a/socials/mutter.xml
+++ b/socials/mutter.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1699" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты маленькая портативная бормоталка!</msgCharAuto>
-  <msgCharFound>Ты бормочешь что-то на ухо $C3.</msgCharFound>
-  <msgCharNoArgument>Ты бормочешь что-то себе под нос.</msgCharNoArgument>
-  <msgCharNotFound>Тебе нечего больше сказать - их нет тут.</msgCharNotFound>
-  <msgOthersAuto>$c1 бормочет без устали.</msgOthersAuto>
-  <msgOthersFound>$c1 бормочет что-то на ухо $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 бормочет что-то себе под нос.</msgOthersNoArgument>
-  <msgVictimFound>$c1 бормочет что-то тебе на ухо.</msgVictimFound>
+  <msgCharAuto l="ru">Ты маленькая портативная бормоталка!</msgCharAuto>
+  <msgCharAuto l="ua">Ти маленька портативна бурмоталка!</msgCharAuto>
+  <msgCharAuto l="en">You are a small portable muttering machine!</msgCharAuto>
+  <msgCharFound l="ru">Ты бормочешь что-то на ухо $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти бурмочеш щось на вухо $C3.</msgCharFound>
+  <msgCharFound l="en">You mutter something into $C1's ear.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты бормочешь что-то себе под нос.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти бурмочеш щось собі під ніс.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You mutter something under your breath.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Тебе нечего больше сказать - их нет тут.</msgCharNotFound>
+  <msgCharNotFound l="ua">Тобі нема чого більше сказати -- їх тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">There is nothing left for you to say -- they are not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 бормочет без устали.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 бурмоче без утоми.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 mutters away tirelessly.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 бормочет что-то на ухо $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 бурмоче щось на вухо $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 mutters something into $C1's ear.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 бормочет что-то себе под нос.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 бурмоче щось собі під ніс.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 mutters something under $gits|his|her|their breath.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 бормочет что-то тебе на ухо.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 бурмоче щось тобі на вухо.</msgVictimFound>
+  <msgVictimFound l="en">$c1 mutters something into your ear.</msgVictimFound>
   <position>rest</position>
   <rusName>бормотать</rusName>
   <uaName>бурмотіти</uaName>
-  <shortDesc>бормотать себе под нос или кому-то на ухо</shortDesc>
+  <shortDesc l="ru">бормотать себе под нос или кому-то на ухо</shortDesc>
+  <shortDesc l="ua">бурмотіти собі під ніс або комусь на вухо</shortDesc>
+  <shortDesc l="en">mutter to yourself, or into somebody's ear</shortDesc>
 </Social>

--- a/socials/nod.xml
+++ b/socials/nod.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1791" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты пытаешься кивнуть себе, и у тебя начинается головокружение.</msgCharAuto>
-  <msgCharFound>Ты киваешь $C3.</msgCharFound>
-  <msgCharNoArgument>Ты киваешь.</msgCharNoArgument>
-  <msgCharNotFound>Прекрати кивать -- здесь таких нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 тихо кивает себе. Интересно, что на уме у этой странной личности?</msgOthersAuto>
-  <msgOthersFound>$c1 кивает $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 кивает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 кивает тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты пытаешься кивнуть себе, и у тебя начинается головокружение.</msgCharAuto>
+  <msgCharAuto l="ua">Ти намагаєшся кивнути собі, і в тебе починається запаморочення.</msgCharAuto>
+  <msgCharAuto l="en">You attempt to nod at yourself and get dizzy instead.</msgCharAuto>
+  <msgCharFound l="ru">Ты киваешь $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти киваєш $C3.</msgCharFound>
+  <msgCharFound l="en">You nod at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты киваешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти киваєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You nod.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Прекрати кивать -- здесь таких нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Припини кивати -- тут таких немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Nod your head off -- they aren't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 тихо кивает себе. Интересно, что на уме у этой странной личности?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 тихо киває собі. Цікаво, що на думці в цієї дивної особи?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 nods quietly to $gitself|himself|herself|themselves. What a wacko.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 кивает $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 киває $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 nods at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 кивает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 киває.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 nods.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 кивает тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 киває тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 nods at you in agreement.</msgVictimFound>
   <position>rest</position>
   <rusName>кивать</rusName>
   <uaName>кивати</uaName>
-  <shortDesc>кивнуть в знак согласия</shortDesc>
+  <shortDesc l="ru">кивнуть в знак согласия</shortDesc>
+  <shortDesc l="ua">кивнути на знак згоди</shortDesc>
+  <shortDesc l="en">nod in agreement</shortDesc>
 </Social>

--- a/socials/noogie.xml
+++ b/socials/noogie.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1637" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты чешешь свою голову, вырабатывая статическое электричество.</msgCharAuto>
-  <msgCharFound>Ты хватаешь $C4, зажимаешь $S голову и ЧЕШЕШЬ ее!</msgCharFound>
-  <msgCharNoArgument>Ты не можешь чесать ВОЗДУХ! У него нет головы.</msgCharNoArgument>
-  <msgCharNotFound>Этот человек сбежал..</msgCharNotFound>
-  <msgOthersAuto>$c1 чешет свою СОБСТВЕННУЮ голову, вырабатывая статическое электричество.</msgOthersAuto>
-  <msgOthersFound>$c1 хватает $C4, зажимает $S голову и ЧЕШЕТ ее... АЙ!</msgOthersFound>
+  <msgCharAuto l="ru">Ты чешешь свою голову, вырабатывая статическое электричество.</msgCharAuto>
+  <msgCharAuto l="ua">Ти чухаєш свою голову, виробляючи статичну електрику.</msgCharAuto>
+  <msgCharAuto l="en">You rub your head and create a static charge...</msgCharAuto>
+  <msgCharFound l="ru">Ты хватаешь $C4, зажимаешь $S голову и ЧЕШЕШЬ ее!</msgCharFound>
+  <msgCharFound l="ua">Ти хапаєш $C4, затискаєш голову і ЧУХАЄШ її!</msgCharFound>
+  <msgCharFound l="en">You grab $C1, get that head in a lock and NOOGIE it!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты не можешь чесать ВОЗДУХ! У него нет головы.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти не можеш чухати ПОВІТРЯ! У нього немає голови.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You cannot noogie the AIR! It has no head.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Этот человек сбежал..</msgCharNotFound>
+  <msgCharNotFound l="ua">Ця людина втекла..</msgCharNotFound>
+  <msgCharNotFound l="en">That person has run off..</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 чешет свою СОБСТВЕННУЮ голову, вырабатывая статическое электричество.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 чухає свою ВЛАСНУ голову, виробляючи статичну електрику.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 rubs that OWN head and creates a static charge... *ZAP*</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 хватает $C4, зажимает $S голову и ЧЕШЕТ ее... АЙ!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 хапає $C4, затискає голову і ЧУХАЄ її... ОЙ!</msgOthersFound>
+  <msgOthersFound l="en">$c1 grabs $C1 in a head lock and NOOGIES away... ARGH!!!</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>О НЕТ, $c1 хватает тебя, зажимает твою голову и ЧЕШЕТ ее!</msgVictimFound>
+  <msgVictimFound l="ru">О НЕТ, $c1 хватает тебя, зажимает твою голову и ЧЕШЕТ ее!</msgVictimFound>
+  <msgVictimFound l="ua">О НІ, $c1 хапає тебе, затискає твою голову і ЧУХАЄ її!</msgVictimFound>
+  <msgVictimFound l="en">Oh NO, $c1 grabs you, throws you in a head lock and NOOGIES you!</msgVictimFound>
   <position>rest</position>
   <rusName>чесать</rusName>
   <uaName>чесати</uaName>
-  <shortDesc>ЧЕСАТЬ голову (не репу. репу - это itch)</shortDesc>
+  <shortDesc l="ru">ЧЕСАТЬ голову (не репу. репу - это itch)</shortDesc>
+  <shortDesc l="ua">ЧУХАТИ голову (не ріпу. ріпу -- це itch)</shortDesc>
+  <shortDesc l="en">SCRATCH a head (not your own -- that's itch)</shortDesc>
 </Social>

--- a/socials/pat.xml
+++ b/socials/pat.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1710" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты хлопаешь себя по голове - Эврика!</msgCharAuto>
-  <msgCharFound>Ты шлепаешь $C4 по $S голове.</msgCharFound>
-  <msgCharNoArgument>Шлепнуть кого?</msgCharNoArgument>
-  <msgCharNotFound>Кого и как?</msgCharNotFound>
-  <msgOthersAuto>$c1 хлопает себя по голове - Эврика!</msgOthersAuto>
-  <msgOthersFound>$c1 шлепает $C4 по $S голове.</msgOthersFound>
+  <msgCharAuto l="ru">Ты хлопаешь себя по голове - Эврика!</msgCharAuto>
+  <msgCharAuto l="ua">Ти плескаєш себе по голові -- Еврика!</msgCharAuto>
+  <msgCharAuto l="en">You pat yourself on the head -- Eureka!</msgCharAuto>
+  <msgCharFound l="ru">Ты шлепаешь $C4 по $S голове.</msgCharFound>
+  <msgCharFound l="ua">Ти плескаєш $C4 по голові.</msgCharFound>
+  <msgCharFound l="en">You pat $C1 on the head.</msgCharFound>
+  <msgCharNoArgument l="ru">Шлепнуть кого?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ляснути кого?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Pat who?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Кого и как?</msgCharNotFound>
+  <msgCharNotFound l="ua">Кого і як?</msgCharNotFound>
+  <msgCharNotFound l="en">Who, where, what?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 хлопает себя по голове - Эврика!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 плескає себе по голові -- Еврика!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 pats $gitself|himself|herself|themselves on the head -- Eureka!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 шлепает $C4 по $S голове.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 плескає $C4 по голові.</msgOthersFound>
+  <msgOthersFound l="en">$c1 pats $C1 on the head.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 шлепает тебя по голове.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 шлепает тебя по голове.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 плескає тебе по голові.</msgVictimFound>
+  <msgVictimFound l="en">$c1 pats you on the head.</msgVictimFound>
   <position>rest</position>
   <rusName>шлепать</rusName>
   <uaName>плескати</uaName>
-  <shortDesc>шлепнуть по голове. хлопнуть себя по лбу в озарении</shortDesc>
+  <shortDesc l="ru">шлепнуть по голове. хлопнуть себя по лбу в озарении</shortDesc>
+  <shortDesc l="ua">ляснути по голові. плеснути себе по лобі в осяянні</shortDesc>
+  <shortDesc l="en">pat a head, or slap your own forehead in revelation</shortDesc>
 </Social>

--- a/socials/peck.xml
+++ b/socials/peck.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1616" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты действительно любишь себя!</msgCharAuto>
-  <msgCharFound>Рискуя получить по лицу, ты целуешь в щечку $C4.</msgCharFound>
-  <msgCharNoArgument>Ты хочешь это сделать с кем-то или просто с воздухом?</msgCharNoArgument>
-  <msgCharNotFound>Боюсь, что они, испугавшись, ушли.</msgCharNotFound>
-  <msgOthersAuto>$c1 бесплодно пытается дотянуться своими губами до своей же щеки :)</msgOthersAuto>
-  <msgOthersFound>$c1 улыбается и касается губами щеки $C2.</msgOthersFound>
+  <msgCharAuto l="ru">Ты действительно любишь себя!</msgCharAuto>
+  <msgCharAuto l="ua">Ти справді любиш себе!</msgCharAuto>
+  <msgCharAuto l="en">You must REALLY like yourself.</msgCharAuto>
+  <msgCharFound l="ru">Рискуя получить по лицу, ты целуешь в щечку $C4.</msgCharFound>
+  <msgCharFound l="ua">Ризикуючи дістати по обличчю, ти цілуєш у щічку $C4.</msgCharFound>
+  <msgCharFound l="en">Risking a slap to the face, you give $C1 a peck on the cheek.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты хочешь это сделать с кем-то или просто с воздухом?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти хочеш це зробити з кимось чи просто з повітрям?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Would you like to do that to a person, or do you prefer air?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Боюсь, что они, испугавшись, ушли.</msgCharNotFound>
+  <msgCharNotFound l="ua">Боюся, що вони, злякавшись, пішли.</msgCharNotFound>
+  <msgCharNotFound l="en">I guess you scared them away...</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 бесплодно пытается дотянуться своими губами до своей же щеки :)</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 безплідно намагається дотягтися своїми губами до власної ж щоки :)</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 tries in vain to reach those own cheeks with those own lips :)</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 улыбается и касается губами щеки $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 усміхається і торкається губами щоки $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 smiles and gives $C1 a chaste peck on the cheek.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 чмокает тебя в щеку - как мило!</msgVictimFound>
+  <msgVictimFound l="ru">$c1 чмокает тебя в щеку - как мило!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 цмокає тебе в щоку -- як мило!</msgVictimFound>
+  <msgVictimFound l="en">$c1 pecks you on the cheek -- how sweet!</msgVictimFound>
   <position>rest</position>
   <rusName>чмок</rusName>
   <uaName>цьом</uaName>
-  <shortDesc>чмокнуть в щечку</shortDesc>
+  <shortDesc l="ru">чмокнуть в щечку</shortDesc>
+  <shortDesc l="ua">цмокнути в щічку</shortDesc>
+  <shortDesc l="en">a peck on the cheek</shortDesc>
 </Social>

--- a/socials/peer.xml
+++ b/socials/peer.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1652" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты смотришь на часы, но их на руке нет - это же средневековье!</msgCharAuto>
-  <msgCharFound>Ты внимательно всматриваешься в $C4.</msgCharFound>
-  <msgCharNoArgument>Ты внимательно разглядываешь себя.</msgCharNoArgument>
-  <msgCharNotFound>Нету здесь.</msgCharNotFound>
-  <msgOthersAuto>$c1 смотрит на свою руку.</msgOthersAuto>
-  <msgOthersFound>$c1 внимательно всматривается в $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 внимательно себя оглядывает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 внимательно всматривается в тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты смотришь на часы, но их на руке нет - это же средневековье!</msgCharAuto>
+  <msgCharAuto l="ua">Ти дивишся на годинник, але його на руці немає -- це ж середньовіччя!</msgCharAuto>
+  <msgCharAuto l="en">You check your watch, but there is none on your wrist -- these are the Middle Ages!</msgCharAuto>
+  <msgCharFound l="ru">Ты внимательно всматриваешься в $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти уважно вдивляєшся в $C4.</msgCharFound>
+  <msgCharFound l="en">You peer intently at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты внимательно разглядываешь себя.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти уважно розглядаєш себе.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You peer at yourself intently.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нету здесь.</msgCharNotFound>
+  <msgCharNotFound l="ua">Немає тут.</msgCharNotFound>
+  <msgCharNotFound l="en">Not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 смотрит на свою руку.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 дивиться на свою руку.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 stares at $gits|his|her|their own hand.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 внимательно всматривается в $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 уважно вдивляється в $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 peers intently at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 внимательно себя оглядывает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 уважно себе оглядає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 peers over $gitself|himself|herself|themselves intently.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 внимательно всматривается в тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 уважно вдивляється в тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 peers at you intently.</msgVictimFound>
   <position>rest</position>
   <rusName>разглядывать</rusName>
   <uaName>роздивлятися</uaName>
-  <shortDesc>внимательно разглядывать</shortDesc>
+  <shortDesc l="ru">внимательно разглядывать</shortDesc>
+  <shortDesc l="ua">уважно розглядати</shortDesc>
+  <shortDesc l="en">peer at somebody intently</shortDesc>
 </Social>

--- a/socials/pinch.xml
+++ b/socials/pinch.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1800" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты щипаешь себя, чтобы убедиться, что это не сон!</msgCharAuto>
-  <msgCharFound>Ты щипаешь $C4 за попку и ухмыляешься.</msgCharFound>
-  <msgCharNoArgument>Ты произносишь: &apos;{gЩепоточку того, щепоточку этого{x&apos;</msgCharNoArgument>
-  <msgCharNotFound>Ты бы рад$gо||а, но кого?</msgCharNotFound>
-  <msgOthersAuto>$c1 щипает себя, чтобы убедиться, что не спит!</msgOthersAuto>
-  <msgOthersFound>$c1 щипает $C4 за попку и ухмыляется.</msgOthersFound>
-  <msgOthersNoArgument>$c1 произносит: &apos;{gЩепоточку того, щепоточку этого{x&apos;</msgOthersNoArgument>
-  <msgVictimFound>$c1 щипает тебя за попку!</msgVictimFound>
+  <msgCharAuto l="ru">Ты щипаешь себя, чтобы убедиться, что это не сон!</msgCharAuto>
+  <msgCharAuto l="ua">Ти щипаєш себе, щоб переконатися, що це не сон!</msgCharAuto>
+  <msgCharAuto l="en">You pinch yourself to see if you are dreaming!</msgCharAuto>
+  <msgCharFound l="ru">Ты щипаешь $C4 за попку и ухмыляешься.</msgCharFound>
+  <msgCharFound l="ua">Ти щипаєш $C4 за попку і посміхаєшся.</msgCharFound>
+  <msgCharFound l="en">You squeeze $C1's bottom and grin.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты произносишь: &apos;{gЩепоточку того, щепоточку этого{x&apos;</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти промовляєш: '{gДрібочку того, дрібочку цього{x'</msgCharNoArgument>
+  <msgCharNoArgument l="en">You say, '{gA pinch of this, and a dab of that{x'</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты бы рад$gо||а, но кого?</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти б рад$gе|ий|а, але кого?</msgCharNotFound>
+  <msgCharNotFound l="en">You would like to, wouldn't you? But whom?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 щипает себя, чтобы убедиться, что не спит!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 щипає себе, щоб переконатися, що не спить!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 pinches $gitself|himself|herself|themselves to see if this is all a dream!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 щипает $C4 за попку и ухмыляется.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 щипає $C4 за попку і посміхається.</msgOthersFound>
+  <msgOthersFound l="en">$c1 pinches $C1's bottom and grins.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 произносит: &apos;{gЩепоточку того, щепоточку этого{x&apos;</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 промовляє: '{gДрібочку того, дрібочку цього{x'</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 says, '{gA pinch of this and a dab of that{x'</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 щипает тебя за попку!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 щипає тебе за попку!</msgVictimFound>
+  <msgVictimFound l="en">$c1 pinches your bottom!</msgVictimFound>
   <position>rest</position>
   <rusName>щипать</rusName>
   <uaName>щипати</uaName>
-  <shortDesc>щипнуть себя или ущипнуть кого-либо за попу</shortDesc>
+  <shortDesc l="ru">щипнуть себя или ущипнуть кого-либо за попу</shortDesc>
+  <shortDesc l="ua">щипнути себе або вщипнути когось за попу</shortDesc>
+  <shortDesc l="en">pinch yourself, or pinch somebody's bottom</shortDesc>
 </Social>

--- a/socials/pissed.xml
+++ b/socials/pissed.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1743" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты з$gол|ол|ла на себя!</msgCharAuto>
-  <msgCharFound>Ты выразительно смотришь на $C4 и играешь своей бейсбольной битой!</msgCharFound>
-  <msgCharNoArgument>Тебе галимо!</msgCharNoArgument>
-  <msgCharNotFound>Таких здесь нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 на себя разозлил$gось|ся|ась. $m и впрямь галимо.</msgOthersAuto>
-  <msgOthersFound>$c1 щас побьет $C4!</msgOthersFound>
-  <msgOthersNoArgument>$c1 в галимом настроении. Щас все разнесет!</msgOthersNoArgument>
-  <msgVictimFound>$c1 на тебя з$gол|ол|ла. И что теперь тебе делать?</msgVictimFound>
+  <msgCharAuto l="ru">Ты з$gол|ол|ла на себя!</msgCharAuto>
+  <msgCharAuto l="ua">Ти зл$gе|ий|а на себе!</msgCharAuto>
+  <msgCharAuto l="en">You are PISSED at yourself!</msgCharAuto>
+  <msgCharFound l="ru">Ты выразительно смотришь на $C4 и играешь своей бейсбольной битой!</msgCharFound>
+  <msgCharFound l="ua">Ти виразно дивишся на $C4 і граєш своєю бейсбольною битою!</msgCharFound>
+  <msgCharFound l="en">You turn a stony gaze on $C1 and toy with your baseball bat!</msgCharFound>
+  <msgCharNoArgument l="ru">Тебе галимо!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Тобі гнітюче!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You are PISSED!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Таких здесь нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">That person is not here...</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 на себя разозлил$gось|ся|ась. $m и впрямь галимо.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 на себе розлюти$gлося|вся|лася. І справді гнітюче.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 is so pissed at $gitself|himself|herself|themselves. How could anyone be so stupid???</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 щас побьет $C4!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 зараз поб'є $C4!</msgOthersFound>
+  <msgOthersFound l="en">$c1 is about to beat $C1 to a pulp!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 в галимом настроении. Щас все разнесет!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 у гнітючому настрої. Зараз усе рознесе!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 is PISSED, so watch out!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 на тебя з$gол|ол|ла. И что теперь тебе делать?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 на тебе зл$gе|ий|а. І що тепер тобі робити?</msgVictimFound>
+  <msgVictimFound l="en">$c1 is pissed at you now... What do you think comes next?</msgVictimFound>
   <position>rest</position>
   <rusName>галимо</rusName>
   <uaName>фігово</uaName>
-  <shortDesc>злиться на кого-то. пребывать в полном упадке духа</shortDesc>
+  <shortDesc l="ru">злиться на кого-то. пребывать в полном упадке духа</shortDesc>
+  <shortDesc l="ua">злитися на когось. перебувати в цілковитому занепаді духу</shortDesc>
+  <shortDesc l="en">be angry at somebody, or be in utter low spirits</shortDesc>
 </Social>

--- a/socials/point.xml
+++ b/socials/point.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1653" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты указываешь на себя, в смущении.</msgCharAuto>
-  <msgCharFound>Ты показываешь на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты тыкаешь пальцем во все стороны, попадая даже в небо :)</msgCharNoArgument>
-  <msgCharNotFound>Куда вставить твой палец?</msgCharNotFound>
-  <msgOthersAuto>$c1 смутившись, указывает на себя.</msgOthersAuto>
-  <msgOthersFound>$c1 указывает пальцем на $C4!</msgOthersFound>
-  <msgOthersNoArgument>$c1 размахивает растопыренными пальцами.</msgOthersNoArgument>
-  <msgVictimFound>$c1 указывает пальцем на тебя. Как невоспитанно!</msgVictimFound>
+  <msgCharAuto l="ru">Ты указываешь на себя, в смущении.</msgCharAuto>
+  <msgCharAuto l="ua">Ти вказуєш на себе, збентежен$gе|ий|а.</msgCharAuto>
+  <msgCharAuto l="en">You point at yourself, obviously very confused.</msgCharAuto>
+  <msgCharFound l="ru">Ты показываешь на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти показуєш на $C4.</msgCharFound>
+  <msgCharFound l="en">You point at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты тыкаешь пальцем во все стороны, попадая даже в небо :)</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти тицяєш пальцем на всі боки, влучаючи навіть у небо :)</msgCharNoArgument>
+  <msgCharNoArgument l="en">You point in every direction, the sky included :)</msgCharNoArgument>
+  <msgCharNotFound l="ru">Куда вставить твой палец?</msgCharNotFound>
+  <msgCharNotFound l="ua">Куди вставити твій палець?</msgCharNotFound>
+  <msgCharNotFound l="en">And where exactly should that finger go?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 смутившись, указывает на себя.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1, збентежившись, вказує на себе.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 points at $gitself|himself|herself|themselves, obviously very confused.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 указывает пальцем на $C4!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 вказує пальцем на $C4!</msgOthersFound>
+  <msgOthersFound l="en">$c1 points excitedly at $C1!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 размахивает растопыренными пальцами.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 розмахує розчепіреними пальцями.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 waves splayed fingers about.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 указывает пальцем на тебя. Как невоспитанно!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 вказує пальцем на тебе. Як невиховано!</msgVictimFound>
+  <msgVictimFound l="en">$c1 points at you. How rude!</msgVictimFound>
   <position>rest</position>
   <rusName>указать</rusName>
   <uaName>вказати</uaName>
-  <shortDesc>указывать пальцем, тыкать пальцами во все стороны</shortDesc>
+  <shortDesc l="ru">указывать пальцем, тыкать пальцами во все стороны</shortDesc>
+  <shortDesc l="ua">вказувати пальцем, тицяти пальцями на всі боки</shortDesc>
+  <shortDesc l="en">point a finger, or jab fingers in every direction</shortDesc>
 </Social>

--- a/socials/poke.xml
+++ b/socials/poke.xml
@@ -2,21 +2,47 @@
 <Social type="Social">
   <help id="1814" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тыкаешь себя под ребро, и при этом очень глупо выглядишь.</msgCharAuto>
-  <msgCharFound>Ты тыкаешь $M под ребро.</msgCharFound>
-  <msgCharNoArgument>Тыкнуть кого??</msgCharNoArgument>
-  <msgCharNotFound>Ты не можешь тыкнуть того, кого здесь нет!</msgCharNotFound>
-  <msgCharObj>Ты тычешь %2$O5 во все стороны.</msgCharObj>
-  <msgCharVictimObj>Ты тыкаешь %2$C4 %3$O5.</msgCharVictimObj>
-  <msgOthersAuto>$c1 тыкает себя под ребро, это выглядит довольно глупо.</msgOthersAuto>
-  <msgOthersFound>$c1 тыкает $C4 под ребро.</msgOthersFound>
+  <msgCharAuto l="ru">Ты тыкаешь себя под ребро, и при этом очень глупо выглядишь.</msgCharAuto>
+  <msgCharAuto l="ua">Ти тицяєш себе під ребро і при цьому маєш дуже безглуздий вигляд.</msgCharAuto>
+  <msgCharAuto l="en">You poke yourself in the ribs and look very silly doing it.</msgCharAuto>
+  <msgCharFound l="ru">Ты тыкаешь $M под ребро.</msgCharFound>
+  <msgCharFound l="ua">Ти тицяєш $C4 під ребро.</msgCharFound>
+  <msgCharFound l="en">You poke $C1 in the ribs.</msgCharFound>
+  <msgCharNoArgument l="ru">Тыкнуть кого??</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Тицьнути кого??</msgCharNoArgument>
+  <msgCharNoArgument l="en">Poke who??</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты не можешь тыкнуть того, кого здесь нет!</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти не можеш тицьнути того, кого тут немає!</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot poke someone who is not here!</msgCharNotFound>
+  <msgCharObj l="ru">Ты тычешь %2$O5 во все стороны.</msgCharObj>
+  <msgCharObj l="ua">Ти тицяєш %2$O5 на всі боки.</msgCharObj>
+  <msgCharObj l="en">You jab %2$O5 in every direction.</msgCharObj>
+  <msgCharVictimObj l="ru">Ты тыкаешь %2$C4 %3$O5.</msgCharVictimObj>
+  <msgCharVictimObj l="ua">Ти тицяєш %2$C4 %3$O5.</msgCharVictimObj>
+  <msgCharVictimObj l="en">You poke %2$C4 with %3$O5.</msgCharVictimObj>
+  <msgOthersAuto l="ru">$c1 тыкает себя под ребро, это выглядит довольно глупо.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 тицяє себе під ребро, це має досить безглуздий вигляд.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 pokes $gitself|himself|herself|themselves in the ribs, looking rather sheepish.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 тыкает $C4 под ребро.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 тицяє $C4 під ребро.</msgOthersFound>
+  <msgOthersFound l="en">$c1 pokes $C1 in the ribs.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgOthersObj>%1$^C1 тычет %2$O5 во все стороны.</msgOthersObj>
-  <msgOthersVictimObj>%1$^C1 тыкает %2$C4 %3$O5.</msgOthersVictimObj>
-  <msgVictimFound>$c1 тыкает тебя под ребро.</msgVictimFound>
-  <msgVictimObj>%1$^C1 тычет в тебя %3$O5.</msgVictimObj>
+  <msgOthersObj l="ru">%1$^C1 тычет %2$O5 во все стороны.</msgOthersObj>
+  <msgOthersObj l="ua">%1$^C1 тицяє %2$O5 на всі боки.</msgOthersObj>
+  <msgOthersObj l="en">%1$^C1 jabs %2$O5 in every direction.</msgOthersObj>
+  <msgOthersVictimObj l="ru">%1$^C1 тыкает %2$C4 %3$O5.</msgOthersVictimObj>
+  <msgOthersVictimObj l="ua">%1$^C1 тицяє %2$C4 %3$O5.</msgOthersVictimObj>
+  <msgOthersVictimObj l="en">%1$^C1 pokes %2$C4 with %3$O5.</msgOthersVictimObj>
+  <msgVictimFound l="ru">$c1 тыкает тебя под ребро.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 тицяє тебе під ребро.</msgVictimFound>
+  <msgVictimFound l="en">$c1 pokes you in the ribs.</msgVictimFound>
+  <msgVictimObj l="ru">%1$^C1 тычет в тебя %3$O5.</msgVictimObj>
+  <msgVictimObj l="ua">%1$^C1 тицяє в тебе %3$O5.</msgVictimObj>
+  <msgVictimObj l="en">%1$^C1 jabs %3$O5 at you.</msgVictimObj>
   <position>rest</position>
   <rusName>тыкать</rusName>
   <uaName>тикати</uaName>
-  <shortDesc>ткнуть под ребро (на всякий случай:)</shortDesc>
+  <shortDesc l="ru">ткнуть под ребро (на всякий случай:)</shortDesc>
+  <shortDesc l="ua">тицьнути під ребро (про всяк випадок:)</shortDesc>
+  <shortDesc l="en">poke somebody in the ribs (just in case:)</shortDesc>
 </Social>

--- a/socials/ponder.xml
+++ b/socials/ponder.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты обдумываешь вопрос.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты обдумываешь вопрос.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти обмірковуєш питання.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You ponder the question.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 садится и глубоко размышляет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 садится и глубоко размышляет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 сідає і глибоко розмірковує.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 sits down and thinks deeply.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>думать</rusName>
   <uaName>думати</uaName>
-  <shortDesc>обдумывать вопрос</shortDesc>
+  <shortDesc l="ru">обдумывать вопрос</shortDesc>
+  <shortDesc l="ua">обмірковувати питання</shortDesc>
+  <shortDesc l="en">ponder a question</shortDesc>
 </Social>

--- a/socials/pound.xml
+++ b/socials/pound.xml
@@ -3,15 +3,29 @@
   <help id="1801" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты вбиваешь $C4 в камень мощным ударом.</msgCharFound>
-  <msgCharNoArgument>Ты разминаешь кулак. Выразительно.</msgCharNoArgument>
-  <msgCharNotFound>Никого тут нет.</msgCharNotFound>
+  <msgCharFound l="ru">Ты вбиваешь $C4 в камень мощным ударом.</msgCharFound>
+  <msgCharFound l="ua">Ти вбиваєш $C4 у камінь могутнім ударом.</msgCharFound>
+  <msgCharFound l="en">You pound $C1 into the stone with one mighty blow.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты разминаешь кулак. Выразительно.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти розминаєш кулак. Виразно.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You limber up your fist. Expressively.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Никого тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нікого тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 бьет $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 с задумчивым видом постукивает кастетом.</msgOthersNoArgument>
-  <msgVictimFound>$c1 делает из тебя кровавый блин.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 бьет $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 б'є $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 pounds $C1 into a bloody mass.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 с задумчивым видом постукивает кастетом.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 із задумливим виглядом постукує кастетом.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 taps a knuckleduster with a thoughtful air.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 делает из тебя кровавый блин.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 робить із тебе кривавий млинець.</msgVictimFound>
+  <msgVictimFound l="en">$c1 pounds you into a bloody pancake.</msgVictimFound>
   <position>rest</position>
   <rusName>бить</rusName>
   <uaName>бити</uaName>
-  <shortDesc>прибить кого-нибудь или демостративно размять кулак</shortDesc>
+  <shortDesc l="ru">прибить кого-нибудь или демостративно размять кулак</shortDesc>
+  <shortDesc l="ua">прибити когось або демонстративно розім'яти кулак</shortDesc>
+  <shortDesc l="en">pound somebody flat, or limber up your fist for show</shortDesc>
 </Social>

--- a/socials/pout.xml
+++ b/socials/pout.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Не принимай так близко к сердцу.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Не принимай так близко к сердцу.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Не бери так близько до серця.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Ah, don't take it so hard.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 корчит недовольные рожи, одну за другой.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 корчит недовольные рожи, одну за другой.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 корчить невдоволені пики, одну за одною.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 pulls one sulky face after another.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>недовольство</rusName>
   <uaName>невдоволення</uaName>
-  <shortDesc>скорчить недовольную рожу</shortDesc>
+  <shortDesc l="ru">скорчить недовольную рожу</shortDesc>
+  <shortDesc l="ua">скорчити невдоволену пику</shortDesc>
+  <shortDesc l="en">pull a sulky face</shortDesc>
 </Social>

--- a/socials/pray.xml
+++ b/socials/pray.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1692" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>И вы шото говорите про самолюбие? Не смешите мои тапки...</msgCharAuto>
-  <msgCharFound>Ты падаешь ниц перед $C5.</msgCharFound>
-  <msgCharNoArgument>Ты чувствуешь себя просветленным и чуть-чуть, совсем чуть-чуть идиотом....</msgCharNoArgument>
-  <msgCharNotFound>Вокруг-ни души, и только бесчисленные Войды внимают твоим молитвам.</msgCharNotFound>
-  <msgOthersAuto>$c1 выворачивается йога-кандебобелем и бормочет молитвы.</msgOthersAuto>
-  <msgOthersFound>$c1 падает ниц перед $C5, и целует пыль у $S ног.</msgOthersFound>
-  <msgOthersNoArgument>$c1 вопит и рвет на себе одежды, взывая к высшим силам.</msgOthersNoArgument>
-  <msgVictimFound>$c1 целует пыль у твоих ног.</msgVictimFound>
+  <msgCharAuto l="ru">И вы шото говорите про самолюбие? Не смешите мои тапки...</msgCharAuto>
+  <msgCharAuto l="ua">І ти щось кажеш про самолюбство? Не смішіть мої капці...</msgCharAuto>
+  <msgCharAuto l="en">And you talk about self-love? Do not make my slippers laugh...</msgCharAuto>
+  <msgCharFound l="ru">Ты падаешь ниц перед $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти падаєш ниць перед $C5.</msgCharFound>
+  <msgCharFound l="en">You crawl in the dust before $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты чувствуешь себя просветленным и чуть-чуть, совсем чуть-чуть идиотом....</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти почуваєшся просвітлен$gим|им|ою і трішки, зовсім трішки ідіотом....</msgCharNoArgument>
+  <msgCharNoArgument l="en">You feel enlightened, and just a little, a very little, foolish....</msgCharNoArgument>
+  <msgCharNotFound l="ru">Вокруг-ни души, и только бесчисленные Войды внимают твоим молитвам.</msgCharNotFound>
+  <msgCharNotFound l="ua">Навколо -- ні душі, і тільки незліченні Войди слухають твої молитви.</msgCharNotFound>
+  <msgCharNotFound l="en">Not a soul around; only the endless Voids hear your prayers.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 выворачивается йога-кандебобелем и бормочет молитвы.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 вивертається йога-кандибобелем і бурмоче молитви.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 twists into some strange yoga knot and mumbles prayers.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 падает ниц перед $C5, и целует пыль у $S ног.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 падає ниць перед $C5 і цілує пил біля ніг.</msgOthersFound>
+  <msgOthersFound l="en">$c1 falls down before $C1 and kisses the dust at those feet.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вопит и рвет на себе одежды, взывая к высшим силам.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 волає і рве на собі одяг, волаючи до вищих сил.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 wails and tears at those clothes, calling on the higher powers.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 целует пыль у твоих ног.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 цілує пил біля твоїх ніг.</msgVictimFound>
+  <msgVictimFound l="en">$c1 kisses the dust at your feet.</msgVictimFound>
   <position>rest</position>
   <rusName>боготворить</rusName>
   <uaName>боготворити</uaName>
-  <shortDesc>ползать в пыли, доставая богов своими молитвами</shortDesc>
+  <shortDesc l="ru">ползать в пыли, доставая богов своими молитвами</shortDesc>
+  <shortDesc l="ua">повзати в пилюці, дістаючи богів своїми молитвами</shortDesc>
+  <shortDesc l="en">crawl in the dust, pestering the gods with your prayers</shortDesc>
 </Social>

--- a/socials/purr.xml
+++ b/socials/purr.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1624" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тихо мурлыкаешь себе.</msgCharAuto>
-  <msgCharFound>Ты трешься о $C4 и мурлыкаешь.</msgCharFound>
-  <msgCharNoArgument>Муррррр ^-^</msgCharNoArgument>
-  <msgCharNotFound>Ты, глупая кошка! Их тут нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 мурлыкает себе.</msgOthersAuto>
-  <msgOthersFound>$c1 трется о $C4 и мурлыкает.</msgOthersFound>
-  <msgOthersNoArgument>$c1 мурлыкает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 трется о твои ноги и мурлыкает.</msgVictimFound>
+  <msgCharAuto l="ru">Ты тихо мурлыкаешь себе.</msgCharAuto>
+  <msgCharAuto l="ua">Ти тихо муркочеш собі.</msgCharAuto>
+  <msgCharAuto l="en">You purr quietly to yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты трешься о $C4 и мурлыкаешь.</msgCharFound>
+  <msgCharFound l="ua">Ти треш об $C4 і муркочеш.</msgCharFound>
+  <msgCharFound l="en">You rub up against $C1 and purr contentedly.</msgCharFound>
+  <msgCharNoArgument l="ru">Муррррр ^-^</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Мурррр ^-^</msgCharNoArgument>
+  <msgCharNoArgument l="en">Purrrrr ^-^</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты, глупая кошка! Их тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти, дурна кішко! Їх тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">You silly cat! They aren't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 мурлыкает себе.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 муркоче собі.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 purrs contentedly to $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 трется о $C4 и мурлыкает.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 треться об $C4 і муркоче.</msgOthersFound>
+  <msgOthersFound l="en">$c1 rubs against $C1 and purrs contentedly.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 мурлыкает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 муркоче.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 purrs contentedly.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 трется о твои ноги и мурлыкает.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 треться об твої ноги і муркоче.</msgVictimFound>
+  <msgVictimFound l="en">$c1 rubs up against your legs and purrs contentedly.</msgVictimFound>
   <position>rest</position>
   <rusName>мурчать</rusName>
   <uaName>мурчати</uaName>
-  <shortDesc>мурчать от удовольствия или тереться о чьи-то ноги</shortDesc>
+  <shortDesc l="ru">мурчать от удовольствия или тереться о чьи-то ноги</shortDesc>
+  <shortDesc l="ua">муркотіти від задоволення або тертися об чиїсь ноги</shortDesc>
+  <shortDesc l="en">purr with pleasure, or rub against somebody's legs</shortDesc>
 </Social>

--- a/socials/rofl.xml
+++ b/socials/rofl.xml
@@ -3,15 +3,27 @@
   <help id="1757" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты падаешь на землю, хохоча над шуткой $C2.</msgCharFound>
-  <msgCharNoArgument>Ты падаешь на землю и катаешься в приступе истеричного смеха.</msgCharNoArgument>
+  <msgCharFound l="ru">Ты падаешь на землю, хохоча над шуткой $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти падаєш на землю, регочучи з жарту $C2.</msgCharFound>
+  <msgCharFound l="en">You fall to the floor laughing at $C1's remark.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты падаешь на землю и катаешься в приступе истеричного смеха.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти падаєш на землю і качаєшся в нападі істеричного сміху.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You roll on the floor, laughing hysterically.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 падает на землю, хохоча над шуткой $C2!</msgOthersFound>
-  <msgOthersNoArgument>$c1 падает на землю и катается в приступе истеричного смеха.</msgOthersNoArgument>
-  <msgVictimFound>$c1 падает на землю, хохоча над твоей шуткой!</msgVictimFound>
+  <msgOthersFound l="ru">$c1 падает на землю, хохоча над шуткой $C2!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 падає на землю, регочучи з жарту $C2!</msgOthersFound>
+  <msgOthersFound l="en">$c1 rolls on the floor laughing at $C1's antics!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 падает на землю и катается в приступе истеричного смеха.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 падає на землю і качається в нападі істеричного сміху.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 falls to the ground and rolls around laughing hysterically.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 падает на землю, хохоча над твоей шуткой!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 падає на землю, регочучи з твого жарту!</msgVictimFound>
+  <msgVictimFound l="en">$c1 rolls on the floor laughing at your antics!</msgVictimFound>
   <position>rest</position>
   <rusName>рофл</rusName>
   <uaName>рофл</uaName>
-  <shortDesc>кататься по полу от смеха</shortDesc>
+  <shortDesc l="ru">кататься по полу от смеха</shortDesc>
+  <shortDesc l="ua">качатися по підлозі від сміху</shortDesc>
+  <shortDesc l="en">roll on the floor laughing</shortDesc>
 </Social>

--- a/socials/romeo.xml
+++ b/socials/romeo.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты достаешь &quot;{BВерховину{x&quot; и с наслаждением затягиваешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты достаешь &quot;{BВерховину{x&quot; и с наслаждением затягиваешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти дістаєш "{BВерховину{x" і з насолодою затягуєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You take out a "{BVerkhovyna{x" and draw on it with pleasure.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 пыхтит своей цыгаркой как паровоз.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 пыхтит своей цыгаркой как паровоз.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 пахкає своєю цигаркою, як паротяг.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 puffs on a cigar like a steam engine.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>цыгарка</rusName>
   <uaName>цигарка</uaName>
-  <shortDesc>пыхнуть цыгаркой</shortDesc>
+  <shortDesc l="ru">пыхнуть цыгаркой</shortDesc>
+  <shortDesc l="ua">пихнути цигаркою</shortDesc>
+  <shortDesc l="en">puff on a cigar</shortDesc>
 </Social>

--- a/socials/rose.xml
+++ b/socials/rose.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1606" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты даришь себе розу в память о дне рождения своей черепашки...</msgCharAuto>
-  <msgCharFound>Ты даришь $M прекрасную розу.</msgCharFound>
-  <msgCharNoArgument>И кому бы розу подарить?</msgCharNoArgument>
-  <msgCharNotFound>Уже ушли.</msgCharNotFound>
-  <msgOthersAuto>$c1 дарит себе розу. Бедное существо!</msgOthersAuto>
-  <msgOthersFound>$c1 дарит $C3 прекрасную розу.</msgOthersFound>
+  <msgCharAuto l="ru">Ты даришь себе розу в память о дне рождения своей черепашки...</msgCharAuto>
+  <msgCharAuto l="ua">Ти даруєш собі троянду на згадку про день народження своєї черепашки...</msgCharAuto>
+  <msgCharAuto l="en">You give yourself a rose in memory of your pet turtle's birthday...</msgCharAuto>
+  <msgCharFound l="ru">Ты даришь $M прекрасную розу.</msgCharFound>
+  <msgCharFound l="ua">Ти даруєш $C3 прекрасну троянду.</msgCharFound>
+  <msgCharFound l="en">You give $C1 a beautiful rose.</msgCharFound>
+  <msgCharNoArgument l="ru">И кому бы розу подарить?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">І кому б троянду подарувати?</msgCharNoArgument>
+  <msgCharNoArgument l="en">And who would you give a rose to?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Уже ушли.</msgCharNotFound>
+  <msgCharNotFound l="ua">Уже пішли.</msgCharNotFound>
+  <msgCharNotFound l="en">Already gone.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 дарит себе розу. Бедное существо!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 дарує собі троянду. Бідне створіння!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 gives $gitself|himself|herself|themselves a rose. Poor creature!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 дарит $C3 прекрасную розу.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дарує $C3 прекрасну троянду.</msgOthersFound>
+  <msgOthersFound l="en">$c1 hands $C1 a beautiful rose.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 дарит тебе прекрасную {g---&apos;---,--{{{r@{x</msgVictimFound>
+  <msgVictimFound l="ru">$c1 дарит тебе прекрасную {g---&apos;---,--{{{r@{x</msgVictimFound>
+  <msgVictimFound l="ua">$c1 дарує тобі прекрасну {g---'---,--{{{r@{x</msgVictimFound>
+  <msgVictimFound l="en">$c1 hands you a beautiful {g---'---,--{{{r@{x</msgVictimFound>
   <position>rest</position>
   <rusName>роза</rusName>
   <uaName>троянда</uaName>
-  <shortDesc>подарить розу</shortDesc>
+  <shortDesc l="ru">подарить розу</shortDesc>
+  <shortDesc l="ua">подарувати троянду</shortDesc>
+  <shortDesc l="en">give a rose</shortDesc>
 </Social>

--- a/socials/ruffle.xml
+++ b/socials/ruffle.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1695" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты ерошишь свои волосы, прикидываясь неврастеником.</msgCharAuto>
-  <msgCharFound>Ты игриво ерошишь волосы $C3.</msgCharFound>
-  <msgCharNoArgument>Кого-то надо тебе.</msgCharNoArgument>
-  <msgCharNotFound>Это трудно сейчас сделать.</msgCharNotFound>
-  <msgOthersAuto>$c1 ерошит свои волосы - явно не хватает {BHead{x &amp; {YShoulders{x!</msgOthersAuto>
-  <msgOthersFound>$c1 игриво ерошит волосы $C3.</msgOthersFound>
+  <msgCharAuto l="ru">Ты ерошишь свои волосы, прикидываясь неврастеником.</msgCharAuto>
+  <msgCharAuto l="ua">Ти куйовдиш своє волосся, вдаючи неврастеніка.</msgCharAuto>
+  <msgCharAuto l="en">You ruffle your hair, playing the neurotic.</msgCharAuto>
+  <msgCharFound l="ru">Ты игриво ерошишь волосы $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти грайливо куйовдиш волосся $C3.</msgCharFound>
+  <msgCharFound l="en">You ruffle $C1's hair playfully.</msgCharFound>
+  <msgCharNoArgument l="ru">Кого-то надо тебе.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Когось тобі треба.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You have got to ruffle SOMEONE.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Это трудно сейчас сделать.</msgCharNotFound>
+  <msgCharNotFound l="ua">Це важко зараз зробити.</msgCharNotFound>
+  <msgCharNotFound l="en">That would be difficult right now.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 ерошит свои волосы - явно не хватает {BHead{x &amp; {YShoulders{x!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 куйовдить своє волосся -- явно бракує {BHead{x &amp; {YShoulders{x!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 ruffles that hair -- clearly short on {BHead{x &amp; {YShoulders{x!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 игриво ерошит волосы $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 грайливо куйовдить волосся $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 ruffles $C1's hair playfully.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 игриво ерошит твои волосы.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 игриво ерошит твои волосы.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 грайливо куйовдить твоє волосся.</msgVictimFound>
+  <msgVictimFound l="en">$c1 ruffles your hair playfully.</msgVictimFound>
   <position>rest</position>
   <rusName>ерошить</rusName>
   <uaName>куйовдити</uaName>
-  <shortDesc>ерошить шевелюру - свою или чужую</shortDesc>
+  <shortDesc l="ru">ерошить шевелюру - свою или чужую</shortDesc>
+  <shortDesc l="ua">куйовдити чуприну -- свою або чужу</shortDesc>
+  <shortDesc l="en">ruffle a head of hair -- yours or somebody else's</shortDesc>
 </Social>

--- a/socials/sage.xml
+++ b/socials/sage.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты киваешь с мудрым видом.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты киваешь с мудрым видом.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти киваєш з мудрим виглядом.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You nod sagely.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 кивает с мудрым видом.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 кивает с мудрым видом.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 киває з мудрим виглядом.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 nods sagely.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>мудро</rusName>
   <uaName>мудро</uaName>
-  <shortDesc>кивать с мудрым видом</shortDesc>
+  <shortDesc l="ru">кивать с мудрым видом</shortDesc>
+  <shortDesc l="ua">кивати з мудрим виглядом</shortDesc>
+  <shortDesc l="en">nod sagely</shortDesc>
 </Social>

--- a/socials/scream.xml
+++ b/socials/scream.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1596" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты истошно ревешь на себя. Да... так можно снимать стрессы!</msgCharAuto>
-  <msgCharFound>ARRRRRRRRRRGH!!!!! Да! Это ошибка $C2!!!</msgCharFound>
-  <msgCharNoArgument>ARRRRRRRRRRGH!!!!!</msgCharNoArgument>
-  <msgCharNotFound>Твои легкие не вдохнут столько воздуха!</msgCharNotFound>
-  <msgOthersAuto>$c1 истошно ревет на себя! Разве сейчас полная луна на небе?</msgOthersAuto>
-  <msgOthersFound>$c1 истошно ревет на $C4. Лучше уйти, пока $c1 не обвинил$gо||а во всем и тебя!!!</msgOthersFound>
-  <msgOthersNoArgument>ARRRRRRRRRRGH!!!!! - ревет $c1.</msgOthersNoArgument>
-  <msgVictimFound>$c1 истошно ревет на тебя! Как некрасиво! *sniff*</msgVictimFound>
+  <msgCharAuto l="ru">Ты истошно ревешь на себя. Да... так можно снимать стрессы!</msgCharAuto>
+  <msgCharAuto l="ua">Ти несамовито ревеш на себе. Так... так можна знімати стреси!</msgCharAuto>
+  <msgCharAuto l="en">You scream at yourself. Yes, that's ONE way of relieving tension!</msgCharAuto>
+  <msgCharFound l="ru">ARRRRRRRRRRGH!!!!! Да! Это ошибка $C2!!!</msgCharFound>
+  <msgCharFound l="ua">ARRRRRRRRRRGH!!!!! Так! Це помилка $C2!!!</msgCharFound>
+  <msgCharFound l="en">ARRRRRRRRRRGH!!!!! Yes! It was $C1's fault!!!</msgCharFound>
+  <msgCharNoArgument l="ru">ARRRRRRRRRRGH!!!!!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">ARRRRRRRRRRGH!!!!!</msgCharNoArgument>
+  <msgCharNoArgument l="en">ARRRRRRRRRRGH!!!!!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Твои легкие не вдохнут столько воздуха!</msgCharNotFound>
+  <msgCharNotFound l="ua">Твої легені не вдихнуть стільки повітря!</msgCharNotFound>
+  <msgCharNotFound l="en">Your lungs cannot take in that much air!</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 истошно ревет на себя! Разве сейчас полная луна на небе?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 несамовито реве на себе! Хіба зараз повний місяць на небі?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 screams loudly at $gitself|himself|herself|themselves! Is there a full moon up?</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 истошно ревет на $C4. Лучше уйти, пока $c1 не обвинил$gо||а во всем и тебя!!!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 несамовито реве на $C4. Краще піти, поки $c1 не звинувати$gло|в|ла в усьому і тебе!!!</msgOthersFound>
+  <msgOthersFound l="en">$c1 screams loudly at $C1. Better leave before $c1 blames you, too!!!</msgOthersFound>
+  <msgOthersNoArgument l="ru">ARRRRRRRRRRGH!!!!! - ревет $c1.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">ARRRRRRRRRRGH!!!!! -- реве $c1.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">ARRRRRRRRRRGH!!!!! -- roars $c1.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 истошно ревет на тебя! Как некрасиво! *sniff*</msgVictimFound>
+  <msgVictimFound l="ua">$c1 несамовито реве на тебе! Як негарно! *sniff*</msgVictimFound>
+  <msgVictimFound l="en">$c1 screams at you! That's not nice! *sniff*</msgVictimFound>
   <position>rest</position>
   <rusName>вопль</rusName>
   <uaName>лемент</uaName>
-  <shortDesc>истошно реветь в ярости</shortDesc>
+  <shortDesc l="ru">истошно реветь в ярости</shortDesc>
+  <shortDesc l="ua">несамовито ревти в люті</shortDesc>
+  <shortDesc l="en">scream your head off in rage</shortDesc>
 </Social>

--- a/socials/sexplode.xml
+++ b/socials/sexplode.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1742" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты бесишься, но это быстро проходит.</msgCharAuto>
-  <msgCharFound>Твоя ярость находит выход!</msgCharFound>
-  <msgCharNoArgument>Кровь вскипает в твоих венах!</msgCharNoArgument>
-  <msgCharNotFound>Попуск :) их нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 разорвало от ярости!!! Только кучка тряпья и железа осталась на $s месте.</msgOthersAuto>
-  <msgOthersFound>$c1 прожигает тело $C2 своей неудержимой яростью!</msgOthersFound>
-  <msgOthersNoArgument>$c1 багровеет, стремясь сдержать свою ярость.</msgOthersNoArgument>
-  <msgVictimFound>$c1 начинает злиться на тебя... Скорее прочь отсюда, а то щас каааак рванет!!!</msgVictimFound>
+  <msgCharAuto l="ru">Ты бесишься, но это быстро проходит.</msgCharAuto>
+  <msgCharAuto l="ua">Ти казишся, але це швидко минає.</msgCharAuto>
+  <msgCharAuto l="en">You seethe, but it passes quickly.</msgCharAuto>
+  <msgCharFound l="ru">Твоя ярость находит выход!</msgCharFound>
+  <msgCharFound l="ua">Твоя лють знаходить вихід!</msgCharFound>
+  <msgCharFound l="en">Your rage finds a way out!</msgCharFound>
+  <msgCharNoArgument l="ru">Кровь вскипает в твоих венах!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кров закипає в твоїх жилах!</msgCharNoArgument>
+  <msgCharNoArgument l="en">The blood boils in your veins!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Попуск :) их нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Попуск :) їх немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Stand down :) they are not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 разорвало от ярости!!! Только кучка тряпья и железа осталась на $s месте.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 розірвало від люті!!! Тільки купка ганчір'я і заліза лишилася на місці.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 was torn apart by sheer rage!!! Only a heap of rags and iron is left on the spot.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 прожигает тело $C2 своей неудержимой яростью!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 пропалює тіло $C2 своєю нестримною люттю!</msgOthersFound>
+  <msgOthersFound l="en">$c1 burns straight through $C1's body with unstoppable rage!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 багровеет, стремясь сдержать свою ярость.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 багровіє, прагнучи стримати свою лють.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 turns crimson, struggling to hold that rage in.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 начинает злиться на тебя... Скорее прочь отсюда, а то щас каааак рванет!!!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 починає злитися на тебе... Швидше геть звідси, а то зараз кааааак рвоне!!!</msgVictimFound>
+  <msgVictimFound l="en">$c1 is starting to get angry at you... Away from here, quick, or it will go BOOOOM!!!</msgVictimFound>
   <position>rest</position>
   <rusName>взрыв</rusName>
   <uaName>вибух</uaName>
-  <shortDesc>беситься или взорваться от ярости</shortDesc>
+  <shortDesc l="ru">беситься или взорваться от ярости</shortDesc>
+  <shortDesc l="ua">казитися або вибухнути від люті</shortDesc>
+  <shortDesc l="en">seethe, or explode with rage</shortDesc>
 </Social>

--- a/socials/shake.xml
+++ b/socials/shake.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1817" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты трясешься.</msgCharAuto>
-  <msgCharFound>Ты пожимаешь руку $C2.</msgCharFound>
-  <msgCharNoArgument>Ты хватаешься за голову.</msgCharNoArgument>
-  <msgCharNotFound>Этой персоны тут не видно.</msgCharNotFound>
-  <msgOthersAuto>$c1 трясется и колыхается, как кусок холодца.</msgOthersAuto>
-  <msgOthersFound>$c1 пожимает руку $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 хватается за голову.</msgOthersNoArgument>
-  <msgVictimFound>$c1 пожимает твою руку.</msgVictimFound>
+  <msgCharAuto l="ru">Ты трясешься.</msgCharAuto>
+  <msgCharAuto l="ua">Ти трясешся.</msgCharAuto>
+  <msgCharAuto l="en">You are shaking.</msgCharAuto>
+  <msgCharFound l="ru">Ты пожимаешь руку $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти потискаєш руку $C2.</msgCharFound>
+  <msgCharFound l="en">You shake $C1's hand.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты хватаешься за голову.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти хапаєшся за голову.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You clutch your head.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Этой персоны тут не видно.</msgCharNotFound>
+  <msgCharNotFound l="ua">Цієї персони тут не видно.</msgCharNotFound>
+  <msgCharNotFound l="en">That person is nowhere in sight.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 трясется и колыхается, как кусок холодца.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 трясеться і колихається, як шматок холодцю.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 shakes and quivers like a bowl full of jelly.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 пожимает руку $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 потискає руку $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 shakes $C1's hand.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 хватается за голову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 хапається за голову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 clutches $gits|his|her|their head.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 пожимает твою руку.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 потискає твою руку.</msgVictimFound>
+  <msgVictimFound l="en">$c1 shakes your hand.</msgVictimFound>
   <position>rest</position>
   <rusName>пожать</rusName>
   <uaName>потиснути</uaName>
-  <shortDesc>пожать руку или схватиться за голову</shortDesc>
+  <shortDesc l="ru">пожать руку или схватиться за голову</shortDesc>
+  <shortDesc l="ua">потиснути руку або схопитися за голову</shortDesc>
+  <shortDesc l="en">shake hands, or clutch your head</shortDesc>
 </Social>

--- a/socials/shrug.xml
+++ b/socials/shrug.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1803" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты пожимаешь плечами, поправляя свою кепку.</msgCharAuto>
-  <msgCharFound>Ты пожимаешь плечами, глядя на $X.</msgCharFound>
-  <msgCharNoArgument>Ты пожимаешь плечами.</msgCharNoArgument>
-  <msgCharNotFound>Ты пожимаешь плечами отсутствующему персонажу.</msgCharNotFound>
-  <msgOthersAuto>$c1 пожимает плечами, оглядывая себя. Странная личность, весьма.</msgOthersAuto>
-  <msgOthersFound>$c1 пожимает плечами, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 беспомощно пожимает плечами.</msgOthersNoArgument>
-  <msgVictimFound>$c1 пожимает плечами, глядя на тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты пожимаешь плечами, поправляя свою кепку.</msgCharAuto>
+  <msgCharAuto l="ua">Ти знизуєш плечима, поправляючи свого кашкета.</msgCharAuto>
+  <msgCharAuto l="en">You shrug to yourself, straightening your cap.</msgCharAuto>
+  <msgCharFound l="ru">Ты пожимаешь плечами, глядя на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти знизуєш плечима, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You shrug in response to $C1's question.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты пожимаешь плечами.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти знизуєш плечима.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You shrug.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты пожимаешь плечами отсутствующему персонажу.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти знизуєш плечима відсутньому персонажу.</msgCharNotFound>
+  <msgCharNotFound l="en">You shrug at a character who is not there.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 пожимает плечами, оглядывая себя. Странная личность, весьма.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 знизує плечима, оглядаючи себе. Дивна особа, вельми.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 shrugs while looking $gitself|himself|herself|themselves over. A strange person indeed.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 пожимает плечами, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 знизує плечима, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 shrugs in response to $C1's question.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 беспомощно пожимает плечами.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 безпорадно знизує плечима.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 shrugs helplessly.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 пожимает плечами, глядя на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 знизує плечима, дивлячись на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 shrugs in response to your question.</msgVictimFound>
   <position>rest</position>
   <rusName>плечи</rusName>
   <uaName>плечі</uaName>
-  <shortDesc>недоуменно пожать плечами</shortDesc>
+  <shortDesc l="ru">недоуменно пожать плечами</shortDesc>
+  <shortDesc l="ua">здивовано знизати плечима</shortDesc>
+  <shortDesc l="en">shrug in puzzlement</shortDesc>
 </Social>

--- a/socials/sigh.xml
+++ b/socials/sigh.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1707" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты вздыхаешь сам$gо||а себе. Должно быть, ты очень одинок$gо||а.</msgCharAuto>
-  <msgCharFound>Ты вздыхаешь, думая о $Z.</msgCharFound>
-  <msgCharNoArgument>Ты вздыхаешь.</msgCharNoArgument>
-  <msgCharNotFound>Ты очень тоскуешь, не видя друга рядом.</msgCharNotFound>
-  <msgOthersAuto>$c1 вздыхает сам$gо||а себе. Это заслуживает сожаления.</msgOthersAuto>
-  <msgOthersFound>$c1 вздыхает, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 вздыхает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 вздыхает... думая о тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты вздыхаешь сам$gо||а себе. Должно быть, ты очень одинок$gо||а.</msgCharAuto>
+  <msgCharAuto l="ua">Ти зітхаєш сам$gе|ий|а до себе. Мабуть, ти дуже самотн$gє|ій|я.</msgCharAuto>
+  <msgCharAuto l="en">You sigh at yourself. You MUST be lonely.</msgCharAuto>
+  <msgCharFound l="ru">Ты вздыхаешь, думая о $Z.</msgCharFound>
+  <msgCharFound l="ua">Ти зітхаєш, думаючи про $C4.</msgCharFound>
+  <msgCharFound l="en">You sigh as you think of $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты вздыхаешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти зітхаєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You sigh.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты очень тоскуешь, не видя друга рядом.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти дуже сумуєш, не бачачи друга поруч.</msgCharNotFound>
+  <msgCharNotFound l="en">You pine away, with no friend in sight.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 вздыхает сам$gо||а себе. Это заслуживает сожаления.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 зітхає сам$gе|ий|а до себе. Це заслуговує на жаль.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 sighs at $gitself|himself|herself|themselves. What a sorry sight.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 вздыхает, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 зітхає, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sighs at the sight of $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вздыхает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 зітхає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 sighs.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 вздыхает... думая о тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 зітхає... думаючи про тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 sighs... thinking of you. Touching, huh?</msgVictimFound>
   <position>rest</position>
   <rusName>вздох</rusName>
   <uaName>зітхання</uaName>
-  <shortDesc>вздохнуть или вздохнуть, думая о ком-либо</shortDesc>
+  <shortDesc l="ru">вздохнуть или вздохнуть, думая о ком-либо</shortDesc>
+  <shortDesc l="ua">зітхнути або зітхнути, думаючи про когось</shortDesc>
+  <shortDesc l="en">sigh, possibly over somebody</shortDesc>
 </Social>

--- a/socials/sing.xml
+++ b/socials/sing.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1792" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты напеваешь сам$gо||а себе странный мотивчик.</msgCharAuto>
-  <msgCharFound>Ты поешь балладу для $X.</msgCharFound>
-  <msgCharNoArgument>Ты поешь своим чистым (?) голосом песню небес.</msgCharNoArgument>
-  <msgCharNotFound>Тебе некому тут спеть.</msgCharNotFound>
-  <msgOthersAuto>$c1 напевает себе под нос какую-то песенку.</msgOthersAuto>
-  <msgOthersFound>$c1 поет балладу для $C2.</msgOthersFound>
-  <msgOthersNoArgument>{gЭЙ ДОКТОРА! ВЫЛЕЧИТЕ МЕНЯ!{x $c1 начинает петь.</msgOthersNoArgument>
-  <msgVictimFound>$c1 поет для тебя балладу! Как мило!</msgVictimFound>
+  <msgCharAuto l="ru">Ты напеваешь сам$gо||а себе странный мотивчик.</msgCharAuto>
+  <msgCharAuto l="ua">Ти наспівуєш сам$gе|ий|а собі дивний мотивчик.</msgCharAuto>
+  <msgCharAuto l="en">You sing a strange little ditty to yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты поешь балладу для $X.</msgCharFound>
+  <msgCharFound l="ua">Ти співаєш баладу для $C2.</msgCharFound>
+  <msgCharFound l="en">You sing a ballad to $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты поешь своим чистым (?) голосом песню небес.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти співаєш своїм чистим (?) голосом пісню небес.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You raise your clear (?) voice in a song of the heavens.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Тебе некому тут спеть.</msgCharNotFound>
+  <msgCharNotFound l="ua">Тобі нема кому тут заспівати.</msgCharNotFound>
+  <msgCharNotFound l="en">There is nobody here to sing to.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 напевает себе под нос какую-то песенку.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 наспівує собі під ніс якусь пісеньку.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 sings a little ditty to $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 поет балладу для $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 співає баладу для $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sings a ballad to $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">{gЭЙ ДОКТОРА! ВЫЛЕЧИТЕ МЕНЯ!{x $c1 начинает петь.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">{gГЕЙ ЛІКАРІ! ВИЛІКУЙТЕ МЕНЕ!{x $c1 починає співати.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">{gHEY CLERICS! I COULD USE A HEAL!{x $c1 has begun to sing.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 поет для тебя балладу! Как мило!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 співає для тебе баладу! Як мило!</msgVictimFound>
+  <msgVictimFound l="en">$c1 sings a ballad to you! How sweet!</msgVictimFound>
   <position>rest</position>
   <rusName>спеть</rusName>
   <uaName>заспівати</uaName>
-  <shortDesc>напевать под нос или исполнить песню для кого-либо</shortDesc>
+  <shortDesc l="ru">напевать под нос или исполнить песню для кого-либо</shortDesc>
+  <shortDesc l="ua">наспівувати під ніс або виконати пісню для когось</shortDesc>
+  <shortDesc l="en">hum to yourself, or sing a song for somebody</shortDesc>
 </Social>

--- a/socials/smile.xml
+++ b/socials/smile.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1741" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты улыбаешься чему-то своему.</msgCharAuto>
-  <msgCharFound>Ты улыбаешься $M.</msgCharFound>
-  <msgCharNoArgument>Ты счастливо улыбаешься.</msgCharNoArgument>
-  <msgCharNotFound>Никого нет здесь с таким именем.</msgCharNotFound>
-  <msgOthersAuto>$c1 улыбается чему-то своему.</msgOthersAuto>
-  <msgOthersFound>$c1 дарит улыбку $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 счастливо улыбается.</msgOthersNoArgument>
-  <msgVictimFound>$c1 улыбается тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты улыбаешься чему-то своему.</msgCharAuto>
+  <msgCharAuto l="ua">Ти усміхаєшся чомусь своєму.</msgCharAuto>
+  <msgCharAuto l="en">You smile at some private thought.</msgCharAuto>
+  <msgCharFound l="ru">Ты улыбаешься $M.</msgCharFound>
+  <msgCharFound l="ua">Ти усміхаєшся $C3.</msgCharFound>
+  <msgCharFound l="en">You smile at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты счастливо улыбаешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти щасливо усміхаєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You smile happily.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Никого нет здесь с таким именем.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нікого немає тут з таким ім'ям.</msgCharNotFound>
+  <msgCharNotFound l="en">There's no one by that name around.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 улыбается чему-то своему.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 усміхається чомусь своєму.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 smiles at some private thought.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 дарит улыбку $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дарує усмішку $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 beams a smile at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 счастливо улыбается.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 щасливо усміхається.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 smiles happily.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 улыбается тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 усміхається тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 smiles at you.</msgVictimFound>
   <position>rest</position>
   <rusName>улыбка</rusName>
   <uaName>усмішка</uaName>
-  <shortDesc>просто улыбнуться</shortDesc>
+  <shortDesc l="ru">просто улыбнуться</shortDesc>
+  <shortDesc l="ua">просто усміхнутися</shortDesc>
+  <shortDesc l="en">just smile</shortDesc>
 </Social>

--- a/socials/smirk.xml
+++ b/socials/smirk.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1764" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты самодовольно ухмыляешься себе, да, крутизна</msgCharAuto>
-  <msgCharFound>Ты самодовольно ухмыляешься $M в ответ.</msgCharFound>
-  <msgCharNoArgument>Ты самодовольно ухмыляешься.</msgCharNoArgument>
-  <msgCharNotFound>Самодовольно ухмыльнуться кому?</msgCharNotFound>
-  <msgOthersAuto>$c1 самодовольно ухмыляется собственной &quot;мудрости&quot;.</msgOthersAuto>
-  <msgOthersFound>$c1 самодовольно ухмыляется в ответ $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 самодовольно ухмыляется.</msgOthersNoArgument>
-  <msgVictimFound>$c1 самодовольно ухмыляется тебе в ответ.</msgVictimFound>
+  <msgCharAuto l="ru">Ты самодовольно ухмыляешься себе, да, крутизна</msgCharAuto>
+  <msgCharAuto l="ua">Ти самовдоволено посміхаєшся собі, так, крутизна</msgCharAuto>
+  <msgCharAuto l="en">You smirk at yourself. Yes, very cool.</msgCharAuto>
+  <msgCharFound l="ru">Ты самодовольно ухмыляешься $M в ответ.</msgCharFound>
+  <msgCharFound l="ua">Ти самовдоволено посміхаєшся $C3 у відповідь.</msgCharFound>
+  <msgCharFound l="en">You smirk at what $C1 said.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты самодовольно ухмыляешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти самовдоволено посміхаєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You smirk.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Самодовольно ухмыльнуться кому?</msgCharNotFound>
+  <msgCharNotFound l="ua">Самовдоволено посміхнутися кому?</msgCharNotFound>
+  <msgCharNotFound l="en">You want to smirk at whom?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 самодовольно ухмыляется собственной &quot;мудрости&quot;.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 самовдоволено посміхається власній "мудрості".</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 smirks at $gits|his|her|their own 'wisdom'.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 самодовольно ухмыляется в ответ $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 самовдоволено посміхається у відповідь $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 smirks at what $C1 said.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 самодовольно ухмыляется.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 самовдоволено посміхається.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 smirks.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 самодовольно ухмыляется тебе в ответ.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 самовдоволено посміхається тобі у відповідь.</msgVictimFound>
+  <msgVictimFound l="en">$c1 smirks at what you said.</msgVictimFound>
   <position>rest</position>
   <rusName>хы</rusName>
   <uaName>хи</uaName>
-  <shortDesc>самодовольно ухмыльнуться</shortDesc>
+  <shortDesc l="ru">самодовольно ухмыльнуться</shortDesc>
+  <shortDesc l="ua">самовдоволено посміхнутися</shortDesc>
+  <shortDesc l="en">smirk smugly</shortDesc>
 </Social>

--- a/socials/sneeze.xml
+++ b/socials/sneeze.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>(*)(*)(*) Апппччхххиии! (*)(*)(*) - у тебя лопнула подтяжка на леггинсах!</msgCharNoArgument>
+  <msgCharNoArgument l="ru">(*)(*)(*) Апппччхххиии! (*)(*)(*) - у тебя лопнула подтяжка на леггинсах!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">(*)(*)(*) Аппппчхиии! (*)(*)(*) -- у тебе луснула шлейка на легінсах!</msgCharNoArgument>
+  <msgCharNoArgument l="en">(*)(*)(*) Aaaachooo! (*)(*)(*) -- there goes the strap on your leggings!</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 чихает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 чихает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 чхає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 sneezes.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>чих</rusName>
   <uaName>чхання</uaName>
-  <shortDesc>чихать</shortDesc>
+  <shortDesc l="ru">чихать</shortDesc>
+  <shortDesc l="ua">чхати</shortDesc>
+  <shortDesc l="en">sneeze</shortDesc>
 </Social>

--- a/socials/snicker.xml
+++ b/socials/snicker.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1809" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тихонько хихикаешь, радуясь своим умыслам.</msgCharAuto>
-  <msgCharFound>Ты тихонько хихикаешь, секретничая с $C5.</msgCharFound>
-  <msgCharNoArgument>Ты тихонько хихикаешь.</msgCharNoArgument>
-  <msgCharNotFound>Хех?</msgCharNotFound>
-  <msgOthersAuto>$c1 тихонько хихикает, радуясь $s умыслам.</msgOthersAuto>
-  <msgOthersFound>$c1 тихонько хихикает, секретничая с $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 тихонько хихикает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 тихонько хихикает с тобой, секретничая.</msgVictimFound>
+  <msgCharAuto l="ru">Ты тихонько хихикаешь, радуясь своим умыслам.</msgCharAuto>
+  <msgCharAuto l="ua">Ти тихенько хихочеш, радіючи своїм задумам.</msgCharAuto>
+  <msgCharAuto l="en">You snicker quietly, pleased with your own scheming.</msgCharAuto>
+  <msgCharFound l="ru">Ты тихонько хихикаешь, секретничая с $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти тихенько хихочеш, секретничаючи з $C5.</msgCharFound>
+  <msgCharFound l="en">You snicker with $C1 about your shared secret.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты тихонько хихикаешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти тихенько хихочеш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You snicker softly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Хех?</msgCharNotFound>
+  <msgCharNotFound l="ua">Хех?</msgCharNotFound>
+  <msgCharNotFound l="en">Huh?</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 тихонько хихикает, радуясь $s умыслам.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 тихенько хихоче, радіючи своїм задумам.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 snickers quietly at some private scheme.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 тихонько хихикает, секретничая с $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 тихенько хихоче, секретничаючи з $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 snickers with $C1 about their shared secret.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 тихонько хихикает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 тихенько хихоче.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 snickers softly.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 тихонько хихикает с тобой, секретничая.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 тихенько хихоче з тобою, секретничаючи.</msgVictimFound>
+  <msgVictimFound l="en">$c1 snickers with you about your shared secret.</msgVictimFound>
   <position>rest</position>
   <rusName>хихикать</rusName>
   <uaName>хихотіти</uaName>
-  <shortDesc>тихонько хихикать или секретничать</shortDesc>
+  <shortDesc l="ru">тихонько хихикать или секретничать</shortDesc>
+  <shortDesc l="ua">тихенько хихотіти або секретничати</shortDesc>
+  <shortDesc l="en">snicker softly, or share a secret</shortDesc>
 </Social>

--- a/socials/snore.xml
+++ b/socials/snore.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Хррррр... пс-пс-пс-пссс...</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Хррррр... пс-пс-пс-пссс...</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Хррррр... пс-пс-пс-пссс...</msgCharNoArgument>
+  <msgCharNoArgument l="en">Zzzzzzz... psh-psh-psh-pshhh...</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 громко храпит.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 громко храпит.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 гучно хропе.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 snores loudly.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>sleep</position>
   <rusName>храп</rusName>
   <uaName>хропіння</uaName>
-  <shortDesc>громко храпеть</shortDesc>
+  <shortDesc l="ru">громко храпеть</shortDesc>
+  <shortDesc l="ua">гучно хропти</shortDesc>
+  <shortDesc l="en">snore loudly</shortDesc>
 </Social>

--- a/socials/snort.xml
+++ b/socials/snort.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1832" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты насмешливо фыркаешь на себя.</msgCharAuto>
-  <msgCharFound>Ты насмешливо фыркаешь на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты насмешливо фыркаешь.</msgCharNoArgument>
-  <msgCharNotFound>Фыркни пока в платочек :)</msgCharNotFound>
-  <msgOthersAuto>$c1 насмешливо фыркает на себя.</msgOthersAuto>
-  <msgOthersFound>$c1 насмешливо фыркает на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 насмешливо фыркает.</msgOthersNoArgument>
-  <msgVictimFound>$c1 насмешливо фыркает на тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты насмешливо фыркаешь на себя.</msgCharAuto>
+  <msgCharAuto l="ua">Ти глузливо пирхаєш на себе.</msgCharAuto>
+  <msgCharAuto l="en">You snort derisively at yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты насмешливо фыркаешь на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти глузливо пирхаєш на $C4.</msgCharFound>
+  <msgCharFound l="en">You snort derisively at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты насмешливо фыркаешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти глузливо пирхаєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You snort derisively.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Фыркни пока в платочек :)</msgCharNotFound>
+  <msgCharNotFound l="ua">Пирхни поки що в хустинку :)</msgCharNotFound>
+  <msgCharNotFound l="en">Snort into a handkerchief for now :)</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 насмешливо фыркает на себя.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 глузливо пирхає на себе.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 snorts derisively at $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 насмешливо фыркает на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 глузливо пирхає на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 snorts derisively at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 насмешливо фыркает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 глузливо пирхає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 snorts derisively.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 насмешливо фыркает на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 глузливо пирхає на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 snorts derisively at you.</msgVictimFound>
   <position>rest</position>
   <rusName>фыркать</rusName>
   <uaName>пирхати</uaName>
-  <shortDesc>насмешливо фыркнуть</shortDesc>
+  <shortDesc l="ru">насмешливо фыркнуть</shortDesc>
+  <shortDesc l="ua">глузливо пирхнути</shortDesc>
+  <shortDesc l="en">snort derisively</shortDesc>
 </Social>

--- a/socials/sob.xml
+++ b/socials/sob.xml
@@ -3,15 +3,27 @@
   <help id="1716" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты тихо рыдаешь, потому что $C1 причинил$Gо||а тебе такую боль!</msgCharFound>
-  <msgCharNoArgument>Ты тихо всхлипываешь от горя.</msgCharNoArgument>
+  <msgCharFound l="ru">Ты тихо рыдаешь, потому что $C1 причинил$Gо||а тебе такую боль!</msgCharFound>
+  <msgCharFound l="ua">Ти тихо ридаєш, бо $C1 $Gзавдало|завдав|завдала|завдали тобі такого болю!</msgCharFound>
+  <msgCharFound l="en">You sob quietly, because $C1 has hurt you so badly!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты тихо всхлипываешь от горя.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти тихо схлипуєш від горя.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You sob quietly with grief.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 тихо рыдает из-за $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 рыдает в печали.</msgOthersNoArgument>
-  <msgVictimFound>Ты чувствуешь себя последним ничтожеством, так как из-за тебя рыдает $c1.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 тихо рыдает из-за $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 тихо ридає через $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sobs quietly because of $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 рыдает в печали.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 ридає в печалі.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 sobs in misery.</msgOthersNoArgument>
+  <msgVictimFound l="ru">Ты чувствуешь себя последним ничтожеством, так как из-за тебя рыдает $c1.</msgVictimFound>
+  <msgVictimFound l="ua">Ти почуваєшся останнім нікчемою, бо через тебе ридає $c1.</msgVictimFound>
+  <msgVictimFound l="en">You feel like an utter cad -- $c1 is sobbing because of you.</msgVictimFound>
   <position>rest</position>
   <rusName>рыдать</rusName>
   <uaName>ридати</uaName>
-  <shortDesc>рыдать или плакать из-за кого-либо</shortDesc>
+  <shortDesc l="ru">рыдать или плакать из-за кого-либо</shortDesc>
+  <shortDesc l="ua">ридати або плакати через когось</shortDesc>
+  <shortDesc l="en">sob, or weep over somebody</shortDesc>
 </Social>

--- a/socials/spank.xml
+++ b/socials/spank.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1632" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты шлепаешь себя. Хммм.</msgCharAuto>
-  <msgCharFound>Ты игриво шлепаешь $C4.</msgCharFound>
-  <msgCharNoArgument>Кого-то шлепнуть?</msgCharNoArgument>
-  <msgCharNotFound>И никого...</msgCharNotFound>
-  <msgOthersAuto>$c1 шлепает себя. Хммм.</msgOthersAuto>
-  <msgOthersFound>$c1 игриво шлепает $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Ты шлепаешь себя. Хммм.</msgCharAuto>
+  <msgCharAuto l="ua">Ти шльопаєш себе. Хммм.</msgCharAuto>
+  <msgCharAuto l="en">You spank yourself. Hmmm.</msgCharAuto>
+  <msgCharFound l="ru">Ты игриво шлепаешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти грайливо шльопаєш $C4.</msgCharFound>
+  <msgCharFound l="en">You spank $C1 playfully.</msgCharFound>
+  <msgCharNoArgument l="ru">Кого-то шлепнуть?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Когось шльопнути?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Spank whom?</msgCharNoArgument>
+  <msgCharNotFound l="ru">И никого...</msgCharNotFound>
+  <msgCharNotFound l="ua">І нікого...</msgCharNotFound>
+  <msgCharNotFound l="en">And nobody around...</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 шлепает себя. Хммм.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 шльопає себе. Хммм.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 spanks $gitself|himself|herself|themselves. Hmmm.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 игриво шлепает $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 грайливо шльопає $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 spanks $C1 playfully.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 игриво шлепает тебя. OUCH!</msgVictimFound>
+  <msgVictimFound l="ru">$c1 игриво шлепает тебя. OUCH!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 грайливо шльопає тебе. OUCH!</msgVictimFound>
+  <msgVictimFound l="en">$c1 spanks you playfully. OUCH!</msgVictimFound>
   <position>rest</position>
   <rusName>шлеп</rusName>
   <uaName>ляп</uaName>
-  <shortDesc>игриво шлепнуть кого-либо</shortDesc>
+  <shortDesc l="ru">игриво шлепнуть кого-либо</shortDesc>
+  <shortDesc l="ua">грайливо шльопнути когось</shortDesc>
+  <shortDesc l="en">spank somebody playfully</shortDesc>
 </Social>

--- a/socials/spit.xml
+++ b/socials/spit.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1732" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты плюешь на себя -- довольно неприятно, а?</msgCharAuto>
-  <msgCharFound>Ты плюешь на $C4... твои манеры ужасны!</msgCharFound>
-  <msgCharNoArgument>Ты с отвращением сплевываешь.</msgCharNoArgument>
-  <msgCharNotFound>Твоя жертва не здесь.</msgCharNotFound>
-  <msgOthersAuto>$c1 плюет себе на леггинсы... а ведь их давно стоит постирать!</msgOthersAuto>
-  <msgOthersFound>$c1 плюет на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 с отвращением сплевывает!</msgOthersNoArgument>
-  <msgVictimFound>$c1 плюет на тебя -- как невежливо!</msgVictimFound>
+  <msgCharAuto l="ru">Ты плюешь на себя -- довольно неприятно, а?</msgCharAuto>
+  <msgCharAuto l="ua">Ти плюєш на себе -- досить неприємно, га?</msgCharAuto>
+  <msgCharAuto l="en">You spit on yourself -- pretty nasty, eh?</msgCharAuto>
+  <msgCharFound l="ru">Ты плюешь на $C4... твои манеры ужасны!</msgCharFound>
+  <msgCharFound l="ua">Ти плюєш на $C4... твої манери жахливі!</msgCharFound>
+  <msgCharFound l="en">You spit on $C1... your manners are terrible!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты с отвращением сплевываешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти з відразою спльовуєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You spit in utter disgust.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Твоя жертва не здесь.</msgCharNotFound>
+  <msgCharNotFound l="ua">Твоя жертва не тут.</msgCharNotFound>
+  <msgCharNotFound l="en">Your victim isn't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 плюет себе на леггинсы... а ведь их давно стоит постирать!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 плює собі на легінси... а їх же давно варто випрати!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 spits on those own leggings... which were long overdue for a wash anyway!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 плюет на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 плює на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 spits on $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 с отвращением сплевывает!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 з відразою спльовує!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 spits in utter disgust!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 плюет на тебя -- как невежливо!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 плює на тебе -- як нечемно!</msgVictimFound>
+  <msgVictimFound l="en">$c1 spits on you -- how rude!</msgVictimFound>
   <position>rest</position>
   <rusName>плевать</rusName>
   <uaName>плювати</uaName>
-  <shortDesc>плюнуть на кого-либо или просто на пол</shortDesc>
+  <shortDesc l="ru">плюнуть на кого-либо или просто на пол</shortDesc>
+  <shortDesc l="ua">плюнути на когось або просто на підлогу</shortDesc>
+  <shortDesc l="en">spit on somebody, or just on the floor</shortDesc>
 </Social>

--- a/socials/squeal.xml
+++ b/socials/squeal.xml
@@ -3,15 +3,27 @@
   <help id="1675" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты смотришь на $C4 и взвизгиваешь от восторга!</msgCharFound>
-  <msgCharNoArgument>Ты взвизгиваешь от восторга!</msgCharNoArgument>
+  <msgCharFound l="ru">Ты смотришь на $C4 и взвизгиваешь от восторга!</msgCharFound>
+  <msgCharFound l="ua">Ти дивишся на $C4 і верещиш від захвату!</msgCharFound>
+  <msgCharFound l="en">You look at $C1 and squeal with delight!</msgCharFound>
+  <msgCharNoArgument l="ru">Ты взвизгиваешь от восторга!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти верещиш від захвату!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You squeal with delight!</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 смотрит на $C4 и взвизгивает от восторга!</msgOthersFound>
-  <msgOthersNoArgument>$c1 взвизгивает от восторга!</msgOthersNoArgument>
-  <msgVictimFound>$c1 смотрит на тебя и взвизгивает от восторга!</msgVictimFound>
+  <msgOthersFound l="ru">$c1 смотрит на $C4 и взвизгивает от восторга!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дивиться на $C4 і верещить від захвату!</msgOthersFound>
+  <msgOthersFound l="en">$c1 squeals with delight at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 взвизгивает от восторга!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 верещить від захвату!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 lets out a sudden squeal of delight!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 смотрит на тебя и взвизгивает от восторга!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 дивиться на тебе і верещить від захвату!</msgVictimFound>
+  <msgVictimFound l="en">$c1 looks at you and squeals with delight!</msgVictimFound>
   <position>rest</position>
   <rusName>взвизг</rusName>
   <uaName>вереск</uaName>
-  <shortDesc>визжать от восторга</shortDesc>
+  <shortDesc l="ru">визжать от восторга</shortDesc>
+  <shortDesc l="ua">верещати від захвату</shortDesc>
+  <shortDesc l="en">squeal with delight</shortDesc>
 </Social>

--- a/socials/squeeze.xml
+++ b/socials/squeeze.xml
@@ -2,18 +2,38 @@
 <Social type="Social">
   <help id="1646" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты стискиваешь себя - может просто расслабишься?!</msgCharAuto>
-  <msgCharFound>Ты нежно стискиваешь $S.</msgCharFound>
-  <msgCharNoArgument>Где, что, кого и как???</msgCharNoArgument>
-  <msgCharNotFound>Где, что, кого и как???</msgCharNotFound>
-  <msgCharObj>Ты сжимаешь в руках %2$O4.</msgCharObj>
-  <msgOthersAuto>$c1 стискивает себя.</msgOthersAuto>
-  <msgOthersFound>$c1 нежно стискивает $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Ты стискиваешь себя - может просто расслабишься?!</msgCharAuto>
+  <msgCharAuto l="ua">Ти стискаєш себе -- може, просто розслабишся?!</msgCharAuto>
+  <msgCharAuto l="en">You squeeze yourself -- how about simply relaxing?!</msgCharAuto>
+  <msgCharFound l="ru">Ты нежно стискиваешь $S.</msgCharFound>
+  <msgCharFound l="ua">Ти ніжно стискаєш $C4.</msgCharFound>
+  <msgCharFound l="en">You squeeze $C1 fondly.</msgCharFound>
+  <msgCharNoArgument l="ru">Где, что, кого и как???</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Де, що, кого і як???</msgCharNoArgument>
+  <msgCharNoArgument l="en">Where, what, how, WHO???</msgCharNoArgument>
+  <msgCharNotFound l="ru">Где, что, кого и как???</msgCharNotFound>
+  <msgCharNotFound l="ua">Де, що, кого і як???</msgCharNotFound>
+  <msgCharNotFound l="en">Where, what, how, WHO???</msgCharNotFound>
+  <msgCharObj l="ru">Ты сжимаешь в руках %2$O4.</msgCharObj>
+  <msgCharObj l="ua">Ти стискаєш у руках %2$O4.</msgCharObj>
+  <msgCharObj l="en">You squeeze %2$O4 in your hands.</msgCharObj>
+  <msgOthersAuto l="ru">$c1 стискивает себя.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 стискає себе.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 squeezes $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 нежно стискивает $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 ніжно стискає $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 squeezes $C1 fondly.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgOthersObj>%1$^C1 сжимает в руках %2$O4.</msgOthersObj>
-  <msgVictimFound>$c1 нежно стискивает тебя.</msgVictimFound>
+  <msgOthersObj l="ru">%1$^C1 сжимает в руках %2$O4.</msgOthersObj>
+  <msgOthersObj l="ua">%1$^C1 стискає в руках %2$O4.</msgOthersObj>
+  <msgOthersObj l="en">%1$^C1 squeezes %2$O4 in those hands.</msgOthersObj>
+  <msgVictimFound l="ru">$c1 нежно стискивает тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 ніжно стискає тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 squeezes you fondly.</msgVictimFound>
   <position>rest</position>
   <rusName>тискать</rusName>
   <uaName>стискати</uaName>
-  <shortDesc>зажимать или тискать кого-либо</shortDesc>
+  <shortDesc l="ru">зажимать или тискать кого-либо</shortDesc>
+  <shortDesc l="ua">затискати або тискати когось</shortDesc>
+  <shortDesc l="en">squeeze somebody tight</shortDesc>
 </Social>

--- a/socials/stare.xml
+++ b/socials/stare.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1701" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты мечтательно смотришь на себя - ну и самовлюбленность!</msgCharAuto>
-  <msgCharFound>Ты мечтательно смотришь на $C4, теряясь в $S глазах..</msgCharFound>
-  <msgCharNoArgument>Ты глазеешь на небо.</msgCharNoArgument>
-  <msgCharNotFound>Ты глядишь и глядишь, а этой персоны все еще здесь нет...</msgCharNotFound>
-  <msgOthersAuto>$c1 мечтательно смотрит на себя - вот где самовлюбленность-то!</msgOthersAuto>
-  <msgOthersFound>$c1 мечтательно смотрит на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 глазеет в небо.</msgOthersNoArgument>
-  <msgVictimFound>$c1 мечтательно смотрит на тебя, теряясь в твоих глазах...</msgVictimFound>
+  <msgCharAuto l="ru">Ты мечтательно смотришь на себя - ну и самовлюбленность!</msgCharAuto>
+  <msgCharAuto l="ua">Ти мрійливо дивишся на себе -- ото самозакоханість!</msgCharAuto>
+  <msgCharAuto l="en">You stare dreamily at yourself -- what narcissism!</msgCharAuto>
+  <msgCharFound l="ru">Ты мечтательно смотришь на $C4, теряясь в $S глазах..</msgCharFound>
+  <msgCharFound l="ua">Ти мрійливо дивишся на $C4, гублячись в очах..</msgCharFound>
+  <msgCharFound l="en">You stare dreamily at $C1, completely lost in those eyes..</msgCharFound>
+  <msgCharNoArgument l="ru">Ты глазеешь на небо.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти витріщаєшся на небо.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You stare at the sky.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты глядишь и глядишь, а этой персоны все еще здесь нет...</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти дивишся і дивишся, а цієї персони все ще тут немає...</msgCharNotFound>
+  <msgCharNotFound l="en">You stare and stare, but that person still isn't here...</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 мечтательно смотрит на себя - вот где самовлюбленность-то!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 мрійливо дивиться на себе -- ось де самозакоханість!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 stares dreamily at $gitself|himself|herself|themselves -- NARCISSIST!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 мечтательно смотрит на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 мрійливо дивиться на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 stares dreamily at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 глазеет в небо.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 витріщається в небо.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 stares at the sky.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 мечтательно смотрит на тебя, теряясь в твоих глазах...</msgVictimFound>
+  <msgVictimFound l="ua">$c1 мрійливо дивиться на тебе, гублячись у твоїх очах...</msgVictimFound>
+  <msgVictimFound l="en">$c1 stares dreamily at you, completely lost in your eyes...</msgVictimFound>
   <position>rest</position>
   <rusName>пристально</rusName>
   <uaName>пильно</uaName>
-  <shortDesc>глазеть на небо. смотреть в чьи-то глаза:)</shortDesc>
+  <shortDesc l="ru">глазеть на небо. смотреть в чьи-то глаза:)</shortDesc>
+  <shortDesc l="ua">витріщатися на небо. дивитися в чиїсь очі:)</shortDesc>
+  <shortDesc l="en">stare at the sky, or into somebody's eyes:)</shortDesc>
 </Social>

--- a/socials/starve.xml
+++ b/socials/starve.xml
@@ -3,15 +3,29 @@
   <help id="1760" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты просишь у $X хоть кусочек булочки...</msgCharFound>
-  <msgCharNoArgument>Ты светишь ребрами и жалобно гремишь голодными костями.</msgCharNoArgument>
-  <msgCharNotFound>И никто даже ухи не подаст перед голодной смертью...</msgCharNotFound>
+  <msgCharFound l="ru">Ты просишь у $X хоть кусочек булочки...</msgCharFound>
+  <msgCharFound l="ua">Ти просиш у $C2 хоч шматочок булочки...</msgCharFound>
+  <msgCharFound l="en">You beg $C1 for even a crust of bread...</msgCharFound>
+  <msgCharNoArgument l="ru">Ты светишь ребрами и жалобно гремишь голодными костями.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти світиш ребрами і жалібно гримиш голодними кістками.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You show off your ribs and rattle your hungry bones pitifully.</msgCharNoArgument>
+  <msgCharNotFound l="ru">И никто даже ухи не подаст перед голодной смертью...</msgCharNotFound>
+  <msgCharNotFound l="ua">І ніхто навіть юшки не подасть перед голодною смертю...</msgCharNotFound>
+  <msgCharNotFound l="en">And nobody will offer so much as a fish soup before you starve to death...</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 просит $C4 накормить $s. Кто бы мог подумать, что в ДЛ так туго с едой!</msgOthersFound>
-  <msgOthersNoArgument>$c1 помирает, ухи просит!!</msgOthersNoArgument>
-  <msgVictimFound>$c1 умирает от голода прямо у тебя на глазах! Пожалей $s!</msgVictimFound>
+  <msgOthersFound l="ru">$c1 просит $C4 накормить $s. Кто бы мог подумать, что в ДЛ так туго с едой!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 просить $C4 нагодувати. Хто б міг подумати, що в ДЛ так сутужно з їжею!</msgOthersFound>
+  <msgOthersFound l="en">$c1 begs $C1 for food. Who would have thought food was this scarce in DL!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 помирает, ухи просит!!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 помирає, юшки просить!!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 is dying, begging for a bowl of soup!!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 умирает от голода прямо у тебя на глазах! Пожалей $s!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 помирає з голоду просто в тебе на очах! Пожалій!</msgVictimFound>
+  <msgVictimFound l="en">$c1 is starving to death right before your eyes! Have some pity!</msgVictimFound>
   <position>rest</position>
   <rusName>голодать</rusName>
   <uaName>голодувати</uaName>
-  <shortDesc>умирать от голода</shortDesc>
+  <shortDesc l="ru">умирать от голода</shortDesc>
+  <shortDesc l="ua">помирати з голоду</shortDesc>
+  <shortDesc l="en">starve to death</shortDesc>
 </Social>

--- a/socials/stretch.xml
+++ b/socials/stretch.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1828" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты сладко потягиваешься.</msgCharAuto>
-  <msgCharFound>Ты сладко потягиваешься, чтобы $E мог$Gло||ла оценить твое гибкое тело. </msgCharFound>
-  <msgCharNoArgument>Ты потягиваешься.</msgCharNoArgument>
-  <msgCharNotFound>Некому оценить твои потягушки.</msgCharNotFound>
-  <msgOthersAuto>$c1 грациозно потягивается.</msgOthersAuto>
-  <msgOthersFound>$c1 грациозно потягивается, пытаясь произвести впечатление на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 потягивается.</msgOthersNoArgument>
-  <msgVictimFound>$c1 грациозно потягивается, поглядывая на тебя искоса. Ты хочешь $s, не так ли?</msgVictimFound>
+  <msgCharAuto l="ru">Ты сладко потягиваешься.</msgCharAuto>
+  <msgCharAuto l="ua">Ти солодко потягуєшся.</msgCharAuto>
+  <msgCharAuto l="en">You stretch out sweetly.</msgCharAuto>
+  <msgCharFound l="ru">Ты сладко потягиваешься, чтобы $E мог$Gло||ла оценить твое гибкое тело. </msgCharFound>
+  <msgCharFound l="ua">Ти солодко потягуєшся, щоб $C1 $Gмогло|міг|могла|могли оцінити твоє гнучке тіло.</msgCharFound>
+  <msgCharFound l="en">You stretch out sweetly, so that $C1 can appreciate your supple body.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты потягиваешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти потягуєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You lean back and streeeeeettch your arms and legs.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Некому оценить твои потягушки.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нема кому оцінити твої потягусі.</msgCharNotFound>
+  <msgCharNotFound l="en">There is nobody to appreciate your stretching.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 грациозно потягивается.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 граційно потягується.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 stretches gracefully.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 грациозно потягивается, пытаясь произвести впечатление на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 граційно потягується, намагаючись справити враження на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 stretches gracefully, trying to make an impression on $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 потягивается.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 потягується.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 stretches luxuriously. Kind of makes you want to as well, doesn't it?</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 грациозно потягивается, поглядывая на тебя искоса. Ты хочешь $s, не так ли?</msgVictimFound>
+  <msgVictimFound l="ua">$c1 граційно потягується, поглядаючи на тебе скоса. Ти хочеш цього, чи не так?</msgVictimFound>
+  <msgVictimFound l="en">$c1 stretches gracefully, watching you sidelong. You want that, don't you?</msgVictimFound>
   <position>rest</position>
   <rusName>потягиваться</rusName>
   <uaName>потягуватися</uaName>
-  <shortDesc>потянуться</shortDesc>
+  <shortDesc l="ru">потянуться</shortDesc>
+  <shortDesc l="ua">потягнутися</shortDesc>
+  <shortDesc l="en">have a stretch</shortDesc>
 </Social>

--- a/socials/stroke.xml
+++ b/socials/stroke.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1735" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Гм... ты делаешь такие вещи, которых делать не долж$gно|ен|на.</msgCharAuto>
-  <msgCharFound>Ты мягко гладишь $S по бедру, $C1 взволнованно дышит.</msgCharFound>
-  <msgCharNoArgument>Ты плавно гладишь воздух.</msgCharNoArgument>
-  <msgCharNotFound>Попрактикуйся на себе?</msgCharNotFound>
+  <msgCharAuto l="ru">Гм... ты делаешь такие вещи, которых делать не долж$gно|ен|на.</msgCharAuto>
+  <msgCharAuto l="ua">Гм... ти робиш такі речі, яких робити не пови$gнне|нен|нна.</msgCharAuto>
+  <msgCharAuto l="en">Hmm... you are about to do something you would rather not be caught doing.</msgCharAuto>
+  <msgCharFound l="ru">Ты мягко гладишь $S по бедру, $C1 взволнованно дышит.</msgCharFound>
+  <msgCharFound l="ua">Ти м'яко гладиш $C4 по стегну, $C1 схвильовано дихає.</msgCharFound>
+  <msgCharFound l="en">You gently stroke $C1's inner thigh. $C1 inhales sharply.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты плавно гладишь воздух.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти плавно гладиш повітря.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You stroke the air vaguely.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Попрактикуйся на себе?</msgCharNotFound>
+  <msgCharNotFound l="ua">Потренуйся на собі?</msgCharNotFound>
+  <msgCharNotFound l="en">Maybe practice on yourself first?</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 мягко гладит $C4 по бедру, $C1 взволнованно дышит.</msgOthersFound>
-  <msgOthersNoArgument>$c1 делает поглаживающие движения.</msgOthersNoArgument>
-  <msgVictimFound>$c1 мягко гладит твое бедро. Ты взволнованно дышишь.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 мягко гладит $C4 по бедру, $C1 взволнованно дышит.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 м'яко гладить $C4 по стегну, $C1 схвильовано дихає.</msgOthersFound>
+  <msgOthersFound l="en">$c1 gently strokes $C1's inner thigh. $C1 inhales sharply.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 делает поглаживающие движения.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 робить погладжувальні рухи.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 makes vague stroking motions.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 мягко гладит твое бедро. Ты взволнованно дышишь.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 м'яко гладить твоє стегно. Ти схвильовано дихаєш.</msgVictimFound>
+  <msgVictimFound l="en">$c1 gently strokes your inner thigh. You inhale sharply.</msgVictimFound>
   <position>rest</position>
   <rusName>гладить</rusName>
   <uaName>гладити</uaName>
-  <shortDesc>эротично гладить. себя или кого получится</shortDesc>
+  <shortDesc l="ru">эротично гладить. себя или кого получится</shortDesc>
+  <shortDesc l="ua">еротично гладити. себе або кого вийде</shortDesc>
+  <shortDesc l="en">stroke erotically. yourself, or whoever is willing</shortDesc>
 </Social>

--- a/socials/strut.xml
+++ b/socials/strut.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1661" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты важно вышагиваешь, бормоча о своих достоинствах.</msgCharAuto>
-  <msgCharFound>Ты важно вышагиваешь, пытаясь привлечь внимание $C2.</msgCharFound>
-  <msgCharNoArgument>Ты важно вышагиваешь.</msgCharNoArgument>
-  <msgCharNotFound>Лучше бы тебе не шевелиться.</msgCharNotFound>
-  <msgOthersAuto>$c1 важно вышагивает, бормоча о своих достоинствах.</msgOthersAuto>
-  <msgOthersFound>$c1 важно вышагивает, пытаясь привлечь внимание $C2.</msgOthersFound>
-  <msgOthersNoArgument>$c1 важно вышагивает по комнате.</msgOthersNoArgument>
-  <msgVictimFound>$c1 важно вышагивает, пытаясь привлечь твое внимание.</msgVictimFound>
+  <msgCharAuto l="ru">Ты важно вышагиваешь, бормоча о своих достоинствах.</msgCharAuto>
+  <msgCharAuto l="ua">Ти поважно вишаговуєш, бурмочучи про свої чесноти.</msgCharAuto>
+  <msgCharAuto l="en">You strut about, muttering about your own merits.</msgCharAuto>
+  <msgCharFound l="ru">Ты важно вышагиваешь, пытаясь привлечь внимание $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти поважно вишаговуєш, намагаючись привернути увагу $C2.</msgCharFound>
+  <msgCharFound l="en">You strut about, trying to get $C1's attention.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты важно вышагиваешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти поважно вишаговуєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You strut your stuff.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Лучше бы тебе не шевелиться.</msgCharNotFound>
+  <msgCharNotFound l="ua">Краще б тобі не ворушитися.</msgCharNotFound>
+  <msgCharNotFound l="en">Better not to move at all.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 важно вышагивает, бормоча о своих достоинствах.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 поважно вишаговує, бурмочучи про свої чесноти.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 struts about, muttering about $gits|his|her|their own merits.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 важно вышагивает, пытаясь привлечь внимание $C2.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 поважно вишаговує, намагаючись привернути увагу $C2.</msgOthersFound>
+  <msgOthersFound l="en">$c1 struts about, hoping to get $C1's attention.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 важно вышагивает по комнате.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 поважно вишаговує по кімнаті.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 struts proudly about the room.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 важно вышагивает, пытаясь привлечь твое внимание.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 поважно вишаговує, намагаючись привернути твою увагу.</msgVictimFound>
+  <msgVictimFound l="en">$c1 struts about, hoping to get your attention.</msgVictimFound>
   <position>rest</position>
   <rusName>вышагивать</rusName>
   <uaName>крокувати</uaName>
-  <shortDesc>важно вышагивать, привлекая внимание</shortDesc>
+  <shortDesc l="ru">важно вышагивать, привлекая внимание</shortDesc>
+  <shortDesc l="ua">поважно вишаговувати, привертаючи увагу</shortDesc>
+  <shortDesc l="en">strut about for attention</shortDesc>
 </Social>

--- a/socials/sweep.xml
+++ b/socials/sweep.xml
@@ -3,15 +3,29 @@
   <help id="1604" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты берешь $C4 на руки и целуешь долго и страстно.</msgCharFound>
-  <msgCharNoArgument>Ты вздыхаешь, глядя на свои пустые руки.</msgCharNoArgument>
-  <msgCharNotFound>Предмет страсти испарился.</msgCharNotFound>
+  <msgCharFound l="ru">Ты берешь $C4 на руки и целуешь долго и страстно.</msgCharFound>
+  <msgCharFound l="ua">Ти береш $C4 на руки і цілуєш довго і пристрасно.</msgCharFound>
+  <msgCharFound l="en">You sweep $C1 into your arms and kiss long and deeply.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты вздыхаешь, глядя на свои пустые руки.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти зітхаєш, дивлячись на свої порожні руки.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You look at your empty arms and sigh.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Предмет страсти испарился.</msgCharNotFound>
+  <msgCharNotFound l="ua">Предмет пристрасті випарувався.</msgCharNotFound>
+  <msgCharNotFound l="en">The object of your passion has evaporated.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 берет $C4 на руки и целует $S долго и страстно.</msgOthersFound>
-  <msgOthersNoArgument>$c1 вздыхает, глядя на свои пустые руки.</msgOthersNoArgument>
-  <msgVictimFound>$c1 берет тебя на руки и целует долго и страстно.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 берет $C4 на руки и целует $S долго и страстно.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 бере $C4 на руки і цілує довго і пристрасно.</msgOthersFound>
+  <msgOthersFound l="en">$c1 sweeps $C1 into those arms and kisses long and deeply.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вздыхает, глядя на свои пустые руки.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 зітхає, дивлячись на свої порожні руки.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 looks at those empty arms and sighs.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 берет тебя на руки и целует долго и страстно.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 бере тебе на руки і цілує довго і пристрасно.</msgVictimFound>
+  <msgVictimFound l="en">$c1 sweeps you into those arms and kisses you long and deeply.</msgVictimFound>
   <position>rest</position>
   <rusName>обхватить</rusName>
   <uaName>обхопити</uaName>
-  <shortDesc>взять на руки и страстно целовать</shortDesc>
+  <shortDesc l="ru">взять на руки и страстно целовать</shortDesc>
+  <shortDesc l="ua">взяти на руки і пристрасно цілувати</shortDesc>
+  <shortDesc l="en">sweep somebody up and kiss them passionately</shortDesc>
 </Social>

--- a/socials/tackle.xml
+++ b/socials/tackle.xml
@@ -3,15 +3,25 @@
   <help id="1718" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты игриво цапаешь $C4.</msgCharFound>
-  <msgCharNoArgument>Ну зачем сразу за всеми в комнате гоняться?!</msgCharNoArgument>
+  <msgCharFound l="ru">Ты игриво цапаешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти грайливо чіпляєш $C4.</msgCharFound>
+  <msgCharFound l="en">You tackle $C1 playfully.</msgCharFound>
+  <msgCharNoArgument l="ru">Ну зачем сразу за всеми в комнате гоняться?!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ну навіщо одразу за всіма в кімнаті ганятися?!</msgCharNoArgument>
+  <msgCharNoArgument l="en">Why chase after everyone in the room at once?!</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 игриво цапает $C4.</msgOthersFound>
+  <msgOthersFound l="ru">$c1 игриво цапает $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 грайливо чіпляє $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 playfully tackles $C1.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 игриво валит тебя на землю... Продолжение следует!</msgVictimFound>
+  <msgVictimFound l="ru">$c1 игриво валит тебя на землю... Продолжение следует!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 грайливо валить тебе на землю... Продовження буде!</msgVictimFound>
+  <msgVictimFound l="en">$c1 playfully brings you down... to be continued!</msgVictimFound>
   <position>rest</position>
   <rusName>ловить</rusName>
   <uaName>ловити</uaName>
-  <shortDesc>игриво цапать или валить на землю</shortDesc>
+  <shortDesc l="ru">игриво цапать или валить на землю</shortDesc>
+  <shortDesc l="ua">грайливо чіпляти або валити на землю</shortDesc>
+  <shortDesc l="en">playfully grab somebody, or take them down</shortDesc>
 </Social>

--- a/socials/thank.xml
+++ b/socials/thank.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1755" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты благодаришь себя, за то, что ты такая приятная во всех отношениях личность!</msgCharAuto>
-  <msgCharFound>Ты сердечно благодаришь $C4.</msgCharFound>
-  <msgCharNoArgument>И тебе спасибо.</msgCharNoArgument>
-  <msgCharNotFound>Никто не откликается на твои благодарности.</msgCharNotFound>
-  <msgOthersAuto>$c1 благодарит себя, потому что никто больше этого не делает.</msgOthersAuto>
-  <msgOthersFound>$c1 сердечно благодарит $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Ты благодаришь себя, за то, что ты такая приятная во всех отношениях личность!</msgCharAuto>
+  <msgCharAuto l="ua">Ти дякуєш собі за те, що ти така приємна в усіх відношеннях особа!</msgCharAuto>
+  <msgCharAuto l="en">You thank yourself for being such a thoroughly pleasant person!</msgCharAuto>
+  <msgCharFound l="ru">Ты сердечно благодаришь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти сердечно дякуєш $C3.</msgCharFound>
+  <msgCharFound l="en">You thank $C1 heartily.</msgCharFound>
+  <msgCharNoArgument l="ru">И тебе спасибо.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">І тобі дякую.</msgCharNoArgument>
+  <msgCharNoArgument l="en">Thank you too.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Никто не откликается на твои благодарности.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ніхто не відгукується на твої подяки.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody answers your thanks.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 благодарит себя, потому что никто больше этого не делает.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 дякує собі, бо ніхто більше цього не робить.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 offers thanks to $gitself|himself|herself|themselves, since nobody else will.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 сердечно благодарит $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 сердечно дякує $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 thanks $C1 heartily.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>$c1 сердечно благодарит тебя.</msgVictimFound>
+  <msgVictimFound l="ru">$c1 сердечно благодарит тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 сердечно дякує тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 thanks you heartily.</msgVictimFound>
   <position>rest</position>
   <rusName>благодарить</rusName>
   <uaName>дякувати</uaName>
-  <shortDesc>сердечно благодарить</shortDesc>
+  <shortDesc l="ru">сердечно благодарить</shortDesc>
+  <shortDesc l="ua">сердечно дякувати</shortDesc>
+  <shortDesc l="en">thank somebody heartily</shortDesc>
 </Social>

--- a/socials/tickle.xml
+++ b/socials/tickle.xml
@@ -2,19 +2,41 @@
 <Social type="Social">
   <help id="1725" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Смехота! Ты щекочешь себя!</msgCharAuto>
-  <msgCharFound>Ты щекочешь $C4.</msgCharFound>
-  <msgCharNoArgument>Кого пощекочем :) ?</msgCharNoArgument>
-  <msgCharNotFound>Это еще кто такой??</msgCharNotFound>
-  <msgCharVictimObj>Ты щекочешь %2$C4 %3$O5.</msgCharVictimObj>
-  <msgOthersAuto>$c1 щекочет себя, глупо хохоча.</msgOthersAuto>
-  <msgOthersFound>$c1 щекочет $C4.</msgOthersFound>
+  <msgCharAuto l="ru">Смехота! Ты щекочешь себя!</msgCharAuto>
+  <msgCharAuto l="ua">Смішно! Ти лоскочеш себе!</msgCharAuto>
+  <msgCharAuto l="en">How funny! You are tickling yourself!</msgCharAuto>
+  <msgCharFound l="ru">Ты щекочешь $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти лоскочеш $C4.</msgCharFound>
+  <msgCharFound l="en">You tickle $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Кого пощекочем :) ?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Кого полоскочемо :) ?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Whom shall we tickle :) ?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Это еще кто такой??</msgCharNotFound>
+  <msgCharNotFound l="ua">Це ще хто такий??</msgCharNotFound>
+  <msgCharNotFound l="en">And who might that be??</msgCharNotFound>
+  <msgCharVictimObj l="ru">Ты щекочешь %2$C4 %3$O5.</msgCharVictimObj>
+  <msgCharVictimObj l="ua">Ти лоскочеш %2$C4 %3$O5.</msgCharVictimObj>
+  <msgCharVictimObj l="en">You tickle %2$C4 with %3$O5.</msgCharVictimObj>
+  <msgOthersAuto l="ru">$c1 щекочет себя, глупо хохоча.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 лоскоче себе, безглуздо регочучи.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 tickles $gitself|himself|herself|themselves, cackling foolishly.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 щекочет $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 лоскоче $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 tickles $C1.</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgOthersVictimObj>%1$^C1 щекочет %2$C4 %3$O5.</msgOthersVictimObj>
-  <msgVictimFound>$c1 щекочет тебя - хи хи хи!</msgVictimFound>
-  <msgVictimObj>%1$^C1 щекочет тебя %3$O5.</msgVictimObj>
+  <msgOthersVictimObj l="ru">%1$^C1 щекочет %2$C4 %3$O5.</msgOthersVictimObj>
+  <msgOthersVictimObj l="ua">%1$^C1 лоскоче %2$C4 %3$O5.</msgOthersVictimObj>
+  <msgOthersVictimObj l="en">%1$^C1 tickles %2$C4 with %3$O5.</msgOthersVictimObj>
+  <msgVictimFound l="ru">$c1 щекочет тебя - хи хи хи!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 лоскоче тебе -- хі хі хі!</msgVictimFound>
+  <msgVictimFound l="en">$c1 tickles you -- hee hee hee!</msgVictimFound>
+  <msgVictimObj l="ru">%1$^C1 щекочет тебя %3$O5.</msgVictimObj>
+  <msgVictimObj l="ua">%1$^C1 лоскоче тебе %3$O5.</msgVictimObj>
+  <msgVictimObj l="en">%1$^C1 tickles you with %3$O5.</msgVictimObj>
   <position>rest</position>
   <rusName>щекотать</rusName>
   <uaName>лоскотати</uaName>
-  <shortDesc>щекотать</shortDesc>
+  <shortDesc l="ru">щекотать</shortDesc>
+  <shortDesc l="ua">лоскотати</shortDesc>
+  <shortDesc l="en">tickle</shortDesc>
 </Social>

--- a/socials/tip.xml
+++ b/socials/tip.xml
@@ -3,15 +3,29 @@
   <help id="1638" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты приподнимаешь шляпу перед $C5.</msgCharFound>
-  <msgCharNoArgument>Ты галантно приподнимаешь шляпу.</msgCharNoArgument>
-  <msgCharNotFound>Тут не на кого производить впечатление.</msgCharNotFound>
+  <msgCharFound l="ru">Ты приподнимаешь шляпу перед $C5.</msgCharFound>
+  <msgCharFound l="ua">Ти підіймаєш капелюха перед $C5.</msgCharFound>
+  <msgCharFound l="en">You tip your hat to $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты галантно приподнимаешь шляпу.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти галантно підіймаєш капелюха.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You tip your hat gallantly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Тут не на кого производить впечатление.</msgCharNotFound>
+  <msgCharNotFound l="ua">Тут нема на кого справляти враження.</msgCharNotFound>
+  <msgCharNotFound l="en">There is nobody here to impress.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$c1 галантно приподнимает свою шляпу перед $C5.</msgOthersFound>
-  <msgOthersNoArgument>$c1 галантно приподнимает свою шляпу.</msgOthersNoArgument>
-  <msgVictimFound>$c1 галантно приподнимает свою шляпу перед тобой.</msgVictimFound>
+  <msgOthersFound l="ru">$c1 галантно приподнимает свою шляпу перед $C5.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 галантно підіймає свого капелюха перед $C5.</msgOthersFound>
+  <msgOthersFound l="en">$c1 gallantly tips a hat to $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 галантно приподнимает свою шляпу.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 галантно підіймає свого капелюха.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 gallantly tips a hat.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 галантно приподнимает свою шляпу перед тобой.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 галантно підіймає свого капелюха перед тобою.</msgVictimFound>
+  <msgVictimFound l="en">$c1 gallantly tips a hat to you.</msgVictimFound>
   <position>rest</position>
   <rusName>шляпа</rusName>
   <uaName>капелюх</uaName>
-  <shortDesc>снять шляпу и приветствовать кого-либо</shortDesc>
+  <shortDesc l="ru">снять шляпу и приветствовать кого-либо</shortDesc>
+  <shortDesc l="ua">зняти капелюха і привітати когось</shortDesc>
+  <shortDesc l="en">take off your hat in greeting</shortDesc>
 </Social>

--- a/socials/twitch.xml
+++ b/socials/twitch.xml
@@ -3,15 +3,29 @@
   <help id="1690" level="-1" type="SocialHelp">
   </help>
   <msgCharAuto></msgCharAuto>
-  <msgCharFound>Ты нервно подергиваешься в присутствии $C2.</msgCharFound>
-  <msgCharNoArgument>Ты нервно дергаешься.</msgCharNoArgument>
-  <msgCharNotFound>Нервничаешь?Но тут никого нет.</msgCharNotFound>
+  <msgCharFound l="ru">Ты нервно подергиваешься в присутствии $C2.</msgCharFound>
+  <msgCharFound l="ua">Ти нервово сіпаєшся в присутності $C2.</msgCharFound>
+  <msgCharFound l="en">You twitch involuntarily in $C1's presence.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты нервно дергаешься.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти нервово сіпаєшся.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You twitch nervously.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нервничаешь?Но тут никого нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нервуєш? Але тут нікого немає.</msgCharNotFound>
+  <msgCharNotFound l="en">Nervous? But there is nobody here.</msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
-  <msgOthersFound>$C1 явно нервирует $c4...</msgOthersFound>
-  <msgOthersNoArgument>$c1 нервно дергается.</msgOthersNoArgument>
-  <msgVictimFound>$c1 замечает тебя и начинает нервно дергаться.</msgVictimFound>
+  <msgOthersFound l="ru">$C1 явно нервирует $c4...</msgOthersFound>
+  <msgOthersFound l="ua">$C1 явно нервує $c4...</msgOthersFound>
+  <msgOthersFound l="en">$C1 is clearly getting on $c2 nerves...</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 нервно дергается.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 нервово сіпається.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 twitches nervously.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 замечает тебя и начинает нервно дергаться.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 помічає тебе і починає нервово сіпатися.</msgVictimFound>
+  <msgVictimFound l="en">$c1 notices you and starts twitching nervously.</msgVictimFound>
   <position>rest</position>
   <rusName>дергаться</rusName>
   <uaName>смикатися</uaName>
-  <shortDesc>нервно дергаться</shortDesc>
+  <shortDesc l="ru">нервно дергаться</shortDesc>
+  <shortDesc l="ua">нервово сіпатися</shortDesc>
+  <shortDesc l="en">twitch nervously</shortDesc>
 </Social>

--- a/socials/voodoo.xml
+++ b/socials/voodoo.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1599" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тыкаешь булавками в свое чучело! Ааа...! как больно!!</msgCharAuto>
-  <msgCharFound>Ты тыкаешь ножи в чучело $C2, и прилюдно сжигаешь $S портрет.</msgCharFound>
-  <msgCharNoArgument>Бу ча ча надо покастать на кого-то конкретного!</msgCharNoArgument>
-  <msgCharNotFound>Некого сглазить. ЭХ!</msgCharNotFound>
-  <msgOthersAuto>$c1 тыкает булавочки в какую-то куклу и бьется в конвульсиях!</msgOthersAuto>
-  <msgOthersFound>$c1 зыркает на $C4, тыкая ножи в $S чучело.</msgOthersFound>
-  <msgOthersNoArgument>$c1 шаманит.</msgOthersNoArgument>
-  <msgVictimFound>Твое сердце уходит в пятки и у тебя начинается жуткая мяугрень!</msgVictimFound>
+  <msgCharAuto l="ru">Ты тыкаешь булавками в свое чучело! Ааа...! как больно!!</msgCharAuto>
+  <msgCharAuto l="ua">Ти тицяєш шпильками у своє опудало! Аааа...! як боляче!!</msgCharAuto>
+  <msgCharAuto l="en">You stab pins into your own effigy! Aaah...! the agony!!</msgCharAuto>
+  <msgCharFound l="ru">Ты тыкаешь ножи в чучело $C2, и прилюдно сжигаешь $S портрет.</msgCharFound>
+  <msgCharFound l="ua">Ти тицяєш ножі в опудало $C2 і прилюдно спалюєш портрет.</msgCharFound>
+  <msgCharFound l="en">You stab knives into $C1's effigy and burn the portrait in public.</msgCharFound>
+  <msgCharNoArgument l="ru">Бу ча ча надо покастать на кого-то конкретного!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Бу ча ча треба покастувати на когось конкретного!</msgCharNoArgument>
+  <msgCharNoArgument l="en">Bad juju like this has to be aimed at somebody in particular!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Некого сглазить. ЭХ!</msgCharNotFound>
+  <msgCharNotFound l="ua">Нема кого зурочити. ЕХ!</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody to hex. AH WELL!</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 тыкает булавочки в какую-то куклу и бьется в конвульсиях!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 тицяє шпильки в якусь ляльку і б'ється в конвульсіях!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 jabs pins into some doll and twitches in convulsions!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 зыркает на $C4, тыкая ножи в $S чучело.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 зиркає на $C4, тицяючи ножі в опудало.</msgOthersFound>
+  <msgOthersFound l="en">$c1 glares balefully at $C1 while stabbing knives into an effigy.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 шаманит.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 шаманить.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 works some shamanic mischief.</msgOthersNoArgument>
+  <msgVictimFound l="ru">Твое сердце уходит в пятки и у тебя начинается жуткая мяугрень!</msgVictimFound>
+  <msgVictimFound l="ua">Твоє серце йде в п'яти і в тебе починається моторошна мявгрень!</msgVictimFound>
+  <msgVictimFound l="en">Your heart lurches into your boots and a ghastly meowgraine sets in!</msgVictimFound>
   <position>rest</position>
   <rusName>вуду</rusName>
   <uaName>вуду</uaName>
-  <shortDesc>шаманить</shortDesc>
+  <shortDesc l="ru">шаманить</shortDesc>
+  <shortDesc l="ua">шаманити</shortDesc>
+  <shortDesc l="en">work a hex</shortDesc>
 </Social>

--- a/socials/wait.xml
+++ b/socials/wait.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Ты терпеливо ждешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Ты терпеливо ждешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти терпляче чекаєш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You wait patiently.</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 терпеливо ждет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 терпеливо ждет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 терпляче чекає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 waits patiently.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>ждать</rusName>
   <uaName>чекати</uaName>
-  <shortDesc>терпеливо ждать</shortDesc>
+  <shortDesc l="ru">терпеливо ждать</shortDesc>
+  <shortDesc l="ua">терпляче чекати</shortDesc>
+  <shortDesc l="en">wait patiently</shortDesc>
 </Social>

--- a/socials/wave.xml
+++ b/socials/wave.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1762" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Куда собираешься? От себя не убежишь...</msgCharAuto>
-  <msgCharFound>Ты машешь рукой $C3.</msgCharFound>
-  <msgCharNoArgument>Ты машешь рукой.</msgCharNoArgument>
-  <msgCharNotFound>Такие люди всегда с тобой - нечего с ними прощаться :)</msgCharNotFound>
-  <msgOthersAuto>$c1 прощается с собой. Хара-кири?</msgOthersAuto>
-  <msgOthersFound>$c1 машет рукой $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 машет руками:Всем счастливо оставаться!</msgOthersNoArgument>
-  <msgVictimFound>$c1 машет рукой тебе. Счастливо оставаться!</msgVictimFound>
+  <msgCharAuto l="ru">Куда собираешься? От себя не убежишь...</msgCharAuto>
+  <msgCharAuto l="ua">Куди зібра$gлося|вся|лася? Від себе не втечеш...</msgCharAuto>
+  <msgCharAuto l="en">Off somewhere? You cannot run away from yourself...</msgCharAuto>
+  <msgCharFound l="ru">Ты машешь рукой $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти махаєш рукою $C3.</msgCharFound>
+  <msgCharFound l="en">You wave goodbye to $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты машешь рукой.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти махаєш рукою.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You wave.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Такие люди всегда с тобой - нечего с ними прощаться :)</msgCharNotFound>
+  <msgCharNotFound l="ua">Такі люди завжди з тобою -- нема чого з ними прощатися :)</msgCharNotFound>
+  <msgCharNotFound l="en">Those people are always with you -- no point waving them off :)</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 прощается с собой. Хара-кири?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 прощається із собою. Харакірі?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 waves goodbye to $gitself|himself|herself|themselves. Hara-kiri?</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 машет рукой $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 махає рукою $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 waves goodbye to $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 машет руками:Всем счастливо оставаться!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 махає руками: Усім щасливо лишатися!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 waves both arms: farewell, everyone!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 машет рукой тебе. Счастливо оставаться!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 махає рукою тобі. Щасливо лишатися!</msgVictimFound>
+  <msgVictimFound l="en">$c1 waves goodbye to you. Have a good journey!</msgVictimFound>
   <position>rest</position>
   <rusName>бай-бай</rusName>
   <uaName>бай-бай</uaName>
-  <shortDesc>прощально помахать рукой</shortDesc>
+  <shortDesc l="ru">прощально помахать рукой</shortDesc>
+  <shortDesc l="ua">прощально помахати рукою</shortDesc>
+  <shortDesc l="en">wave goodbye</shortDesc>
 </Social>

--- a/socials/whine.xml
+++ b/socials/whine.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1812" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты жалобно хнычешь о своем одиночестве.</msgCharAuto>
-  <msgCharFound>Ты жалобно хнычешь, глядя на $X.</msgCharFound>
-  <msgCharNoArgument>Ты жалобно хнычешь.</msgCharNoArgument>
-  <msgCharNotFound>Им все равно.</msgCharNotFound>
-  <msgOthersAuto>$c1 жалобно хнычет о своем одиночестве. Хоть не пристает к тебе, и то хорошо.</msgOthersAuto>
-  <msgOthersFound>$c1 жалобно хнычет, глядя на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 жалобно хнычет.</msgOthersNoArgument>
-  <msgVictimFound>$c1 жалобно хнычет, глядя на тебя. Эка невидаль!</msgVictimFound>
+  <msgCharAuto l="ru">Ты жалобно хнычешь о своем одиночестве.</msgCharAuto>
+  <msgCharAuto l="ua">Ти жалібно скиглиш про свою самотність.</msgCharAuto>
+  <msgCharAuto l="en">You whine plaintively about your loneliness.</msgCharAuto>
+  <msgCharFound l="ru">Ты жалобно хнычешь, глядя на $X.</msgCharFound>
+  <msgCharFound l="ua">Ти жалібно скиглиш, дивлячись на $C4.</msgCharFound>
+  <msgCharFound l="en">You whine plaintively at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты жалобно хнычешь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти жалібно скиглиш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You whine plaintively.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Им все равно.</msgCharNotFound>
+  <msgCharNotFound l="ua">Їм байдуже.</msgCharNotFound>
+  <msgCharNotFound l="en">They really don't care.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 жалобно хнычет о своем одиночестве. Хоть не пристает к тебе, и то хорошо.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 жалібно скиглить про свою самотність. Хоч не чіпляється до тебе, і то добре.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 whines plaintively about being lonely. At least it is not aimed at YOU.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 жалобно хнычет, глядя на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 жалібно скиглить, дивлячись на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 whines pathetically at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 жалобно хнычет.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 жалібно скиглить.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 whines pathetically to anyone who will listen.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 жалобно хнычет, глядя на тебя. Эка невидаль!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 жалібно скиглить, дивлячись на тебе. Оце новина!</msgVictimFound>
+  <msgVictimFound l="en">$c1 whines pathetically at you. What a loser!</msgVictimFound>
   <position>rest</position>
   <rusName>хныкать</rusName>
   <uaName>нити</uaName>
-  <shortDesc>жалобно хныкать</shortDesc>
+  <shortDesc l="ru">жалобно хныкать</shortDesc>
+  <shortDesc l="ua">жалібно скиглити</shortDesc>
+  <shortDesc l="en">whine plaintively</shortDesc>
 </Social>

--- a/socials/whip.xml
+++ b/socials/whip.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1623" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты в ярости хлещешь кнутом сам{Sfу{sx себя.</msgCharAuto>
-  <msgCharFound>Ты полосуешь $C4 по спине кнутом.</msgCharFound>
-  <msgCharNoArgument>Ты грозно пощелкиваешь кнутом.</msgCharNoArgument>
-  <msgCharNotFound>Некого располосовать.</msgCharNotFound>
-  <msgOthersAuto>$c1 избивает себя кнутом. Мазохист?</msgOthersAuto>
-  <msgOthersFound>$c1 избивает $C4 кнутом по спине.</msgOthersFound>
-  <msgOthersNoArgument>$c1 щелкает кнутом. Злобно и угрожаюше.</msgOthersNoArgument>
-  <msgVictimFound>$c1 избивает тебя кнутом! О-о-о! Это может быть приятно!</msgVictimFound>
+  <msgCharAuto l="ru">Ты в ярости хлещешь кнутом сам{Sfу{sx себя.</msgCharAuto>
+  <msgCharAuto l="ua">Ти в люті шмагаєш батогом сам$gе|ий|а себе.</msgCharAuto>
+  <msgCharAuto l="en">You whip yourself into a frenzy.</msgCharAuto>
+  <msgCharFound l="ru">Ты полосуешь $C4 по спине кнутом.</msgCharFound>
+  <msgCharFound l="ua">Ти шмагаєш $C4 по спині батогом.</msgCharFound>
+  <msgCharFound l="en">You flick your whip across $C1's bare back.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты грозно пощелкиваешь кнутом.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти грізно поклацуєш батогом.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You crack your bullwhip menacingly.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Некого располосовать.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нема кого пошматувати.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here to flay.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 избивает себя кнутом. Мазохист?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 б'є себе батогом. Мазохіст?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 whips $gitself|himself|herself|themselves into a frenzy. Masochist?</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 избивает $C4 кнутом по спине.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 б'є $C4 батогом по спині.</msgOthersFound>
+  <msgOthersFound l="en">$c1 flicks a whip across $C1's bare back.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 щелкает кнутом. Злобно и угрожаюше.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 клацає батогом. Злобно і загрозливо.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 cracks a bullwhip. Angrily and menacingly.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 избивает тебя кнутом! О-о-о! Это может быть приятно!</msgVictimFound>
+  <msgVictimFound l="ua">$c1 б'є тебе батогом! О-о-о! Це може бути приємно!</msgVictimFound>
+  <msgVictimFound l="en">$c1 flicks a whip across your back! O-o-oh! This could be rather nice!</msgVictimFound>
   <position>rest</position>
   <rusName>кнут</rusName>
   <uaName>батіг</uaName>
-  <shortDesc>щелкать кнутом или избивать кого-либо кнутом</shortDesc>
+  <shortDesc l="ru">щелкать кнутом или избивать кого-либо кнутом</shortDesc>
+  <shortDesc l="ua">клацати батогом або бити когось батогом</shortDesc>
+  <shortDesc l="en">crack a whip, or whip somebody with it</shortDesc>
 </Social>

--- a/socials/whistle.xml
+++ b/socials/whistle.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1700" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты тихонько насвистываешь.</msgCharAuto>
-  <msgCharFound>Ты свистишь $M.</msgCharFound>
-  <msgCharNoArgument>Ты свистишь.</msgCharNoArgument>
-  <msgCharNotFound>Некому тут свистнуть.</msgCharNotFound>
-  <msgOthersAuto>$c1 тихонько насвистывает.</msgOthersAuto>
-  <msgOthersFound>$c1 свистит $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 свистит.</msgOthersNoArgument>
-  <msgVictimFound>$c1 свистит тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты тихонько насвистываешь.</msgCharAuto>
+  <msgCharAuto l="ua">Ти тихенько насвистуєш.</msgCharAuto>
+  <msgCharAuto l="en">You whistle a little tune to yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты свистишь $M.</msgCharFound>
+  <msgCharFound l="ua">Ти свистиш $C3.</msgCharFound>
+  <msgCharFound l="en">You whistle at the sight of $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты свистишь.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти свистиш.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You whistle appreciatively.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Некому тут свистнуть.</msgCharNotFound>
+  <msgCharNotFound l="ua">Нема кому тут свиснути.</msgCharNotFound>
+  <msgCharNotFound l="en">Nobody here to whistle at.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 тихонько насвистывает.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 тихенько насвистує.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 whistles a little tune to $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 свистит $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 свистить $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 whistles at the sight of $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 свистит.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 свистить.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 whistles appreciatively.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 свистит тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 свистить тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 whistles at the sight of you.</msgVictimFound>
   <position>rest</position>
   <rusName>свистеть</rusName>
   <uaName>свистіти</uaName>
-  <shortDesc>насвистывать или свистеть кому-то</shortDesc>
+  <shortDesc l="ru">насвистывать или свистеть кому-то</shortDesc>
+  <shortDesc l="ua">насвистувати або свистіти комусь</shortDesc>
+  <shortDesc l="en">whistle to yourself, or whistle at somebody</shortDesc>
 </Social>

--- a/socials/wink.xml
+++ b/socials/wink.xml
@@ -9,16 +9,34 @@
     <extra l="ru">подмигивать подмигнуть</extra>
     <extra l="ua"></extra>
   </help>
-  <msgCharAuto>Ты подмигиваешь себе? Зеркала вроде тут нет...</msgCharAuto>
-  <msgCharFound>Ты подмигиваешь с намеком $C3.</msgCharFound>
-  <msgCharNoArgument>Что-то попало в глаз?</msgCharNoArgument>
-  <msgCharNotFound>Нет никого с таким именем.</msgCharNotFound>
-  <msgOthersAuto>$c1 подмигивает себе - шось странное происходит.</msgOthersAuto>
-  <msgOthersFound>$c1 подмигивает $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 подмигивает с намеком.</msgOthersNoArgument>
-  <msgVictimFound>$c1 подмигивает с намеком тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты подмигиваешь себе? Зеркала вроде тут нет...</msgCharAuto>
+  <msgCharAuto l="ua">Ти підморгуєш собі? Дзеркала начебто тут немає...</msgCharAuto>
+  <msgCharAuto l="en">Winking at yourself? There doesn't seem to be a mirror here...</msgCharAuto>
+  <msgCharFound l="ru">Ты подмигиваешь с намеком $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти підморгуєш з натяком $C3.</msgCharFound>
+  <msgCharFound l="en">You wink suggestively at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Что-то попало в глаз?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Щось потрапило в око?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Have you got something in your eye?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нет никого с таким именем.</msgCharNotFound>
+  <msgCharNotFound l="ua">Немає нікого з таким ім'ям.</msgCharNotFound>
+  <msgCharNotFound l="en">No one with that name is present.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 подмигивает себе - шось странное происходит.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 підморгує собі -- шось дивне відбувається.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 winks at $gitself|himself|herself|themselves -- something strange is going on...</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 подмигивает $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 підморгує $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 winks at $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 подмигивает с намеком.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 підморгує з натяком.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 winks suggestively.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 подмигивает с намеком тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 підморгує з натяком тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 winks suggestively at you.</msgVictimFound>
   <position>rest</position>
   <rusName>моргать</rusName>
   <uaName>моргати</uaName>
-  <shortDesc>моргать или подмигивать кому-либо</shortDesc>
+  <shortDesc l="ru">моргать или подмигивать кому-либо</shortDesc>
+  <shortDesc l="ua">кліпати або підморгувати комусь</shortDesc>
+  <shortDesc l="en">blink, or wink at somebody</shortDesc>
 </Social>

--- a/socials/wonder.xml
+++ b/socials/wonder.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1671" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты удивляешься себе и цели своего пребывания здесь.</msgCharAuto>
-  <msgCharFound>Ты смотришь на $C4 и удивляешься - что происходит!?</msgCharFound>
-  <msgCharNoArgument>Ты удивляешься, как бог смог сотворить ТАКОЙ мир?</msgCharNoArgument>
-  <msgCharNotFound>Ты удивляешься, что таких тут нет.</msgCharNotFound>
-  <msgOthersAuto>На лице $c2 появляется выражение удивления. Интересно, чему?</msgOthersAuto>
-  <msgOthersFound>$c1 смотрит на $C4 с удивлением.</msgOthersFound>
-  <msgOthersNoArgument>На лице $c2 появляется выражение удивления. Интересно, чему?</msgOthersNoArgument>
-  <msgVictimFound>$c1 смотрит на тебя с удивлением.</msgVictimFound>
+  <msgCharAuto l="ru">Ты удивляешься себе и цели своего пребывания здесь.</msgCharAuto>
+  <msgCharAuto l="ua">Ти дивуєшся собі і меті свого перебування тут.</msgCharAuto>
+  <msgCharAuto l="en">You wonder about yourself and your purpose here.</msgCharAuto>
+  <msgCharFound l="ru">Ты смотришь на $C4 и удивляешься - что происходит!?</msgCharFound>
+  <msgCharFound l="ua">Ти дивишся на $C4 і дивуєшся -- що відбувається!?</msgCharFound>
+  <msgCharFound l="en">You look at $C1 and wonder -- what is going on!?</msgCharFound>
+  <msgCharNoArgument l="ru">Ты удивляешься, как бог смог сотворить ТАКОЙ мир?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти дивуєшся, як бог зміг створити ТАКИЙ світ?</msgCharNoArgument>
+  <msgCharNoArgument l="en">You wonder how a god could have made a world like THIS?</msgCharNoArgument>
+  <msgCharNotFound l="ru">Ты удивляешься, что таких тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Ти дивуєшся, що таких тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">You wonder at the fact that they are not here.</msgCharNotFound>
+  <msgOthersAuto l="ru">На лице $c2 появляется выражение удивления. Интересно, чему?</msgOthersAuto>
+  <msgOthersAuto l="ua">На обличчі $c2 з'являється вираз подиву. Цікаво, з чого?</msgOthersAuto>
+  <msgOthersAuto l="en">A look of wonder crosses $c2 face. Wonder at what?</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 смотрит на $C4 с удивлением.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 дивиться на $C4 з подивом.</msgOthersFound>
+  <msgOthersFound l="en">$c1 looks at $C1 in wonder.</msgOthersFound>
+  <msgOthersNoArgument l="ru">На лице $c2 появляется выражение удивления. Интересно, чему?</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">На обличчі $c2 з'являється вираз подиву. Цікаво, з чого?</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">A look of wonder crosses $c2 face. Wonder at what?</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 смотрит на тебя с удивлением.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 дивиться на тебе з подивом.</msgVictimFound>
+  <msgVictimFound l="en">$c1 looks at you in wonder.</msgVictimFound>
   <position>rest</position>
   <rusName>удивляться</rusName>
   <uaName>дивуватися</uaName>
-  <shortDesc>удивляться или смотреть на кого-либо с удивлением</shortDesc>
+  <shortDesc l="ru">удивляться или смотреть на кого-либо с удивлением</shortDesc>
+  <shortDesc l="ua">дивуватися або дивитися на когось з подивом</shortDesc>
+  <shortDesc l="en">wonder, or look at somebody in wonder</shortDesc>
 </Social>

--- a/socials/worry.xml
+++ b/socials/worry.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1660" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты волнуешься - что происходит с тобой.</msgCharAuto>
-  <msgCharFound>Ты взволнованно смотришь на $C4.</msgCharFound>
-  <msgCharNoArgument>Ты волнуешься - что происходит.</msgCharNoArgument>
-  <msgCharNotFound>О них нечего волноваться! Их тут просто нет!</msgCharNotFound>
-  <msgOthersAuto>$c1 волнуется. Интересно, о чем?</msgOthersAuto>
-  <msgOthersFound>$c1 взволнованно смотрит на $C4.</msgOthersFound>
-  <msgOthersNoArgument>$c1 волнуется. Интересно, о чем?</msgOthersNoArgument>
-  <msgVictimFound>$c1 взволнованно смотрит на тебя.</msgVictimFound>
+  <msgCharAuto l="ru">Ты волнуешься - что происходит с тобой.</msgCharAuto>
+  <msgCharAuto l="ua">Ти хвилюєшся -- що відбувається з тобою.</msgCharAuto>
+  <msgCharAuto l="en">You worry about what is happening to you.</msgCharAuto>
+  <msgCharFound l="ru">Ты взволнованно смотришь на $C4.</msgCharFound>
+  <msgCharFound l="ua">Ти схвильовано дивишся на $C4.</msgCharFound>
+  <msgCharFound l="en">You look at $C1 worriedly.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты волнуешься - что происходит.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти хвилюєшся -- що відбувається.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You worry about what is going to happen.</msgCharNoArgument>
+  <msgCharNotFound l="ru">О них нечего волноваться! Их тут просто нет!</msgCharNotFound>
+  <msgCharNotFound l="ua">Про них нема чого хвилюватися! Їх тут просто немає!</msgCharNotFound>
+  <msgCharNotFound l="en">Nothing to worry about there! They simply are not here!</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 волнуется. Интересно, о чем?</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 хвилюється. Цікаво, через що?</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 is worried. Wonder what about?</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 взволнованно смотрит на $C4.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 схвильовано дивиться на $C4.</msgOthersFound>
+  <msgOthersFound l="en">$c1 looks at $C1 with a troubled gaze.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 волнуется. Интересно, о чем?</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 хвилюється. Цікаво, через що?</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 is worried. Wonder what about?</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 взволнованно смотрит на тебя.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 схвильовано дивиться на тебе.</msgVictimFound>
+  <msgVictimFound l="en">$c1 looks at you worriedly.</msgVictimFound>
   <position>rest</position>
   <rusName>волноваться</rusName>
   <uaName>хвилюватися</uaName>
-  <shortDesc>переживать за кого-то, волноваться</shortDesc>
+  <shortDesc l="ru">переживать за кого-то, волноваться</shortDesc>
+  <shortDesc l="ua">переживати за когось, хвилюватися</shortDesc>
+  <shortDesc l="en">worry about somebody, or just worry</shortDesc>
 </Social>

--- a/socials/worship.xml
+++ b/socials/worship.xml
@@ -5,16 +5,34 @@
     <extra l="ru">'бей челом' 'бить челом'</extra>
     <extra l="ua"></extra>
   </help>
-  <msgCharAuto>Ты поклоняешься себе.</msgCharAuto>
-  <msgCharFound>Ты повергаешься на землю и кланяешься $C3.</msgCharFound>
-  <msgCharNoArgument>Ты повергаешься на землю и бьешь челом богам!</msgCharNoArgument>
-  <msgCharNotFound>Нельзя поклониться тому, кого тут нет.</msgCharNotFound>
-  <msgOthersAuto>$c1 поклоняется себе.</msgOthersAuto>
-  <msgOthersFound>$c1 повергается на землю и кланяется $C3.</msgOthersFound>
-  <msgOthersNoArgument>$c1 повергается на землю и бьет челом богам!</msgOthersNoArgument>
-  <msgVictimFound>$c1 повергается на землю и кланяется тебе.</msgVictimFound>
+  <msgCharAuto l="ru">Ты поклоняешься себе.</msgCharAuto>
+  <msgCharAuto l="ua">Ти поклоняєшся собі.</msgCharAuto>
+  <msgCharAuto l="en">You worship yourself.</msgCharAuto>
+  <msgCharFound l="ru">Ты повергаешься на землю и кланяешься $C3.</msgCharFound>
+  <msgCharFound l="ua">Ти падаєш на землю і вклоняєшся $C3.</msgCharFound>
+  <msgCharFound l="en">You fall on your knees and worship $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты повергаешься на землю и бьешь челом богам!</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти падаєш на землю і б'єш чолом богам!</msgCharNoArgument>
+  <msgCharNoArgument l="en">You prostrate yourself and worship the gods!</msgCharNoArgument>
+  <msgCharNotFound l="ru">Нельзя поклониться тому, кого тут нет.</msgCharNotFound>
+  <msgCharNotFound l="ua">Не можна вклонитися тому, кого тут немає.</msgCharNotFound>
+  <msgCharNotFound l="en">You cannot worship someone who isn't here.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 поклоняется себе.</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 поклоняється собі.</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 worships $gitself|himself|herself|themselves.</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 повергается на землю и кланяется $C3.</msgOthersFound>
+  <msgOthersFound l="ua">$c1 падає на землю і вклоняється $C3.</msgOthersFound>
+  <msgOthersFound l="en">$c1 falls on those knees and worships $C1.</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 повергается на землю и бьет челом богам!</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 падає на землю і б'є чолом богам!</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 prostrates $gitself|himself|herself|themselves and worships the gods!</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 повергается на землю и кланяется тебе.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 падає на землю і вклоняється тобі.</msgVictimFound>
+  <msgVictimFound l="en">$c1 falls to the ground and worships you.</msgVictimFound>
   <position>rest</position>
   <rusName>челобитие</rusName>
   <uaName>чолобитна</uaName>
-  <shortDesc>поклоняться кому-либо или богам</shortDesc>
+  <shortDesc l="ru">поклоняться кому-либо или богам</shortDesc>
+  <shortDesc l="ua">поклонятися комусь або богам</shortDesc>
+  <shortDesc l="en">worship somebody, or the gods</shortDesc>
 </Social>

--- a/socials/yae.xml
+++ b/socials/yae.xml
@@ -2,16 +2,34 @@
 <Social type="Social">
   <help id="1731" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Ты бешь себя по тупорылой башке! БЭММММЦ!</msgCharAuto>
-  <msgCharFound>В комнате есть идиот и ты смотришь точно на $X.</msgCharFound>
-  <msgCharNoArgument>Ты взыхаешь, констатируя присутствие в комнате очередного придурка.</msgCharNoArgument>
-  <msgCharNotFound>Вообще-то в Мире идиотов хватает, но в данный момент рядом с тобой нет ни одного.</msgCharNotFound>
-  <msgOthersAuto>$c1 бьется головой об стенку, уверяя всех что он полный ИДИОТ!</msgOthersAuto>
-  <msgOthersFound>$c1 свято уверен, что $C4 долго били в детстве по голове чупа-чупсом!</msgOthersFound>
-  <msgOthersNoArgument>$c1 вздыхает, намекая на то, что кто-то тут больной на всю голову.</msgOthersNoArgument>
-  <msgVictimFound>$c1 выразительно смотрит на тебя, полагая что ты полн$Gое|ый|ая кретин$Gко||ка.</msgVictimFound>
+  <msgCharAuto l="ru">Ты бешь себя по тупорылой башке! БЭММММЦ!</msgCharAuto>
+  <msgCharAuto l="ua">Ти б'єш себе по тупорилій довбешці! БЕММММЦ!</msgCharAuto>
+  <msgCharAuto l="en">You bonk yourself on your own thick skull! CLAAAANG!</msgCharAuto>
+  <msgCharFound l="ru">В комнате есть идиот и ты смотришь точно на $X.</msgCharFound>
+  <msgCharFound l="ua">У кімнаті є ідіот, і ти дивишся точно на $C4.</msgCharFound>
+  <msgCharFound l="en">There is Yet Another Eeediot in the room, and you are looking right at $C1.</msgCharFound>
+  <msgCharNoArgument l="ru">Ты взыхаешь, констатируя присутствие в комнате очередного придурка.</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ти зітхаєш, констатуючи присутність у кімнаті чергового придурка.</msgCharNoArgument>
+  <msgCharNoArgument l="en">You sigh, noting the presence of Yet Another Eeediot in the room.</msgCharNoArgument>
+  <msgCharNotFound l="ru">Вообще-то в Мире идиотов хватает, но в данный момент рядом с тобой нет ни одного.</msgCharNotFound>
+  <msgCharNotFound l="ua">Взагалі-то у Світі ідіотів вистачає, але в цю мить поруч із тобою немає жодного.</msgCharNotFound>
+  <msgCharNotFound l="en">There are plenty of Eeediots in the World, but not one of them is next to you right now.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 бьется головой об стенку, уверяя всех что он полный ИДИОТ!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 б'ється головою об стінку, запевняючи всіх, що він повний ІДІОТ!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 bangs that head against the wall, assuring everyone of being a complete IDIOT!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 свято уверен, что $C4 долго били в детстве по голове чупа-чупсом!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 свято переконан$gе|ий|а, що $C4 довго били в дитинстві по голові чупа-чупсом!</msgOthersFound>
+  <msgOthersFound l="en">$c1 is quite certain that $C1 was beaten about the head with a lollipop as a child!</msgOthersFound>
+  <msgOthersNoArgument l="ru">$c1 вздыхает, намекая на то, что кто-то тут больной на всю голову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 зітхає, натякаючи на те, що хтось тут хворий на всю голову.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 sighs, hinting that somebody here is sick in the head.</msgOthersNoArgument>
+  <msgVictimFound l="ru">$c1 выразительно смотрит на тебя, полагая что ты полн$Gое|ый|ая кретин$Gко||ка.</msgVictimFound>
+  <msgVictimFound l="ua">$c1 виразно дивиться на тебе, вважаючи, що ти $Gповне|повний|повна кретин$Gеня||ка.</msgVictimFound>
+  <msgVictimFound l="en">$c1 gives you a pointed look, evidently taking you for a complete cretin.</msgVictimFound>
   <position>rest</position>
   <rusName>идиот</rusName>
   <uaName>ідіот</uaName>
-  <shortDesc>считать себя или кого-либо идиотом</shortDesc>
+  <shortDesc l="ru">считать себя или кого-либо идиотом</shortDesc>
+  <shortDesc l="ua">вважати себе або когось ідіотом</shortDesc>
+  <shortDesc l="en">consider yourself, or somebody else, an idiot</shortDesc>
 </Social>

--- a/socials/yawn.xml
+++ b/socials/yawn.xml
@@ -4,14 +4,20 @@
   </help>
   <msgCharAuto></msgCharAuto>
   <msgCharFound></msgCharFound>
-  <msgCharNoArgument>Наверное, пора в люлю?</msgCharNoArgument>
+  <msgCharNoArgument l="ru">Наверное, пора в люлю?</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Мабуть, час у люлю?</msgCharNoArgument>
+  <msgCharNoArgument l="en">Time for bed, perhaps?</msgCharNoArgument>
   <msgCharNotFound></msgCharNotFound>
   <msgOthersAuto></msgOthersAuto>
   <msgOthersFound></msgOthersFound>
-  <msgOthersNoArgument>$c1 зевает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ru">$c1 зевает.</msgOthersNoArgument>
+  <msgOthersNoArgument l="ua">$c1 позіхає.</msgOthersNoArgument>
+  <msgOthersNoArgument l="en">$c1 yawns.</msgOthersNoArgument>
   <msgVictimFound></msgVictimFound>
   <position>rest</position>
   <rusName>зевать</rusName>
   <uaName>позіхати</uaName>
-  <shortDesc>зевать</shortDesc>
+  <shortDesc l="ru">зевать</shortDesc>
+  <shortDesc l="ua">позіхати</shortDesc>
+  <shortDesc l="en">yawn</shortDesc>
 </Social>

--- a/socials/zerbert.xml
+++ b/socials/zerbert.xml
@@ -2,16 +2,32 @@
 <Social type="Social">
   <help id="1697" level="-1" type="SocialHelp">
   </help>
-  <msgCharAuto>Лучше отвернись, а то люди смотрят...</msgCharAuto>
-  <msgCharFound>Ты задираешь рубашку $C2 на голову и дуешь со всей дури $M в пуп!</msgCharFound>
-  <msgCharNoArgument>Ну так нечестно, и дунуть некуда....</msgCharNoArgument>
-  <msgCharNotFound>Промазал$gо||а.</msgCharNotFound>
-  <msgOthersAuto>$c1 нервно оглядывается по сторонам, потом задирает свою рубашку и акробатически дует себе в пуп!</msgOthersAuto>
-  <msgOthersFound>$c1 резко натягивает $C3 рубашку на голову и дует своей жертве прямо в пуп!</msgOthersFound>
+  <msgCharAuto l="ru">Лучше отвернись, а то люди смотрят...</msgCharAuto>
+  <msgCharAuto l="ua">Краще відвернися, бо люди дивляться...</msgCharAuto>
+  <msgCharAuto l="en">Better turn away, people are staring...</msgCharAuto>
+  <msgCharFound l="ru">Ты задираешь рубашку $C2 на голову и дуешь со всей дури $M в пуп!</msgCharFound>
+  <msgCharFound l="ua">Ти задираєш сорочку $C2 на голову і дмухаєш з усієї дурі в пуп!</msgCharFound>
+  <msgCharFound l="en">You pull $C1's shirt up over the head and blow with all your might into that navel!</msgCharFound>
+  <msgCharNoArgument l="ru">Ну так нечестно, и дунуть некуда....</msgCharNoArgument>
+  <msgCharNoArgument l="ua">Ну так нечесно, і дмухнути нікуди....</msgCharNoArgument>
+  <msgCharNoArgument l="en">That is hardly fair, there is nowhere to blow....</msgCharNoArgument>
+  <msgCharNotFound l="ru">Промазал$gо||а.</msgCharNotFound>
+  <msgCharNotFound l="ua">Промаза$gло|в|ла.</msgCharNotFound>
+  <msgCharNotFound l="en">You missed.</msgCharNotFound>
+  <msgOthersAuto l="ru">$c1 нервно оглядывается по сторонам, потом задирает свою рубашку и акробатически дует себе в пуп!</msgOthersAuto>
+  <msgOthersAuto l="ua">$c1 нервово озирається навсібіч, потім задирає свою сорочку і акробатично дмухає собі в пуп!</msgOthersAuto>
+  <msgOthersAuto l="en">$c1 glances around furtively, then lifts that shirt and acrobatically blows into that own navel!</msgOthersAuto>
+  <msgOthersFound l="ru">$c1 резко натягивает $C3 рубашку на голову и дует своей жертве прямо в пуп!</msgOthersFound>
+  <msgOthersFound l="ua">$c1 різко натягує $C3 сорочку на голову і дмухає своїй жертві просто в пуп!</msgOthersFound>
+  <msgOthersFound l="en">$c1 yanks $C1's shirt up over the head and blows straight into the victim's navel!</msgOthersFound>
   <msgOthersNoArgument></msgOthersNoArgument>
-  <msgVictimFound>АЙАЙАЙ! $c1 натяну$gло|л|ла тебе на голову рубашку и дует тебе в пуп! Щекотно!!!!</msgVictimFound>
+  <msgVictimFound l="ru">АЙАЙАЙ! $c1 натяну$gло|л|ла тебе на голову рубашку и дует тебе в пуп! Щекотно!!!!</msgVictimFound>
+  <msgVictimFound l="ua">ОЙОЙОЙ! $c1 натягну$gло|в|ла тобі на голову сорочку і дмухає тобі в пуп! Лоскітно!!!!</msgVictimFound>
+  <msgVictimFound l="en">Yeek! $c1 pulled your shirt over your head and is blowing into your navel! That tickles!!!!</msgVictimFound>
   <position>rest</position>
   <rusName>дунуть</rusName>
   <uaName>дмухнути</uaName>
-  <shortDesc>это не то, что вы подумали, это означает дунуть в пупок:)</shortDesc>
+  <shortDesc l="ru">это не то, что вы подумали, это означает дунуть в пупок:)</shortDesc>
+  <shortDesc l="ua">це не те, що ви подумали, це означає дмухнути в пупок:)</shortDesc>
+  <shortDesc l="en">not what you were thinking -- it means blowing into a navel:)</shortDesc>
 </Social>


### PR DESCRIPTION
Fills every empty `l="en"`/`l="ua"` slot across the 144 socials left after the prune (#461): **1131 Russian source strings → 2262 translations**, short descriptions included. Needs dreamland-mud/dreamland_code#867 + #868.

**English seeded from Anatolia** (`jaromil/anatoliamud` `lib/areas/social.are`) where the social still exists there — 80% of slots — with ROM act-codes rewritten into Dreamland's (`$n`→`$c1`, `$N`→`$C1`, pronouns→`$g` branches). Anatolia is a seed, not an authority: where 30 years of Dreamland rewrites made the Russian say something else, the Russian wins and the English follows it (`goose` is a dentist joke here, a pinch on the rear there; `mosh` acquired a macaque).

**The pronoun trap.** `$e $s $m $x $y $z` and uppercase twins resolve through `%P`/`%T`, whose tables in `msgformatter.cpp` are hardcoded Russian words — they render "его"/"твой" to an English reader. All 54 occurrences were reworded or moved into a `$g`/`$G` gender branch carrying the English/Ukrainian word itself (4 branches, `neuter|masc|fem|plural`, each branch ending at a space).

**Gate:** `scripts/dl-social-l10n.py lint` — 0 HARD. Checks Russian-only pronoun codes in en/ua, KOI8-U representability (U+02BC would be silently dropped), typography (`—`/`…`/guillemets/spaced hyphen), mixed Latin/Cyrillic inside a word, lost `$c`/`$C`/`$O` substitutions, and `%N$` argument parity. It caught a Latin `i` in `поліруєш` and a Latin `e` in `збоченець`.

**Verified after apply:** all 144 files parse; every Russian string byte-identical to before; 1132 nodes per language.

`aargh` and `scream` carry a wordless Latin cry, which `XMLMultiString` classifies as English by content — both are now tagged `l="ru"` explicitly instead of leaning on the guess.