### PR TITLE
Drop the dead TRAINING hint label

### DIFF
--- a/config/translations/newbie.json
+++ b/config/translations/newbie.json
@@ -1,10 +1,4 @@
 {
- "newbie/helpers": {
-  "{Y[{GОБУЧЕНИЕ{Y]{x {g%s{x": {
-   "en": "{Y[{GTRAINING{Y]{x {g%s{x",
-   "ua": "{Y[{GНАВЧАННЯ{Y]{x {g%s{x"
-  }
- },
  "newbie/nanny": {
   "%1$^C1 восстанови%1$Gло|л|ла связь с этим миром.": {
    "en": "%1$^C1 has reconnected to this world.",


### PR DESCRIPTION
The `{Y[{GОБУЧЕНИЕ{Y]{x {g%s{x` key -- rendered `[TRAINING]` in English, `[НАВЧАННЯ]` in Ukrainian -- lost its only caller when dreamland_fenia#386 moved the label into `.tmp.intro.hintLabel(ch)`. It was the last surviving copy of the pre-canon wording.

It was the sole key in its `newbie/helpers` section, so the empty section goes with it. Verified nothing else emits that Russian string. `lint-l10n.py`: 0 HARD.