### PR TITLE
Move the morris dancer catalog key to the affect's real name

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -519,7 +519,7 @@
    "ua": "Ти виходиш із трансу, почуваючись значно краще."
   }
  },
- "affect/morris dancer/onFightChar": {
+ "affect/set morris dancer/onFightChar": {
   "{WТы внезапно ощущаешь повышенную активность!{x": {
    "en": "{WYou suddenly feel a surge of energy!{x",
    "ua": "{WТи раптово відчуваєш приплив активності!{x"
@@ -1293,12 +1293,6 @@
   "Пламя из этой местности перекидывается в соседнюю! {RНачинается пожар!{x": {
    "en": "The flames spread from this area into the next! {RA fire breaks out!{x",
    "ua": "Полум'я з цієї місцевості перекидається на сусідню! {RПочинається пожежа!{x"
-  }
- },
- "affect/morris dancer/onUpdateChar": {
-  "{WЖелание непременно с кем-то потанцевать охватывает тебя!{x": {
-   "en": "{WAn irresistible urge to dance with someone grips you!{x",
-   "ua": "{WБажання неодмінно з кимось потанцювати охоплює тебе!{x"
   }
  },
  "affect/set morris dancer/onUpdateChar": {


### PR DESCRIPTION
Catalog half of dreamland_fenia#416.

The affect was renamed to `set morris dancer`; the fight handler never followed, so its catalog key (`affect/morris dancer/onFightChar`) described a file that could not be deployed and a key that could never match a running script. The key moves with the file; the en/ua values are byte-identical.

The stale `affect/morris dancer/onUpdateChar` key is dropped -- `affect/set morris dancer/onUpdateChar` already has its own entry and is the version that runs.