### PR TITLE
Add non-metal material pools for dagger and mace

### DIFF
--- a/fight/weapon_classes.json
+++ b/fight/weapon_classes.json
@@ -1,4 +1,6 @@
 // Описывает ограничения и предпочтения по аффиксам и повреждениям для каждого класса сгенерированного оружия.
+// "nonmetal": materials to fall back to when the weapon is generated for a player who can never
+// wield metal (druids) and the chosen name has no 'mtypes' of its own in weapon_names.json.
 {
     "sword": {
             "attacks": "slice slash cleave chop bite pierce scratch peckb sting chomp thrust flbite flame acbite frbite shbite",
@@ -9,8 +11,9 @@
             "attacks": "bite pierce scratch peckb sting chomp thrust flbite flame acbite frbite shbite negative",
             "forbids": ["two_hands", "vorpal"],
             "prefers": ["sharp", "poison", "dr"],
+            "nonmetal": ["bone", "ivory", "stone"],
             "flags": { "tattoo": 20 }
-    }, 
+    },
 
     "spear": {
             "attacks": "pound crush beating charge smash thwack bite pierce scratch peckb sting chomp thrust acbite frbite shbite",
@@ -21,8 +24,9 @@
     "mace": {
             "attacks": "pound crush beating charge smash thwack divine negative",
             "forbids": ["vorpal", "sharp", "poison", "flaming"],
-            "prefers": ["shocking", "hr", "pack_hp"]
-    }, 
+            "prefers": ["shocking", "hr", "pack_hp"],
+            "nonmetal": ["wood", "stone", "bone"]
+    },
 
     "axe": {
             "attacks": "slice slash cleave chop wrath flbite acbite frbite shbite",


### PR DESCRIPTION
Data half of dreamland-mud/dreamland_code#919.

`WeaponGenerator::findMaterial()` used to end with a hardcoded `"metal"` for any weapon name that has no `mtypes` of its own -- which is every dagger name and half the mace names. For a player who can never wield metal (druid) the generator now falls back to the class's new `nonmetal` list instead.

* dagger: `bone`, `ivory`, `stone`
* mace: `wood`, `stone`, `bone`

Spear and flail need no entry: every one of their names already declares `mtypes`, so the fallback is never reached for them.

`obsidian` and `glass` are deliberately left out -- they carry `fragile`, and a fragile item has a 40% chance to shatter when dropped outside water, air, forest or desert (`plug-ins/comm/drop.cpp`). Losing a legendary drop to a stray `drop` command is not the experience we are fixing.