### PR TITLE
Eggshell is fragile, as its own data always meant to say

### DIFF
--- a/fight/material.json
+++ b/fight/material.json
@@ -91,7 +91,7 @@
  { "name": "coral", "breaks_into": "28017", "rho": 2940, "hardness": 5, "burns": 0, "floats": -1, "type": "organic mineral", "flags": "", "vuln": "", "uaname": "корал||у|ові||ом|і", "rname": "коралл||а|у||ом|е" },
  { "name": "pearl", "breaks_into": "28017", "rho": 2730, "hardness": 4, "burns": 0, "floats": -1, "type": "organic mineral", "flags": "", "vuln": "", "uaname": "перлин|а|и|і|у|ою|і", "rname": "жемчуг||а|у||ом|е" },
  { "name": "shell", "breaks_into": "28017", "rho": 2000, "hardness": 4, "burns": 0, "floats": -1, "type": "organic mineral", "flags": "", "vuln": "", "uaname": "мушл|я|і|і|ю|ею|і", "rname": "раковин|а|ы|е|у|ой|е" },
- { "name": "eggshell", "breaks_into": "8711", "rho": 1820, "hardness": 1, "burns": 0, "floats": -1, "type": "organic mineral", "flags: fragile": "", "vuln": "", "uaname": "шкаралуп|а|и|і|у|ою|і", "rname": "скорлуп|а|ы|е|у|ой|е" },
+ { "name": "eggshell", "breaks_into": "8711", "rho": 1820, "hardness": 1, "burns": 0, "floats": -1, "type": "organic mineral", "flags": "fragile", "vuln": "", "uaname": "шкаралуп|а|и|і|у|ою|і", "rname": "скорлуп|а|ы|е|у|ой|е" },
  { "name": "wax", "breaks_into": "9613", "rho": 1000, "hardness": 1, "burns": 1, "floats": 0, "type": "organic", "flags": "melting", "vuln": "", "uaname": "в|іск|оску|оскові|іск|оском|оскові", "rname": "воск||а|у||ом|е" },
                    
  // papers


### PR DESCRIPTION
`fight/material.json:94` spelled the key `"flags: fragile": ""` instead of `"flags": "fragile"`, so eggshell carried no flags at all and `MAT_FRAGILE` was never set.

Everything that keys on the flag has been silently skipping eggshell: the quadruple damage in `.tmp.object.damageObj`, and the shatter-on-drop roll in `utils/object: commands`. 23 objects across 10 areas are made of it.

Found while writing the elemental-physics spec (defect 5 of section 12) -- scream and the object destruction engine both want fragile to mean something.

Needs a reboot to take effect.