### PR TITLE
Translate the last wrapped-but-untranslated strings

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -16865,6 +16865,10 @@
   "[ Ном.| Ур.  Цена Кол-во] Товар": {
    "en": "[ No. | Lvl  Cost    Qty] Item",
    "ua": "[ Ном.| Рів  Ціна  К-сть] Товар"
+  },
+  "$c1 покупает $o4[%d].": {
+   "en": "$c1 buys $o4[%d].",
+   "ua": "$c1 купує $o4[%d]."
   }
  },
  "plug-ins/services/shop/shoptrader.cpp": {
@@ -19517,6 +19521,48 @@
   "См. справку по каждому социалу, чтобы увидеть, как он выглядит.": {
    "en": "See the help on any social to watch how it looks.",
    "ua": "Дивись довідку по кожному соціалу, щоб побачити, як він виглядає."
+  }
+ },
+ "plug-ins/comm/pcname.cpp": {
+  "Английская форма имени должна быть латиницей.": {
+   "en": "The English form of a name must be in Latin letters.",
+   "ua": "Англійська форма імені має бути латиницею."
+  },
+  "Готово. Теперь на этом языке тебя видят как: %s": {
+   "en": "Done. In that language you now appear as: %s",
+   "ua": "Готово. Тепер цією мовою тебе бачать як: %s"
+  },
+  "Задавать имена по языкам можно только с %d уровня.": {
+   "en": "Setting per-language names is available from level %d.",
+   "ua": "Задавати імена за мовами можна лише з %d рівня."
+  },
+  "Используй: имя <en|ru|ua> <имя>. Без аргументов -- показать формы.": {
+   "en": "Use: name <en|ru|ua> <name>. With no arguments -- show the forms.",
+   "ua": "Використовуй: ім'я <en|ru|ua> <ім'я>. Без аргументів -- показати форми."
+  },
+  "Русская и украинская формы имени должны быть кириллицей.": {
+   "en": "The Russian and Ukrainian forms of a name must be in Cyrillic.",
+   "ua": "Російська та українська форми імені мають бути кирилицею."
+  },
+  "Слишком длинное имя.": {
+   "en": "That name is too long.",
+   "ua": "Занадто довге ім'я."
+  },
+  "Укажи, как записать имя: имя <en|ua> <имя>.": {
+   "en": "Say how the name should be written: name <en|ua> <name>.",
+   "ua": "Вкажи, як записати ім'я: ім'я <en|ua> <ім'я>."
+  },
+  "Эта форма слишком отличается от твоего имени (%s) -- такую замену должен подтвердить бессмертный. Обратись к нему.": {
+   "en": "That form differs too much from your name (%s) -- a change like this has to be confirmed by an immortal. Go and ask one.",
+   "ua": "Ця форма надто відрізняється від твого імені (%s) -- таку заміну має підтвердити безсмертний. Звернися до нього."
+  },
+  "Это имя уже занято другим игроком.": {
+   "en": "Another player has taken that name already.",
+   "ua": "Це ім'я вже зайняте іншим гравцем."
+  },
+  "Это язык, под которым ты зарегистрирован -- эту форму менять нельзя.": {
+   "en": "This is the language you registered under -- that form cannot be changed.",
+   "ua": "Це мова твоєї реєстрації -- цю форму змінювати не можна."
   }
  }
 }


### PR DESCRIPTION
`lint-catalog-gaps.py` found 11 strings that are wrapped for translation but have no catalog entry. A missing entry falls back to the Russian source silently -- no error, no log line -- so these looked finished in the diff and were Russian in play.

- `plug-ins/comm/pcname.cpp` (10) -- the whole file key was absent from every shard, so the entire `name en|ru|ua` command spoke Russian to everyone
- `plug-ins/services/shop/oldshop.cpp` (1) -- `$c1 покупает $o4[%d].`

After this the corpus reports **0 gaps** across 13079 wrapped strings.

One note for whoever reads the tool output next: `l10n-catalog-add.py --verify-source` warned that the long name-mismatch key was "not found verbatim in source". That is a false negative -- the string is written as two adjacent literals which the compiler joins into a single runtime key. All ten keys were verified against the joined form and match exactly.