### PR TITLE
Send English newcomers to Discord in nanny's parting line

### DIFF
--- a/config/translations/newbie.json
+++ b/config/translations/newbie.json
@@ -109,7 +109,7 @@
    "ua": "Ти прогнівив Богів, і вони заборонили тобі з'являтися у світі."
   },
   "С вопросами обращайся в наш Телеграм: https://t.me/dreamland_rocks": {
-   "en": "With any questions, reach out to our Telegram: https://t.me/dreamland_rocks",
+   "en": "With any questions, reach out to our Discord: https://discord.gg/fVtaeePyey",
    "ua": "З питаннями звертайся до нашого Телеграму: https://t.me/dreamland_rocks"
   },
   "Сожалею, но сегодня мне велено пропускать только Бессмертных.": {


### PR DESCRIPTION
Telegram is the Russian/Ukrainian community channel; English speakers are on Discord. Engine-side intro hints are dreamland_fenia#393.

Only the English slot of the `newbie/nanny` entry changes; Russian and Ukrainian keep Telegram.

`newbie/newnanny` holds an identical string and is deliberately left untouched -- it is an old test file rather than the live endpoint, so changing it would only add drift.