### PR TITLE
Say what an active skill attempt actually costs

### DIFF
--- a/commands/skills.xml
+++ b/commands/skills.xml
@@ -18,6 +18,8 @@ To see the abilities available to your character, their level, study, and mana c
 
 Skills are either =active= or =passive=. For active skills, you need to issue commands: for example, to use the combat skill '{hh807kick{x', you need to type {hckick{x. To use magic, you need to type {hccast{x and the name of the spell -- see %H% {hh1361cast{x.
 
+An active skill costs mana, movement and a moment of delay -- but you pay only for an attempt that actually happened. When the game refuses before you even swing -- no target, the wrong weapon, you are hidden already, the door is out of reach -- it costs you nothing at all. An attempt that did happen and simply failed is another matter: the theft that got noticed, the shove that did not budge, the escape that did not make it are all paid for in full.
+
 By contrast, passive skills work on their own if they are sufficiently learned. For example, defensive skills work automatically and do not need commands: {hh726shield block{x, {hh754dodge{x, {hh576parry{x, etc.
 
 %FMT% *%CMD%* _active_
@@ -52,6 +54,8 @@ Sorts the list by level, name, or percentage of leveling.</text>
 Чтобы увидеть умения, доступные твоему персонажу, их уровень, изученность и расход маны, просто набери *умения*. А чтобы отфильтровать отдельно навыки или заклинания, допиши это в конце.
 
 Навыки бывают =активные= и =пассивные=. Для активных навыков надо писать команды: например, для использования боевого навыка '{hh807пинок{x', надо написать {hcпнуть{x. Для использования магии, надо писать {hcколдовать{x и название заклинания -- читай %H% {hh1361колдовать{x.
+
+Активное умение стоит маны, движений и мгновения задержки -- но платишь ты только за попытку, которая действительно случилась. Когда игра отказывает еще до замаха -- нет цели, не то оружие, ты и так спрятан, до двери не дотянуться -- это не стоит ничего. А вот попытка, которая случилась и просто не удалась, оплачивается полностью: замеченная кража, толчок, который не сдвинул, побег, который не вышел.
 
 А вот пассивные навыки работают сами по себе, если они достаточно разучены. Например, защитные навыки работают автоматически и не требуют написания команд: {hh726блок щитом{x, {hh754уклонение{x, {hh576парирование{x и т.д.
 
@@ -88,6 +92,8 @@ Sorts the list by level, name, or percentage of leveling.</text>
 Щоб побачити вміння, доступні твоєму персонажу, їх рівень, вивченість та витрати мани, просто введи *вміння*. А щоб відфільтрувати окремо навички або заклинання, додай це в кінці.
 
 Навички бувають =активні= та =пасивні=. Для активних навичок потрібно набирати команди: наприклад, для використання бойової навички '{hh807удар{x', треба написати {hcвдарити{x. Для використання магії треба написати {hcчаклувати{x і назву заклинання -- читай %H% {hh1361чаклувати{x.
+
+Активне вміння коштує мани, рухів і миті затримки -- але платиш ти лише за спробу, яка справді сталася. Коли гра відмовляє ще до замаху -- нема цілі, не та зброя, ти й так схований, до дверей не дотягтися -- це не коштує нічого. А от спроба, яка сталася і просто не вдалася, оплачується повністю: помічена крадіжка, штовхання, що не зрушило, втеча, що не вийшла.
 
 Пасивні ж навички працюють самостійно, якщо вони достатньо вивчені. Наприклад, захисні навички працюють автоматично і не потребують команд: {hh726блок щитом{x, {hh754ухилення{x, {hh576парирування{x і т.д.
 


### PR DESCRIPTION
dreamland_code#924 + dreamland_fenia#423 moved sixteen skills' and spells' eligibility checks ahead of the mana/movement/lag deduction, so a refusal is now free where it used to cost a full attempt. Nothing documented that.

Adds a paragraph to help 1352 (`skills`), beside the one introducing active skills, in EN, RU and UA. It states the rule and the distinction that matters -- refused before the swing costs nothing, an attempt that happened and failed is paid in full -- and deliberately lists no skills, since the migrated set keeps growing.

Written while drafting the changelog entry; Kit asked for the explanation to live in the help rather than in the change.