### PR TITLE
Cuisinart cap counts what is inside bags: message and help

### DIFF
--- a/behaviors/cuisinart.xml
+++ b/behaviors/cuisinart.xml
@@ -10,13 +10,13 @@
     <extra l="ua">кузинатра дробарка розібрати розбір</extra>
     <text l="en">%FMT% *use* {Dcuisinart{x
 
-Put the items you want to scrap inside the cuisinart, close its lid, and use it. For a fee it grinds the contents into {hh294components{x -- raw material for crafting -- shredding objects into chunks and chunks into dust. Load it with five identical heaps of dust instead, and it presses them back into a single chunk. Not every item can be broken down, and it refuses to start with more than ten of them inside.</text>
+Put the items you want to scrap inside the cuisinart, close its lid, and use it. For a fee it grinds the contents into {hh294components{x -- raw material for crafting -- shredding objects into chunks and chunks into dust. Load it with five identical heaps of dust instead, and it presses them back into a single chunk. Not every item can be broken down, and it refuses to start with more than ten of them inside, counting whatever is stuffed into bags.</text>
     <text l="ru">%FMT% *использовать* {Dкузинатра{x
 
-Сложи вещи, которые не жалко, внутрь кузинатры, закрой крышку и запусти. За плату она перемелет содержимое в {hh294компоненты{x -- сырье для крафта, -- дробя предметы в куски, а куски в пыль. А засыплешь вместо этого пять одинаковых горстей пыли -- спрессует их обратно в кусок. Не всякая вещь поддается разбору, и больше десяти штук за один заход она не примет.</text>
+Сложи вещи, которые не жалко, внутрь кузинатры, закрой крышку и запусти. За плату она перемелет содержимое в {hh294компоненты{x -- сырье для крафта, -- дробя предметы в куски, а куски в пыль. А засыплешь вместо этого пять одинаковых горстей пыли -- спрессует их обратно в кусок. Не всякая вещь поддается разбору, и больше десяти штук за один заход она не примет, считая и то, что рассовано по сумкам.</text>
     <text l="ua">%FMT% *використати* {Dкузинатра{x
 
-Склади речі, яких не шкода, всередину кузинатри, зачини кришку і запусти. За плату вона перемеле вміст на {hh294компоненти{x -- сировину для крафту, -- дроблячи предмети на куски, а куски на пил. А всиплеш натомість пʼять однакових жмень пилу -- спресує їх назад у кусок. Не кожна річ піддається розбору, і більше десяти штук за один захід вона не візьме.</text>
+Склади речі, яких не шкода, всередину кузинатри, зачини кришку і запусти. За плату вона перемеле вміст на {hh294компоненти{x -- сировину для крафту, -- дроблячи предмети на куски, а куски на пил. А всиплеш натомість пʼять однакових жмень пилу -- спресує їх назад у кусок. Не кожна річ піддається розбору, і більше десяти штук за один захід вона не візьме, рахуючи й те, що напхано по торбах.</text>
   </help>
   <id>58</id>
   <nameRus>кузинатра</nameRus>

--- a/config/translations/behaviors.json
+++ b/config/translations/behaviors.json
@@ -1394,9 +1394,9 @@
    "en": "%1$^O1 beeps and blinks its power indicator -- then goes dead. Starting it up requires %2$s.",
    "ua": "%1$^O1 гуднул%1$Gо|а|и|и, блимнул%1$Gо|а|и|и індикатором живлення -- і заглухл%1$Gо|а|и|и. Для запуску потрібно %2$s."
   },
-  "%1$^O1 недовольно клаца%1$nет|ют заслонкой: больше 10 предметов за раз не бер%1$nет|ут -- а сейчас внутри %2$d предмет%2$I|а|ов.": {
-   "en": "%1$^O1 clack%1$ns| the hatch in disapproval: no more than 10 items at a time, and right now there are %2$d inside.",
-   "ua": "%1$^O1 невдоволено клаца%1$nє|ють заслінкою: більше 10 предметів за раз не бер%1$nе|уть -- а зараз усередині %2$d предмет%2$I|и|ів."
+  "%1$^O1 недовольно клаца%1$nет|ют заслонкой: больше 10 предметов за раз не бер%1$nет|ут, а внутри сейчас %2$d предмет%2$I|а|ов, считая все, что рассовано по сумкам.": {
+   "en": "%1$^O1 clack%1$ns| the hatch in disapproval: no more than 10 items at a time, and there are %2$d inside right now, counting everything stuffed into bags.",
+   "ua": "%1$^O1 невдоволено клаца%1$nє|ють заслінкою: більше 10 предметів за раз не бер%1$nе|уть, а всередині зараз %2$d предмет%2$I|и|ів, рахуючи все, що напхано по торбах."
   }
  },
  "behaviors/cuisinart/postUse": {


### PR DESCRIPTION
Companion to dreamland_fenia#454, which makes the ten-item cap count the contents of nested containers.

- `config/translations/behaviors.json`: the RU refusal string changed, so its old catalog key is dead -- deleted and replaced in the same batch. 3 lines changed, no other entry touched.
- `behaviors/cuisinart.xml`: help id 293 now says the count includes what is stuffed into bags, in en/ru/ua.

Neither half is live yet: `plug_reload_safe` refuses while #59's C++ sits staged, so this rides the next boot along with world#527.