### PR TITLE
Call damage 'пошкодження' in the Ukrainian config option

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -103,13 +103,13 @@
         <hint>формат отображения урона: числами или в процентах</hint>
         <msgOff l="en">Damage is shown as numbers.</msgOff>
         <msgOff l="ru">Урон отображается числами.</msgOff>
-        <msgOff l="ua">Шкода відображається числами.</msgOff>
+        <msgOff l="ua">Пошкодження відображається числами.</msgOff>
         <msgOn l="en">Damage is shown as a percentage.</msgOn>
         <msgOn l="ru">Урон отображается в процентах.</msgOn>
-        <msgOn l="ua">Шкода відображається у відсотках.</msgOn>
+        <msgOn l="ua">Пошкодження відображається у відсотках.</msgOn>
         <name>damage</name>
         <rname>урон</rname>
-        <uaname>шкода</uaname>
+        <uaname>пошкодження</uaname>
       </node>
       <name l="en">Gameplay settings:</name>
       <name l="ru">Настройки игрового процесса:</name>
@@ -286,7 +286,7 @@
   <help id="1087" level="-1" type="CommandHelp" labels="comm">
     <extra l="en">autoassist autoloot autosac nocancel nobuff notransfer nofollow damage brief shortflags affscore prompt screenreader color lines lang holylight noiac notelnet telnetga</extra>
     <extra l="ru">автопомощь автограбеж автожертва неотменять неследовать урон кратко краткофлаги аффектывсчет состояние незрячий цвет строк язык боговзор</extra>
-    <extra l="ua">автодопомога автограбунок автожертва невідміняти неслідувати шкода стисло короткофлаги афективрахунок стан незрячий колір рядки мова боговзір</extra>
+    <extra l="ua">автодопомога автограбунок автожертва невідміняти неслідувати пошкодження стисло короткофлаги афективрахунок стан незрячий колір рядки мова боговзір</extra>
     <text l="en">Write *%CMD%* to see all your settings, grouped by section. To change one, write *%CMD%* _option_ *%YES%*|*%NO%* -- for example, *%CMD%* _autoloot_ *%NO%* to stop looting items from corpses.
 
 A few useful ones: *autoassist* makes you join your group's fights; *autoloot* and *autosac* deal with enemy corpses; *nocancel* and *nofollow* keep others from cancelling your spells or following you; *brief* shortens room descriptions; *shortflags* abbreviates item flags; *damage* shows damage as numbers or as a percentage; *screenreader* turns on screen-reader support.


### PR DESCRIPTION
`налаш урон ні` answered `Шкода відображається числами.` -- `шкода` reads as *pity* or *a shame* at least as readily as *damage*.

Renames four things together so the word a player types still matches the word they read: `uaname`, both `msgOff`/`msgOn` Ukrainian messages, and the entry in the UA keyword list on line 289.

⚠️ **Terminology split worth a decision.** The corpus already leans the other way: `ушкодження`/`ушкоджень` appears 12 times (combat verbs, `compare`'s stat labels) against 6 for `пошкодження`. This PR uses `пошкодження` because that is what was asked for, but it leaves two terms in play. Normalising is a small, separate pass -- say which one wins and I will make the rest follow.