### PR TITLE
Document that clan recall halves your remaining movement

### DIFF
--- a/clan-skills/clanrecall.xml
+++ b/clan-skills/clanrecall.xml
@@ -116,18 +116,18 @@
     <extra l="en">'clan recall'</extra>
     <extra l="ru">'клан возврат' кланреколл</extra>
     <extra l="ua">'повернення в клан' кланреколл</extra>
-    <text l="en">Ask the gods to move to the clan. You can't ask too often, and you must wait some time before the next attempt. The waiting time increases with level and is visible by the command 'affects'. Returning to the clan won't work if you are under {hh2146adrenaline{x from recent battles with other players.
+    <text l="en">Ask the gods to move to the clan. You can't ask too often, and you must wait some time before the next attempt. The waiting time increases with level and is visible by the command 'affects'. Returning to the clan won't work if you are under {hh2146adrenaline{x from recent battles with other players. Beside the movement the skill itself costs, the journey home takes half of whatever movement you have left.
 
 %SA% %H% {hh674word of return{x</text>
     <text l="ru">%FMT% *%CMD%*
 
-Попросить богов о перемещении в клан. Просить можно не часто, и до следующей попытки придется какое-то время подождать. Время ожидания растет с уровнем и видно по команде *эффекты*. Возврат в клан не сработает, если ты находишься под {hh2146адреналином{x от недавнего сражения с другими игроками.
+Попросить богов о перемещении в клан. Просить можно не часто, и до следующей попытки придется какое-то время подождать. Время ожидания растет с уровнем и видно по команде *эффекты*. Возврат в клан не сработает, если ты находишься под {hh2146адреналином{x от недавнего сражения с другими игроками. Кроме указанного расхода шагов, сама дорога домой отнимает половину тех шагов, что у тебя остались.
 
 %SA% %H% {hh674слово возврата{x
 </text>
     <text l="ua">%FMT% *%CMD%*
 
-Попросити богів про переміщення в клан. Просити можна не часто, і до наступної спроби доведеться трохи почекати. Час очікування зростає з рівнем і видно по команді *ефекти*. Повернення в клан не спрацює, якщо ти перебуваєш під {hh2146адреналіном{x від недавнього бою з іншими гравцями.
+Попросити богів про переміщення в клан. Просити можна не часто, і до наступної спроби доведеться трохи почекати. Час очікування зростає з рівнем і видно по команді *ефекти*. Повернення в клан не спрацює, якщо ти перебуваєш під {hh2146адреналіном{x від недавнього бою з іншими гравцями. Крім зазначеної витрати кроків, сама дорога додому забирає половину тих кроків, що в тебе лишились.
 
 %SA% %H% {hh674слово повернення{x
 </text>


### PR DESCRIPTION
Addresses `[524] Todomori` on the Bugs card: *"умение кланрекал * Расход шагов 10. по факту сняло больше 500 шагов"*.

He is measuring correctly. Two separate charges land:

1. `<move>10</move>` in `clanrecall.xml`, charged and displayed by the skill framework.
2. `ClanRecallMovement` inherits `RecallMovement::applyMovepoints` (`recallmovement.cpp:165-169`), which is `ch->move /= 2` — **half of your current movement**, so a full bar costs far more than an empty one. `clan/impl/common.cpp:90` calls it and does not override.

The help text never mentioned it.

### Why documentation and not a mechanic change

Halving is the traditional recall cost and is shared with home recall (`mansion/homerecall.cpp:143`), so dropping it for clan recall is a balance decision rather than a bug fix — especially as the skill is already gated by a level-scaling cooldown. **If you would rather clan recall simply cost its stated 10, say so and I will do that instead** — it is a one-line override.

Added one sentence to the EN, RU and UA `<text>` blocks. XML parses clean.