### PR TITLE
Translate the container examine hint

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -6717,6 +6717,14 @@
   "Пара ярко-красных глаз и ослепительно острых клыков сверкают на фоне обсидиановой, почти черной, как ночь, кожи.": {
    "en": "A pair of bright red eyes and dazzlingly sharp fangs glint against skin of obsidian, almost black as night.",
    "ua": "Пара яскраво-червоних очей і сліпучо-гострих іклів виблискують на тлі обсидіанової, майже чорної, як ніч, шкіри."
+  },
+  "Заглянуть внутрь: {y{hcизучить %1$s{x.": {
+   "en": "To see inside: {y{hcexamine %1$s{x.",
+   "ua": "Зазирнути всередину: {y{hcвивчити %1$s{x."
+  },
+  "Посмотреть, что сверху: {y{hcизучить %1$s{x.": {
+   "en": "To see what is on it: {y{hcexamine %1$s{x.",
+   "ua": "Подивитися, що зверху: {y{hcвивчити %1$s{x."
   }
  },
  "plug-ins/comm/move.cpp": {


### PR DESCRIPTION
Pairs with dreamland_code#965. Two variants, because a table is a container you put things **on** and `examine` words it differently from a bag.

The `{hc` verb is the reader's own command name in each language (изучить / examine / вивчити), so the hint stays clickable and typeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)