### PR TITLE
Straighten four format lines the review turned up

### DIFF
--- a/generic-skills/gate.xml
+++ b/generic-skills/gate.xml
@@ -29,7 +29,7 @@
     <extra l="en">gate spell</extra>
     <extra l="ru">гейт ворота 'заклинание врат'</extra>
     <extra l="ua">гейт ворота 'заклинання врат'</extra>
-    <text l="en"> %FMT% *%SPELL%* _%CHAR%_
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
 
 The gate spell is a powerful transportation spell that opens a portal between you and another character somewhere in the world. Your {hh15favorite animal{x may pass through the portal, but not your {hh1378group{x members or charmed ones. The probability of success is influenced by the target's {hh2035spell protection{x and {hh101resistance{x or vulnerability to summoning.
 

--- a/generic-skills/green arrow.xml
+++ b/generic-skills/green arrow.xml
@@ -16,7 +16,7 @@
 This skill allows rangers to craft several green arrows and then use them for {hh810archery{x. Green arrows are {hh837poisonous{x, hitting the opponent to poison and weaken them.
 
 Unlike regular {hh537wooden arrows{x, these will require a special recipe and ingredients.</text>
-    <text l="ru">%FMT% * смастерить* _зеленая стрела_
+    <text l="ru">%FMT% *смастерить* _зеленая стрела_
 
 Это умение позволяет рейнджерам смастерить несколько зеленых стрел и затем использовать их для {hh810стрельбы из лука{x. Зеленые стрелы {hh837ядовиты{x, при попадании они отравляют и ослабляют противника.
 

--- a/generic-skills/mist walk.xml
+++ b/generic-skills/mist walk.xml
@@ -14,8 +14,7 @@
     <extra l="en">misty trail</extra>
     <extra l="ru">тропа туманная</extra>
     <extra l="ua">туманна стежка</extra>
-    <text l="en">  
-%FMT% *%SPELL%* _%CHAR%_
+    <text l="en">%FMT% *%SPELL%* _%CHAR%_
 
 The Mist Walk is a powerful transportation spell that allows a vampire and its {hh15pet{x to teleport to any creature in the world.
 

--- a/generic-skills/white arrow.xml
+++ b/generic-skills/white arrow.xml
@@ -14,7 +14,7 @@
     <text l="en">%FMT% *craft* _white arrow_
 
 This skill allows rangers to craft several white arrows and then use them for {hh810archery{x. White arrows have a freezing effect, piercing opponents with a {hh610wave of cold{x, weakening them, and also covering some items in the inventory with frost. Unlike ordinary {hh537wooden arrows{x, these require a special recipe and ingredients.</text>
-    <text l="ru">%FMT% * смастерить* _белая стрела_
+    <text l="ru">%FMT% *смастерить* _белая стрела_
 
 Это умение позволяет рейнджерам смастерить несколько белых стрел и затем использовать их для {hh810стрельбы из лука{x. Белые стрелы обладают обмораживающим эффектом, пронизывая противников {hh610волной холода{x и ослабляя их, а также покрывая инеем некоторые предметы в инвентаре.
 


### PR DESCRIPTION
Three cosmetic defects the #554 review flagged as pre-existing:

- `mist walk.xml` English text opened with a whitespace-only line, `gate.xml` with a leading space, so both rendered a stray gap before `Format:`
- `green arrow.xml` and `white arrow.xml` Russian lines read `* смастерить*` with a space inside the asterisks, which emphasises a leading blank rather than the command

All 336 skill XML files still parse.