### PR TITLE
Give the breath spells and optic resonance a damage tier

### DIFF
--- a/clan-skills/optic resonance.xml
+++ b/clan-skills/optic resonance.xml
@@ -39,6 +39,7 @@ Through this spell, {hh1461The Ruler{x creates a dim beam of light that reflects
     <flags>magic</flags>
     <position>fight</position>
     <target>char_room</target>
+    <tier>5</tier>
     <type>offensive</type>
   </spell>
 </skill>

--- a/other-skills/acid breath.xml
+++ b/other-skills/acid breath.xml
@@ -25,6 +25,7 @@
     <position>fight</position>
     <ranged>false</ranged>
     <target>char_room</target>
+    <tier>2</tier>
     <type>offensive</type>
   </spell>
 </skill>

--- a/other-skills/fire breath.xml
+++ b/other-skills/fire breath.xml
@@ -28,6 +28,7 @@ This same effect (brief blindness from smoke and damage to items) is inflicted b
     <position>fight</position>
     <ranged>false</ranged>
     <target>char_room</target>
+    <tier>1</tier>
     <type>offensive</type>
   </spell>
 </skill>

--- a/other-skills/frost breath.xml
+++ b/other-skills/frost breath.xml
@@ -25,6 +25,7 @@
     <position>fight</position>
     <ranged>false</ranged>
     <target>char_room</target>
+    <tier>2</tier>
     <type>offensive</type>
   </spell>
 </skill>

--- a/other-skills/gas breath.xml
+++ b/other-skills/gas breath.xml
@@ -25,6 +25,7 @@
     <position>fight</position>
     <ranged>false</ranged>
     <target>people</target>
+    <tier>4</tier>
     <type>offensive</type>
   </spell>
 </skill>


### PR DESCRIPTION
These five were the only damage-dealing spells left without a `<tier>`. Each hand-rolls its damage from a fixed `dice(level, K)`, so nothing reads the tier today -- the four breaths are Fenia ports that assign `dam` themselves, and optic resonance is still a C++ `SPELL()`. The tier records how hard the spell hits next to the tiered ones, and keeps the spell context's `dam` a sane number for anything ported onto `calcDamage()` later.

Values match each spell's K against the interpolated table in `spell/damage_tiers.json` over the levels these actually get cast at:

| spell | roll | tier |
|---|---|---|
| fire breath | `dice(level, 20)` | 1, same as lightning breath |
| acid breath | `dice(level, 16)` | 2 |
| frost breath | `dice(level, 16)` | 2 |
| gas breath | `dice(level, 12)` | 4, exact at level 110 |
| optic resonance | `dice(level, 5)` | 5 |

The other 164 tier-less spells deal no damage and correctly stay that way -- a damage tier on `bless` would be noise. dreamland-mud/dreamland_code#959 makes a missing tier safe instead of undefined.

Trello: https://trello.com/c/p6eO0hUS