### PR TITLE
Catalog the wake-up line for fight_position.cpp

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -19784,5 +19784,11 @@
    "en": "This is the language you registered under -- that form cannot be changed.",
    "ua": "Це мова твоєї реєстрації -- цю форму змінювати не можна."
   }
+ },
+ "plug-ins/fight_core/fight_position.cpp": {
+  "Ты просыпаешься от внезапной боли.": {
+   "en": "You wake up from a sudden pain.",
+   "ua": "Ти прокидаєшся від раптового болю."
+  }
  }
 }


### PR DESCRIPTION
Companion to dreamland-mud/dreamland_code#922.

`stand_up_after_round` wakes a sleeper at the end of the round and prints `Ты просыпаешься от внезапной боли.` from `plug-ins/fight_core/fight_position.cpp`, which had no section in the catalog at all. `_()` keys by `__FILE__`, so the identical line already translated under `damage.cpp` does not cover it — same en/ua copied across.

`lint-catalog-gaps.py` is clean afterwards apart from one pre-existing gap (`plug-ins/loadsave/save.cpp:623`, '$o1 исчезает!').