### PR TITLE
Drop the double article from the incandescent onGive refusal

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -1335,7 +1335,7 @@
  },
  "affect/incandescent/onGive": {
   "Боги не позволяют тебе всучить %2$C3 раскаленн%1$Gое|ый|ую|ые %1$O4.": {
-   "en": "The gods will not let you foist the red-hot %1$O4 on %2$C3.",
+   "en": "The gods will not let you foist %1$O4 on %2$C3 while %1$nit is|they are red-hot.",
    "ua": "Боги не дозволяють тобі втелющити %2$C3 розжарен%1$Gе|ий|у|і %1$O4."
   }
  }


### PR DESCRIPTION
Follow-up to dreamland_world#486, caught live-testing dreamland_code#893 on reboot #49.

`%1$O4` renders an object's `short_descr` including its own article, so `the red-hot %1$O4` printed as **"The gods will not let you foist the red-hot a short sword on wizard."**

Reworded so the object leads with its own article and the state trails: `The gods will not let you foist %1$O4 on %2$C3 while %1$nit is|they are red-hot.` The `%1$n` split covers plural objects.

RU is the catalog key and is unchanged; UA has no articles and is unchanged.