### PR TITLE
Document the help index browser (#858)

### DIFF
--- a/commands/help.xml
+++ b/commands/help.xml
@@ -23,6 +23,9 @@ Provides help for the requested words. Words can be abbreviated. If more than on
 %FMT% *%CMD%* skill|spell|class|zone|religion|clan _keywords_
 Filters the help output by the specified category.
 
+%FMT% *%CMD%* index _section_
+Browses the help by topic. Without a section it lists every section together with the number of articles in it; with one it lists that section's articles, sorted by title and ready to click. The word *index* may be shortened to three letters, but the section is named in full -- exactly as the list shows it.
+
 %FMT% *%CMD%*
 Provides a quick guide on the basic commands.
 
@@ -41,6 +44,9 @@ If the help for your request is not found, it is automatically added to the list
 
 %FMT% *%CMD%* умение|заклинание|класс|зона|религия|клан _ключевые слова_
 Фильтрует выдачу справки по заданной категории.
+
+%FMT% *%CMD%* разделы _раздел_
+Листает справку по темам. Без раздела показывает все разделы и число статей в каждом, с разделом -- статьи этого раздела по алфавиту, сразу ссылками. Слово *разделы* можно сократить до трех букв, а название раздела пишется целиком -- ровно так, как оно показано в списке.
 
 %FMT% *%CMD%*
 Выдает краткий справочник по основным командам.
@@ -65,6 +71,9 @@ If the help for your request is not found, it is automatically added to the list
 
 %FMT% *%CMD%* вміння|заклинання|клас|зона|релігія|клан _ключові слова_
 Фільтрує видачу довідки за заданою категорією.
+
+%FMT% *%CMD%* розділи _розділ_
+Гортає довідку за темами. Без розділу показує всі розділи і кількість статей у кожному, з розділом -- статті цього розділу за абеткою, одразу посиланнями. Слово *розділи* можна скоротити до трьох літер, а назву розділу пишемо повністю -- рівно так, як вона показана у списку.
 
 %FMT% *%CMD%*
 Надає короткий довідник по основним командам.


### PR DESCRIPTION
`help index` shipped in dreamland_code#858 with no mention in help 995, the help command's own article, which still listed only the keyword search, the category filter and the bare form.

Adds a `%FMT%` block in EN, RU and UA covering both shapes -- the bare summary of sections with article counts, and a named section listing its articles sorted by title -- plus the two rules a player would otherwise guess wrong: the keyword abbreviates to three letters (`is_index_keyword`), the section name does not abbreviate at all (`help_category_from_argument` matches the key or a full display name).

The section count is deliberately left unstated: `help_index_summary` skips categories with no visible articles, so the number is per-viewer.

Found while writing the changelog entry that announces the browser.