### PR TITLE
Translate the bank balance lines

### DIFF
--- a/config/translations/command.json
+++ b/config/translations/command.json
@@ -75,6 +75,14 @@
   "Это больше, чем есть у тебя в кошельке.": {
    "en": "That's more than you have in your purse.",
    "ua": "Це більше, ніж є в тебе в гаманці."
+  },
+  "У тебя в банке %s.": {
+   "en": "You have %s in the bank.",
+   "ua": "У тебе в банку %s."
+  },
+  "Очень щедро.": {
+   "en": "Very generous.",
+   "ua": "Дуже щедро."
   }
  },
  "command/dismount/runFunc": {
@@ -745,6 +753,14 @@
   "Очень щедро.": {
    "en": "Very generous.",
    "ua": "Дуже щедро."
+  },
+  "У тебя в банке %s.": {
+   "en": "You have %s in the bank.",
+   "ua": "У тебе в банку %s."
+  },
+  "У тебя больше нет денег в банке.": {
+   "en": "You have no money left in the bank.",
+   "ua": "У тебе більше немає грошей у банку."
   }
  }
 }


### PR DESCRIPTION
Pairs with dreamland_fenia#495 (negative-deposit exploit fix + Zodd's idea 3008 balance line).

A catalog key is `(file, Russian phrase)`, so `"У тебя в банке %s."` needs its own entry under `command/deposit/runFunc` and `command/withdraw/runFunc` even though the identical phrase already resolves under `command/balance/runFunc`. Same for `"Очень щедро."`, which withdraw owned and deposit now also uses.

`lint-l10n.py` on `command.json`: 0 HARD.

The Fenia half shipped first on purpose — the exploit it closes was live — so non-Russian players saw these two lines in Russian for a few minutes until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)