### PR TITLE
Reserve the Cyrillic forms of legendary names too

### DIFF
--- a/badnames.xml
+++ b/badnames.xml
@@ -52,6 +52,35 @@
       <node>zauber</node>
       <node>zav</node>
       <node>zverodral</node>
+      <node>Арсин</node>
+      <node>Архант</node>
+      <node>Бурзум</node>
+      <node>Гален</node>
+      <node>Гаррет</node>
+      <node>Гром</node>
+      <node>Деккер</node>
+      <node>Дред</node>
+      <node>Залешанин</node>
+      <node>Заубер</node>
+      <node>Керрад</node>
+      <node>Корвин</node>
+      <node>Краус</node>
+      <node>Крил</node>
+      <node>Мерикс</node>
+      <node>Миямото</node>
+      <node>Нимоа</node>
+      <node>Прадд</node>
+      <node>Пьянка</node>
+      <node>Ромашка</node>
+      <node>Саботеур</node>
+      <node>Сатан</node>
+      <node>Сусанин</node>
+      <node>Тилак</node>
+      <node>Финрааг</node>
+      <node>Фиориннэ</node>
+      <node>Харт</node>
+      <node>Хиноре</node>
+      <node>Шерхан</node>
   </legendary>
     <names>
       <node>ugly</node>


### PR DESCRIPTION
`BadNames::checkRussianName()` runs against the same list as the English check, so until now a legendary name was only protected in Latin -- someone could still take `Бурзум` or `Сатан` as a Russian display name.

29 Cyrillic forms added, every one from an authoritative source rather than transliterated by hand:
- `russianName` in the surviving profiles (24)
- help `immortals` (id 92), which is translated into both Russian and Ukrainian
- dreamland.rocks/ru/values.html

Help `credits` was no use here -- its Russian and Ukrainian texts are untranslated copies of the English.

**Still open:** 21 names have no Russian form on record (Adron, Aivengo, Branwen, Dayeneriss, Demogorgon, Derini, Eirenar, Eugene, Fantik, Glorund, Joker, Manwe, Nazar, Reistlyn, Reorx, Resky, Rjak, Shur, Xok, Zav, Zverodral) and Ukrainian coverage is thinner still -- no profile carries a `ukrainianName`. **Sturm is contradictory**: the profile and help `immortals` say `Стурм`, the values page says `Штурм`; left out until it is settled.