### PR TITLE
UA damage option is 'шкода' everywhere it is named

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -103,13 +103,13 @@
         <hint>формат отображения урона: числами или в процентах</hint>
         <msgOff l="en">Damage is shown as numbers.</msgOff>
         <msgOff l="ru">Урон отображается числами.</msgOff>
-        <msgOff l="ua">Ушкодження відображається числами.</msgOff>
+        <msgOff l="ua">Шкода відображається числами.</msgOff>
         <msgOn l="en">Damage is shown as a percentage.</msgOn>
         <msgOn l="ru">Урон отображается в процентах.</msgOn>
-        <msgOn l="ua">Ушкодження відображається у відсотках.</msgOn>
+        <msgOn l="ua">Шкода відображається у відсотках.</msgOn>
         <name>damage</name>
         <rname>урон</rname>
-        <uaname>ушкодження</uaname>
+        <uaname>шкода</uaname>
       </node>
       <name l="en">Gameplay settings:</name>
       <name l="ru">Настройки игрового процесса:</name>
@@ -299,7 +299,7 @@
   <help id="1087" level="-1" type="CommandHelp" labels="comm">
     <extra l="en">autoassist autoloot autosac nocancel nobuff notransfer nofollow damage brief autoexit shortflags affscore prompt screenreader color lines lang holylight noiac notelnet telnetga</extra>
     <extra l="ru">автопомощь автограбеж автожертва неотменять неследовать урон кратко автовыходы краткофлаги аффектывсчет состояние незрячий цвет строк язык боговзор</extra>
-    <extra l="ua">автодопомога автограбунок автожертва невідміняти неслідувати ушкодження пошкодження стисло автовиходи короткофлаги афективрахунок стан незрячий колір рядки мова боговзір</extra>
+    <extra l="ua">автодопомога автограбунок автожертва невідміняти неслідувати шкода ушкодження пошкодження стисло автовиходи короткофлаги афективрахунок стан незрячий колір рядки мова боговзір</extra>
     <text l="en">Write *%CMD%* to see all your settings, grouped by section. To change one, write *%CMD%* _option_ *%YES%*|*%NO%* -- for example, *%CMD%* _autoloot_ *%NO%* to stop looting items from corpses.
 
 A few useful ones: *autoassist* makes you join your group's fights; *autoloot* and *autosac* deal with enemy corpses; *nocancel* and *nofollow* keep others from cancelling your spells or following you; *brief* shortens room descriptions; *autoexit* lists the room's exits after every move; *shortflags* abbreviates item flags; *damage* shows damage as numbers or as a percentage; *screenreader* turns on screen-reader support.

--- a/helps/help.xml
+++ b/helps/help.xml
@@ -2329,7 +2329,7 @@ The {hh140Rangers{x guild is located in {hh1862Haon Dor{x, entrance from the Hid
     <extra l="ua">нові ушкодження пошкодження шкала ушкоджень пошкоджень урону бойова система режим</extra>
     <keyword l="en">damage</keyword>
     <keyword l="ru">повреждения</keyword>
-    <keyword l="ua">ушкодження</keyword>
+    <keyword l="ua">шкода</keyword>
     <text l="en">%FMT% {yconfig damage yes|no{x
 
 With the setting enabled ({yyes{x) damage is displayed on a =combined scale=: the text indicates the damage dealt relative to the enemy's maximum health, while the colour and symbols around it correspond to the absolute damage. This mode is usually a little clearer for {hh2127newcomers{x.


### PR DESCRIPTION
Found while fixing the `autoexit` help: the UA body of help #1087 tells players `*шкода* показує шкоду числами чи у відсотках`, but the typeable name was `ушкодження`. So a UA player read the help and typed a word the parser rejects. Per Kit, world#358's call was `шкода` — the **data** had drifted, not the help.

- `commands/config.xml` — `<uaname>` → `шкода`, both `msgOn`/`msgOff` UA strings reworded, `шкода` added to the `<extra>` help keywords.
- `helps/help.xml` node 45 — UA `<keyword>` → `шкода`.

`ушкодження` and `пошкодження` stay in both `<extra>` lists and in `grammar/synonyms.json`, so every old form remains typeable and `help ушкодження` still resolves.

### Deliberately NOT changed

The ~45 skill/spell/help descriptions that use `ушкодження` as an ordinary noun. That is not a mechanical swap: `ушкодження` is neuter and reads as a plural in those sentences (`ушкодження зростають`, `ушкодження зменшуються на третину`), while `шкода` is feminine singular, and the idiom is genitive (`завдати шкоди`, not `завдати шкода`). A blanket replace would break agreement in every one of them. Separate decision, separate pass.