### PR TITLE
Ukrainian names for the note threads, and a catalog hook at push time

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# pre-push -- put the catalog linters in front of you before the push, not after
+# a player reports it.
+#
+# WARN ONLY, on purpose. Both linters carry pre-existing findings that are not
+# worth blocking on (and a couple of false positives where a command is real but
+# absent from the vocabulary sources), and a hook that fails every push is a hook
+# that gets switched off. It prints; you decide.
+#
+# Install:  git config core.hooksPath .githooks
+# Skip once: git push --no-verify
+
+set -u
+
+world="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+shared="$(cd "$world/../../scripts" 2>/dev/null && pwd)"
+
+# Only the catalog shards actually being pushed -- linting all 30 on every push
+# buries the two lines that are about your change.
+shards=$(git diff --name-only @{push}..HEAD 2>/dev/null || git diff --name-only origin/master..HEAD 2>/dev/null)
+shards=$(echo "$shards" | sed -n 's#^config/translations/\(.*\.json\)$#\1#p')
+
+if [ -z "$shards" ]; then
+    exit 0
+fi
+
+echo "--- pre-push: linting $(echo "$shards" | tr '\n' ' ')"
+
+# {hc} links whose command word is not a command of the language they sit in --
+# a dead clickable link for the player who gets that translation.
+if [ -x "$world/scripts/lint-hc-command-lang.py" ]; then
+    python3 "$world/scripts/lint-hc-command-lang.py" $shards || true
+fi
+
+# Strings wrapped for translation but never translated: they reach an EN or UA
+# player in Russian, silently. Whole-corpus by design -- it matches call sites
+# against the catalog, so there is no per-shard form of the question.
+if [ -n "${shared:-}" ] && [ -f "$shared/lint-catalog-gaps.py" ]; then
+    python3 "$shared/lint-catalog-gaps.py" --limit 20 || true
+fi
+
+echo "--- pre-push: advisory only, push continues"
+exit 0

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -14037,7 +14037,7 @@
    "ua": "Скопіювати який номер?"
   },
   "Так много %N2 еще не написали.": {
-   "en": "So much %N2 hasn't been written yet.",
+   "en": "There aren't that many %N2 yet.",
    "ua": "Так багато %N2 ще не написали."
   },
   "Текущее сообщение скопировано в буфер.": {
@@ -14094,6 +14094,10 @@
   }
  },
  "plug-ins/note/notehooks.cpp": {
+  "{CТихий голос из $o2: {WУ тебя:": {
+   "en": "{CA quiet voice from $o2: {WYou have:",
+   "ua": "{CТихий голос із $o2: {WУ тебе:"
+  },
   "Все новости и изменения сохранены в %s.": {
    "en": "All news and changes have been saved to %s.",
    "ua": "Усі новини та зміни збережено в %s."

--- a/notes/change.xml
+++ b/notes/change.xml
@@ -22,5 +22,8 @@
   <readLevel>0</readLevel>
   <rusName>изменени|е|я|ю|е|ем|и</rusName>
   <rusNameMlt>изменени|я|й|ям|я|ями|ях</rusNameMlt>
+  <uaGender>female</uaGender>
+  <uaName>змін|а|и|і|у|ою|і</uaName>
+  <uaNameMlt>змін|и||ам|и|ами|ах</uaNameMlt>
   <writeLevel>106</writeLevel>
 </NoteThread>

--- a/notes/crime.xml
+++ b/notes/crime.xml
@@ -22,5 +22,8 @@
   <readLevel>0</readLevel>
   <rusName>сообщени|е|я|ю|е|ем|и о наказании</rusName>
   <rusNameMlt>сообщени|я|й|ям|я|ями|ях о наказаниях</rusNameMlt>
+  <uaGender>neutral</uaGender>
+  <uaName>повідомленн|я|я|ю|я|ям|і про злочин</uaName>
+  <uaNameMlt>повідомленн|я|ь|ям|я|ями|ях про злочини</uaNameMlt>
   <writeLevel>0</writeLevel>
 </NoteThread>

--- a/notes/dream.xml
+++ b/notes/dream.xml
@@ -89,5 +89,8 @@ You can edit and write without the web editor:
   <readLevel>102</readLevel>
   <rusName>с|он|на|ну|он|ном|не</rusName>
   <rusNameMlt>сн|ы|ов|ам|ы|ами|ах</rusNameMlt>
+  <uaGender>male</uaGender>
+  <uaName>с|он|ну|ну|он|ном|ні</uaName>
+  <uaNameMlt>сн|и|ів|ам|и|ами|ах</uaNameMlt>
   <writeLevel>1</writeLevel>
 </NoteThread>

--- a/notes/news.xml
+++ b/notes/news.xml
@@ -22,5 +22,8 @@
   <readLevel>0</readLevel>
   <rusName>новост|ь|и|и|ь|ью|и</rusName>
   <rusNameMlt>новост|и|ей|ям|и|ями|ях</rusNameMlt>
+  <uaGender>female</uaGender>
+  <uaName>новин|а|и|і|у|ою|і</uaName>
+  <uaNameMlt>новин|и||ам|и|ами|ах</uaNameMlt>
   <writeLevel>103</writeLevel>
 </NoteThread>

--- a/notes/note.xml
+++ b/notes/note.xml
@@ -22,5 +22,8 @@
   <readLevel>0</readLevel>
   <rusName>письм|о|а|у|о|ом|е</rusName>
   <rusNameMlt>пис|ьма|ем|ьмам|ьма|ьмами|ьмах</rusNameMlt>
+  <uaGender>male</uaGender>
+  <uaName>лист||а|у||ом|і</uaName>
+  <uaNameMlt>лист|и|ів|ам|и|ами|ах</uaNameMlt>
   <writeLevel>0</writeLevel>
 </NoteThread>

--- a/notes/penalty.xml
+++ b/notes/penalty.xml
@@ -20,7 +20,10 @@
   <name>penalty</name>
   <nameMlt>penalties</nameMlt>
   <readLevel>0</readLevel>
-  <rusName>penalty</rusName>
-  <rusNameMlt>penalties</rusNameMlt>
+  <rusName>наказани|е|я|ю|е|ем|и</rusName>
+  <rusNameMlt>наказани|я|й|ям|я|ями|ях</rusNameMlt>
+  <uaGender>neutral</uaGender>
+  <uaName>покаранн|я|я|ю|я|ям|і</uaName>
+  <uaNameMlt>покаранн|я|ь|ям|я|ями|ях</uaNameMlt>
   <writeLevel>103</writeLevel>
 </NoteThread>

--- a/notes/qnote.xml
+++ b/notes/qnote.xml
@@ -22,5 +22,8 @@
   <readLevel>0</readLevel>
   <rusName>квестнот|а|ы|е|у|ой|е</rusName>
   <rusNameMlt>квестнот|ы||ам|ы|ами|ах</rusNameMlt>
+  <uaGender>female</uaGender>
+  <uaName>квестнот|а|и|і|у|ою|і</uaName>
+  <uaNameMlt>квестнот|и||ам|и|ами|ах</uaNameMlt>
   <writeLevel>102</writeLevel>
 </NoteThread>

--- a/notes/story.xml
+++ b/notes/story.xml
@@ -22,5 +22,8 @@
   <readLevel>0</readLevel>
   <rusName>истори|я|и|и|ю|ей|и</rusName>
   <rusNameMlt>истори|и|й|ям|и|ями|ях</rusNameMlt>
+  <uaGender>female</uaGender>
+  <uaName>істор|ія|ії|ії|ію|ією|ії</uaName>
+  <uaNameMlt>істор|ії|ій|іям|ії|іями|іях</uaNameMlt>
   <writeLevel>0</writeLevel>
 </NoteThread>


### PR DESCRIPTION
Data half of dreamland_code#907, which taught `NoteThread` to hand out a name in the reader's language instead of always the Russian one.

`uaGender` is a separate field because the two Slavic genders disagree often enough to matter: 'письмо' is neuter, 'лист' is masculine, and the singular adjective in the crystal-orb line agrees with whichever one the reader gets.

Also fills `penalty`'s Russian name, which was the literal string `penalty`, and adds a `pre-push` hook that runs the two catalog linters. Advisory only -- `lint-hc-command-lang.py` would have caught four of the five dead command links fixed in #502 long ago, but only if someone ran it.