### PR TITLE
Reserve 51 legendary names

### DIFF
--- a/badnames.xml
+++ b/badnames.xml
@@ -1,5 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BadNames>
+  <legendary>
+      <node>adron</node>
+      <node>aivengo</node>
+      <node>arhant</node>
+      <node>arsin</node>
+      <node>branwen</node>
+      <node>burzum</node>
+      <node>corvin</node>
+      <node>dayeneriss</node>
+      <node>dekker</node>
+      <node>demogorgon</node>
+      <node>derini</node>
+      <node>dred</node>
+      <node>eirenar</node>
+      <node>eugene</node>
+      <node>fantik</node>
+      <node>finraag</node>
+      <node>fiorine</node>
+      <node>galen</node>
+      <node>garret</node>
+      <node>glorund</node>
+      <node>grom</node>
+      <node>hart</node>
+      <node>hinore</node>
+      <node>joker</node>
+      <node>kerrad</node>
+      <node>krauss</node>
+      <node>kril</node>
+      <node>manwe</node>
+      <node>meriks</node>
+      <node>miyamoto</node>
+      <node>nazar</node>
+      <node>nimoa</node>
+      <node>pianka</node>
+      <node>pradd</node>
+      <node>reistlyn</node>
+      <node>reorx</node>
+      <node>resky</node>
+      <node>rjak</node>
+      <node>romashka</node>
+      <node>saboteur</node>
+      <node>satan</node>
+      <node>sherhan</node>
+      <node>shur</node>
+      <node>sturm</node>
+      <node>susanin</node>
+      <node>teelak</node>
+      <node>xok</node>
+      <node>zaleshanin</node>
+      <node>zauber</node>
+      <node>zav</node>
+      <node>zverodral</node>
+  </legendary>
     <names>
       <node>ugly</node>
       <node>set</node>


### PR DESCRIPTION
The list behind `BadNames::nameLegendary()` (dreamland_code#876). Sources: help `credits` (id 1010), help `immortals` (id 92), `HISTORY.md`, and dreamland.rocks/ru/values.html -- every spelling comes from those English-language sources, none was transliterated by hand.

Reviewed name by name with Kit. Dropped on review: Axtraxis, Malkiri (a place, not a person), Krotus, Frath, Trandil, Feltesres, Ydri, Shohan, Todomore, Redrum, Kiddy, Lexx, Baar, plus Roch'tar and Shadar-Lunn (apostrophe and hyphen -- cannot be logins anyway).

25 of the 51 still have a profile, which already reserves the name and keeps `whois` answering; the list matters for the other 26.