### PR TITLE
EN/UA for the incandescent onGive refusal message

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -1332,5 +1332,11 @@
    "en": "You disgustedly rip %1$O4 off yourself, soaked in the vile stench of magic.",
    "ua": "Ти з огидою здираєш із себе %1$O4, просякнут%1$Gе|ий|а|і мерзенним духом магії."
   }
+ },
+ "affect/incandescent/onGive": {
+  "Боги не позволяют тебе всучить %2$C3 раскаленн%1$Gое|ый|ую|ые %1$O4.": {
+   "en": "The gods will not let you foist the red-hot %1$O4 on %2$C3.",
+   "ua": "Боги не дозволяють тобі втелющити %2$C3 розжарен%1$Gе|ий|у|і %1$O4."
+  }
  }
 }


### PR DESCRIPTION
Catalog entry for the new `affect/incandescent/onGive` handler (dreamland_fenia#411, engine side dreamland_code#893).

One string. `lint-catalog-gaps.py` reports 0 wrapped-but-untranslated file keys after the add.