### PR TITLE
Galeon: reward line no longer names an awl

### DIFF
--- a/config/translations/areas3.json
+++ b/config/translations/areas3.json
@@ -3028,13 +3028,13 @@
    "en": "And we've almost docked -- go see the Captain and say your goodbyes.",
    "ua": "А ми вже майже причалили -- сходи до Капітана і попрощайся наостанок."
   },
-  "А тебе в награду я отдам свое верное шило.": {
-   "en": "And as a reward, I'll give you my trusty awl.",
-   "ua": "А тобі в нагороду я віддам своє вірне шило."
+  "А тебе в награду я отдам свое верное оружие.": {
+   "en": "And as a reward, I'll give you my trusty weapon.",
+   "ua": "А тобі в нагороду я віддам свою вірну зброю."
   },
   "Я добыл его в бою -- надеюсь, и тебе оно послужит верой и правдой.": {
    "en": "I won it in battle -- I hope it serves you faithfully too.",
-   "ua": "Я здобув його в бою -- сподіваюся, і тобі воно послужить вірою і правдою."
+   "ua": "Я здобув її в бою -- сподіваюся, і тобі вона послужить вірою і правдою."
   }
  },
  "areas/newthalos.are/mob/9594.q9501_step1_end_onGive": {


### PR DESCRIPTION
Quest 40005's reward becomes a generated weapon in whatever class the player handles best, so the sailor can no longer promise them his awl.

The Russian line stays neuter, so the follow-up line ("его" / "оно") still agrees and its key is untouched. Ukrainian has to move, because "зброя" is feminine: "здобув її" / "вона послужить".

Pairs with the Fenia change to `areas/galeon.are/mob/40006.q40005_step4_begin_postGive` and dreamland_code#952.