### PR TITLE
Language commands readable while asleep; atheist sacrifice wording and help

### DIFF
--- a/commands/sacrifice.xml
+++ b/commands/sacrifice.xml
@@ -11,7 +11,7 @@
     <text l="en">%FMT% *%CMD%* all
 %FMT% *%CMD%* _item_
 
-Sacrifices an item (or all items) on the ground to the gods -- the gods grant a bit of silver. Some things (like player corpses) cannot be sacrificed. Anti-paladins can gain {hh695magical{x energy from sacrifices.
+Sacrifices an item (or all items) on the ground to the gods -- the gods grant a bit of silver. Some things (like player corpses) cannot be sacrificed. Anti-paladins can gain {hh695magical{x energy from sacrifices. An {hh1atheist{x has nobody to offer anything to: the item is simply thrown away, and nobody pays a coin for it.
 
 Altars can be constructed for the gods of ancient cults -- the gods and goddesses of the {hh1official pantheon{x do not accept sacrifices.
 
@@ -35,7 +35,7 @@ Having gathered a worthy offering, you can perform a sacrifice with this command
     <text l="ru">%FMT% *%CMD%* все 
 %FMT% *%CMD%* _предмет_ 
 
-Приносит предмет (или все) на земле в жертву богам -- боги дадут чуток серебра. Некоторые вещи (например, трупы игроков) жертвовать нельзя. Анти-паладины могут получать {hh695магическую{x энергию от жертв.
+Приносит предмет (или все) на земле в жертву богам -- боги дадут чуток серебра. Некоторые вещи (например, трупы игроков) жертвовать нельзя. Анти-паладины могут получать {hh695магическую{x энергию от жертв. {hh1Атеисту{x приносить жертву некому: вещь просто выбрасывается, и за нее никто не платит ни монеты.
 
 Божествам древних культов можно соорудить =алтарь= -- Боги и богини {hh1официального пантеона{x жертвоприношений не приемлют.
 
@@ -59,7 +59,7 @@ Having gathered a worthy offering, you can perform a sacrifice with this command
     <text l="ua">%FMT% *%CMD%* все 
 %FMT% *%CMD%* _предмет_ 
 
-Приносить предмет (або все) на землі в жертву богам -- боги дадуть трохи срібла. Деякі речі (наприклад, трупи гравців) жертвувати не можна. Анти-паладини можуть отримувати {hh695магічну{x енергію від жертв.
+Приносить предмет (або все) на землі в жертву богам -- боги дадуть трохи срібла. Деякі речі (наприклад, трупи гравців) жертвувати не можна. Анти-паладини можуть отримувати {hh695магічну{x енергію від жертв. {hh1Атеїсту{x приносити жертву нема кому: річ просто викидається, і за неї ніхто не платить ні монети.
 
 Божествам стародавніх культів можна спорудити =вівтар= -- Боги і богині {hh1офіційного пантеону{x жертвоприношень не приймають.
 

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -12779,6 +12779,10 @@
   "Ты проводишь рукой над %O5 и изрекаешь '{C%s{x'.": {
    "en": "You pass your hand over %O5 and utter '{C%s{x'.",
    "ua": "Ти проводиш рукою над %O5 і промовляєш '{C%s{x'."
+  },
+  "Во сне? Или может сначала проснешься...": {
+   "en": "In your sleep? Maybe wake up first...",
+   "ua": "Уві сні? А може спершу прокинешся..."
   }
  },
  "plug-ins/languages/core/languagemanager.cpp": {
@@ -16711,6 +16715,34 @@
   "%^C1 приносит в жертву %N3 все, что находится %s.": {
    "en": "%^C1 sacrifices to %N3 everything found %s.",
    "ua": "%^C1 приносить у жертву %N3 все, що знаходиться %s."
+  },
+  "Ты выбрасываешь %O4 прочь.": {
+   "en": "You throw %O4 away.",
+   "ua": "Ти викидаєш %O4 геть."
+  },
+  "%^C1 выбрасывает %O4 прочь.": {
+   "en": "%^C1 throws %O4 away.",
+   "ua": "%^C1 викидає %O4 геть."
+  },
+  "%^C1 предлагает себя в жертву пустоте, но слышит в ответ тактичное молчание.": {
+   "en": "%^C1 offers themselves up as a sacrifice to the void, but hears only a tactful silence in reply.",
+   "ua": "%^C1 пропонує себе в жертву порожнечі, але чує у відповідь тактовну мовчанку."
+  },
+  "Ты предлагаешь себя в жертву пустоте и слышишь в ответ лишь тактичное молчание.": {
+   "en": "You offer yourself as a sacrifice to the void, and hear only tactful silence in reply.",
+   "ua": "Ти пропонуєш себе в жертву порожнечі й чуєш у відповідь лише тактовну мовчанку."
+  },
+  "%^C1 выбрасывает прочь все, что находится %s.": {
+   "en": "%^C1 throws away everything found %s.",
+   "ua": "%^C1 викидає геть усе, що знаходиться %s."
+  },
+  "Ты выбрасываешь прочь все, что находится %s.": {
+   "en": "You throw away everything found %s.",
+   "ua": "Ти викидаєш геть усе, що знаходиться %s."
+  },
+  "Здесь ничего не пропадает бесследно.": {
+   "en": "Nothing vanishes without a trace here.",
+   "ua": "Тут ніщо не зникає безслідно."
   }
  },
  "plug-ins/remort/cmlt.cpp": {

--- a/generic-skills/crusify.xml
+++ b/generic-skills/crusify.xml
@@ -12,10 +12,10 @@
   <group registry="skillGroup">adventure</group>
   <hard>4</hard>
   <help id="695" level="-1" type="SkillHelp">
-    <text l="en">Works when offering corpses as {hh1375sacrifice{x. {hh138Anti-paladins{x can develop the skill to perform a special ritual of sacrificing the corpses of their enemies. For which the dark gods endow them with magical {hh59energy{x.</text>
-    <text l="ru">Работает при принесении трупов {hh1375в жертву{x. {hh138Анти-паладины{x могут развить умение совершать специальный обряд принесения в жертву трупов своих врагов. За что темные боги наделяют их магической {hh59энергией{x.
+    <text l="en">Works when offering corpses as {hh1375sacrifice{x. {hh138Anti-paladins{x can develop the skill to perform a special ritual of sacrificing the corpses of their enemies. For which the dark gods endow them with magical {hh59energy{x. An {hh1atheist{x has nobody to perform the ritual for, and so gets nothing out of it.</text>
+    <text l="ru">Работает при принесении трупов {hh1375в жертву{x. {hh138Анти-паладины{x могут развить умение совершать специальный обряд принесения в жертву трупов своих врагов. За что темные боги наделяют их магической {hh59энергией{x. {hh1Атеисту{x обряд творить не для кого, а потому и толку с него никакого.
 </text>
-    <text l="ua">Працює при принесенні трупів {hh1375у жертву{x. {hh138Анти-паладини{x можуть розвивати уміння здійснювати спеціальний обряд жертвопринесення трупів своїх ворогів. За що темні боги наділяють їх магічною {hh59енергією{x.</text>
+    <text l="ua">Працює при принесенні трупів {hh1375у жертву{x. {hh138Анти-паладини{x можуть розвивати уміння здійснювати спеціальний обряд жертвопринесення трупів своїх ворогів. За що темні боги наділяють їх магічною {hh59енергією{x. {hh1Атеїсту{x обряд творити нема для кого, а тому й пуття з нього ніякого.</text>
   </help>
   <name l="en">crusify</name>
   <name l="ru">распятие</name>

--- a/helps/religion.xml
+++ b/helps/religion.xml
@@ -66,7 +66,7 @@ Many gods =patronise= certain races, classes or clans. If your deity is your pat
 
 Not every god takes every worshipper. Some demand a certain {hh33character{x or ethos, others accept only their own race, class or clan, and a few weigh your years or the strength of your body and mind; if you are refused, the priest will name the reason. The heaviest vow is the {hh192druid{x's: bound to the wild, a druid may follow only the gods of the Paths of {hh49Nature{x, {hh6Light{x, {hh10Fury{x and {hh23Order{x -- the forge, the flame and the affairs of society stay shut to them.
 
-The Midgaard priest and the dark elf in Old Midgaard can relieve you of your current sign and religion, turning you into a godless atheist. Simply say {Cmake me atheist{x in their presence. This can be done {RONLY ONCE ACROSS ALL REBIRTHS.{x Use this opportunity wisely.
+The Midgaard priest and the dark elf in Old Midgaard can relieve you of your current sign and religion, turning you into a godless atheist. Simply say {Cmake me atheist{x in their presence. This can be done {RONLY ONCE ACROSS ALL REBIRTHS.{x Use this opportunity wisely. Bear in mind that a godless character has nobody to {hh1375sacrifice{x to: their offerings buy nothing and pay nothing back.
 
 Unlike official religions, cult gods enjoy being {hh1375sacrificed to{x, and in return they may reward you with something pleasant. For details on each god see the help article, for example: {hchelp teshub{x.
 
@@ -131,7 +131,7 @@ Unlike official religions, cult gods enjoy being {hh1375sacrificed to{x, and in 
 
 Не всякое божество принимает всякого поклонника. Одни требуют определенной {hh33натуры{x или этоса, другие принимают только свою расу, класс или клан, а иные смотрят на твои годы или на силу твоего тела и разума; если тебе откажут, священник назовет причину. Тяжелее всех обет {hh192друида{x: связанный с дикой природой, друид может следовать лишь богам Путей {hh49Природы{x, {hh6Света{x, {hh10Ярости{x и {hh23Порядка{x -- кузня, пламя и дела общества для него закрыты.
 
-Священник Мидгаарда и темная эльфийка в Старом Мидгаарде могут избавить тебя от текущего знака и религии, превратив тебя в безбожн{Smого{Sfую{Sx атеист{Smа{Sfку{Sx. Просто произнеси {Cхочу стать атеистом{x рядом с ними. Сделать это можно {RТОЛЬКО ОДИН РАЗ ЗА ВСЕ ПЕРЕРОЖДЕНИЯ.{x Используй эту возможность с умом.
+Священник Мидгаарда и темная эльфийка в Старом Мидгаарде могут избавить тебя от текущего знака и религии, превратив тебя в безбожн{Smого{Sfую{Sx атеист{Smа{Sfку{Sx. Просто произнеси {Cхочу стать атеистом{x рядом с ними. Сделать это можно {RТОЛЬКО ОДИН РАЗ ЗА ВСЕ ПЕРЕРОЖДЕНИЯ.{x Используй эту возможность с умом. И имей в виду: безбожнику {hh1375жертвовать{x некому -- его подношения ничего не стоят и ничего не приносят.
 
 В отличие от официальных религий, боги культов любят, когда им {hh1375приносят жертвы{x, а в обмен они могут наградить чем-то приятным. Подробнее о каждом боге смотри в справке, например: {hcсправка тешуб{x.
 
@@ -196,7 +196,7 @@ Unlike official religions, cult gods enjoy being {hh1375sacrificed to{x, and in 
 
 Не всяке божество приймає всякого поклонника. Одні вимагають певної {hh33натури{x чи етосу, інші приймають лише свою расу, клас або клан, а ще інші дивляться на твої роки або на силу твого тіла і розуму; якщо тобі відмовлять, священник назве причину. Найтяжча обітниця у {hh192друїда{x: повʼязаний з дикою природою, друїд може йти лише за богами Шляхів {hh49Природи{x, {hh6Світла{x, {hh10Ярості{x та {hh23Порядку{x -- кузня, полумʼя і справи суспільства для нього зачинені.
 
-Священник Мідгаарда і темна ельфійка у Старому Мідгаарді можуть позбавити тебе від поточного знака і релігії, перетворивши тебе на безбожн{Smого{Sfу{Sx атеїст{Smа{Sfку{Sx. Просто вимов {Cхочу стать атеистом{x поряд з ними. Зробити це можна {RТІЛЬКИ ОДИН РАЗ ЗА УСІ ПЕРЕРОДЖЕННЯ.{x Використай цю можливість розумно.
+Священник Мідгаарда і темна ельфійка у Старому Мідгаарді можуть позбавити тебе від поточного знака і релігії, перетворивши тебе на безбожн{Smого{Sfу{Sx атеїст{Smа{Sfку{Sx. Просто вимов {Cхочу стать атеистом{x поряд з ними. Зробити це можна {RТІЛЬКИ ОДИН РАЗ ЗА УСІ ПЕРЕРОДЖЕННЯ.{x Використай цю можливість розумно. І май на увазі: безбожнику {hh1375жертвувати{x нема кому -- його підношення нічого не варті й нічого не приносять.
 
 На відміну від офіційних релігій, боги культів люблять, коли їм {hh1375приносять жертви{x, а в обмін вони можуть нагородити чимось приємним. Детальніше про кожного бога дивись у довідці, наприклад: {hcдовідка тешуб{x.
 

--- a/languages/ahenn.xml
+++ b/languages/ahenn.xml
@@ -66,7 +66,7 @@
     <name l="ru">ахэнн</name>
     <name l="ua">ахен</name>
     <order>player_only</order>
-    <position>rest</position>
+    <position>sleep</position>
   </command>
   <effects>
     <node name="bad" type="BadSpellWE">

--- a/languages/arcadian.xml
+++ b/languages/arcadian.xml
@@ -93,7 +93,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <name l="ru">аркади</name>
     <name l="ua">аркаді</name>
     <order>player_only</order>
-    <position>rest</position>
+    <position>sleep</position>
   </command>
   <effects>
     <node name="beer_armor" type="BeerArmorWE">

--- a/languages/khuzdul.xml
+++ b/languages/khuzdul.xml
@@ -61,7 +61,7 @@
     <name l="ru">кхуздул</name>
     <name l="ua">кхуздул</name>
     <order>player_only</order>
-    <position>rest</position>
+    <position>sleep</position>
   </command>
   <effects>
     <node name="berserk" type="BerserkWE">

--- a/languages/quenia.xml
+++ b/languages/quenia.xml
@@ -66,7 +66,7 @@
     <name l="ru">квенья</name>
     <name l="ua">квенья</name>
     <order>player_only</order>
-    <position>rest</position>
+    <position>sleep</position>
   </command>
   <effects>
     <node name="accuracy" type="AccuracyWE">

--- a/skill-groups/ancient languages.xml
+++ b/skill-groups/ancient languages.xml
@@ -24,7 +24,7 @@ Modern descendants of ancient races sometimes dream unusual dreams - the memory 
 
 You can eavesdrop and remember the word someone else is saying, or remember the word someone told you: {x {yquenia remember{x {Dword{x
 
-You can see a list of all the dreamed and remembered words like this: {x {ykhuzdul list{x
+You can see a list of all the dreamed and remembered words like this, without even waking up: {x {ykhuzdul list{x
 
 Forget all words or a specific one: {x {ykhuzdul forget all{x {x {yarcadi forget{x {Dword{x
 
@@ -46,7 +46,7 @@ The help will tell you more about each of the languages.
 
 Можно подслушать и запомнить слово, которое произносит кто-то еще, или же запомнить слово, сообщенное тебе кем-то: {x {yквенья запомнить{x {Dслово{x
 
-Посмотреть список всех приснившихся и запомненных слов можно так: {x {yкхуздул список{x
+Посмотреть список всех приснившихся и запомненных слов можно так, в том числе и не просыпаясь: {x {yкхуздул список{x
 
 Забыть все слова или какое-то конкретное: {x {yкхуздул забыть все{x {x {yаркади забыть{x {Dслово{x
 
@@ -68,7 +68,7 @@ The help will tell you more about each of the languages.
 
 Можна підслухати і запамʼятати слово, яке промовляє хтось інший, або ж запамʼятати слово, повідомлене тобі кимось: {x {yквенья запамʼятати{x {Dслово{x
 
-Подивитися список всіх приснилих і запамʼятованих слів можна так: {x {yкхуздул список{x
+Подивитися список всіх приснилих і запамʼятованих слів можна так, навіть не прокидаючись: {x {yкхуздул список{x
 
 Забути всі слова або якесь конкретне: {x {yкхуздул забути все{x {x {yаркади забути{x {Dслово{x
 


### PR DESCRIPTION
Data half of dreamland-mud/dreamland_code#957 -- merge that one too, this is inert without it.

Two ideas off the Trello Ideas card.

**Word list in your sleep** (Rayan). Ancient-language words arrive in dreams, but the language command sat at `position rest`, so the game gave you a word and then told you to wake up before you could read the list. The four language XMLs drop to `sleep`; the engine guard in the paired PR keeps everything else awake-only. Help 234 says so.

**Atheists junk instead of sacrificing** (Klementina). The altar path already refused them; the loose-item path named "the gods" and paid silver. Now a godless character just throws the thing away. Help 1375, 1 and 695 spell out that nobody accepts their offering and nobody pays.

Catalog: 8 new EN/UA entries. `lint-l10n.py` on plug-ins.json is unchanged at 1 HARD / 433 warn, the HARD being pre-existing in `plug-ins/comm/configs.cpp`.

Not live until a reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)