### PR TITLE
Add English clan names and trilingual short forms

### DIFF
--- a/clans/battlerager.xml
+++ b/clans/battlerager.xml
@@ -33,12 +33,16 @@
   <monument>{YИз забитого рта {R%1$#C2{Y торчит титульный лист &quot;Властелина Колец&quot; с надписью: &quot;О%1$Gно|н|на не чита%1$Gло|л|ла классику&quot; {B%2$#C1{Y.{x</monument>
   <monumentName>титульный лист властелин колец title page lord rings</monumentName>
   <orgs/>
+  <nameEn>{RFury Clan{x</nameEn>
   <nameRus>{RКлан||а|у||ом|е Ярости{x</nameRus>
   <nameUa>{RКлан||у|у||ом|і Ярості{x</nameUa>
   <padName>{RКлан Ярости{x</padName>
   <recallVnum>548</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Battleragers</shortEn>
   <shortName>BATTLERAGER</shortName>
+  <shortRus>Клан Ярости</shortRus>
+  <shortUa>Клан Ярості</shortUa>
   <titles type="ClanTitlesByClass">
     <node name="all">
       <node>

--- a/clans/chaos.xml
+++ b/clans/chaos.xml
@@ -44,12 +44,16 @@
     <node>%1$^C1 смеется и произносит слова заклинания задом наперед, глядя на тебя.</node>
     <node>Тень %1$C2 на мгновение делает что-то свое, и до тебя долетает слово {1{MХаоса{2.</node>
   </msgVict>
+  <nameEn>{MChaos Circle{x</nameEn>
   <nameRus>{MКруг||а|у||ом|е Хаоса{x</nameRus>  
   <nameUa>{MКол|о|а|у|о|ом|і Хаосу{x</nameUa>
   <padName>{M       Хаос{x</padName>
   <recallVnum>553</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Chaos</shortEn>
   <shortName>CHAOS</shortName>
+  <shortRus>Хаос</shortRus>
+  <shortUa>Хаос</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>дитя хаоса</female>

--- a/clans/flowers.xml
+++ b/clans/flowers.xml
@@ -18,12 +18,16 @@
   </membership>
   <monument></monument>
   <orgs/>
+  <nameEn>{GFlower Children Commune{x</nameEn>
   <nameRus>{GКоммун|а|ы|е|у|ой|е Детей Цветов{x</nameRus>   
   <nameUa>{GКомун|а|и|і|у|ою|і Дітей Квітів{x</nameUa>
   <padName>{GДети Цветов{x</padName>
   <recallVnum>4389</recallVnum>
   <recruiter>1</recruiter>
+  <shortEn>Flower Children</shortEn>
   <shortName>Flower Children</shortName>
+  <shortRus>Дети Цветов</shortRus>
+  <shortUa>Діти Квітів</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>хиппи</female>

--- a/clans/ghost.xml
+++ b/clans/ghost.xml
@@ -21,12 +21,16 @@
   <monument>{YСилуэт {D%1$#C2{Y отпечатался под твоими ногами. В ногах табличка &apos;{CЗдесь не место призракам! {Y({R%2$#C1{Y)&apos;.{x</monument>
   <monumentName>силуэт табличка silhouette sign plaque tablet</monumentName>
   <orgs/>
+  <nameEn>{cGhosts Clan{x</nameEn>
   <nameRus>{cКлан||а|у||ом|е Призраков{x</nameRus>   
   <nameUa>{cКлан||у|у||ом|і Привидів{x</nameUa>
   <padName>{c   Призраки{x</padName>
   <recallVnum>708</recallVnum>
   <recruiter>1</recruiter>
+  <shortEn>Ghosts</shortEn>
   <shortName>GHOST</shortName>
+  <shortRus>Призраки</shortRus>
+  <shortUa>Привиди</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>посвященная</female>

--- a/clans/hunter.xml
+++ b/clans/hunter.xml
@@ -42,12 +42,16 @@
     <node>%1$^C1 бросает пару коротких слов, как свистят собаке, и кивает на тебя.</node>
     <node>%1$^C1 чиркает ногтем по ладони и договаривает заклинание сквозь зубы.</node>
   </msgVict>
+  <nameEn>{YHunters Company{x</nameEn>
   <nameRus>{YАртел|ь|и|и|ь|ью|и Охотников{x</nameRus>    
   <nameUa>{YАрті|ль|лі|лі|ль|ллю|лі Мисливців{x</nameUa>
   <padName>{Y   Охотники{x</padName>
   <recallVnum>573</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Hunters</shortEn>
   <shortName>HUNTER</shortName>
+  <shortRus>Охотники</shortRus>
+  <shortUa>Мисливці</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <abbr>jr</abbr>

--- a/clans/invader.xml
+++ b/clans/invader.xml
@@ -54,12 +54,16 @@
     <node>%1$^C1 произносит что-то одними губами, и ты понимаешь, что это про тебя.</node>
     <node>Тени в углах тянутся к %1$C3, и ты чувствуешь, как одна из них проходит сквозь тебя.</node>
   </msgVict>
+  <nameEn>{DInvaders Cabal{x</nameEn>
   <nameRus>{DКабал||а|у||ом|е Захватчиков{x</nameRus>    
   <nameUa>{DКабал||у|у||ом|і Загарбників{x</nameUa>
   <padName>{D Захватчики{x</padName>
   <recallVnum>733</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Invaders</shortEn>
   <shortName>INVADER</shortName>
+  <shortRus>Захватчики</shortRus>
+  <shortUa>Загарбники</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>зомби</female>

--- a/clans/knight.xml
+++ b/clans/knight.xml
@@ -186,12 +186,16 @@
     <node>%1$^C1 произносит слова заклинания в полный голос, ничего не скрывая.</node>
     <node>%1$^C1 касается рукояти оружия, и по ней пробегает {1{Yзолотой отблеск{2.</node>
   </msgVict>
+  <nameEn>{WKnights Order{x</nameEn>
   <nameRus>{WОрден||а|у||ом|е Рыцарей{x</nameRus>    
   <nameUa>{WОрден||у|у||ом|і Лицарів{x</nameUa>
   <padName>{W     Рыцари{x</padName>
   <recallVnum>524</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Knights</shortEn>
   <shortName>KNIGHT</shortName>
+  <shortRus>Рыцари</shortRus>
+  <shortUa>Лицарі</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>ученик</female>

--- a/clans/lion.xml
+++ b/clans/lion.xml
@@ -55,12 +55,16 @@
     <node>%1$^C1 глухо рычит, и слова заклинания выходят почти звериными.</node>
     <node>%1$^C1 втягивает воздух, и в заклинании появляется запах {1{gлеса и шерсти{2.</node>
   </msgVict>
+  <nameEn>{gLions Pride{x</nameEn>
   <nameRus>{gПрайд||а|у||ом|е Львов{x</nameRus>   
   <nameUa>{gПрайд||у|у||ом|і Левів{x</nameUa>
   <padName>{g       Львы{x</padName>
   <recallVnum>504</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Lions</shortEn>
   <shortName>LION</shortName>
+  <shortRus>Львы</shortRus>
+  <shortUa>Леви</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>коготь</female>

--- a/clans/none.xml
+++ b/clans/none.xml
@@ -14,6 +14,9 @@
   <padName>{x   NONE    {x</padName>
   <recallVnum>0</recallVnum>
   <recruiter>-1</recruiter>
+  <shortEn>NONE</shortEn>
   <shortName>NONE</shortName>
+  <shortRus>NONE</shortRus>
+  <shortUa>NONE</shortUa>
   <titles/>
 </Clan>

--- a/clans/ruler.xml
+++ b/clans/ruler.xml
@@ -43,12 +43,16 @@
     <node>%1$^C1 зачитывает над тобой формулу ровно и раздельно, будто указ.</node>
     <node>%1$^C1 прикладывает ладонь к клановому символу, и тот теплеет {1{Yзолотом{2.</node>
   </msgVict>
+  <nameEn>{wRulers Order{x</nameEn>
   <nameRus>{wОрден||а|у||ом|е Правителей{x</nameRus>   
   <nameUa>{wОрден||у|у||ом|і Правителів{x</nameUa>
   <padName>{w  Правители{x</padName>
   <recallVnum>512</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Rulers</shortEn>
   <shortName>RULER</shortName>
+  <shortRus>Правители</shortRus>
+  <shortUa>Правителі</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>постигающая</female>

--- a/clans/shalafi.xml
+++ b/clans/shalafi.xml
@@ -54,6 +54,7 @@
     <node>%1$^C1 выстраивает над тобой заклинание как чертеж, выверяя каждую линию.</node>
     <node>Воздух вокруг %1$C2 разлиновывается {1{Bтонкой синей сеткой{2.</node>
   </msgVict>
+  <nameEn>{BShalafi Order{x</nameEn>
   <nameRus>{BОрден||а|у||ом|е Шалафи{x</nameRus>   
   <nameUa>{BОрден||у|у||ом|і Шалафі{x</nameUa>
   <padName>{B     Шалафи{x</padName>
@@ -191,7 +192,10 @@
   </orgs>
   <recallVnum>5712</recallVnum>
   <recruiter>7</recruiter>
+  <shortEn>Shalafi</shortEn>
   <shortName>SHALAFI</shortName>
+  <shortRus>Шалафи</shortRus>
+  <shortUa>Шалафі</shortUa>
   <titles type="ClanTitlesByLevel">
     <node>
       <female>одаренная</female>

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -3485,6 +3485,14 @@
   "Практикуется у {gкланового охранника{x.": {
    "en": "Practiced with the {gclan guard{x.",
    "ua": "Практикується у {gкланового охоронця{x."
+  },
+  ", навык %1$s": {
+   "en": ", a clan skill of %1$s",
+   "ua": ", вміння %1$s"
+  },
+  ", навык неизвестного клана": {
+   "en": ", a skill of an unknown clan",
+   "ua": ", вміння невідомого клану"
   }
  },
  "plug-ins/comm/account.cpp": {

--- a/grammar/synonyms.json
+++ b/grammar/synonyms.json
@@ -95,7 +95,8 @@
 "remember": ["запам'ятати", "запомнить"],
 
 // skills
-"sortby":   ["сортирувати", "сортировать"],
+// "сортирувати" is a calque and stays only so anyone who learned it keeps working.
+"sortby":   ["сортувати", "сортирувати", "сортировать"],
 "learned":  ["вивчено", "изучено"],
 "skills":   ["навички", "навыки"],
 "spells":   ["заклинання", "заклинания"],


### PR DESCRIPTION
Data half of dreamland-mud/dreamland_code#903.

| key | `nameEn` | short ru / ua / en |
|---|---|---|
| battlerager | Fury Clan | Клан Ярости / Клан Ярості / Battleragers |
| chaos | Chaos Circle | Хаос / Хаос / Chaos |
| flowers | Flower Children Commune | Дети Цветов / Діти Квітів / Flower Children |
| ghost | Ghosts Clan | Призраки / Привиди / Ghosts |
| hunter | Hunters Company | Охотники / Мисливці / Hunters |
| invader | Invaders Cabal | Захватчики / Загарбники / Invaders |
| knight | Knights Order | Рыцари / Лицарі / Knights |
| lion | Lions Pride | Львы / Леви / Lions |
| ruler | Rulers Order | Правители / Правителі / Rulers |
| shalafi | Shalafi Order | Шалафи / Шалафі / Shalafi |

Plus two catalog keys for `clanskill.cpp` and the `сортувати` synonym. `lint-l10n.py`: 0 HARD.