### PR TITLE
Complete the Russian and Ukrainian legendary forms

### DIFF
--- a/badnames.xml
+++ b/badnames.xml
@@ -81,6 +81,45 @@
       <node>Харт</node>
       <node>Хиноре</node>
       <node>Шерхан</node>
+      <node>Адрон</node>
+      <node>Айвенго</node>
+      <node>Арсін</node>
+      <node>Бранвен</node>
+      <node>Глорунд</node>
+      <node>Дейенерис</node>
+      <node>Дейенеріс</node>
+      <node>Демогоргон</node>
+      <node>Дерини</node>
+      <node>Дерині</node>
+      <node>Джокер</node>
+      <node>Ейренар</node>
+      <node>Зав</node>
+      <node>Зверодрал</node>
+      <node>Корвін</node>
+      <node>Манве</node>
+      <node>Манвэ</node>
+      <node>Міямото</node>
+      <node>Назар</node>
+      <node>Німоа</node>
+      <node>Пʼянка</node>
+      <node>Рʼяк</node>
+      <node>Рейстлин</node>
+      <node>Рейстлін</node>
+      <node>Реоркс</node>
+      <node>Рески</node>
+      <node>Рескі</node>
+      <node>Рьяк</node>
+      <node>Стурм</node>
+      <node>Сусанін</node>
+      <node>Тілак</node>
+      <node>Фантик</node>
+      <node>Фінрааг</node>
+      <node>Фіоринне</node>
+      <node>Хок</node>
+      <node>Хіноре</node>
+      <node>Шур</node>
+      <node>Эйренар</node>
+      <node>Юджин</node>
   </legendary>
     <names>
       <node>ugly</node>


### PR DESCRIPTION
Fills the two gaps left by #469: 20 names had no Russian form on record, and Ukrainian was uncovered entirely -- no profile carries a `ukrainianName`, and the Ukrainian text of help `immortals` keeps Russian-looking forms, so its nine entries deduplicated into the Russian ones and added nothing.

- **Sturm settled as `Стурм`** (Kit): the profile and help `immortals` agree; dreamland.rocks/ru/values.html says `Штурм` and is the odd one out -- worth correcting there.
- **`Зверодрал`** recovered from HISTORY.md, which spells it out.
- The remaining 20 Russian forms and all 51 Ukrainian ones are transliterations, applying the usual conventions: no `э` in Ukrainian, the modifier-letter apostrophe (`Пʼянка`, `Рʼяк`), Latin `i` to `і` (`Арсін`, `Німоа`, `Тілак`, `Корвін`).

List is now 119 entries, no duplicates, no mixed-script words.

**Worth pruning if you disagree:** a few forms are ordinary words or common given names, and someone who picks one will be told their name is protected due to legendary status -- `Назар`, `Ромашка`, `Фантик`, `Джокер`, `Гром`, and `Зав` at three letters. They are genuinely these people's names, so they are in; say the word and any of them come out.