### PR TITLE
Give sixty skill helps their English syntax line

### DIFF
--- a/generic-skills/ambush.xml
+++ b/generic-skills/ambush.xml
@@ -23,7 +23,9 @@
   <dammsg mg="f">атака из засады</dammsg>
   <group registry="skillGroup">suddendeath</group>
   <help id="689" level="-1" type="SkillHelp">
-    <text l="en">A camouflaged character can attack someone from ambush, but only if the victim does not see them. The ambush can be prepared in advance, and it is not necessary to be near the victim for this - just specify their name. As soon as the person in ambush makes a move and comes out of cover, the ambush will naturally be broken.
+    <text l="en">%FMT% *%CMD%* _victim_
+
+A camouflaged character can attack someone from ambush, but only if the victim does not see them. The ambush can be prepared in advance, and it is not necessary to be near the victim for this - just specify their name. As soon as the person in ambush makes a move and comes out of cover, the ambush will naturally be broken.
 </text>
     <text l="ru">%FMT% *%CMD%* _имя жертвы_
 

--- a/generic-skills/astral walk.xml
+++ b/generic-skills/astral walk.xml
@@ -11,7 +11,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">transportation</group>
   <help id="602" level="-1" type="SkillHelp">
-    <text l="en">Astral walk is a powerful transportation spell that opens an astral path between the witch and any creature in the world. All her {hh15followers{x, except players, are transported through such a gate as well.
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+Astral walk is a powerful transportation spell that opens an astral path between the witch and any creature in the world. All her {hh15followers{x, except players, are transported through such a gate as well.
 
 The same restrictions apply to this spell as to others from the transportation magic group -- see {y{hchelp gate{x.
 

--- a/generic-skills/bat swarm.xml
+++ b/generic-skills/bat swarm.xml
@@ -40,7 +40,9 @@
     <extra l="en">bat swarm</extra>
     <extra l="ru">летучих мышей стая</extra>
     <extra l="ua">стая кажанів</extra>
-    <text l="en">Vampires, necromancers, and druids can summon a swarm of bats to aid them, surrounding you with a living cloud that prevents enemy attacks from reaching you.
+    <text l="en">%FMT% *%SPELL%*
+
+Vampires, necromancers, and druids can summon a swarm of bats to aid them, surrounding you with a living cloud that prevents enemy attacks from reaching you.
 
 Bats are capricious creatures, and their efficiency depends on the time of day, terrain, {hh122the type of weapon{x of the opponent, and many other factors. Controlling bats expends your mana.
 

--- a/generic-skills/black death.xml
+++ b/generic-skills/black death.xml
@@ -17,7 +17,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">maladictions</group>
   <help id="601" level="-1" type="SkillHelp">
-    <text l="en">This spell allows you to cast a {hh614plague{x on a specific area -- everyone who is there has a chance to become infected. Does not affect players outside your {hh32PK-range{x.
+    <text l="en">%FMT% *%SPELL%*
+
+This spell allows you to cast a {hh614plague{x on a specific area -- everyone who is there has a chance to become infected. Does not affect players outside your {hh32PK-range{x.
     
 Victims who die from your plague miasmas will be credited to you -- in PK or in {hh125quests{x.
 

--- a/generic-skills/bless.xml
+++ b/generic-skills/bless.xml
@@ -26,7 +26,9 @@
     <extra l="en">holy water</extra>
     <extra l="ru">аура благословения благословления голубая святая вода</extra>
     <extra l="ua">аура благословення голуба свята вода</extra>
-    <text l="en">This prayer increases {hh47accuracy{x and provides enhanced protection against {hh2035spells{x. The blessing prayer does not work simultaneously with a {hh860battle cry{x.
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+This prayer increases {hh47accuracy{x and provides enhanced protection against {hh2035spells{x. The blessing prayer does not work simultaneously with a {hh860battle cry{x.
 
 %FMT% *%SPELL%* _%OBJ%_
 

--- a/generic-skills/blindness dust.xml
+++ b/generic-skills/blindness dust.xml
@@ -25,7 +25,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">fightmaster</group>
   <help id="706" level="-1" type="SkillHelp">
-    <text l="en">Ninjas possess the secret of creating a special powder, which when dispersed, {hh831blinds{x everyone around. All nearby individuals to the ninja are affected unless they make a successful {hh2035saving throw{x. The powder will not affect party members.
+    <text l="en">%FMT% *%CMD%*
+
+Ninjas possess the secret of creating a special powder, which when dispersed, {hh831blinds{x everyone around. All nearby individuals to the ninja are affected unless they make a successful {hh2035saving throw{x. The powder will not affect party members.
 
 %SA% {hh831blindness{x</text>
     <text l="ru">%FMT% *%CMD%*

--- a/generic-skills/broom ritual.xml
+++ b/generic-skills/broom ritual.xml
@@ -17,7 +17,9 @@
     <extra l="en">broom ritual</extra>
     <extra l="ru">метла персональная</extra>
     <extra l="ua">персональна мітла</extra>
-    <text l="en">The witch can perform a ritual to create a personal broom that will grant her new abilities and enhance the work of certain spells.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+The witch can perform a ritual to create a personal broom that will grant her new abilities and enhance the work of certain spells.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Ведьма может провести ритуал по созданию персональной метлы, которая наделит ее новыми способностями и усилит работу некоторых заклинаний.

--- a/generic-skills/chill touch.xml
+++ b/generic-skills/chill touch.xml
@@ -41,7 +41,9 @@
     <extra l="en">frostbite chilling touch</extra>
     <extra l="ru">ледяное обморожение прикосновение заледеней</extra>
     <extra l="ua">льодяне обмороження дотик заморожування</extra>
-    <text l="en">This spell does damage to the victim as well as frostbite, reducing strength. Similar effects are given by {hh96frostbiting{x weapons and most spells dealing damage {hh101by cold{x or ice. To get rid of frostbite, one can warm up {hh249by the fire{x or in the {hh86desert{x. Or, take a fireball to the face.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This spell does damage to the victim as well as frostbite, reducing strength. Similar effects are given by {hh96frostbiting{x weapons and most spells dealing damage {hh101by cold{x or ice. To get rid of frostbite, one can warm up {hh249by the fire{x or in the {hh86desert{x. Or, take a fireball to the face.
 
 This spell can also freeze various things! It can freeze some liquids in {hh1075containers and fountains{x, making them temporarily undrinkable. You can temporarily freeze something impermanent and organic (for example, body parts) to preserve them longer. Frozen items can be melted or warmed with {hh839burning hands{x. Freezing can also cool {hh4heated{x items on the ground.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_

--- a/generic-skills/compound.xml
+++ b/generic-skills/compound.xml
@@ -18,7 +18,9 @@
     <extra l="en">morph weapon</extra>
     <extra l="ru">'превратить оружие' 'превратить в булаву' утяжелить</extra>
     <extra l="ua">'перетворити зброю' 'перетворити в булаву' обтяжити</extra>
-    <text l="en">This prayer temporarily weights the weapon, turning it into a {hh638mace{x familiar to the cleric, and also making the weapon your personal property. The success chance depends on the level of the item and its additional flags. Bows, arrows, or daggers, limits, or personal items cannot be turned into a mace.
+    <text l="en">%FMT% *%SPELL%* _%OBJ%_
+
+This prayer temporarily weights the weapon, turning it into a {hh638mace{x familiar to the cleric, and also making the weapon your personal property. The success chance depends on the level of the item and its additional flags. Bows, arrows, or daggers, limits, or personal items cannot be turned into a mace.
 
 All created maces look the same, however, you can spend a {hh56restring coupon{x and get a unique description of the mace -- for this service, contact the Gods. The new description should be suitable for a weapon that does not shed blood and deals damage with a heavy blow. For details see {y{hchelp restring{x.</text>
     <text l="ru">%FMT% *%SPELL%* _%OBJ%_

--- a/generic-skills/create rose.xml
+++ b/generic-skills/create rose.xml
@@ -34,7 +34,9 @@
     <extra l="en"></extra>
     <extra l="ru">создать розу</extra>
     <extra l="ua"></extra>
-    <text l="en">This wonderful spell allows you to create a beautiful rose. And present it to your chosen one.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This wonderful spell allows you to create a beautiful rose. And present it to your chosen one.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это замечательное заклинание позволяет создать прекрасную розу. И подарить своей избраннице или избраннику.

--- a/generic-skills/deadly venom.xml
+++ b/generic-skills/deadly venom.xml
@@ -20,7 +20,9 @@
     <extra l="en">'deadly venom' 'poisonous vapors'</extra>
     <extra l="ru">'пары яда' 'ядовитые пары'</extra>
     <extra l="ua">'пари отрути' 'отруйні пари'</extra>
-    <text l="en">This spell allows you to poison the area with toxic fumes -- everyone who is there may {hh837be poisoned{x. It does not affect players outside your {hh32PC-range{x.
+    <text l="en">%FMT% *%SPELL%*
+
+This spell allows you to poison the area with toxic fumes -- everyone who is there may {hh837be poisoned{x. It does not affect players outside your {hh32PC-range{x.
 
 Victims who died from poisonous vapors will count towards you - in PK or in {hh125quests{x.
 

--- a/generic-skills/deafen.xml
+++ b/generic-skills/deafen.xml
@@ -15,7 +15,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">maladictions</group>
   <help id="606" level="-1" type="SkillHelp">
-    <text l="en">Antipaladins can deafen their foes so that they become unable to hear or speak-- unable to hear anything or articulate words. When attempting to cast a spell, they will fail to get the intonation right in half of the cases.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Antipaladins can deafen their foes so that they become unable to hear or speak-- unable to hear anything or articulate words. When attempting to cast a spell, they will fail to get the intonation right in half of the cases.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Анти-паладины могут оглушать своих врагов так, что те становятся глухонемыми -- ничего не слышат и не произносят. При попытке произнести заклинание они в половине случаев не смогут настроиться на правильную интонацию.

--- a/generic-skills/detect undead.xml
+++ b/generic-skills/detect undead.xml
@@ -22,7 +22,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">detection</group>
   <help id="671" level="-1" type="SkillHelp">
-    <text l="en">This spell helps necromancers distinguish undead for control, whereas paladins use it for banishing.
+    <text l="en">%FMT% *%SPELL%*
+
+This spell helps necromancers distinguish undead for control, whereas paladins use it for banishing.
 
 %SA% %H% {hh559control undead{x</text>
     <text l="ru">%FMT% *%SPELL%*

--- a/generic-skills/disintegrate.xml
+++ b/generic-skills/disintegrate.xml
@@ -11,7 +11,9 @@
   <dammsg mg="m">луч дезинтеграции</dammsg>
   <group registry="skillGroup">suddendeath</group>
   <help id="791" level="-1" type="SkillHelp">
-    <text l="en">This is the most powerful spell of warlocks that can incinerate an opponent in an instant, and if used against mobs, it will also burn every single item in their inventory and equipment. The only way to escape from it is {hh2035spell protection{x.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This is the most powerful spell of warlocks that can incinerate an opponent in an instant, and if used against mobs, it will also burn every single item in their inventory and equipment. The only way to escape from it is {hh2035spell protection{x.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Это мощнейшее заклинание колдунов может в одно мгновение испепелить противника, а если применить против мобов -- еще и сжечь все до единой вещи в инвентаре и экипировке. Единственный способ спастись от этого -- {hh2035защита от заклинаний{x.

--- a/generic-skills/dispel evil.xml
+++ b/generic-skills/dispel evil.xml
@@ -20,7 +20,9 @@
     <extra l="en">dispel evil</extra>
     <extra l="ru">изгнание зла</extra>
     <extra l="ua">вигнання зла</extra>
-    <text l="en">Using this prayer, one can deal serious damage to evil opponents, and if they are much weaker than you, they might even be disembodied on the spot.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Using this prayer, one can deal serious damage to evil opponents, and if they are much weaker than you, they might even be disembodied on the spot.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Используя эту молитву, можно нанести серьезные повреждения злым противникам, а если они намного слабее тебя -- то и вовсе развоплотить на месте.

--- a/generic-skills/dispel good.xml
+++ b/generic-skills/dispel good.xml
@@ -17,7 +17,9 @@
   <dammsg mg="n">изгнание добра</dammsg>
   <group registry="skillGroup">maladictions</group>
   <help id="668" level="-1" type="SkillHelp">
-    <text l="en">Using this prayer, you can inflict serious damage on good opponents, and if they are much weaker than you, you can even disintegrate them on the spot.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Using this prayer, you can inflict serious damage on good opponents, and if they are much weaker than you, you can even disintegrate them on the spot.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Используя эту молитву, можно нанести серьезные повреждения добрым противникам, а если они намного слабее тебя -- то и вовсе развоплотить на месте.

--- a/generic-skills/dragon skin.xml
+++ b/generic-skills/dragon skin.xml
@@ -35,7 +35,9 @@
     <keyword l="en"></keyword>
     <keyword l="ru">'кожа дракона'</keyword>
     <keyword l="ua">'кожа дракона'</keyword>
-    <text l="en">This spell covers your skin with dragon scales, which decrease (improve) the {hh83character's defense class{x, and also absorbs some part of the non-physical damage dealt to you.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This spell covers your skin with dragon scales, which decrease (improve) the {hh83character's defense class{x, and also absorbs some part of the non-physical damage dealt to you.</text>
     <text l="ru">%FMT% *%SPELL%* 
 
 Это заклинание покрывает твою кожу драконьей чешуей, которая уменьшает (улучшает) {hh83класс защиты{x персонажа, а также поглощает какую-то часть нанесенного тебе не-физического урона.

--- a/generic-skills/earthquake.xml
+++ b/generic-skills/earthquake.xml
@@ -19,7 +19,9 @@
     <extra l="en">earthquake</extra>
     <extra l="ru">землетрясение</extra>
     <extra l="ua">землетрус</extra>
-    <text l="en">Earthquake -- a powerful spell causing significant damage to everyone in the area. Be careful! It also allows you to dig out vampires from the {hh652graves{x.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+Earthquake -- a powerful spell causing significant damage to everyone in the area. Be careful! It also allows you to dig out vampires from the {hh652graves{x.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Землетрясение -- мощное заклинание, причиняющее большие повреждения всем в данной местности. Осторожней! Также позволяет выкапывать из {hh652могил{x вампиров.

--- a/generic-skills/enchant armor.xml
+++ b/generic-skills/enchant armor.xml
@@ -27,7 +27,9 @@
     <extra l="en"></extra>
     <extra l="ru">броню доспехи заколдовать зачаровать</extra>
     <extra l="ua">броню доспехи закодувати зачарувати</extra>
-    <text l="en">This spell allows you to temporarily enhance {hh65armor{x, improving its damage, accuracy, health, or mana characteristics.
+    <text l="en">%FMT% *%SPELL%* _%OBJ%_
+
+This spell allows you to temporarily enhance {hh65armor{x, improving its damage, accuracy, health, or mana characteristics.
 
 The degree of enhancement, duration, and success chance depend on many parameters: item and spellcaster levels, intelligence or wisdom, skill mastery, and many others. Followers of {hh974Enki{x and those driven by the {hh725urge to create{x receive bonuses to enchantment.</text>
     <text l="ru">%FMT% *%SPELL%* _%OBJ%_

--- a/generic-skills/entangle.xml
+++ b/generic-skills/entangle.xml
@@ -20,7 +20,9 @@
   <dammsg mg="p">побеги терновника</dammsg>
   <group registry="skillGroup">nature</group>
   <help id="835" level="-1" type="SkillHelp">
-    <text l="en">This spell allows you to surround the opponent with thorny thickets, preventing them from leaving the area, taking {hh60movement points{x and dealing damage. The successfully ensnared victim experiences a thorn reminiscent of the {hh852web{x spell -- the victim can break free after several attempts to move in some direction.
+    <text l="en">%FMT% *%CAST%* *%SKILL%* _%CHAR%_
+
+This spell allows you to surround the opponent with thorny thickets, preventing them from leaving the area, taking {hh60movement points{x and dealing damage. The successfully ensnared victim experiences a thorn reminiscent of the {hh852web{x spell -- the victim can break free after several attempts to move in some direction.
 
 {hh153Cloud giants{x and other insubstantial or semi-substantial creatures can free themselves from the thickets more quickly.
 

--- a/generic-skills/faerie fog.xml
+++ b/generic-skills/faerie fog.xml
@@ -29,7 +29,9 @@
     <extra l="en">fairy fog</extra>
     <extra l="ru"></extra>
     <extra l="ua">фейковий туман</extra>
-    <text l="en">This very useful spell allows you to detect all invisible, hidden, concealed, or disguised creatures in the area. Furthermore, the detected creatures receive a temporary {hh554faerie fire{x effect, preventing them from hiding again.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This very useful spell allows you to detect all invisible, hidden, concealed, or disguised creatures in the area. Furthermore, the detected creatures receive a temporary {hh554faerie fire{x effect, preventing them from hiding again.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это весьма полезное заклинание позволяет обнаружить всех невидимых, скрытых, спрятанных или замаскированных существ в данной местности. Вдобавок, обнаруженные существа получают кратковременный аффект {hh554огня фей{x, не давая им снова спрятаться.

--- a/generic-skills/fear.xml
+++ b/generic-skills/fear.xml
@@ -31,7 +31,9 @@
     <extra l="en">intimidate intimidation</extra>
     <extra l="ru">запугать запугивание</extra>
     <extra l="ua">залякувати залякування</extra>
-    <text l="en">This powerful spell causes terror in its victims, weakening them in battle, preventing them from using some skills and causing them to {hh1025flee{x from the caster. Fear can also bring victims out of states of {hh829battle rage{x or {hh619frenzy{x. An unsuccessful attempt to intimidate the victim will do some slight damage with mental magic.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This powerful spell causes terror in its victims, weakening them in battle, preventing them from using some skills and causing them to {hh1025flee{x from the caster. Fear can also bring victims out of states of {hh829battle rage{x or {hh619frenzy{x. An unsuccessful attempt to intimidate the victim will do some slight damage with mental magic.
 
 Experienced {hh136samurai{x are not susceptible to fear, the spell will not affect them. It's also impossible to intimidate undead or constructs like golems.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_

--- a/generic-skills/fireproof.xml
+++ b/generic-skills/fireproof.xml
@@ -37,7 +37,9 @@
     <extra l="en">burnproof</extra>
     <extra l="ru">'защита от огня' 'защитная аура'</extra>
     <extra l="ua">'захист від вогню' 'захисна аура'</extra>
-    <text l="en">This spell temporarily prevents the destruction of the item {hh101by fire{x or acid. It also helps against the prayer of {hh682heating{x. Some items have a permanent {hh96property{x of fire protection.
+    <text l="en">%FMT% *%SPELL%* _%OBJ%_
+
+This spell temporarily prevents the destruction of the item {hh101by fire{x or acid. It also helps against the prayer of {hh682heating{x. Some items have a permanent {hh96property{x of fire protection.
 
 {RWARNING:{x fireproofing is not the same as {hh633high temperature protection{x. Fireproofing primarily protects against ignition rather than melting, and it also helps against acid etching.
 

--- a/generic-skills/gaseous form.xml
+++ b/generic-skills/gaseous form.xml
@@ -14,7 +14,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">transportation enhancement</group>
   <help id="673" level="-1" type="SkillHelp">
-    <text l="en">Vampires can temporarily take on a gaseous form, dissipating into clouds of mist. In battle, this skill can help a vampire avoid an unfavorable outcome by transporting them to a random location within the same zone. In peaceful times, the mist form can help pass through {hh647doors{x and more quickly free from {hh852webs{x or {hh835thorns{x.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+Vampires can temporarily take on a gaseous form, dissipating into clouds of mist. In battle, this skill can help a vampire avoid an unfavorable outcome by transporting them to a random location within the same zone. In peaceful times, the mist form can help pass through {hh647doors{x and more quickly free from {hh852webs{x or {hh835thorns{x.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Вампиры умеют ненадолго принимать газообразную форму, рассеиваясь в облаках тумана. В бою это умение поможет вампиру избежать неудачного исхода, перенося его в произвольное место в пределах той же зоны. А в мирное время туманная форма поможет проходить {hh647сквозь двери{x и быстрее освобождаться от {hh852паутины{x или {hh835терновника{x.

--- a/generic-skills/grave.xml
+++ b/generic-skills/grave.xml
@@ -22,7 +22,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">vampiric</group>
   <help id="652" level="-1" type="SkillHelp">
-    <text l="en">Vampires' ability to hide underground from enemies and sunlight. Being in close contact with the ground helps vampires recover their strength faster. Almost any movement (except {hh1020sleep{x and {hh1020wake up{x) causes the buried vampire to emerge.
+    <text l="en">%FMT% *grave*
+
+Vampires' ability to hide underground from enemies and sunlight. Being in close contact with the ground helps vampires recover their strength faster. Almost any movement (except {hh1020sleep{x and {hh1020wake up{x) causes the buried vampire to emerge.
 
 Sometimes {hh653Earthquake{x opens graves. The {hh835thorn spell{x forces plant roots to penetrate deep into the ground, disturbing the vampire lying there.</text>
     <text l="ru">%FMT% *могила*

--- a/generic-skills/green arrow.xml
+++ b/generic-skills/green arrow.xml
@@ -11,7 +11,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">weaponsmaster</group>
   <help id="764" level="-1" type="SkillHelp">
-    <text l="en">This skill allows rangers to craft several green arrows and then use them for {hh810archery{x. Green arrows are {hh837poisonous{x, hitting the opponent to poison and weaken them.
+    <text l="en">%FMT% *craft* _green arrow_
+
+This skill allows rangers to craft several green arrows and then use them for {hh810archery{x. Green arrows are {hh837poisonous{x, hitting the opponent to poison and weaken them.
 
 Unlike regular {hh537wooden arrows{x, these will require a special recipe and ingredients.</text>
     <text l="ru">%FMT% * смастерить* _зеленая стрела_

--- a/generic-skills/hand of undead.xml
+++ b/generic-skills/hand of undead.xml
@@ -15,7 +15,9 @@
     <extra l="en">'hand of dead'</extra>
     <extra l="ru">длань мертвых</extra>
     <extra l="ua">длань мертвих</extra>
-    <text l="en">The spell of powerful necromancers not only inflicts damage to the victim through negative energy, but also halves the number of {hh60steps{x and {hh59mana{x, if there is no {hh2035saving throw{x. Part of the energy thus taken will be converted into the necromancer's own health.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+The spell of powerful necromancers not only inflicts damage to the victim through negative energy, but also halves the number of {hh60steps{x and {hh59mana{x, if there is no {hh2035saving throw{x. Part of the energy thus taken will be converted into the necromancer's own health.
 
 %SA% %H% {hh1361cast{x
 </text>

--- a/generic-skills/infected mushroom.xml
+++ b/generic-skills/infected mushroom.xml
@@ -14,7 +14,9 @@
     <extra l="en">hallucinogenic mushroom</extra>
     <extra l="ru">галлюциногенный гриб</extra>
     <extra l="ua">галюциногенний гриб</extra>
-    <text l="en">With this prayer, druids create special mushrooms infected with {hh196hallucinogenic spores{x. These spores have a symbiosis with druids -- they sharply enhance the druid's ability to restore {hh2131magic energy{x. However, it's better for everyone else not to try these mushrooms -- the effects of the hallucinogens can damage the mind and speech.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+With this prayer, druids create special mushrooms infected with {hh196hallucinogenic spores{x. These spores have a symbiosis with druids -- they sharply enhance the druid's ability to restore {hh2131magic energy{x. However, it's better for everyone else not to try these mushrooms -- the effects of the hallucinogens can damage the mind and speech.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 С помощью этой молитвы друиды создают специальные грибы, зараженные {hh196галлюциногенными спорами{x. С друидами у этих спор симбиоз -- они резко усиливают способность друида восстанавливать {hh2131магическую энергию{x. А вот всем остальным эти грибочки лучше не пробовать -- эффекты галлюциногенов могут повредить рассудок и дар речи.

--- a/generic-skills/infravision.xml
+++ b/generic-skills/infravision.xml
@@ -40,7 +40,9 @@
     <extra l="en">'dark vision' 'night vision' nightvision</extra>
     <extra l="ru">инфразрение ночное обнаружение темноте видение зрение</extra>
     <extra l="ua">інфразір ночне виявлення темноті бачення зір</extra>
-    <text l="en">This spell allows the target to see warm-blooded creatures in the dark and notice when they enter or leave the room.
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+This spell allows the target to see warm-blooded creatures in the dark and notice when they enter or leave the room.
 
 {hh720Life form detection{x for vampires also works in a similar manner.</text>
     <text l="ru">%FMT% *%SPELL%* _%CHAR%_

--- a/generic-skills/insanity.xml
+++ b/generic-skills/insanity.xml
@@ -18,7 +18,9 @@
     <keyword l="en">crazy</keyword>
     <keyword l="ru">сумасшествие</keyword>
     <keyword l="ua">божевілля</keyword>
-    <text l="en">Experienced necromancers keep the secret of this spell. The victim becomes {hh942bloodthirsty{x and completely insane, attacking everything that moves or stands.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Experienced necromancers keep the secret of this spell. The victim becomes {hh942bloodthirsty{x and completely insane, attacking everything that moves or stands.
 
 This spell cannot be used in clans, in safe or law-protected areas or places -- or on beings from such places.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_

--- a/generic-skills/key forgery.xml
+++ b/generic-skills/key forgery.xml
@@ -30,7 +30,9 @@
     <keyword l="en"></keyword>
     <keyword l="ru">'изготовить отмычку' 'сделать отмычку'</keyword>
     <keyword l="ua">'виготовити відмичку' 'зробити відмичку'</keyword>
-    <text l="en">*forge* a _door, portal, or container_
+    <text l="en">%FMT% *forge* _door, portal or container_
+
+*forge* a _door, portal, or container_
 
 Experienced thieves can turn a special blank into a lockpick for the model of the specified lock. Such lockpicks are generally of better quality than those found in the world and have the special ability to remember all the locks they have successfully opened.
 

--- a/generic-skills/lightning ward.xml
+++ b/generic-skills/lightning ward.xml
@@ -19,7 +19,9 @@
     <extra l="en">'lightning shield'</extra>
     <extra l="ru"></extra>
     <extra l="ua">'оберіг блискавок'</extra>
-    <text l="en">The lightning ward is a powerful defensive spell that activates either in the current battle or when an enemy attempts to enter the area.
+    <text l="en">%FMT% *%SPELL%*
+
+The lightning ward is a powerful defensive spell that activates either in the current battle or when an enemy attempts to enter the area.
 
 In the current battle, the ward will occasionally strike your opponents with lightning as long as you remain in the same area as the ward.
 

--- a/generic-skills/magic concentrate.xml
+++ b/generic-skills/magic concentrate.xml
@@ -25,7 +25,9 @@
     <extra l="en">focus</extra>
     <extra l="ru">фокусировать фокусировка концентрация магию магии магическая сконцентрировать</extra>
     <extra l="ua">фокусувати фокусування концентрація магію магії магічна сконцентрувати</extra>
-    <text l="en">Drawing strength from the depths of magical sources, true mages are capable of creating destructive charges of incredible power. However, the energy of charges dissipates too quickly in space and fades away as the distance to the target increases. Using this magical reservoir, a mage will deplete their magical powers much faster.
+    <text l="en">%FMT% *%SPELL%*
+
+Drawing strength from the depths of magical sources, true mages are capable of creating destructive charges of incredible power. However, the energy of charges dissipates too quickly in space and fades away as the distance to the target increases. Using this magical reservoir, a mage will deplete their magical powers much faster.
 
 Magical concentration enhances only long-range magic.</text>
     <text l="ru">%FMT% *%SPELL%*

--- a/generic-skills/mass invis.xml
+++ b/generic-skills/mass invis.xml
@@ -16,7 +16,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">illusion</group>
   <help id="583" level="-1" type="SkillHelp">
-    <text l="en">This spell casts {hh607invisibility{x and {hh85improved invisibility{x on the caster and everyone in his {hh1378group{x.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This spell casts {hh607invisibility{x and {hh85improved invisibility{x on the caster and everyone in his {hh1378group{x.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это заклинание накладывает {hh607невидимость{x и {hh85улучшенную невидимость{x на колдуна и всех, кто в его {hh1378группе{x.

--- a/generic-skills/mind light.xml
+++ b/generic-skills/mind light.xml
@@ -19,7 +19,9 @@
     <extra l="en">mind light</extra>
     <extra l="ru">разума сияние свет чистого</extra>
     <extra l="ua">сяйво розуму чистого світла</extra>
-    <text l="en">This prayer fills the room with energetic power, accelerating the recovery of {hh59mana{x in this area for some time.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This prayer fills the room with energetic power, accelerating the recovery of {hh59mana{x in this area for some time.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Эта молитва наполняет комнату энергетической силой, ускоряя восстановление {hh59маны{x в этой местности на какое-то время.

--- a/generic-skills/paralysis.xml
+++ b/generic-skills/paralysis.xml
@@ -18,7 +18,9 @@
     <extra l="en">'power word stun'</extra>
     <extra l="ru">'слово оглушения'</extra>
     <extra l="ua">'слово приголомшення'</extra>
-    <text l="en">Experienced anti-paladins can {hh120paralyze{x the opponent for a couple of hours. The effect of the spell not only blocks any attempts of the victim to attack or defend but also significantly reduces their agility, accuracy, damage, and {hh83armor class{x.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Experienced anti-paladins can {hh120paralyze{x the opponent for a couple of hours. The effect of the spell not only blocks any attempts of the victim to attack or defend but also significantly reduces their agility, accuracy, damage, and {hh83armor class{x.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Опытные анти-паладины могут {hh120парализовать{x противника на пару часов. Эффект заклинания не только блокирует любые попытки жертвы атаковать или защищаться, но еще и сильно ухудшает ее ловкость, точность, урон и {hh83класс защиты{x.

--- a/generic-skills/pass door.xml
+++ b/generic-skills/pass door.xml
@@ -35,7 +35,9 @@
     <extra l="en">passdoor</extra>
     <extra l="ru">полупрозрачность 'проходить сквозь двери' прозрачность</extra>
     <extra l="ua">напівпрозорість 'проходити через двері' прозорість</extra>
-    <text l="en">This spell will allow you to become semi-transparent, enabling you to pass through most closed doors. However, there are doors in the world that are protected even from semi-transparent guests.
+    <text l="en">%FMT% *%SPELL%*
+
+This spell will allow you to become semi-transparent, enabling you to pass through most closed doors. However, there are doors in the world that are protected even from semi-transparent guests.
 
 Additionally, semi-transparency is a racial trait of cave elves, known as {hh164rockseers{x.</text>
     <text l="ru">%FMT% *%SPELL%*

--- a/generic-skills/pick lock.xml
+++ b/generic-skills/pick lock.xml
@@ -31,7 +31,9 @@
     <keyword l="en">picklock</keyword>
     <keyword l="ru">'взлом замков' взломать замок</keyword>
     <keyword l="ua">'злом замків' зламати замок</keyword>
-    <text l="en">Thieves can crack open locks of various constructions given they have the corresponding {hh22lockpick{x.
+    <text l="en">%FMT% *pick* _lock_ _lockpick_
+
+Thieves can crack open locks of various constructions given they have the corresponding {hh22lockpick{x.
 
 %SA% %H% {hh612key forgery{x, {hh634golden eye{x</text>
     <text l="ru">%FMT% *взломать* _замок_ _отмычка_

--- a/generic-skills/protection negative.xml
+++ b/generic-skills/protection negative.xml
@@ -20,7 +20,9 @@
     <keyword l="en">negative</keyword>
     <keyword l="ru">'негативная энергия' 'темная энергия' 'защита негатив'</keyword>
     <keyword l="ua">'негативна енергія' 'темна енергія' 'захист негативи'</keyword>
-    <text l="en">This powerful spell of {hh143necromancers{x grants resistance to all dark energy attacks. =Dark energy= is one of the {hh101types of damage{x commonly applicable to {hh96vampiric{x weapons and skills, dark magic, and most {hh1117curses{x.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This powerful spell of {hh143necromancers{x grants resistance to all dark energy attacks. =Dark energy= is one of the {hh101types of damage{x commonly applicable to {hh96vampiric{x weapons and skills, dark magic, and most {hh1117curses{x.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Мощное заклятие {hh143некромантов{x, дающее сопротивляемость ко всем атакам темной энергией. =Темная энергия= -- один из {hh101типов повреждений{x, обычно применимый к {hh96вампирическому{x оружию и умениям, темной магии и большинству {hh1117проклятий{x.

--- a/generic-skills/reclaim.xml
+++ b/generic-skills/reclaim.xml
@@ -12,7 +12,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">nature</group>
   <help id="179" level="-1" type="SkillHelp">
-    <text l="en">With the help of reclaiming, a druid can cleanse any non-urban space from most curses, such as {hh855cursed lands{x, {hh787deadly venom{x, and others. This prayer also helps to remove any alien things temporarily introduced by anyone -- including totems or amulets.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+With the help of reclaiming, a druid can cleanse any non-urban space from most curses, such as {hh855cursed lands{x, {hh787deadly venom{x, and others. This prayer also helps to remove any alien things temporarily introduced by anyone -- including totems or amulets.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 С помощью окультуривания друид может очищать любое не-городское пространство от от большинства чар, таких как {hh855проклятые земли{x, {hh787смертельный яд{x и прочих. Также эта молитва помогает убирать любые чужеродные вещи, временно привнесенные кем угодно -- включая тотемы или обереги.

--- a/generic-skills/remove curse.xml
+++ b/generic-skills/remove curse.xml
@@ -19,7 +19,9 @@
     <extra l="en">nodrop noremove nouncurse</extra>
     <extra l="ru">'нельзя бросить' 'нельзя снять' 'неснимаемое проклятие' предметы проклятие проклятые вещи</extra>
     <extra l="ua">'не можна кинути' 'не можна зняти' 'незнімне прокляття' предмети прокляття прокляті речі</extra>
-    <text l="en">This prayer removes the {hh548curse{x affect from the character, and also removes the curse from items with {hh96flags{x {cno drop{x or {cno remove{x. The prayer must be applied to the character itself, it will work on the first cursed item in inventory or equipment.
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+This prayer removes the {hh548curse{x affect from the character, and also removes the curse from items with {hh96flags{x {cno drop{x or {cno remove{x. The prayer must be applied to the character itself, it will work on the first cursed item in inventory or equipment.
 
 Curses with a {hh2036level{x higher than yours are harder to remove. Curse removal services are also provided by {hh202healers{x.
 

--- a/generic-skills/rescue.xml
+++ b/generic-skills/rescue.xml
@@ -38,7 +38,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">defensive</group>
   <help id="613" level="-1" type="SkillHelp">
-    <text l="en">This martial skill allows you to pull a {hh1378groupmate{x out of the attack by taking hits for them. The chance of success depends on the level of skill development and the level difference between you and the future opponent.
+    <text l="en">%FMT% *%SKILL%* _%CHAR%_
+
+This martial skill allows you to pull a {hh1378groupmate{x out of the attack by taking hits for them. The chance of success depends on the level of skill development and the level difference between you and the future opponent.
 
 The team member pulled out of the attack can use the {hh744circular strike{x skill.
 

--- a/generic-skills/restoring light.xml
+++ b/generic-skills/restoring light.xml
@@ -14,7 +14,9 @@
     <extra l="en">restoration</extra>
     <extra l="ru"></extra>
     <extra l="ua">відновлення</extra>
-    <text l="en">Experienced clerics can transform their energy (mana) into a healing beam of light. When directed at someone, such a beam will heal all wounds, taking one energy point from the cleric for each health point restored. Additionally, the healing beam attempts to cure {hh614plague{x, {hh837poison{x, {hh831blindness{x, remove {hh548curse{x, and {hh715awaken{x.</text>
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+Experienced clerics can transform their energy (mana) into a healing beam of light. When directed at someone, such a beam will heal all wounds, taking one energy point from the cleric for each health point restored. Additionally, the healing beam attempts to cure {hh614plague{x, {hh837poison{x, {hh831blindness{x, remove {hh548curse{x, and {hh715awaken{x.</text>
     <text l="ru">%FMT% *%SPELL%* _%CHAR%_
 
 Опытные клерики могут превратить свою энергию (ману) в исцеляющий луч света. Направленный на кого-то, такой луч излечит все раны, отбирая от клерика по одному очку энергии за каждый восстановленный пункт здоровья. Помимо этого, исцеляющий луч попытается излечить от {hh614чумы{x, {hh837яда{x, {hh831слепоты{x, избавить от {hh548проклятия{x и {hh715разбудить{x.

--- a/generic-skills/sand storm.xml
+++ b/generic-skills/sand storm.xml
@@ -22,7 +22,9 @@
     <extra l="en">sand storm</extra>
     <extra l="ru">песчаный шторм</extra>
     <extra l="ua">пісчаний шторм</extra>
-    <text l="en">Experienced sorcerers can conjure up a sandstorm, causing considerable damage to those around them. The spell will not work if there is no sand underfoot (for example, in cities or forests).</text>
+    <text l="en">%FMT% *%SPELL%*
+
+Experienced sorcerers can conjure up a sandstorm, causing considerable damage to those around them. The spell will not work if there is no sand underfoot (for example, in cities or forests).</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Опытные колдуны могут вызывать песчаную бурю, причиняя при этом большие повреждения окружающим. Если под ногами нет песка (например, в городах или в лесу), заклинание не сработает.

--- a/generic-skills/scourge.xml
+++ b/generic-skills/scourge.xml
@@ -16,7 +16,9 @@
     <extra l="en">'scourge of the violet spider'</extra>
     <extra l="ru">'бич фиолетового паука' фиолетовый</extra>
     <extra l="ua">'бич фіолетового павука' фіолетовий</extra>
-    <text l="en">This offensive necromancer magic strikes all within sight with poison or dark energy, depending on the victim's vulnerabilities. It can {hh831blind{x, {hh705slow{x, {hh837poison{x or {hh704weaken{x opponents.
+    <text l="en">%FMT% *%SPELL%*
+
+This offensive necromancer magic strikes all within sight with poison or dark energy, depending on the victim's vulnerabilities. It can {hh831blind{x, {hh705slow{x, {hh837poison{x or {hh704weaken{x opponents.
 
 The Scourge of the Violet Spider draws its power from the cruel goddess {hh171Lloth{x. Unavailable to good or lawful characters.</text>
     <text l="ru">%FMT% *%SPELL%*

--- a/generic-skills/severity force.xml
+++ b/generic-skills/severity force.xml
@@ -19,7 +19,9 @@
     <extra l="en">underground subterranean force severe blow of the earth</extra>
     <extra l="ru">подземных подземный сила силы суровые удар земли</extra>
     <extra l="ua">підземних підземний сила сили суворі удар землі</extra>
-    <text l="en">This spell is a more powerful analogue of {hh653earthquake{x, but with a directed action. The ground under the enemy's feet opens up, causing truly horrifying damage.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This spell is a more powerful analogue of {hh653earthquake{x, but with a directed action. The ground under the enemy's feet opens up, causing truly horrifying damage.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Это заклинание -- более мощный аналог {hh653землетрясения{x, но направленного действия. Земля под ногами противника разверзается, причиняя поистине ужасающие повреждения.

--- a/generic-skills/shocking trap.xml
+++ b/generic-skills/shocking trap.xml
@@ -24,7 +24,9 @@
     <extra l="en">shocking waves</extra>
     <extra l="ru">силовые волны</extra>
     <extra l="ua">силові хвилі</extra>
-    <text l="en">The force trap will deal energy damage and {hh120delay{x characters in your {hh32PK-interval{x or creatures that are following your trail.
+    <text l="en">%FMT% *%SPELL%*
+
+The force trap will deal energy damage and {hh120delay{x characters in your {hh32PK-interval{x or creatures that are following your trail.
 
 The way you {hh18move{x into the room matters: stepping in carefully, sneaking or crawling, gives you a chance to skirt the trap, while charging in at speed does not.
 </text>

--- a/generic-skills/sleep.xml
+++ b/generic-skills/sleep.xml
@@ -29,7 +29,9 @@
     <extra l="en">sleep</extra>
     <extra l="ru">усыпить</extra>
     <extra l="ua">приспати</extra>
-    <text l="en">This spell puts the target into a deep sleep. A sleeping target can be affected by various {hh1117curses{x, but an attack or damage will awaken the target, of course.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This spell puts the target into a deep sleep. A sleeping target can be affected by various {hh1117curses{x, but an attack or damage will awaken the target, of course.
 
 The success rate depends on the target's {hh2035spell resistance{x, level difference, the caster's {hh38intelligence{x, the target's {hh36constitution{x, and the skill {hh1359proficiency{x, as well as other random factors.
 </text>

--- a/generic-skills/solar flight.xml
+++ b/generic-skills/solar flight.xml
@@ -12,7 +12,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">transportation</group>
   <help id="631" level="-1" type="SkillHelp">
-    <text l="en">Solar flight is a powerful transportation prayer that carries a paladin and his faithful {hh15favorite{x to any creature in the world. Of course, solar flight only works during the day and only if both you and the target are outdoors.
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+Solar flight is a powerful transportation prayer that carries a paladin and his faithful {hh15favorite{x to any creature in the world. Of course, solar flight only works during the day and only if both you and the target are outdoors.
 
 The same restrictions apply to this spell as to others in the group of teleportation magic - see {y{hchelp gates{x.
 

--- a/generic-skills/spell resistance.xml
+++ b/generic-skills/spell resistance.xml
@@ -30,7 +30,9 @@
     <extra l="en">'protection magic'</extra>
     <extra l="ru">'отпор заклинаний'</extra>
     <extra l="ua">'захист від заклинань'</extra>
-    <text l="en">This powerful spell grants {hh101resistance{x to all spells, but {hh808dispel{x this protection is easier than other effects.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+This powerful spell grants {hh101resistance{x to all spells, but {hh808dispel{x this protection is easier than other effects.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 Это мощное заклинание дарует {hh101сопротивляемость{x ко всем заклинаниям, но {hh808развеять{x эту защиту легче, чем другие аффекты.

--- a/generic-skills/spring.xml
+++ b/generic-skills/spring.xml
@@ -39,7 +39,9 @@
     <extra l="en">'create spring'</extra>
     <extra l="ru">родник сотворить создать</extra>
     <extra l="ua">джерело створити створити</extra>
-    <text l="en">With this spell, you can create (or simply find) a source of water, a spring, near you. The spring works like fountains in cities -- you can {hh1074drink{x from it or {hh1075collect water{x to take on your journey.</text>
+    <text l="en">%FMT% *%SPELL%*
+
+With this spell, you can create (or simply find) a source of water, a spring, near you. The spring works like fountains in cities -- you can {hh1074drink{x from it or {hh1075collect water{x to take on your journey.</text>
     <text l="ru">%FMT% *%SPELL%*
 
 С помощью этого заклинания можно создать (или попросту отыскать) источник воды, родник, рядом с собой. Родник работает как фонтаны в городах -- из него можно {hh1074пить{x или {hh1075набрать воды{x с собой в путешествие.

--- a/generic-skills/stone golem.xml
+++ b/generic-skills/stone golem.xml
@@ -15,7 +15,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">necromancy</group>
   <help id="547" level="-1" type="SkillHelp">
-    <text l="en">Stone Golem is an improved version of the {hh545clay golem{x, with increased health and damage.
+    <text l="en">%FMT% *%SPELL%*
+
+Stone Golem is an improved version of the {hh545clay golem{x, with increased health and damage.
 
 {CPROPERTIES{x
 {C%A%{x {hh63Summoned Creature{x, needs =resubjugation= after {hh922leaving{x the world

--- a/generic-skills/summon shadow.xml
+++ b/generic-skills/summon shadow.xml
@@ -18,7 +18,9 @@
     <extra l="en">summoned</extra>
     <extra l="ru">призванная призвать тень</extra>
     <extra l="ua">призвана призвати тінь</extra>
-    <text l="en">This spell animates the necromancer's shadow, turning it into a shadow double. The created shadow resembles the owner in health and mana parameters. The shadow is resistant to weapons, possesses many spells from the necromancer's repertoire, and can {hh1361cast{x them by {hh1091command{x -- and even of its own will.
+    <text l="en">%FMT% *%SPELL%*
+
+This spell animates the necromancer's shadow, turning it into a shadow double. The created shadow resembles the owner in health and mana parameters. The shadow is resistant to weapons, possesses many spells from the necromancer's repertoire, and can {hh1361cast{x them by {hh1091command{x -- and even of its own will.
 
 {CPROPERTIES{x
 {C%A%{x {hh63Summoned entity{x, must be =re-subdued= after {hh922leaving{x the world

--- a/generic-skills/summon.xml
+++ b/generic-skills/summon.xml
@@ -34,7 +34,9 @@
     <extra l="en">nosummon</extra>
     <extra l="ru">непризыв 'призвать существо' призывать запрет</extra>
     <extra l="ua">невиклик 'викликати істоту' заборона на виклик</extra>
-    <text l="en">This powerful spell or prayer summons characters to the room where the caller is located.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+This powerful spell or prayer summons characters to the room where the caller is located.
 
 You can summon characters below your {hh2036spell level{x, but not below your {hh32PK-range{x (if they are players).
 

--- a/generic-skills/teleport.xml
+++ b/generic-skills/teleport.xml
@@ -31,7 +31,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">transportation</group>
   <help id="701" level="-1" type="SkillHelp">
-    <text l="en">This risky transportation spell teleports you or your victim to some completely random place in the world. Be careful{C, {xyou might end up {HH862trapped{x or near aggressive creatures. Many magic-wielding creatures can also use this spell against you in battle.
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
+
+This risky transportation spell teleports you or your victim to some completely random place in the world. Be careful{C, {xyou might end up {HH862trapped{x or near aggressive creatures. Many magic-wielding creatures can also use this spell against you in battle.
 
 You cannot teleport from places and to places where {hh862return{x is disallowed. While under {hh2146adrenaline{x, {hh32assassins{x and {hh686thieves{x also won't be able to escape using teleport.</text>
     <text l="ru">%FMT% *%SPELL%* _%CHAR%_

--- a/generic-skills/throwing weapon.xml
+++ b/generic-skills/throwing weapon.xml
@@ -89,7 +89,9 @@
     <extra l="en">'throw stone'</extra>
     <extra l="ru">камень камни метать швырнуть</extra>
     <extra l="ua">камінь камені метати кидати</extra>
-    <text l="en">This skill allows you to attack an opponent from a distance -- especially useful for {hh28warrior classes{x who do not want to get into a crowd of {hh998aggressive{x creatures. You can throw a weapon, an item held in your hands, or {hh681knives{x and {hh871stones{x from your inventory. Targeting is optional, and you can throw just for fun.
+    <text l="en">%FMT% *%CMD%* _%OBJ%_ _%DIR%_ _%VICT%_
+
+This skill allows you to attack an opponent from a distance -- especially useful for {hh28warrior classes{x who do not want to get into a crowd of {hh998aggressive{x creatures. You can throw a weapon, an item held in your hands, or {hh681knives{x and {hh871stones{x from your inventory. Targeting is optional, and you can throw just for fun.
 
 The best results in throwing disciplines are achieved by {hh135thieves{x with knives, warriors with one-handed {hh784axes{x or {hh699spears{x, or races accustomed to it -- {hh169hobbits{x and {hh2134giants{x with stones, {hh163orks{x with spears, and {hh146dwarves{x with axes. Besides knives, stones, axes, and spears, you can throw almost any light item that can be held in your hands.
 

--- a/generic-skills/tornado.xml
+++ b/generic-skills/tornado.xml
@@ -15,7 +15,9 @@
   <dammsg mg="f">воронка торнадо</dammsg>
   <group registry="skillGroup">nature</group>
   <help id="180" level="-1" type="SkillHelp">
-    <text l="en">The tornado spell is one of the most effective in the druid's arsenal. During the ritual {hh184channeling{x, the druid will bring any flying creature to the ground and lift a non-flying victim into the air, completely immobilizing them and preventing escape. Of course, neither the victim's physical attacks nor attacks against them will reach their target while the victim is suspended in the air. However, this restriction does not apply to spells and long-range weapons. When channeling is interrupted, the victim is thrown to the ground - it hurts. The longer the victim is suspended, the more it hurts.</text>
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+The tornado spell is one of the most effective in the druid's arsenal. During the ritual {hh184channeling{x, the druid will bring any flying creature to the ground and lift a non-flying victim into the air, completely immobilizing them and preventing escape. Of course, neither the victim's physical attacks nor attacks against them will reach their target while the victim is suspended in the air. However, this restriction does not apply to spells and long-range weapons. When channeling is interrupted, the victim is thrown to the ground - it hurts. The longer the victim is suspended, the more it hurts.</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
 
 Заклинание торнадо -- одно из самых эффективных в арсенале друида. В процессе ритуального {hh184ченнелинга{x друид приземлит любого летуна, а нелетучую жертву поднимет в воздух и полностью обездвижит, не позволяя ей сбежать. Разумеется, что ни физические атаки самой жертвы, ни атаки по ней не достигнут цели, пока жертва висит в воздухе. Впрочем, на заклинания и дальнобойное оружие это ограничение не подействует. Когда ченнелинг прерывается, жертва с размаху падает на землю -- это больно. И чем дольше жертва провисит -- тем больнее.

--- a/generic-skills/white arrow.xml
+++ b/generic-skills/white arrow.xml
@@ -11,7 +11,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">weaponsmaster</group>
   <help id="824" level="-1" type="SkillHelp">
-    <text l="en">This skill allows rangers to craft several white arrows and then use them for {hh810archery{x. White arrows have a freezing effect, piercing opponents with a {hh610wave of cold{x, weakening them, and also covering some items in the inventory with frost. Unlike ordinary {hh537wooden arrows{x, these require a special recipe and ingredients.</text>
+    <text l="en">%FMT% *craft* _white arrow_
+
+This skill allows rangers to craft several white arrows and then use them for {hh810archery{x. White arrows have a freezing effect, piercing opponents with a {hh610wave of cold{x, weakening them, and also covering some items in the inventory with frost. Unlike ordinary {hh537wooden arrows{x, these require a special recipe and ingredients.</text>
     <text l="ru">%FMT% * смастерить* _белая стрела_
 
 Это умение позволяет рейнджерам смастерить несколько белых стрел и затем использовать их для {hh810стрельбы из лука{x. Белые стрелы обладают обмораживающим эффектом, пронизывая противников {hh610волной холода{x и ослабляя их, а также покрывая инеем некоторые предметы в инвентаре.

--- a/generic-skills/winters touch.xml
+++ b/generic-skills/winters touch.xml
@@ -17,7 +17,9 @@
     <extra l="en">frost touch freeze winter</extra>
     <extra l="ru">касание обледенение обледенить зимы</extra>
     <extra l="ua">дотик обледеніння замерзати зими</extra>
-    <text l="en">Spell that imbues a weapon with the power of cold. In addition to regular damage, such a weapon will also {hh96frostbite{x the victim, penetrating them with cold to the bone and weakening them.
+    <text l="en">%FMT% *%SPELL%* _%OBJ%_
+
+Spell that imbues a weapon with the power of cold. In addition to regular damage, such a weapon will also {hh96frostbite{x the victim, penetrating them with cold to the bone and weakening them.
 
 Rumors say that those who draw {hh725inspiration{x from the ancient word {hh234ahenn{x can endow the weapon with additional properties.</text>
     <text l="ru">%FMT% *%SPELL%* _%OBJ%_

--- a/generic-skills/witch curse.xml
+++ b/generic-skills/witch curse.xml
@@ -18,7 +18,9 @@
     <extra l="en">witchcurse</extra>
     <extra l="ru">'проклятие ведьмы' 'ведьмино проклятье' 'ведьминское проклятье'</extra>
     <extra l="ua">'прокляття відьми' 'відьмине прокляття' 'відьминське прокляття'</extra>
-    <text l="en">Powerful deadly witch's curse that cannot be {hh808removed{x or {hh821canceled{x. To cast this spell, the witch gives up a small part of her life.
+    <text l="en">%FMT% *%SPELL%* _%VICT%_
+
+Powerful deadly witch's curse that cannot be {hh808removed{x or {hh821canceled{x. To cast this spell, the witch gives up a small part of her life.
 
 Every {hh16tick{x, the victim's maximum health points begin to decrease. The rate of decrease depends on the level of the witch's spells and doubles every tick. Whether the victim survives or not depends on the witch's intelligence, the victim's physique, and other factors.
 </text>


### PR DESCRIPTION
Tuk filed a typo report against help 706: no syntax line for an English reader. It turned out not to be one article — **205** English skill helps open with `%FMT%` and **60** do not, while their Russian does. An English player reading any of those sixty learns what the skill does and never learns how to type it.

The line is taken from each article's own Russian rather than a fixed string, because the macro differs by skill: spells use `%SPELL%`, commands use `%CMD%`, and some carry an argument slot.

Six of the sixty spell their command out in Russian words instead of macros (`*подделать* _дверь, портал или контейнер_`). Copying those verbatim would put Russian into English help, so they were written out from each skill's own registered English command name — `craft`, `forge`, `pick`, `grave` — read out of the skill files, not guessed.

Verified: every one of the sixty is a **pure prepend**, article body byte-identical, checked mechanically against `HEAD`. All 336 skill XML files still parse. Nothing outside `<text l="en">` moved in any file.

Reporter still owed 20 qp. Part of [Трилінгвальність: усі мовні протікання](https://trello.com/c/blFXD5sf).