### PR TITLE
Rekey the three catalog strings that lost their {lR}/{lE} markup

### DIFF
--- a/config/translations/areas3.json
+++ b/config/translations/areas3.json
@@ -2412,9 +2412,9 @@
   }
  },
  "areas/midgaard.are/mob/3012.q3001_step3_begin_postGreet": {
-  "Запомни как добраться сюда от того места, куда тебя переносит команда {y{lRвозврат{lErecall{x.": {
-   "en": "Remember how to get here from wherever the {y{lRвозврат{lErecall{x command takes you.",
-   "ua": "Запам'ятай, як дістатися сюди з того місця, куди тебе переносить команда {y{lRвозврат{lErecall{x."
+  "Запомни как добраться сюда от того места, куда тебя переносит команда {yвозврат{x.": {
+   "en": "Remember how to get here from wherever the {yrecall{x command takes you.",
+   "ua": "Запам'ятай, як дістатися сюди з того місця, куди тебе переносить команда {yповернення{x."
   },
   "Если ты ранен%1$Gо||а, ослеплен%1$Gо||а или отравлен%1$Gо||а, просто подойди ко мне, и я попытаюсь помочь.": {
    "en": "If you're wounded, blinded, or poisoned, just come to me and I'll try to help.",

--- a/config/translations/newbie.json
+++ b/config/translations/newbie.json
@@ -804,11 +804,11 @@
    "en": "{CA Valkyrie resurrects you back to life!{x",
    "ua": "{CВалькірія воскрешає тебе до життя!{x"
   },
-  "Подробности смотри по команде {hc{y{lRуроки{lElessons{x.": {
+  "Подробности смотри по команде {hc{yуроки{x.": {
    "en": "For details, check the {hc{ylessons{x command.",
    "ua": "Подробиці дивись за командою {hc{yуроки{x."
   },
-  "Твой первый урок: {Gнайти в храме лекаря и выполнить команду '{y{lRуслуга{lEservice{x'.": {
+  "Твой первый урок: {Gнайти в храме лекаря и выполнить команду '{yуслуга{x'.": {
    "en": "Your first lesson: {Gfind the healer in the temple and run the command '{yservice{x'.",
    "ua": "Твій перший урок: {Gзнайти в храмі лікаря і виконати команду '{yпослуга{x'."
   },


### PR DESCRIPTION
Pairs with `dreamland_fenia`#409, which changed those three `._()` source strings.

Two of the three already carried correct English and Ukrainian text and only needed the key updated. The `recall` one also had the markup inside its `en` and `ua` **values**, so a Ukrainian reader was told to type `возврат`.

`lint-l10n.py`: 0 HARD.