### PR TITLE
Drop two stray Latin letters from anti-paladin titles

### DIFF
--- a/professions/anti-paladin.xml
+++ b/professions/anti-paladin.xml
@@ -421,7 +421,7 @@
     </node>
     <node>
       <female>Дама Перевернутого Креста</female>
-      <male>Кавалер Перевернутого Крестаs</male>
+      <male>Кавалер Перевернутого Креста</male>
       <maleUa>Кавалер Перевернутого Хреста</maleUa>
       <femaleUa>Дама Перевернутого Хреста</femaleUa>
       <maleEn>Knight of the Inverted Cross</maleEn>
@@ -692,7 +692,7 @@
       <femaleEn>Bringer of Famine</femaleEn>
     </node>
     <node>
-      <female>tВсадница на вороном коне</female>
+      <female>Всадница на вороном коне</female>
       <male>Всадник на вороном коне</male>
       <maleUa>Вершник на вороному коні</maleUa>
       <femaleUa>Вершниця на вороному коні</femaleUa>


### PR DESCRIPTION
`Крестаs` -> `Креста`, `tВсадница` -> `Всадница`.

Both are proven by a duplicate title node eight lines away in the same file that already spells them correctly, not by guesswork.

Part of the trilingual epic https://trello.com/c/blFXD5sf -- the "stray letters and lost tags" checklist item.