### PR TITLE
Restore the Russian config hint key so English lands without a reboot

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -4972,9 +4972,9 @@
    "en": "Your character is linked to Telegram user {C%s{x. Use {hc{ymode telegram clear{x to clear it.\r\n",
    "ua": "Твій персонаж пов'язаний з користувачем Telegram {C%s{x. Використай {hc{yрежим телеграм очистити{x для очищення.\r\n"
   },
-  "\nИспользуй команду {hc{yрежим %1$s %2$s{x для изменения.": {
+  "\nИспользуй команду {hc{yрежим %s %s{x для изменения.": {
    "en": "\nUse the command {hc{yconfig %3$s %4$s{x to change it.",
-   "ua": "\nВикористовуй команду {hc{yрежим %5$s %6$s{x, щоб змінити."
+   "ua": "\nВикористовуй команду {hc{yрежим %s %s{x, щоб змінити."
   },
   "\r\nПодробнее смотри по команде {yрежим {Dнастройка{w.": {
    "en": "\r\nFor details see the {yconfig {Dsetting{w command.",


### PR DESCRIPTION
Fixes the regression I introduced in #505.

Renumbering the **Russian** format there changed the catalog key. Russian is both the key and the universal fallback, so against the running binary the new key matched nothing and every language fell back to Russian -- the reported half-English line became fully Russian.

- Key restored to `\nИспользуй команду {hc{yрежим %s %s{x для изменения.`
- English: `\nUse the command {hc{yconfig %3$s %4$s{x to change it.` -- correct **today**, because the running binary already passes four arguments, so `%3$`/`%4$` land on the English name and the English yes/no word. This is the half Ruffina reported, and it is hot.
- Ukrainian: back on the first pair (unchanged behaviour -- it shows the Russian option name, as it did before). It must not point at `%5$s %6$s` until dreamland_code#910 is built and rebooted: `shiftArg` (`act.cpp:228`) pulls straight from `va_arg` with no bounds check, so `%5$` against a four-argument call reads past the end of the list.

The Ukrainian flip is queued on the Trello card for after the reboot.