### PR TITLE
Catalog the galley refusal under its new file key

### DIFF
--- a/config/translations/areas3.json
+++ b/config/translations/areas3.json
@@ -3071,6 +3071,14 @@
   "Теперь это похоже на настоящий монокль!": {
    "en": "Now it looks like a real monocle!",
    "ua": "Тепер це схоже на справжній монокль!"
+  },
+  "Соваться на камбуз без дела -- верный способ отхватить по лбу сковородкой.": {
+   "en": "Poking around the galley with nothing to do is a sure way to catch a frying pan to the forehead.",
+   "ua": "Пхатися на камбуз без діла -- певний спосіб отримати сковорідкою по лобі."
+  },
+  "Давай-ка для начала освоимся на корабле чуть получше.": {
+   "en": "Let's get a bit more familiar with the ship first.",
+   "ua": "Давай-но спершу трохи краще освоїмося на кораблі."
   }
  },
  "areas/emerald.are/room/200.q29102_step4_begin_postGreet": {


### PR DESCRIPTION
The two lines moved from the 40006 `CantMove` handler into `galeon.are/common` so both galley entrances can share them (dreamland_fenia#429). The catalog keys by the file where `._()` runs, so they need an entry under the new key as well. Same EN/UA text.