### PR TITLE
Catalog: EN/UA for the flood aftermath messages

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -1338,5 +1338,15 @@
    "en": "%1$^O1 %1$nis|are too red-hot to hand to %2$C3 -- the gods will not allow it.",
    "ua": "Боги не дозволяють тобі втелющити %2$C3 розжарен%1$Gе|ий|у|і %1$O4."
   }
+ },
+ "affect/flood/onRemoveRoom": {
+  "Вода схлынула, не оставив после себя ничего, кроме сырости.": {
+   "en": "The water drains away, leaving nothing behind but damp ground.",
+   "ua": "Вода збігає, не лишаючи по собі нічого, крім вологи."
+  },
+  "Вода отступает, оставляя после себя мутные лужи.": {
+   "en": "The water recedes, leaving murky puddles behind.",
+   "ua": "Вода відступає, лишаючи по собі каламутні калюжі."
+  }
  }
 }


### PR DESCRIPTION
Two new strings in `affect/flood/onRemoveRoom` (Trello 2645, dreamland_fenia#412). Added via `l10n-catalog-add.py --verify-source`, so the RU keys are byte-exact against the source and no pre-existing entry changed.