### PR TITLE
Follow the kill-milestone format string's placeholder fix

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -9378,9 +9378,9 @@
    "en": "You have {%2$s%1$d{x character corpse%1$I|s|s {%2$s%3$s{x to your credit.",
    "ua": "На твоєму рахунку {%2$s%1$d{x труп%1$I|и|ів {%2$s%3$s{x персонажів."
   },
-  "На твоем счету {W%1$d{x труп%1$I|а|ов {W%s{x персонажей.": {
-   "en": "You have {W%1$d{x corpse%1$I|s|s of {W%s{x characters to your name.",
-   "ua": "На твоєму рахунку {W%1$d{x труп%1$I|и|ів {W%s{x персонажів."
+  "На твоем счету {W%1$d{x труп%1$I|а|ов {W%2$s{x персонажей.": {
+   "en": "You have {W%1$d{x corpse%1$I|s|s of {W%2$s{x characters to your name.",
+   "ua": "На твоєму рахунку {W%1$d{x труп%1$I|и|ів {W%2$s{x персонажів."
   },
   "Твое обаяние повысилось на единицу.": {
    "en": "Your charisma has increased by one.",


### PR DESCRIPTION
Companion to dreamland_code [#929](https://github.com/dreamland-mud/dreamland_code/pull/929).

That PR numbered a trailing bare `%s` to `%2$s` in the "other alignment" kill milestone. The RU string is the catalog lookup key, so without this the EN/UA entries would silently stop matching and the line would print Russian to everyone.

Key renamed in place, `%s` numbered in the EN and UA values too. No other entries touched.