### PR TITLE
Fill in the missing English area names

### DIFF
--- a/commands/fenia/map.xml
+++ b/commands/fenia/map.xml
@@ -25,7 +25,7 @@ From the streets of Midgaard, you can reach places such as:
 {Y%A%{x {hh2078Graveyard{x, with a descent to {hh1865Chapel{x
 {R%A%{x {hh2079Dangerous Neighborhood{x and {hh1845Prison{x
 
-If you fly from the Temple Square, you'll find yourself {hh2047In the Air{x, from where you can get to {hh2048Astral Plane{x({R%A%{x) and the domains of the Githanki. And if you climb up the Naris Chain, you can reach {hh2022Redferne Residence{x, {hh2093Dylan Area{x({Y%A%{x), and {hh2023Divided Souls{x({R%A%{x), with an exit to the {hh1527Bangzui Gardens{x({R%A%{x).
+If you fly from the Temple Square, you'll find yourself in the {hh2047Skies of Midgaard{x, from where you can get to {hh2048Astral Plane{x({R%A%{x) and the domains of the Githanki. And if you climb up the Naris Chain, you can reach {hh2022Redferne Residence{x, {hh2093Dylan Area{x({Y%A%{x), and {hh2023Divided Souls{x({R%A%{x), with an exit to the {hh1527Bangzui Gardens{x({R%A%{x).
 
 Lovers of dungeon exploration will be able to descend from Midgaard to {hh1849Metro{x, with stops at the Zoo, {hh1850Prairie{x, and {hh1851Descent to Hell{x({R%A%{x), and in {hh1856Sewers{x({Y%A%{x), with a passage to the vast and mysterious {hh1854UnderDark{x.
 
@@ -101,7 +101,7 @@ P.S. All major cities are surrounded by {hh50suburbs{x, where mansions of wealth
 {Y%A%{x {hh2078Кладбище{x, со спуском в {hh1865Подземелье Часовни{x
 {R%A%{x {hh2079Опасный Район{x и {hh1845Тюрьма{x
 
-Если взлететь от Храмовой Площади, окажешься {hh2047В Воздухе{x, откуда можно добраться до {hh2048Астрала{x({R%A%{x) и владений гитианки. А если взобраться вверх по цепи Нариса, можно попасть в {hh2022Резиденцию Редферна{x, {hh2093Зону Дилана{x({Y%A%{x) и {hh2023Разделенные Души{x({R%A%{x), с выходом в {hh1527Бангзуйские Сады{x({R%A%{x).
+Если взлететь от Храмовой Площади, окажешься на {hh2047Небесах Мидгаарда{x, откуда можно добраться до {hh2048Астрала{x({R%A%{x) и владений гитианки. А если взобраться вверх по цепи Нариса, можно попасть в {hh2022Резиденцию Редферна{x, {hh2093Зону Дилана{x({Y%A%{x) и {hh2023Разделенные Души{x({R%A%{x), с выходом в {hh1527Бангзуйские Сады{x({R%A%{x).
 
 Любители исследовать подземелья смогут спуститься из Мидгаарда в {hh1849Метрополитен{x, с остановками в Зоопарке, {hh1850Прериях{x и {hh1851Аду{x({R%A%{x), и в {hh1856Канализацию{x({Y%A%{x), с проходом в огромное и таинственное {hh1854Подземье{x.
 
@@ -178,7 +178,7 @@ P.S. Все крупные города окружены {hh50пригорода
 {Y%A%{x {hh2078Кладовище{x, з входом у {hh1865Підземелля Часовні{x
 {R%A%{x {hh2079Небезпечний Район{x і {hh1845Вʼязниця{x
 
-Якщо здійнятись від Храмової Площі, опинишся {hh2047У Повітрі{x, звідки можливо дістатися до {hh2048Астралу{x({R%A%{x) і володінь гітіанки. А якщо піднятися вгору за ланцюгом Нарису, можна потрапити в {hh2022Резиденцію Редферна{x, {hh2093Зону Ділана{x({Y%A%{x) і {hh2023Розділені Душі{x({R%A%{x), з виходом у {hh1527Бангзуїцькі Сади{x({R%A%{x).
+Якщо здійнятись від Храмової Площі, опинишся на {hh2047Небесах Мідгаарда{x, звідки можливо дістатися до {hh2048Астралу{x({R%A%{x) і володінь гітіанки. А якщо піднятися вгору за ланцюгом Нарису, можна потрапити в {hh2022Резиденцію Редферна{x, {hh2093Зону Ділана{x({Y%A%{x) і {hh2023Розділені Душі{x({R%A%{x), з виходом у {hh1527Бангзуїцькі Сади{x({R%A%{x).
 
 Любителі досліджувати підземелля зможуть спуститися з Мідгаарда в {hh1849Метрополітен{x, з зупинками у Зоопарку, {hh1850Прерії{x і {hh1851Пеклі{x({R%A%{x), і в {hh1856Каналізацію{x({Y%A%{x), з проходом в велетенське і таємниче {hh1854Підземʼя{x.
 


### PR DESCRIPTION
Follow-up to the `where` locative change (areas#445 / code#900), which puts the EN area name into a sentence for the first time and so exposed four bad ones.

| area | was | now |
|---|---|---|
| `air` | `In the Air` → *"You are in In the Air."* | `Skies of Midgaard` |
| `land` | `Land` (placeholder for Тэра) | `Thera` |
| `cotton` | **no EN name** → *"in Горючие материалы"* | `Combustible Materials` |
| `ganjah` | **no EN name** → *"in Облако драгоценного дыма"* | `Cloud of Precious Smoke` |

`cotton` and `ganjah` are hidden system zones, so only immortals ever read them, but `getForLang` was falling back to the Russian string for want of an English one.

`help in the air` still resolves — the old spelling moved to the article's EN `extra` aliases, and `skies`/`midgaard` are the new keywords.

Also aligned the `{hh2047` anchor in `commands/fenia/map.xml`, which said "In the Air" / "В Воздухе" / "У Повітрі" — three spellings, none of them the area's own name in that language — and the three `THERA_ATLAS.md` rows (whose UA column still had the stale "У Повітрі").