### PR TITLE
help: document 'path <room number>'

### DIFF
--- a/commands/path.xml
+++ b/commands/path.xml
@@ -12,6 +12,10 @@ This useful command helps those who, for some reason, cannot use the maps in our
 
 For example, if standing on the Market Square of Midgaard you type {y{hcpath mag melan{x, you will see the path to the room "Melancholic Map Shop" -- {y{hcrun 3southwest{x.
 
+%FMT% *%CMD%* _room number_
+
+A room number points at exactly one place, with no guessing between rooms that share a name. It is also what a room name in the {y{hcwhere{x listing sends when you click it in the web client.
+
 The command will find the path even through portals and {hh1016extra exits{x, but not through places where exits are confused by the influence of Chaos. It will also not work in clans, suburbs, and other hidden or special areas, or if the character is blinded.
 
 %SA% %H% {hh1078run{x
@@ -22,6 +26,10 @@ The command will find the path even through portals and {hh1016extra exits{x, bu
 
 Например, если стоя на Рыночной площади Мидгаарда написать {y{hcпуть маг меланх{x, то увидишь путь к комнате "Магазин Карт Меланхолика" -- {y{hcбежать 3юзс{x.
 
+%FMT% *%CMD%* _номер комнаты_
+
+Номер комнаты указывает ровно на одно место, без выбора между комнатами с одинаковым названием. Его же отправляет название комнаты в списке {y{hcгде{x, если щелкнуть по нему в веб-клиенте.
+
 Команда найдет путь даже через порталы и {hh1016экстра-выходы{x, но не через места, где выходы перепутаны влиянием Хаоса. Также не сработает в кланах, пригородах и других скрытых или специальных зонах, или если персонаж ослеплен. 
 
 %SA% %H% {hh1078бежать{x
@@ -31,6 +39,10 @@ The command will find the path even through portals and {hh1016extra exits{x, bu
 Ця корисна команда допомагає тим, хто з якоїсь причини не може користуватися картами в нашому {hh2133веб-клієнті{x, зручніше знаходити шлях до будь-якої кімнати в поточній зоні за назвою кімнати -- навіть у частковому чи скороченому вигляді.
 
 Наприклад, якщо стоячи на Ринковій площі Мідгарда написати {y{hcшлях маг меланх{x, то побачиш шлях до кімнати "Магазин Карт Меланхоліка" -- {y{hcбігти 3південно-захід{x.
+
+%FMT% *%CMD%* _номер кімнати_
+
+Номер кімнати вказує рівно на одне місце, без вибору між кімнатами з однаковою назвою. Його ж надсилає назва кімнати у списку {y{hcде{x, якщо клацнути по ній у веб-клієнті.
 
 Команда знайде шлях навіть через портали та {hh1016екстра-виходи{x, але не через місця, де виходи сплутані впливом Хаосу. Також вона не спрацює в кланах, передмістях та інших прихованих або спеціальних зонах, або якщо персонаж засліплений.
 


### PR DESCRIPTION
Player idea (Trello Idea card, Dementsiya 2026/08/11): clicking a room name in 'where' plots the route there.

Client half already merged: mudjs#154 (must deploy first).

Adversarial review: /Users/kit/claude/reviews/2026-08-11-where-room-path-links.md (BLOCK -> fixed -> RELEASE). Two blockers found and fixed: an unbounded vnum argument that could kill the server via toInt() overflow, and a masked-command phishing vector now closed by a client-side allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)