### PR TITLE
Help 566 describes what energy drain now actually does

### DIFF
--- a/config/translations/spell2.json
+++ b/config/translations/spell2.json
@@ -1969,6 +1969,18 @@
   "{1{RТемная воронка разрывает тебя на куски!{2": {
    "en": "{1{RThe dark funnel tears you to pieces!{2",
    "ua": "{1{RТемна вирва розриває тебе на шматки!{2"
+  },
+  "Ноги подкашиваются, и ты едва держишься на них.": {
+   "en": "Your legs buckle, and you can barely keep your feet.",
+   "ua": "Ноги підкошуються, і ти ледве тримаєшся на них."
+  },
+  "Чужая сила вливается в тебя.": {
+   "en": "Somebody else's strength pours into you.",
+   "ua": "Чужа сила вливається в тебе."
+  },
+  "%1$^C1 слабе%1$nет|ют на глазах!": {
+   "en": "%1$^C1 weaken%1$ns| before your very eyes!",
+   "ua": "%1$^C1 слабш%1$nає|ають на очах!"
   }
  },
  "spell/wrath/runVict": {

--- a/generic-skills/energy drain.xml
+++ b/generic-skills/energy drain.xml
@@ -37,15 +37,27 @@
     <extra l="ua">'втрата життя'</extra>
     <text l="en">%FMT% *%SPELL%* _%VICT%_
 
-This spell deals damage with dark energy, and on a saving throw failure {hh2035it drains{x {hh59mana{x and {hh60movement points{x from the victim.
+This spell deals damage with dark energy. On a failed {hh2035saving throw{x it also drains two thirds of the victim's {hh59mana{x and {hh60movement points{x, and leaves them {hh704weakened{x, too spent to keep their footing.
+
+What is taken does not vanish: the caster absorbs the stolen vigour along with a share of the life torn loose, up to their own maximum. A victim of a tenth of the caster's level or less is simply torn apart.
+
+The undead and soulless constructs have no energy to give, and the spell finds nothing in them at all.
 </text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
-Это заклинание наносит урон темной энергией, а при провале {hh2035спасброска{x отнимает {hh59ману{x и {hh60очки движения{x у жертвы.
+Это заклинание наносит урон темной энергией. При провале {hh2035спасброска{x оно отнимает у жертвы две трети {hh59маны{x и {hh60очков движения{x, и накладывает на нее {hh704слабость{x -- ноги ее уже не держат.
+
+Отнятое не пропадает: украденная бодрость и часть вырванной жизни вливаются в заклинателя, но не выше его собственного предела. Жертву десятого уровня от уровня заклинателя и ниже воронка просто разрывает на куски.
+
+У нежити и бездушных конструкций энергии нет, и заклинание не находит в них ничего.
 </text>
     <text l="ua">%FMT% *%SPELL%* _%VICT%_
 
-Це заклинання завдає шкоди темною енергією, а в разі невдачі {hh2035рятівного кидка{x відбирає {hh59ману{x і {hh60очки руху{x у жертви.
+Це заклинання завдає шкоди темною енергією. У разі невдачі {hh2035рятівного кидка{x воно відбирає у жертви дві третини {hh59мани{x і {hh60очок руху{x, і накладає на неї {hh704слабкість{x -- ноги її вже не тримають.
+
+Відібране не зникає: вкрадена бадьорість і частка вирваного життя вливаються в заклинача, але не вище його власної межі. Жертву десятого рівня від рівня заклинача і нижче вирва просто розриває на шматки.
+
+У нежиті й бездушних конструкцій енергії немає, і заклинання не знаходить у них нічого.
 </text>
   </help>
   <mana>40</mana>


### PR DESCRIPTION
The article promised the spell drains mana and movement from the victim
and said nothing else. Since fenia#473 it also hands what it takes to
the caster, leaves the victim weakened, and tears apart anyone at a
tenth of the caster's level or less -- and the mana and movement it
takes is now two thirds rather than an unstated amount.

The undead clause was in the code all along and in no article, so a
player could only find it by casting into a crypt and watching nothing
happen.

Also carries the three catalog entries for the strings fenia#473 adds.
The catalog is keyed per file before it is keyed per string, so the
weaken room line needs its own entry under the energy drain key even
though the identical wording is already translated under weaken's.