### PR TITLE
Document the druid Path restriction in religion helps

### DIFF
--- a/helps/religion.xml
+++ b/helps/religion.xml
@@ -60,9 +60,11 @@ available from the {Cdark elf{W in Old Midgaard and from the {Cpriest{W in Midga
 {hh971Prometheus{x          {C%A%{x   god of fire and craftsmanship
 {hh1868Azazel{x              {C%A%{x   god of pride, ambition and the lust for power
 
-Everyone may choose a religion or cult to their taste and {hh33character{x. To do so, seek out the priest in Midgaard or Old Midgaard, and in his presence {Wspeak the name of the god{x you will worship all your life. Afterwards, having gathered 200 quest points, you can have the =sign of your religion= applied by one of the {hh125questors{x. Through this sign your deity will aid you and strike down your enemies.
+Choose a religion or cult to your taste and {hh33character{x -- though not every god will accept everyone. To do so, seek out the priest in Midgaard or Old Midgaard, and in his presence {Wspeak the name of the god{x you will worship all your life. Afterwards, having gathered 200 quest points, you can have the =sign of your religion= applied by one of the {hh125questors{x. Through this sign your deity will aid you and strike down your enemies.
 
 Many gods =patronise= certain races, classes or clans. If your deity is your patron, your religion sign and some of your skills will trigger a little more often. Clerics are always patronised by their deity.
+
+Not every god takes every worshipper. Some demand a certain {hh33character{x or ethos, others accept only their own race, class or clan, and a few weigh your years or the strength of your body and mind; if you are refused, the priest will name the reason. The heaviest vow is the {hh192druid{x's: bound to the wild, a druid may follow only the gods of the Paths of {hh49Nature{x, {hh6Light{x, {hh10Fury{x and {hh23Order{x -- the forge, the flame and the affairs of society stay shut to them.
 
 The Midgaard priest and the dark elf in Old Midgaard can relieve you of your current sign and religion, turning you into a godless atheist. Simply say {Cmake me atheist{x in their presence. This can be done {RONLY ONCE ACROSS ALL REBIRTHS.{x Use this opportunity wisely.
 
@@ -123,9 +125,11 @@ Unlike official religions, cult gods enjoy being {hh1375sacrificed to{x, and in 
 {hh971Прометей{x            {C%A%{x   бог огня и ремесел
 {hh1868Азазель{x             {C%A%{x   бог гордыни, амбиций и жажды власти
 
-Каждый может выбрать религию или культ по своему вкусу и {hh33характеру{x. Для этого надо обратиться к священнику в Мидгаарде или Старом Мидгаарде, и рядом с ним {Wпроизнести имя бога{x, которому будешь поклоняться всю свою жизнь. После этого, собрав 200 квестовых очков, можно нанести =знак своей религии= у одного из {hh125квесторов{x. Через этот знак твое божество будет помогать тебе и повергать твоих врагов.
+Религию или культ выбирают по своему вкусу и {hh33характеру{x -- хотя не всякое божество примет всякого. Для этого надо обратиться к священнику в Мидгаарде или Старом Мидгаарде, и рядом с ним {Wпроизнести имя бога{x, которому будешь поклоняться всю свою жизнь. После этого, собрав 200 квестовых очков, можно нанести =знак своей религии= у одного из {hh125квесторов{x. Через этот знак твое божество будет помогать тебе и повергать твоих врагов.
 
 Многие боги =покровительствуют= каким-то расам, классам или кланам. Если твое божество тебе покровительствует, знак религии и некоторые твои умения будут срабатывать немного чаще. Клерикам их божество покровительствует всегда.
+
+Не всякое божество принимает всякого поклонника. Одни требуют определенной {hh33натуры{x или этоса, другие принимают только свою расу, класс или клан, а иные смотрят на твои годы или на силу твоего тела и разума; если тебе откажут, священник назовет причину. Тяжелее всех обет {hh192друида{x: связанный с дикой природой, друид может следовать лишь богам Путей {hh49Природы{x, {hh6Света{x, {hh10Ярости{x и {hh23Порядка{x -- кузня, пламя и дела общества для него закрыты.
 
 Священник Мидгаарда и темная эльфийка в Старом Мидгаарде могут избавить тебя от текущего знака и религии, превратив тебя в безбожн{Smого{Sfую{Sx атеист{Smа{Sfку{Sx. Просто произнеси {Cхочу стать атеистом{x рядом с ними. Сделать это можно {RТОЛЬКО ОДИН РАЗ ЗА ВСЕ ПЕРЕРОЖДЕНИЯ.{x Используй эту возможность с умом.
 
@@ -186,9 +190,11 @@ Unlike official religions, cult gods enjoy being {hh1375sacrificed to{x, and in 
 {hh971Прометей{x            {C%A%{x   бог вогню і ремесел
 {hh1868Азазель{x             {C%A%{x   бог гордині, амбіцій і жаги до влади
 
-Кожен може обрати релігію або культ на свій смак і до свого {hh33характеру{x. Для цього треба звернутися до священника у Мідгаарді або Старому Мідгаарді, і поряд з ним {Wвимовити імʼя бога{x, якому будеш поклонятися все своє життя. Після цього, зібравши 200 квестових очок, можна нанести =знак своєї релігії= у одного з {hh125квесторів{x. Через цей знак твоє божество буде допомагати тобі і повергати твоїх ворогів.
+Релігію або культ обирають на свій смак і до свого {hh33характеру{x -- хоча не всяке божество прийме всякого. Для цього треба звернутися до священника у Мідгаарді або Старому Мідгаарді, і поряд з ним {Wвимовити імʼя бога{x, якому будеш поклонятися все своє життя. Після цього, зібравши 200 квестових очок, можна нанести =знак своєї релігії= у одного з {hh125квесторів{x. Через цей знак твоє божество буде допомагати тобі і повергати твоїх ворогів.
 
 Багато богів =покровительствують= певним расам, класам або кланам. Якщо твоє божество тобі покровительствує, знак релігії і деякі твої уміння будуть спрацьовувати трохи частіше. Клірикам їхнє божество покровительствує завжди.
+
+Не всяке божество приймає всякого поклонника. Одні вимагають певної {hh33натури{x чи етосу, інші приймають лише свою расу, клас або клан, а ще інші дивляться на твої роки або на силу твого тіла і розуму; якщо тобі відмовлять, священник назве причину. Найтяжча обітниця у {hh192друїда{x: повʼязаний з дикою природою, друїд може йти лише за богами Шляхів {hh49Природи{x, {hh6Світла{x, {hh10Ярості{x та {hh23Порядку{x -- кузня, полумʼя і справи суспільства для нього зачинені.
 
 Священник Мідгаарда і темна ельфійка у Старому Мідгаарді можуть позбавити тебе від поточного знака і релігії, перетворивши тебе на безбожн{Smого{Sfу{Sx атеїст{Smа{Sfку{Sx. Просто вимов {Cхочу стать атеистом{x поряд з ними. Зробити це можна {RТІЛЬКИ ОДИН РАЗ ЗА УСІ ПЕРЕРОДЖЕННЯ.{x Використай цю можливість розумно.
 

--- a/religions/prometheus.xml
+++ b/religions/prometheus.xml
@@ -6,7 +6,7 @@
   <ethos>lawful neutral chaotic</ethos>
   <flags>cult</flags>
   <help id="971" level="-1" type="ReligionHelp">
-    <text l="en">{CPrometheus{x is the blacksmith god, giver of fire, and creator of the crafts. After the Supreme Goddess {hh1565Varda{x brought elves into our world, it was he who helped Father {hh1576Leo{x mold the second mortal race, humans, from clay and endow them with reason. Prometheus stands apart from the great confrontation of the Eight Principles; helping people concerns him far more than divine intrigues. Because of this the other gods dislike him and sometimes visit punishments upon him.
+    <text l="en">{CPrometheus{x is the blacksmith god, giver of fire, and creator of the crafts. After the Supreme Goddess {hh1565Varda{x brought elves into our world, it was he who helped Father {hh1576Leo{x mold the second mortal race, humans, from clay and endow them with reason. Prometheus stands apart from the great confrontation of the Eight Principles; helping people concerns him far more than divine intrigues. Because of this the other gods dislike him and sometimes visit punishments upon him. And because he stands outside the Paths, the {hh192druids{x will have none of him: their vows admit only the gods of {hh49Nature{x, {hh6Light{x, {hh10Fury{x and {hh23Order{x, and neither forge nor flame has a place among them.
 
 %A% =Gifts:= the mark of Prometheus will periodically {hh273repair{x and clean your armor of {hh2168corrosion{x, and in battle will fire a {hh625fireball{x at your enemy. The mark of Prometheus also helps with {hh273repairs{x and crafting items by {hh195artisans{x.
 %A% =Sacrifices:= Prometheus prefers magical items with spells of item magic. Prometheus likes to receive books, scrolls, textbooks and spellbooks as sacrifice, as well as good weapons.
@@ -15,7 +15,7 @@ According to legend, the old gods of {hh1864Olympus{x imprisoned Prometheus, but
 
 %SA% %H% {hh81Eight Paths{x
 </text>
-    <text l="ru">{CПрометей{x -- бог-кузнец, даритель огня и создатель ремесел. После того как Верховная Богиня {hh1565Варда{x привела в наш мир эльфов, именно он помог Отцу {hh1576Лео{x создать из глины вторую смертную расу, людей, и наделить их разумом. Прометей стоит в стороне от великого противоборства Восьми Начал, помощь людям заботит его гораздо больше, чем божественные перипетии. Поэтому остальные боги недолюбливают его и иногда насылают на него кары.
+    <text l="ru">{CПрометей{x -- бог-кузнец, даритель огня и создатель ремесел. После того как Верховная Богиня {hh1565Варда{x привела в наш мир эльфов, именно он помог Отцу {hh1576Лео{x создать из глины вторую смертную расу, людей, и наделить их разумом. Прометей стоит в стороне от великого противоборства Восьми Начал, помощь людям заботит его гораздо больше, чем божественные перипетии. Поэтому остальные боги недолюбливают его и иногда насылают на него кары. А поскольку он стоит вне Путей, {hh192друиды{x его не признают: их обеты допускают только богов {hh49Природы{x, {hh6Света{x, {hh10Ярости{x и {hh23Порядка{x, и ни кузне, ни пламени места среди них нет.
 
 %A% =Дары:= знак Прометея будет периодически {hh273чинить{x и чистить от {hh2168коррозии{x твои доспехи, а в бою выстрелит в твоего противника {hh625огненным шаром{x. Также знак Прометея помогает при {hh273починке{x и создании вещей {hh195ремесленниками{x.
 %A% =Жертвоприношения:= Прометей предпочитает волшебные предметы с заклинаниями предметной магии. Прометею нравится, когда ему в жертву приносят книги, свитки, учебники и книги заклинаний. а также хорошее оружие.
@@ -24,7 +24,7 @@ According to legend, the old gods of {hh1864Olympus{x imprisoned Prometheus, but
 
 %SA% %H% {hh81Восемь Путей{x
 </text>
-    <text l="ua">{CПрометей{x -- бог-коваль, дарувальник вогню та творець ремесел. Після того як Верховна Богиня {hh1565Варда{x привела до нашого світу ельфів, саме він допоміг Батькові {hh1576Лео{x створити з глини другу смертну расу, людей, і наділити їх розумом. Прометей стоїть осторонь великого протистояння Восьми Начал -- допомога людям цікавить його набагато більше, ніж божественні перипетії. Тому решта богів недолюблює його і іноді насилає на нього кари.
+    <text l="ua">{CПрометей{x -- бог-коваль, дарувальник вогню та творець ремесел. Після того як Верховна Богиня {hh1565Варда{x привела до нашого світу ельфів, саме він допоміг Батькові {hh1576Лео{x створити з глини другу смертну расу, людей, і наділити їх розумом. Прометей стоїть осторонь великого протистояння Восьми Начал -- допомога людям цікавить його набагато більше, ніж божественні перипетії. Тому решта богів недолюблює його і іноді насилає на нього кари. А позаяк він стоїть поза Шляхами, {hh192друїди{x його не визнають: їхні обітниці допускають лише богів {hh49Природи{x, {hh6Світла{x, {hh10Ярості{x та {hh23Порядку{x, і ні кузні, ні полумʼю місця серед них немає.
 
 %A% =Дари:= знак Прометея буде час від часу {hh273лагодити{x і чистити від {hh2168корозії{x твої обладунки, а в бою вистрілить у твого противника {hh625вогняною кулею{x. Також знак Прометея допомагає при {hh273ремонті{x та виготовленні речей {hh195ремісниками{x.
 %A% =Жертвоприношення:= Прометей надає перевагу чарівним предметам із заклинаннями предметної магії. Прометею подобається, коли йому в жертву приносять книги, сувої, підручники та книги заклинань, а також хорошу зброю.


### PR DESCRIPTION
Druids may only follow gods of the Paths of Nature, Light, Fury and Order. The rule is enforced by the per-religion `<classes>` whitelist (`DefaultReligion::reasonWhy`) and was already stated in the druid article (help 192), but it was not discoverable from the general religion article or from the help of any god that refuses them.

- **help 1** (`helps/religion.xml`): the article claimed "Everyone may choose a religion or cult to their taste", which is not true. Replaced with an accurate line, and added a paragraph covering how gods restrict worshippers (character/ethos, race, class, clan, age, stats) with the druid Path rule spelled out.
- **help 971** (`religions/prometheus.xml`): added why he refuses druids -- he stands outside the Paths.

All three languages. No data or mechanic changes -- helps only.

Reported in game by Bromir (report 6130).