### PR TITLE
Catalog the sneak re-arm line for its new Fenia home

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -1003,6 +1003,12 @@
    "ua": "Ти випадково хляпаєш по калюжі і перестаєш рухатися нечутно!"
   }
  },
+ "affect/sneak/onRefresh": {
+  "Ты пытаешься двигаться незаметно.": {
+   "en": "You try to move unnoticed.",
+   "ua": "Ти намагаєшся рухатися непомітно."
+  }
+ },
  "affect/stone skin/onHit": {
   "{DТвоя прочная как камень кожа поглощает часть урона.{x": {
    "en": "{DYour skin, tough as stone, absorbs some of the damage.{x",


### PR DESCRIPTION
Companion to dreamland_fenia#432, which moves racial sneak off the raw `SET_BIT` in `update.cpp:420` and onto a real affect built by `affect/sneak/onRefresh`.

The player-visible string is unchanged -- "Ты пытаешься двигаться незаметно." -- but the catalog is keyed by source file, so the new Fenia call site needs its own section. Without it, EN and UA players would fall back to the RU original.

EN and UA copied verbatim from the existing `plug-ins/updates/update.cpp` entry so the wording stays identical across the switch.

Needs the next reboot (or a `plug reload`) to take effect; the Fenia half is live already.