### PR TITLE
Add EN and UA translations for the Taliesin quest dialogue

### DIFF
--- a/config/translations/mirror2.json
+++ b/config/translations/mirror2.json
@@ -1,0 +1,264 @@
+{
+  "areas/mirror2.are/mirrorquest": {
+    "%1$C1 в ужасе убегает в отверстие в потолке.": {
+      "en": "%1$C1 bolts in terror through the opening in the ceiling.",
+      "ua": "%1$C1 з жахом тікає в отвір у стелі."
+    },
+    "%1$C1 распахивает люк в потолке и в ужасе убегает.": {
+      "en": "%1$C1 throws open the hatch in the ceiling and flees in terror.",
+      "ua": "%1$C1 розчахує люк у стелі й з жахом тікає."
+    },
+    "%1$^C1 вручает %2$C3 %3$O4.": {
+      "en": "%1$^C1 hands %3$O4 to %2$C3.",
+      "ua": "%1$^C1 вручає %2$C3 %3$O4."
+    },
+    "%1$^C1 вручает тебе %2$O4.": {
+      "en": "%1$^C1 hands you %2$O4.",
+      "ua": "%1$^C1 вручає тобі %2$O4."
+    },
+    "%1$^C1 замечает в твоих руках %2$O4.": {
+      "en": "%1$^C1 notices %2$O4 in your hands.",
+      "ua": "%1$^C1 помічає у твоїх руках %2$O4."
+    },
+    "Мне это ни к чему.": {
+      "en": "I have no use for that.",
+      "ua": "Мені це ні до чого."
+    }
+  },
+  "areas/mirror2.are/mob/19003.onGreet": {
+    "Рано тебе во вторую башню. Возвращайся, когда рука окрепнет.": {
+      "en": "The second tower is too soon for you. Come back when your arm has grown stronger.",
+      "ua": "Зарано тобі до другої вежі. Повертайся, коли рука зміцніє."
+    }
+  },
+  "areas/mirror2.are/mob/19003.onTell": {
+    "Не шепчи. Хочешь говорить о нем -- надо {1{y{hcсказать талиесин{x{2 вслух.": {
+      "en": "Do not whisper. If you would speak of it, you must {1{y{hcsay taliesin{x{2 aloud.",
+      "ua": "Не шепочи. Хочеш говорити про нього -- треба {1{y{hcсказати таліесін{x{2 вголос."
+    }
+  },
+  "areas/mirror2.are/mob/19003.q19001_step0_begin_postGreet": {
+    "%1$^C1 медленно поворачивает голову и окидывает тебя взглядом.": {
+      "en": "%1$^C1 slowly turns and looks you over.",
+      "ua": "%1$^C1 повільно повертає голову й окидає тебе поглядом."
+    },
+    "Если тебе есть дело до здешних легенд -- {1{y{hcсказать талиесин{x{2.": {
+      "en": "If the legends of this place concern you -- {1{y{hcsay taliesin{x{2.",
+      "ua": "Якщо тобі є діло до тутешніх легенд -- {1{y{hcсказати таліесін{x{2."
+    },
+    "Королевство Зеркал видало времена и получше, странник.": {
+      "en": "The Kingdom of Mirrors has seen better days, wanderer.",
+      "ua": "Королівство Дзеркал бачило й кращі часи, мандрівнику."
+    }
+  },
+  "areas/mirror2.are/mob/19003.q19001_step1_begin_postSpeech": {
+    "В Радужной Башне семь ярусов, и на каждом стоит хранитель.": {
+      "en": "The Rainbow Tower has seven floors, and a keeper stands on each.",
+      "ua": "У Веселковій Вежі сім ярусів, і на кожному стоїть охоронець."
+    },
+    "Значит, ты слыша%1$Gло|л|ла о нем.": {
+      "en": "So you have heard of it.",
+      "ua": "Отже, ти чу%1$Gло|в|ла про нього."
+    },
+    "Начни с рубинового. Красный страж стоит у подножия башни.": {
+      "en": "Begin with the ruby. The Red Master stands at the foot of the tower.",
+      "ua": "Почни з рубінового. Червоний Майстер стоїть біля підніжжя вежі."
+    },
+    "Отыщи их и отдай каждому Мастеру его цвет, снизу вверх.": {
+      "en": "Find them and give each Master his own colour, from the bottom up.",
+      "ua": "Відшукай їх і віддай кожному Майстру його колір, знизу вгору."
+    },
+    "По королевству разбросаны талисманы -- семь камней, семь цветов.": {
+      "en": "Talismans lie scattered across the kingdom -- seven stones, seven colours.",
+      "ua": "По королівству розкидані талісмани -- сім каменів, сім кольорів."
+    }
+  },
+  "areas/mirror2.are/mob/19003.q19001_step8_end_onGive": {
+    "В будущем, когда рука твоя окрепнет в боях, ты сможешь доказать свое мужество и лояльность Свету.": {
+      "en": "In time, when your arm has been hardened in battle, you will be able to prove your courage and your loyalty to the Light.",
+      "ua": "Згодом, коли рука твоя зміцніє в боях, ти зможеш довести свою мужність і відданість Світлу."
+    },
+    "Ныне ты долж%1$Gно|ен|на доказать свое мужество и лояльность Свету.": {
+      "en": "Now you must prove your courage and your loyalty to the Light.",
+      "ua": "Нині ти пови%1$Gнно|нен|нна довести свою мужність і відданість Світлу."
+    },
+    "Пускай этот щит поможет тебе в этом.": {
+      "en": "Let this shield aid you in that.",
+      "ua": "Хай цей щит тобі в цьому допоможе."
+    },
+    "Ты доказа%1$Gло|л|ла свои знания земель Зеркального Королевства.": {
+      "en": "You have proven your knowledge of the lands of the Mirror Kingdom.",
+      "ua": "Ти дов%1$Gело|ів|ела свої знання земель Дзеркального Королівства."
+    },
+    "У тебя злая душа, королевство не нуждается в твоей помощи.": {
+      "en": "Your soul is evil; the kingdom has no need of your help.",
+      "ua": "У тебе зла душа, королівство не потребує твоєї допомоги."
+    }
+  },
+  "areas/mirror2.are/mob/19003.q19002_step0_begin_postGreet": {
+    "%1$^C1 узнает тебя и мрачнеет.": {
+      "en": "%1$^C1 recognizes you and darkens.",
+      "ua": "%1$^C1 упізнає тебе й хмурніє."
+    },
+    "Если ты гото%1$Gво|в|ва слушать про вторую башню -- {1{y{hcсказать талиесин{x{2.": {
+      "en": "If you are ready to hear of the second tower -- {1{y{hcsay taliesin{x{2.",
+      "ua": "Якщо ти гото%1$Gве|вий|ва слухати про другу вежу -- {1{y{hcсказати таліесін{x{2."
+    },
+    "Ты вернул%1$Gось|ся|ась, и рука твоя окрепла.": {
+      "en": "You have returned, and your arm has grown stronger.",
+      "ua": "Ти поверну%1$Gлося|вся|лася, і рука твоя зміцніла."
+    }
+  },
+  "areas/mirror2.are/mob/19003.q19002_step1_begin_postSpeech": {
+    "В ней четверо хранителей, белые и черные.": {
+      "en": "Four keepers dwell in it, white and black.",
+      "ua": "У ній четверо охоронців, білі та чорні."
+    },
+    "За зеркалом стоит вторая башня -- черная, без окон.": {
+      "en": "Beyond the mirror stands a second tower -- black, without windows.",
+      "ua": "За дзеркалом стоїть друга вежа -- чорна, без вікон."
+    },
+    "Люки между ярусами заперты наглухо, и ключей к ним нет.": {
+      "en": "The hatches between the floors are sealed fast, and there are no keys to them.",
+      "ua": "Люки між ярусами замкнені наглухо, і ключів до них немає."
+    },
+    "Но щит, что я тебе дал, они узнают -- и откроют путь сами, со страху.": {
+      "en": "But they will know the shield I gave you -- and open the way themselves, out of fear.",
+      "ua": "Але щит, що я тобі дав, вони впізнають -- і відчинять шлях самі, зі страху."
+    },
+    "Принеси талисман мне, и меч будет твой.": {
+      "en": "Bring the talisman to me, and the sword will be yours.",
+      "ua": "Принеси талісман мені, і меч буде твій."
+    },
+    "Убей всех четверых. На вершине сторожит нечто, при нем темный талисман.": {
+      "en": "Kill all four. Something stands guard at the top, and the dark talisman is with it.",
+      "ua": "Убий усіх чотирьох. На вершині вартує дещо, при ньому темний талісман."
+    }
+  },
+  "areas/mirror2.are/mob/19003.q19002_step1_end_onGive": {
+    "И вот награда за твои подвиги.": {
+      "en": "And here is the reward for your deeds.",
+      "ua": "І ось нагорода за твої подвиги."
+    },
+    "Ты доказа%1$Gло|л|ла, что не боишься сил тьмы и в состоянии им противостоять.": {
+      "en": "You have proven that you do not fear the powers of darkness and can stand against them.",
+      "ua": "Ти дов%1$Gело|ів|ела, що не боїшся сил темряви і здат%1$Gне|ен|на їм протистояти."
+    },
+    "Ты долж%1$Gно|ен|на бы%1$Gло|л|ла пройти весь путь са%1$Gмо|м|ма, без посторонней помощи.": {
+      "en": "You were to walk the whole path yourself, without help from anyone.",
+      "ua": "Ти ма%1$Gло|в|ла пройти весь шлях са%1$Gмо|м|ма, без сторонньої допомоги."
+    },
+    "Ты не заслуживаешь права обладать Талиесином.": {
+      "en": "You do not deserve the right to wield Taliesin.",
+      "ua": "Ти не заслуговуєш на право володіти Таліесіном."
+    },
+    "У тебя злая душа, королевство не нуждается в твоей помощи.": {
+      "en": "Your soul is evil; the kingdom has no need of your help.",
+      "ua": "У тебе зла душа, королівство не потребує твоєї допомоги."
+    }
+  },
+  "areas/mirror2.are/mob/19055.q19001_step2_begin_postGive": {
+    "Ключ твой. Ступенью выше ждет янтарный страж -- он нетерпелив.": {
+      "en": "The key is yours. A step higher the amber keeper waits -- he is impatient.",
+      "ua": "Ключ твій. Щаблем вище чекає бурштиновий охоронець -- він нетерплячий."
+    }
+  },
+  "areas/mirror2.are/mob/19056.q19001_step3_begin_postGive": {
+    "Ступай выше. Желтый хранитель редко поднимает глаза, но видит все.": {
+      "en": "Go higher. The yellow keeper rarely lifts his eyes, yet he sees everything.",
+      "ua": "Іди вище. Жовтий охоронець рідко підводить очі, та бачить усе."
+    }
+  },
+  "areas/mirror2.are/mob/19057.q19001_step5_begin_postGive": {
+    "Голубой Мастер ждет наверху. Он не любит суеты -- не торопи его.": {
+      "en": "The Blue Master waits above. He dislikes haste -- do not hurry him.",
+      "ua": "Блакитний Майстер чекає нагорі. Він не любить метушні -- не квап його."
+    }
+  },
+  "areas/mirror2.are/mob/19058.q19001_step6_begin_postGive": {
+    "Остался фиолетовый ярус. За ним -- свет, и он ярче, чем ты думаешь.": {
+      "en": "The violet floor remains. Beyond it lies the light, and it is brighter than you think.",
+      "ua": "Лишився фіолетовий ярус. За ним -- світло, і воно яскравіше, ніж ти гадаєш."
+    }
+  },
+  "areas/mirror2.are/mob/19059.q19001_step7_begin_postGive": {
+    "Радуга замкнулась. Поднимайся в Призматическую комнату, тебя там ждут.": {
+      "en": "The rainbow is complete. Climb to the Prismatic Chamber; you are expected there.",
+      "ua": "Веселка замкнулася. Піднімайся до Призматичної кімнати, на тебе там чекають."
+    }
+  },
+  "areas/mirror2.are/mob/19060.q19001_step4_begin_postGive": {
+    "Дальше -- зеленый ярус. Там тебя выслушают, но не сразу.": {
+      "en": "Next is the green floor. There you will be heard, though not at once.",
+      "ua": "Далі -- зелений ярус. Там тебе вислухають, але не одразу."
+    }
+  },
+  "areas/mirror2.are/mob/19061.q19001_step8_begin_postGive": {
+    "Отнеси талисман королю Лоранхиру. Он рассудит, чего ты стоишь.": {
+      "en": "Take the talisman to King Loranhir. He will judge what you are worth.",
+      "ua": "Віднеси талісман королю Лоранхіру. Він розсудить тобі ціну."
+    },
+    "Ты доказа%1$Gло|л|ла, что знако%1$Gмо|м|ма с Королевством Зеркал.": {
+      "en": "You have proven that you know the Kingdom of Mirrors.",
+      "ua": "Ти дов%1$Gело|ів|ела, що знайом%1$Gе|ий|а з Королівством Дзеркал."
+    }
+  },
+  "areas/mirror2.are/obj/19157.onGet": {
+    "%1$^C1 вскрикивает от боли и роняет меч на землю.": {
+      "en": "%1$^C1 cries out in pain and drops the sword to the ground.",
+      "ua": "%1$^C1 скрикує від болю й упускає меч на землю."
+    },
+    "Глубоко порезав руку, ты роняешь %1$O4 на землю.": {
+      "en": "Cutting your hand deeply, you drop %1$O4 to the ground.",
+      "ua": "Глибоко порізавши руку, ти впускаєш %1$O4 на землю."
+    },
+    "Рукоять, за которую ты его схвати%1$Gло|л|ла, неуловимо меняется местами с лезвием.": {
+      "en": "The hilt you seized it by imperceptibly trades places with the blade.",
+      "ua": "Руків'я, за яке ти його схопи%1$Gло|в|ла, непомітно міняється місцями з лезом."
+    },
+    "Тьма на мгновение окутывает %1$O4.": {
+      "en": "Darkness envelops %1$O4 for an instant.",
+      "ua": "Темрява на мить огортає %1$O4."
+    }
+  },
+  "areas/mirror2.are/obj/19157.onWear": {
+    "Руны на лезвии %1$O2 на мгновение вспыхивают.": {
+      "en": "The runes on the blade of %1$O2 flare for an instant.",
+      "ua": "Руни на лезі %1$O2 на мить спалахують."
+    }
+  },
+  "areas/mirror2.are/obj/19158.onFight": {
+    "{YВырвавшись из середины %1$O2, ослепительный {Wлуч света{Y ударяет в %2$C4!{x": {
+      "en": "{YBursting from the centre of %1$O2, a blinding {Wray of light{Y strikes %2$C4!{x",
+      "ua": "{YВирвавшись із середини %1$O2, сліпучий {Wпромінь світла{Y б'є в %2$C4!{x"
+    },
+    "{YЗолотистое сияние, исходящее от обратной стороны %1$O2, пронизывает твое тело.{x": {
+      "en": "{YA golden radiance from the back of %1$O2 courses through your body.{x",
+      "ua": "{YЗолотисте сяйво, що йде від зворотного боку %1$O2, пронизує твоє тіло.{x"
+    }
+  },
+  "areas/mirror2.are/obj/19158.onGet": {
+    "%1$^C1 не в силах удержать внезапно потяжелевший щит и роняет его.": {
+      "en": "%1$^C1 cannot hold the suddenly heavy shield and drops it.",
+      "ua": "%1$^C1 не в змозі втримати раптово обважнілий щит і впускає його."
+    },
+    "Внезапно он становится невыносимо тяжелым, и ты роняешь его на землю.": {
+      "en": "Suddenly it becomes unbearably heavy, and you drop it to the ground.",
+      "ua": "Раптом він стає нестерпно важким, і ти впускаєш його на землю."
+    },
+    "Драгоценные камни, украшающие %1$O4, чернеют.": {
+      "en": "The gems adorning %1$O4 turn black.",
+      "ua": "Коштовні камені, що оздоблюють %1$O4, чорніють."
+    }
+  },
+  "areas/mirror2.are/obj/19158.onWear": {
+    "%1$^O1 на мгновение озаряет все вокруг ярким солнечным светом.": {
+      "en": "%1$^O1 lights everything around with bright sunlight for an instant.",
+      "ua": "%1$^O1 на мить осяює все навколо яскравим сонячним світлом."
+    },
+    "Драгоценные камни, украшающие %1$O4, отбрасывают тысячи разноцветных бликов.": {
+      "en": "The gems adorning %1$O4 cast a thousand coloured glints.",
+      "ua": "Коштовні камені, що оздоблюють %1$O4, розкидають тисячі різнобарвних відблисків."
+    }
+  }
+}


### PR DESCRIPTION
55 entries across 21 file keys, covering every `._()` string in the rewritten mirror2 quest.

The old scenario spoke raw Russian with no catalog coverage. Without this an English player gets an English quest journal and a Russian king.

UA values use ASCII `'`, not `ʼ` (U+02BC). The catalog is converted to KOI8-U at load with `//IGNORE`, which drops U+02BC silently, so the character never reaches the player. `lint-l10n.py` gates this; every existing shard already uses ASCII.

Pairs with dreamland_fenia#475 and dreamland_areas#457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)