### PR TITLE
Drop the missile column from str_app

### DIFF
--- a/fight/str_app.json
+++ b/fight/str_app.json
@@ -1,33 +1,32 @@
 [
 /*   hit% carry wield web damage% */
-/* TO-DO: remove missile field after clearing C++ shoot */
-    { "hit": -35, "missile": -40, "carry": 0, "wield": 0, "web": 5, "damage": -40     },  /* 0  */
-    { "hit": -30, "missile": -40, "carry": 3, "wield": 1, "web": 5, "damage": -40     },  /* 1  */
-    { "hit": -20, "missile": -20, "carry": 3, "wield": 2, "web": 5, "damage": -30     },
-    { "hit": -20, "missile": -10, "carry": 10, "wield": 3, "web": 5, "damage": -30     },  /* 3  */
-    { "hit": -15, "missile": -10, "carry": 25, "wield": 4, "web": 5, "damage": -30     },
-    { "hit": -15, "missile": -10, "carry": 55, "wield": 5, "web": 5, "damage": -30     },  /* 5  */
-    { "hit": -10, "missile": 0, "carry": 80, "wield": 6, "web": 5, "damage": -25     },
-    {  "hit": -5, "missile": 0, "carry": 90, "wield": 7, "web": 5, "damage": -25     },
-    {   "hit": 0, "missile": 0, "carry": 100, "wield": 8, "web": 5, "damage": -25     },
-    {   "hit": 0, "missile": 0, "carry": 100, "wield": 9, "web": 5, "damage": -25     },
-    {   "hit": 0, "missile": 0, "carry": 115, "wield": 10, "web": 5, "damage": -25     }, /* 10  */
-    {   "hit": 0, "missile": 0, "carry": 115, "wield": 11, "web": 5, "damage": -20     },
-    {   "hit": 0, "missile": 0, "carry": 130, "wield": 12, "web": 5, "damage": -20     },
-    {   "hit": 0, "missile": 0, "carry": 130, "wield": 13, "web": 5, "damage": -20     }, /* 13  */
-    {   "hit": 2, "missile": 10, "carry": 140, "wield": 14, "web": 6, "damage": -17     },
-    {   "hit": 2, "missile": 10, "carry": 150, "wield": 15, "web": 7, "damage": -15     }, /* 15  */
-    {   "hit": 3, "missile": 20, "carry": 165, "wield": 16, "web": 8, "damage": -13     },
-    {   "hit": 3, "missile": 30, "carry": 180, "wield": 22, "web": 12, "damage": -10     },
-    {   "hit": 3, "missile": 30, "carry": 200, "wield": 25, "web": 13, "damage": -7     }, /* 18  */
-    {   "hit": 4, "missile": 40, "carry": 225, "wield": 30, "web": 16, "damage": -5     },
-    {   "hit": 4, "missile": 50, "carry": 250, "wield": 35, "web": 20, "damage": 0     }, /* 20  */
-    {   "hit": 5, "missile": 60, "carry": 300, "wield": 40, "web": 24, "damage": 3     },
-    {   "hit": 5, "missile": 60, "carry": 350, "wield": 45, "web": 25, "damage": 6     },
-    {   "hit": 6, "missile": 70, "carry": 400, "wield": 50, "web": 28, "damage": 10     },
-    {   "hit": 6, "missile": 80, "carry": 450, "wield": 55, "web": 32, "damage": 13     },
-    {   "hit": 7, "missile": 90, "carry": 500, "wield": 60, "web": 34, "damage": 15     }, /* 25 */
-    {   "hit": 7, "missile": 95, "carry": 550, "wield": 65, "web": 36, "damage": 17     }, /* 26 */
-    {   "hit": 8, "missile": 100, "carry": 600, "wield": 70, "web": 38, "damage": 18     }, /* 27 */
-    {   "hit": 8, "missile": 105, "carry": 650, "wield": 75, "web": 40, "damage": 19     }  /* 28 */
+    { "hit": -35, "carry": 0, "wield": 0, "web": 5, "damage": -40     },  /* 0  */
+    { "hit": -30, "carry": 3, "wield": 1, "web": 5, "damage": -40     },  /* 1  */
+    { "hit": -20, "carry": 3, "wield": 2, "web": 5, "damage": -30     },
+    { "hit": -20, "carry": 10, "wield": 3, "web": 5, "damage": -30     },  /* 3  */
+    { "hit": -15, "carry": 25, "wield": 4, "web": 5, "damage": -30     },
+    { "hit": -15, "carry": 55, "wield": 5, "web": 5, "damage": -30     },  /* 5  */
+    { "hit": -10, "carry": 80, "wield": 6, "web": 5, "damage": -25     },
+    {  "hit": -5, "carry": 90, "wield": 7, "web": 5, "damage": -25     },
+    {   "hit": 0, "carry": 100, "wield": 8, "web": 5, "damage": -25     },
+    {   "hit": 0, "carry": 100, "wield": 9, "web": 5, "damage": -25     },
+    {   "hit": 0, "carry": 115, "wield": 10, "web": 5, "damage": -25     }, /* 10  */
+    {   "hit": 0, "carry": 115, "wield": 11, "web": 5, "damage": -20     },
+    {   "hit": 0, "carry": 130, "wield": 12, "web": 5, "damage": -20     },
+    {   "hit": 0, "carry": 130, "wield": 13, "web": 5, "damage": -20     }, /* 13  */
+    {   "hit": 2, "carry": 140, "wield": 14, "web": 6, "damage": -17     },
+    {   "hit": 2, "carry": 150, "wield": 15, "web": 7, "damage": -15     }, /* 15  */
+    {   "hit": 3, "carry": 165, "wield": 16, "web": 8, "damage": -13     },
+    {   "hit": 3, "carry": 180, "wield": 22, "web": 12, "damage": -10     },
+    {   "hit": 3, "carry": 200, "wield": 25, "web": 13, "damage": -7     }, /* 18  */
+    {   "hit": 4, "carry": 225, "wield": 30, "web": 16, "damage": -5     },
+    {   "hit": 4, "carry": 250, "wield": 35, "web": 20, "damage": 0     }, /* 20  */
+    {   "hit": 5, "carry": 300, "wield": 40, "web": 24, "damage": 3     },
+    {   "hit": 5, "carry": 350, "wield": 45, "web": 25, "damage": 6     },
+    {   "hit": 6, "carry": 400, "wield": 50, "web": 28, "damage": 10     },
+    {   "hit": 6, "carry": 450, "wield": 55, "web": 32, "damage": 13     },
+    {   "hit": 7, "carry": 500, "wield": 60, "web": 34, "damage": 15     }, /* 25 */
+    {   "hit": 7, "carry": 550, "wield": 65, "web": 36, "damage": 17     }, /* 26 */
+    {   "hit": 8, "carry": 600, "wield": 70, "web": 38, "damage": 18     }, /* 27 */
+    {   "hit": 8, "carry": 650, "wield": 75, "web": 40, "damage": 19     }  /* 28 */
 ]


### PR DESCRIPTION
Archery takes its to-hit and damage from `dex_app` `missile_hit` /
`missile_damage` now, so the strength column had no reader left. The last one in
the engine was `arrow_damage()`, dead code behind the Fenia bow.

The header comment already listed only the remaining columns.

Pairs with dreamland_code#958, which removes the struct field and its last use.

Trello: https://trello.com/c/48FHRmAn

🤖 Generated with [Claude Code](https://claude.com/claude-code)