### PR TITLE
Catalog the hide re-arm line for its Fenia home

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -395,6 +395,12 @@
    "ua": "Раптом сонячне світло ніби виявляє щось, раніше приховане..."
   }
  },
+ "affect/hide/onRefresh": {
+  "Ты прячешься обратно в тень.": {
+   "en": "You slip back into the shadow.",
+   "ua": "Ти ховаєшся назад у тінь."
+  }
+ },
  "affect/holy armor/onImmune": {
   "{WСвященная броня %1$C2 {Wзащищает %1$Gего|его|ее|их от повреждений!{x": {
    "en": "{WThe holy armor of %1$C2 {Wprotects them from harm!{x",


### PR DESCRIPTION
Companion to dreamland_fenia#436 and dreamland_code#935. The string is unchanged; the catalog is keyed by source file, so the Fenia call site needs its own entry or EN and UA players fall back to the RU original. Copied verbatim from the existing `plug-ins/updates/update.cpp` entry.

Harmless on its own, but pointless until those two land.