### PR TITLE
Catalog: sneak wearoff under the placement.cpp key

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -13577,6 +13577,10 @@
   "$c1 выходит из $s укрытия.": {
    "en": "$c1 comes out of its hiding spot.",
    "ua": "$c1 виходить зі свого сховку."
+  },
+  "Ты чувствуешь, что снова производишь слишком много шума при ходьбе.": {
+   "en": "You feel that you are once again making too much noise while walking.",
+   "ua": "Ти відчуваєш, що знову створюєш забагато шуму під час ходьби."
   }
  },
  "plug-ins/loadsave/player_exp.cpp": {


### PR DESCRIPTION
Catalog half of dreamland_code#912.

`strip_sneak` prints the sneak wearoff from `placement.cpp`, and C++ `_()` keys by `__FILE__` — so without an entry under that file key, English and Ukrainian players would see the Russian line. The en/ua values are copied verbatim from the entry already live for this same string under `plug-ins/skills_impl/defaultaffecthandler.cpp` (the skill-driven wearoff path), so the two paths read identically.

One added entry; a guard verified no other `(file-key, ru)` pair changed.