### PR TITLE
Fix number agreement in the incandescent onGive refusal

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -1335,7 +1335,7 @@
  },
  "affect/incandescent/onGive": {
   "Боги не позволяют тебе всучить %2$C3 раскаленн%1$Gое|ый|ую|ые %1$O4.": {
-   "en": "The gods will not let you foist %1$O4 on %2$C3 while %1$nit is|they are red-hot.",
+   "en": "%1$^O1 %1$nis|are too red-hot to hand to %2$C3 -- the gods will not allow it.",
    "ua": "Боги не дозволяють тобі втелющити %2$C3 розжарен%1$Gе|ий|у|і %1$O4."
   }
  }


### PR DESCRIPTION
Second follow-up to dreamland_world#486/#487, both caught live-testing on reboot #49.

#487 reworded around the double article but used `%1$nit is|they are`, which printed **literally**: `... while it is|they are red-hot.`

`MsgFormatter` terminates an alternation branch at the first space -- and also at `-`, `,`, `.`, `:`, `?`, `!`, `{`, `(`, `)` (`plug-ins/output/msgformatter.cpp:345-353`). A branch has to be one bare token, which is why every working entry looks like `%1$ns|` or `%1$nет|ют`. `red-hot` inside a branch would break on the hyphen too.

Reworded so the object leads and only the verb alternates:

    %1$^O1 %1$nis|are too red-hot to hand to %2$C3 -- the gods will not allow it.

Singular: "A short sword is too red-hot to hand to wizard -- the gods will not allow it."

`check-translation-batch.py` flags the EN-only `%1$n` as "codes not in ru". That check is too strict for `%n`: five existing catalog entries already do this, because RU carries number in the adjective ending while EN needs it on the verb. The code addresses arg 1, which RU uses as `%1$G` and `%1$O4`, so there is no missing-argument risk.

RU is the catalog key and unchanged; UA unchanged.