### PR TITLE
Repair the recite preposition in English and Ukrainian

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -12066,6 +12066,10 @@
    "en": "%^C1 recites the spell %s at %O2.",
    "ua": "%^C1 зачитує заклинання %s на %O2."
   },
+  "%^C1 зачитывает заклинание %w %O2.": {
+   "en": "%^C1 recites a spell %w %O2.",
+   "ua": "%^C1 зачитує заклинання %w %O2."
+  },
   "%^O1 превращается в пыль.": {
    "en": "%^O1 crumbles into dust.",
    "ua": "%^O1 перетворюється на пил."
@@ -12115,11 +12119,11 @@
    "ua": "Ти змахуєш $o5."
   },
   "Ты зачитываешь одно из заклинаний %s %O2, но оно не находит, на кого подействовать.": {
-   "en": "You read one of the %s spells from %O2, but it finds nothing to affect.",
+   "en": "You read out one of the spells %s %O2, but it finds no one to affect.",
    "ua": "Ти зачитуєш одне із заклинань %s %O2, але воно не знаходить, на кого подіяти."
   },
   "Ты зачитываешь одно из заклинаний %s %O2, но оно не находит, на что подействовать.": {
-   "en": "You read out one of the spells of %s %O2, but it finds nothing to affect.",
+   "en": "You read out one of the spells %s %O2, but it finds nothing to affect.",
    "ua": "Ти зачитуєш одне із заклинань %s %O2, але воно не знаходить, на що подіяти."
   },
   "Ты можешь взмахнуть только волшебным жезлом!": {


### PR DESCRIPTION
Pairs with `dreamland_code#980`.

`%s` in the recite lines is a preposition picked to agree with the scroll's name (`с`/`со`, and now `from` / `з`/`зі`). Two English values had been authored on the assumption it was an adjective and supplied a preposition of their own:

- `You read one of the **%s** spells **from** %O2` → `You read out one of the spells %s %O2, but it finds no one to affect.`
- `You read out one of the spells **of %s** %O2` → `You read out one of the spells %s %O2, but it finds nothing to affect.`

Both were rendering "…one of the **со** spells from a scroll…" to every English player today.

Adds `"%^C1 зачитывает заклинание %w %O2."` **alongside** the existing `%s` key rather than replacing it, following the movement `$w`/`$W` precedent: the catalog can reach live ahead of the binary, and the old key keeps resolving until the new engine emits the new one.