### PR TITLE
Close two druid Path holes and document the Tirna exception

### DIFF
--- a/professions/druid.xml
+++ b/professions/druid.xml
@@ -16,7 +16,7 @@ The price of communion with Nature is a string of specific restrictions: druids 
 
 Nature magic is slow-going, so many druid skills come with a longer than usual delay and often trigger {hh97fatigue{x. Many druid skills mirror those of the ranger: like them, druids are masters of forest {hh546camouflage{x.
 
-To use their powers, druids must choose a {hh1religion{x -- and only gods of the Paths of {hh49Nature{x, {hh6Light{x, {hh10Fury{x or {hh23Order{x are accepted. Reaching the highest =rank= of druid requires passing initiations in the {hh2080Holy Grove{x.
+To use their powers, druids must choose a {hh1religion{x -- and only gods of the Paths of {hh49Nature{x, {hh6Light{x, {hh10Fury{x or {hh23Order{x are accepted -- the one standing exception being {hh1584Tirna{x, who takes in all those who walk a path of their own. Reaching the highest =rank= of druid requires passing initiations in the {hh2080Holy Grove{x.
 
 %A% =Pros:= one of the most protected and survivable classes
 %A% =Cons:= complex gameplay that demands knowing the world's mechanics; not for newcomers
@@ -27,7 +27,7 @@ To use their powers, druids must choose a {hh1religion{x -- and only gods of the
 
 Магия Природы очень нетороплива, поэтому многие умения друида имеют более долгую задержку, чем обычно, и часто вызывают {hh97усталость{x. Многие умения друидов сходны с умениями рейнджеров, как и они друиды мастерски умеют {hh546маскироваться{x в лесу.
 
-Для использования своих умений друидам обязательно выбрать {hh1религию{x -- и притом допускаются только боги Путей {hh49Природы{x, {hh6Света{x, {hh10Ярости{x или {hh23Порядка{x. Чтобы достичь высшего =ранга= друида, нужно пройти инициации в {hh2080Священной Роще{x.
+Для использования своих умений друидам обязательно выбрать {hh1религию{x -- и притом допускаются только боги Путей {hh49Природы{x, {hh6Света{x, {hh10Ярости{x или {hh23Порядка{x -- единственное исключение составляет {hh1584Тирна{x, принимающий всех, кто идет своим собственным путем. Чтобы достичь высшего =ранга= друида, нужно пройти инициации в {hh2080Священной Роще{x.
 
 %A% =Плюсы:= один из наиболее защищенных и хорошо выживающих классов
 %A% =Минусы:= сложный геймплей, требующий знания механик мира, не для новичков
@@ -38,7 +38,7 @@ To use their powers, druids must choose a {hh1religion{x -- and only gods of the
 
 Магія Природи дуже неквапна, тому багато вмінь друїда мають довшу затримку, ніж зазвичай, і часто викликають {hh97втому{x. Багато вмінь друїдів схожі на вміння рейнджерів, як і вони друїди майстерно вміють {hh546маскуватися{x у лісі.
 
-Для використання своїх умінь друїдам обовʼязково вибрати {hh1релігію{x -- і притому допускаються тільки боги Шляхів {hh49Природи{x, {hh6Світла{x, {hh10Ярості{x чи {hh23Порядку{x. Щоб досягти вищого =рангу= друїда, треба пройти ініціації у {hh2080Священному Гаю{x.
+Для використання своїх умінь друїдам обовʼязково вибрати {hh1релігію{x -- і притому допускаються тільки боги Шляхів {hh49Природи{x, {hh6Світла{x, {hh10Ярості{x чи {hh23Порядку{x -- єдиний виняток становить {hh1584Тирна{x, що приймає всіх, хто йде власним шляхом. Щоб досягти вищого =рангу= друїда, треба пройти ініціації у {hh2080Священному Гаю{x.
 
 %A% =Плюси:= один із найзахищеніших і добре виживаючих класів
 %A% =Мінуси:= складний геймплей, що потребує знання механік світу, не для новачків

--- a/religions/godiva.xml
+++ b/religions/godiva.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Religion type="DefaultReligion">
   <align>good neutral evil</align>
+  <classes registry="profession">thief samurai warrior necromancer ranger cleric witch anti-paladin ninja paladin warlock vampire</classes>
   <description>Богиня древних легенд и таинств</description>
   <ethos>lawful neutral chaotic</ethos>
   <help id="1586" level="-1" type="ReligionHelp">

--- a/religions/nofate.xml
+++ b/religions/nofate.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Religion type="DefaultReligion">
   <align>neutral</align>
+  <classes registry="profession">thief samurai warrior necromancer ranger cleric witch anti-paladin ninja paladin warlock vampire</classes>
   <description>Верховный бог науки, бесстрастный демиург</description>
   <ethos>neutral</ethos>
   <help id="1570" level="-1" type="ReligionHelp">

--- a/scripts/lint-religion-access.py
+++ b/scripts/lint-religion-access.py
@@ -12,17 +12,24 @@ Light, Fury and Order. There is no Path field on a religion -- the Paths are the
 colour groupings of the master index in helps/religion.xml, so that is where the
 mapping is read from.
 
-Two directions of drift are reported:
+Three findings, only the first of which is a defect:
 
-  HOLE       the gate lets a druid in on a Path the rule forbids
-  UNREACHED  the rule promises a Path but some other gate shuts druids out anyway
+  HOLE     the gate lets a druid in on a Path the rule forbids -- fixable by
+           adding a <classes> whitelist. Exits 1.
+  OR-TRAP  same, but the god has <races> set, and reasonWhy ORs races with
+           classes -- adding <classes> would ADMIT every listed class of every
+           race instead of narrowing. Needs an engine change, not data.
+  NOTE     the god is on an accepted Path yet some other gate refuses druids.
+           NOT a defect: help 192 states a necessary condition (which Paths are
+           acceptable), never a promise that every god on them is reachable.
+           align/class/clan gates compose on top of it independently.
 
 An empty <classes> means "no class restriction", NOT "no class allowed" -- the
 whole-of-13 whitelist and the empty element are equivalent for access but only
 the empty one stays correct when a 14th profession is added.
 
 Usage:  python3 scripts/lint-religion-access.py [--quiet]
-Exit 1 if any mismatch is found.
+Exit 1 if any gate contradicts the rule.
 """
 import glob
 import os
@@ -42,6 +49,8 @@ PATH_BY_COLOUR = {
 # help 192: "only gods of the Paths of Nature, Light, Fury or Order are accepted"
 DRUID_PATHS = {"Nature", "Light", "Fury", "Order"}
 DRUID_ALIGN = "neutral"          # professions/druid.xml <align>
+# Gods help 192 names as standing exceptions to the Path rule (by help id).
+DRUID_EXCEPTIONS = {"1584"}      # Tirna -- patron of those who walk paths of their own
 
 
 def text(node, tag):
@@ -90,6 +99,7 @@ def main():
     quiet = "--quiet" in sys.argv
     by_id = paths_from_index()
     problems = []
+    notes = []
     checked = 0
 
     for path in sorted(glob.glob(os.path.join(WORLD, "religions", "*.xml"))):
@@ -108,26 +118,36 @@ def main():
             continue
         checked += 1
 
-        allowed = godpath in DRUID_PATHS
+        allowed = godpath in DRUID_PATHS or hid in DRUID_EXCEPTIONS
         # race-gated / race-or-class still admit a druid of a qualifying race
         can = gate in (None, "race-gated", "race-or-class", "clan-gated")
 
         if can and not allowed:
-            problems.append(("HOLE", god, godpath, gate or "open",
-                             "druid may worship a %s god" % godpath))
+            # A god with <races> set cannot be narrowed by adding <classes>:
+            # reasonWhy ORs the two, so that would ADMIT every listed class of
+            # every race. Closing these needs an engine change, not data.
+            if gate in ("race-gated", "race-or-class"):
+                notes.append(("OR-TRAP", god, godpath, gate,
+                              "a druid of a listed race gets in; NOT closable by data"))
+            else:
+                problems.append(("HOLE", god, godpath, gate or "open",
+                                 "druid may worship a %s god" % godpath))
         elif allowed and not can:
-            problems.append(("UNREACHED", god, godpath, gate,
-                             "help 192 promises %s but <%s> shuts druids out" % (godpath, gate)))
+            # Not a defect: help 192 states a NECESSARY condition (which Paths are
+            # acceptable), never a promise that every god on them is reachable.
+            # align/class/clan gates compose on top of it independently.
+            notes.append(("NOTE", god, godpath, gate,
+                          "%s god, but <%s> applies independently" % (godpath, gate)))
 
     if not quiet:
         print("religions checked: %d\n" % checked)
-    for kind, god, godpath, gate, why in problems:
+    for kind, god, godpath, gate, why in problems + notes:
         print("  %-10s %-16s Path=%-8s gate=%-14s %s" % (kind, god, godpath, gate, why))
 
     if problems:
-        print("\n%d mismatch(es) between the gates and help 192." % len(problems))
+        print("\n%d gate(s) contradict help 192." % len(problems))
         return 1
-    print("OK -- every gate agrees with the druid Path rule.")
+    print("\nOK -- no gate contradicts the druid Path rule (%d informational)." % len(notes))
     return 0
 
 


### PR DESCRIPTION
help 192 restricts druids to gods of the Paths of Nature, Light, Fury and Order, but six gates let them through anyway.

**Blast radius measured first.** Of 216 druids only 45 carry a religion, and just six sit on a hole -- four of them untouched since a bulk re-save in September 2024:

| character | god | level | last saved |
|---|---|---|---|
| lilian | nofate | 8 | 2024-09-07 |
| mettes | nofate | 12 | 2024-09-07 |
| yezhik | godiva | 9 | 2024-09-07 |
| mordi | tirna | 42 | 2024-09-07 |
| bast | bast | 1 | 2026-07-27 |
| eerie | tirna | 100 | 2026-07-27 |

**Closed:** `nofate` and `godiva` -- no class restriction at all and no `<races>`, so the standard whitelist closes them. `nofate` mattered most: supreme god of science, wide open, the opposite pole to a nature priest. No live character affected.

**Left open on purpose:** `tirna`, now named in help 192 (all three languages) as the one standing exception. He is the patron of those who walk paths of their own, so a druid on Tirna is the intent rather than a leak -- and the only live character involved is a level 100 druid.

**Cannot be closed with data:** `lloth`, `bast`, `erevan ilesere`. They set `<races>`, and `reasonWhy` **ORs** races with classes (`myRace || myClass`), so adding a whitelist would *admit* every listed class of every race instead of narrowing. Closing them needs an engine change; the lint now reports them as **OR-TRAP** so nobody attempts the data fix.

**Lint reclassified.** An accepted Path plus an independent align/class gate is no longer a mismatch -- help 192 states a necessary condition, not a promise that every god on those Paths is reachable. `varda`, `razer`, `atum-ra` and `turlok` are correct as they stand. Lint now exits 0.