### PR TITLE
Rainbow pieces in three languages; drop the dead config hint

### DIFF
--- a/commands/config.xml
+++ b/commands/config.xml
@@ -9,7 +9,6 @@
     <node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">nocancel</bit>
-        <hint>запрет не-соклановикам применять заклинание отмена</hint>
         <msgOff l="en">Anyone can cast 'cancellation' on you.</msgOff>
         <msgOff l="ru">Заклинание &apos;отмена&apos; на тебя смогут применить все.</msgOff>
         <msgOff l="ua">Закляття 'відміна' на тебе зможуть застосувати всі.</msgOff>
@@ -22,7 +21,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">nobuff</bit>
-        <hint>запрет посторонним накладывать на тебя и твоих питомцев положительные заклинания</hint>
         <msgOff l="en">Anyone can cast beneficial spells on you and your pets.</msgOff>
         <msgOff l="ru">Положительные заклинания на тебя и твоих питомцев смогут накладывать все.</msgOff>
         <msgOff l="ua">Позитивні закляття на тебе й твоїх улюбленців зможуть накладати всі.</msgOff>
@@ -35,7 +33,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">notransfer</bit>
-        <hint>запрет посторонним игрокам передавать тебе вещи и деньги</hint>
         <msgOff l="en">Anyone can give items and money to you.</msgOff>
         <msgOff l="ru">Передавать тебе вещи и деньги смогут все.</msgOff>
         <msgOff l="ua">Передавати тобі речі й гроші зможуть усі.</msgOff>
@@ -48,7 +45,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">nofollow</bit>
-        <hint>запретить следовать за собой</hint>
         <msgOff l="en">You allow others to follow you.</msgOff>
         <msgOff l="ru">Ты разрешаешь следовать за собой.</msgOff>
         <msgOff l="ua">Ти дозволяєш іти за собою.</msgOff>
@@ -61,7 +57,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autoassist</bit>
-        <hint>вступать в бой при нападении на группу</hint>
         <msgOff l="en">You will not join combat when your group is attacked.</msgOff>
         <msgOff l="ru">Ты не будешь вступать в бой при нападении на твою группу.</msgOff>
         <msgOff l="ua">Ти не вступатимеш у бій, коли нападають на твою групу.</msgOff>
@@ -74,7 +69,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autoloot</bit>
-        <hint>забирать вещи из трупов</hint>
         <msgOff l="en">You will not automatically loot items from enemy corpses.</msgOff>
         <msgOff l="ru">Ты не будешь автоматически забирать все вещи из трупа врага.</msgOff>
         <msgOff l="ua">Ти не забиратимеш речі з трупів ворогів автоматично.</msgOff>
@@ -87,7 +81,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autosac</bit>
-        <hint>приносить трупы в жертву после убийства</hint>
         <msgOff l="en">You will not sacrifice corpses after a kill.</msgOff>
         <msgOff l="ru">Ты не будешь приносить в жертву труп после убийства.</msgOff>
         <msgOff l="ua">Ти не жертвуватимеш труп після вбивства.</msgOff>
@@ -100,7 +93,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">newdamage</bit>
-        <hint>формат отображения урона: числами или в процентах</hint>
         <msgOff l="en">Damage is shown as numbers.</msgOff>
         <msgOff l="ru">Урон отображается числами.</msgOff>
         <msgOff l="ua">Шкода відображається числами.</msgOff>
@@ -118,7 +110,6 @@
     <node>
       <node type="ConfigElement">
         <bit table="config_flags">short_objflag</bit>
-        <hint>показывать флаги на предметах в сокращенной форме</hint>
         <msgOff l="en">Item flags are shown in full form.</msgOff>
         <msgOff l="ru">Флаги на предметах отображаются в развернутом виде.</msgOff>
         <msgOff l="ua">Флаги на предметах показуються повністю.</msgOff>
@@ -131,7 +122,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">fightspam</bit>
-        <hint>показывать ли боевые автоумения</hint>
         <msgOff l="en">You do not see parries, dodges and so on.</msgOff>
         <msgOff l="ru">Ты не видишь парирований, уворотов и так далее.</msgOff>
         <msgOff l="ua">Ти не бачиш парирувань, ухилянь тощо.</msgOff>
@@ -144,7 +134,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">skillspam</bit>
-        <hint>показывать ли промахи умений</hint>
         <msgOff l="en">You do not see skill misses.</msgOff>
         <msgOff l="ru">Ты не видишь промахи умений.</msgOff>
         <msgOff l="ua">Ти не бачиш промахів умінь.</msgOff>
@@ -157,7 +146,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">weaponspam</bit>
-        <hint>не показывать действия флагов оружия</hint>
         <msgOff l="en">You see all {hh96weapon flag{x effects.</msgOff>
         <msgOff l="ru">Ты видишь все действия {hh96флагов оружия{x.</msgOff>
         <msgOff l="ua">Ти бачиш усі дії {hh96флагів зброї{x.</msgOff>
@@ -170,7 +158,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">show_affects</bit>
-        <hint>показывать аффекты по команде счет</hint>
         <msgOff l="en">Affects are not shown by the score command.</msgOff>
         <msgOff l="ru">Аффекты не видны по команде счет.</msgOff>
         <msgOff l="ua">Ефекти не видно за командою рахунок.</msgOff>
@@ -183,7 +170,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">brief</bit>
-        <hint>видеть сокращенное описание комнаты</hint>
         <msgOff l="en">Room descriptions are shown in full.</msgOff>
         <msgOff l="ru">Описание комнаты отображается в полном виде.</msgOff>
         <msgOff l="ua">Описи кімнат показуються повністю.</msgOff>
@@ -196,7 +182,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">autoexit</bit>
-        <hint>отображать выходы из комнаты</hint>
         <msgOff l="en">Room exits are not shown automatically.</msgOff>
         <msgOff l="ru">Выходы не отображаются автоматически.</msgOff>
         <msgOff l="ua">Виходи з кімнати не показуються автоматично.</msgOff>
@@ -209,7 +194,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">prompt</bit>
-        <hint>выводить строку состояния с параметрами персонажа</hint>
         <msgOff l="en">The {hh1012status line{x is off.</msgOff>
         <msgOff l="ru">Вывод {hh1012строки состояния{x отключен.</msgOff>
         <msgOff l="ua">Виведення {hh1012рядка стану{x вимкнено.</msgOff>
@@ -222,7 +206,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="config_flags">screenreader</bit>
-        <hint>режим поддержки screen reader</hint>
         <msgOff l="en">Screen reader support mode is off.</msgOff>
         <msgOff l="ru">Режим поддержки читалки для незрячих{x выключен.</msgOff>
         <msgOff l="ua">Режим підтримки читача екрана вимкнено.</msgOff>
@@ -235,7 +218,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="plr_flags">holylight</bit>
-        <hint>божественный взор</hint>
         <level>102</level>
         <msgOff l="en">Holy light is off.</msgOff>
         <msgOff l="ru">Божественный взор выключен.</msgOff>
@@ -254,7 +236,6 @@
     <node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">noiac</bit>
-        <hint>не заменять IAC на большое YA при выводе текста</hint>
         <msgOff l="en">IAC bytes will be replaced by another letter (YA in cp1251).</msgOff>
         <msgOff l="ru">IAC-и будут заменяться другой буквой (YA в кодировке cp1251).</msgOff>
         <msgOff l="ua">IAC-байти замінюватимуться іншою літерою (YA в cp1251).</msgOff>
@@ -267,7 +248,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="add_comm_flags">notelnet</bit>
-        <hint>отключить фильтр TELNET на приходящий текст</hint>
         <msgOff l="en">The TELNET filter is on.</msgOff>
         <msgOff l="ru">Фильтр TELNET включен.</msgOff>
         <msgOff l="ua">Фільтр TELNET увімкнено.</msgOff>
@@ -280,7 +260,6 @@
       </node>
       <node type="ConfigElement">
         <bit table="comm_flags">telnet_ga</bit>
-        <hint>посылать последовательность TELNET GA после строки состояния</hint>
         <msgOff l="en">Sending TELNET GA is off.</msgOff>
         <msgOff l="ru">Отправка TELNET GA отключена.</msgOff>
         <msgOff l="ua">Надсилання TELNET GA вимкнено.</msgOff>

--- a/gquests/rainbow.xml
+++ b/gquests/rainbow.xml
@@ -15,13 +15,41 @@
       <noWinnerMsg>Увы, никто из героев не сумел вновь зажечь радугу над миром.</noWinnerMsg>
       <pieceVnum>28011</pieceVnum>
       <pieces>
-        <node>{Rкрасн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</node>
-        <node>{yоранжев|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</node>
-        <node>{Yжелт|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</node>
-        <node>{Gзелен|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</node>
-        <node>{Cголуб|ой{x|ого{x|ому{x|ой{x|ым{x|ом{x</node>
-        <node>{Bсин|ий{x|его{x|ему{x|ий{x|им{x|ем{x</node>
-        <node>{Mфиолетов|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</node>
+        <node>
+          <name l="en">{Rred{x</name>
+          <name l="ru">{Rкрасн|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</name>
+          <name l="ua">{Rчервон|ий{x|ого{x|ому{x|ий{x|им{x|ому{x</name>
+        </node>
+        <node>
+          <name l="en">{yorange{x</name>
+          <name l="ru">{yоранжев|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</name>
+          <name l="ua">{yпомаранчев|ий{x|ого{x|ому{x|ий{x|им{x|ому{x</name>
+        </node>
+        <node>
+          <name l="en">{Yyellow{x</name>
+          <name l="ru">{Yжелт|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</name>
+          <name l="ua">{Yжовт|ий{x|ого{x|ому{x|ий{x|им{x|ому{x</name>
+        </node>
+        <node>
+          <name l="en">{Ggreen{x</name>
+          <name l="ru">{Gзелен|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</name>
+          <name l="ua">{Gзелен|ий{x|ого{x|ому{x|ий{x|им{x|ому{x</name>
+        </node>
+        <node>
+          <name l="en">{Clight blue{x</name>
+          <name l="ru">{Cголуб|ой{x|ого{x|ому{x|ой{x|ым{x|ом{x</name>
+          <name l="ua">{Cблакитн|ий{x|ого{x|ому{x|ий{x|им{x|ому{x</name>
+        </node>
+        <node>
+          <name l="en">{Bblue{x</name>
+          <name l="ru">{Bсин|ий{x|его{x|ему{x|ий{x|им{x|ем{x</name>
+          <name l="ua">{Bсин|ій{x|ього{x|ьому{x|ій{x|ім{x|ьому{x</name>
+        </node>
+        <node>
+          <name l="en">{Mviolet{x</name>
+          <name l="ru">{Mфиолетов|ый{x|ого{x|ому{x|ый{x|ым{x|ом{x</name>
+          <name l="ua">{Mфіолетов|ий{x|ого{x|ому{x|ий{x|им{x|ому{x</name>
+        </node>
       </pieces>
       <startMsg>Ярко вспыхнув, радуга разлетелась на множество осколков!</startMsg>
       <winnerMsg l="en"></winnerMsg>
@@ -39,13 +67,41 @@
       <noWinnerMsg>Увы, на эту {1{rадскую должность{2 так и не нашлось достойного кандидата.</noWinnerMsg>
       <pieceVnum>28013</pieceVnum>
       <pieces>
-        <node>зеркал|о|а|у|о|ом|е</node>
-        <node>мягк|ий|ого|ому|ий|ом|ом диван||а|у||ом|е</node>
-        <node>похотлив|ый|ого|ому|ый|ым|ом взгляд||а|у||ом|е</node>
-        <node>тройн|ой|ого|ому|ой|ым|ом подбород|ок|ка|ку|ок|ком|ке</node>
-        <node>жаб|а|и|i|у|ой|i зелен|а|оi|iй|у|ою|iй</node>
-        <node>дурн|ой|ого|ому|ой|ым|ом глаз||а|у||ом|е</node>
-        <node>желчн|ый|ого|ому|ый|ым|ом пузыр|ь|я|ю|ь|ем|е</node>
+        <node>
+          <name l="en">a mirror</name>
+          <name l="ru">зеркал|о|а|у|о|ом|е</name>
+          <name l="ua">дзеркал|о|а|у|о|ом|і</name>
+        </node>
+        <node>
+          <name l="en">a soft sofa</name>
+          <name l="ru">мягк|ий|ого|ому|ий|ом|ом диван||а|у||ом|е</name>
+          <name l="ua">зручн|ий|ого|ому|ий|им|ому диван||а|у||ом|і</name>
+        </node>
+        <node>
+          <name l="en">a lustful gaze</name>
+          <name l="ru">похотлив|ый|ого|ому|ый|ым|ом взгляд||а|у||ом|е</name>
+          <name l="ua">хтив|ий|ого|ому|ий|им|ому погляд||у|у||ом|і</name>
+        </node>
+        <node>
+          <name l="en">a triple chin</name>
+          <name l="ru">тройн|ой|ого|ому|ой|ым|ом подбород|ок|ка|ку|ок|ком|ке</name>
+          <name l="ua">потрійн|е|ого|ому|е|им|ому підборідд|я|я|ю|я|ям|і</name>
+        </node>
+        <node>
+          <name l="en">a green frog</name>
+          <name l="ru">зелен|ая|ой|ой|ую|ой|ой жаб|а|ы|е|у|ой|е</name>
+          <name l="ua">зелен|а|ої|ій|у|ою|ій жаб|а|и|і|у|ою|і</name>
+        </node>
+        <node>
+          <name l="en">an evil eye</name>
+          <name l="ru">дурн|ой|ого|ому|ой|ым|ом глаз||а|у||ом|е</name>
+          <name l="ua">лих|е|ого|ому|е|им|ому ок|о|а|у|о|ом|ці</name>
+        </node>
+        <node>
+          <name l="en">a gall bladder</name>
+          <name l="ru">желчн|ый|ого|ому|ый|ым|ом пузыр|ь|я|ю|ь|ем|е</name>
+          <name l="ua">жовчн|ий|ого|ому|ий|им|ому міхур||а|у||ом|і</name>
+        </node>
       </pieces>
       <startMsg>В {1{rАду{2 открылась новая вакансия!</startMsg>
       <winnerMsg l="en"></winnerMsg>


### PR DESCRIPTION
Data half of the rainbow change; the schema half is dreamland_code#970. Also removes 21 `<hint>` values for a field the engine reads nowhere.

**The frog is the reason this exists.** Its Russian slot held *Ukrainian* text, because that was the only slot. It has been fixed and un-fixed in a loop:

| commit | state |
|---|---|
| `48bc09d2` initial | Latin `i` |
| `92394fdb` (#550) | fixed to `і`/`ї` |
| `ce93d937` (#551) | fixed `ой` -> `ою` |
| `c3a57707` hosting | **exactly back to initial** |

Not git being odd: `GlobalQuestManager::save()` serialises the whole `GlobalQuestInfo` out of memory, the live server never loaded either fix, and `gquests/` is rewritten that way **105 times in 60 days**. Anything edited on disk there dies within ~12h unless the server boots with it first -- so this must land at reboot, not before.

RU and UA carry the same case-slot count in all fourteen entries (checked mechanically). Sofa reads `зручний` not `мʼякий` -- Kit's call, so the file takes no position on the open apostrophe question.

Part of https://trello.com/c/blFXD5sf