### PR TITLE
Say bin, not vat, in the intro ANSWER 2 line

### DIFF
--- a/config/translations/areas.json
+++ b/config/translations/areas.json
@@ -2587,7 +2587,7 @@
    "ua": "{D[ВІДПОВІДЬ 1]:{x {y{hcсказати Ееє... що?{x"
   },
   "{D[ОТВЕТ 2]:{x {y{hcсказать Вы хотите бак открыть -- я правильно понял%1$G||а?.{x": {
-   "en": "{D[ANSWER 2]:{x {y{hcsay You want to open the vat -- did I get that right?{x",
+   "en": "{D[ANSWER 2]:{x {y{hcsay You want to open the bin -- did I get that right?{x",
    "ua": "{D[ВІДПОВІДЬ 2]:{x {y{hcсказати Ви хочете відкрити бак -- я правильно зрозумів%1$G||ла?.{x"
   },
   "%1$^C1 задумчиво шевелит мусорный бак носком ботинка.": {


### PR DESCRIPTION
Companion to dreamland_fenia#383. Object 4510 in the intro area is `<keyword l="en">can trash bin</keyword>`; the tutorial hints now all call it a bin, so this scripted answer line follows. RU and UA untouched.