### PR TITLE
Translate the quest-info lines for kill, heal and staff

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -16525,6 +16525,30 @@
   "У тебя есть {Y%d{G минут%s на выполнение задания.": {
    "en": "You have {Y%d{G minute%s to complete the task.",
    "ua": "У тебе є {Y%d{G хвилин%s на виконання завдання."
+  },
+  "У тебя задание - вернуть %1$s.": {
+   "en": "Your task is to bring back %1$s.",
+   "ua": "Твоє завдання -- повернути %1$s."
+  },
+  "Место, где спрятано сокровище, называется %1$s.": {
+   "en": "The place where the treasure is hidden is called %1$s.",
+   "ua": "Місце, де сховано скарб, зветься %1$s."
+  },
+  "И находится это место в районе под названием {hh%1$s{hx.": {
+   "en": "And that place is in the area called {hh%1$s{hx.",
+   "ua": "А розташоване воно в місцевості під назвою {hh%1$s{hx."
+  },
+  "Доставить квестору %1$s из %2$s (%3$s).": {
+   "en": "Deliver %1$s from %2$s (%3$s) to the quest giver.",
+   "ua": "Доставити квестодавцю %1$s з %2$s (%3$s)."
+  },
+  "Ты передаешь $w $C3.": {
+   "en": "You hand $w to $C3.",
+   "ua": "Ти передаєш $w $C3."
+  },
+  "$c1 передает $w $C3.": {
+   "en": "$c1 hands $w to $C3.",
+   "ua": "$c1 передає $w $C3."
   }
  },
  "plug-ins/quest/stealquest/mobiles.cpp": {
@@ -19375,6 +19399,22 @@
   "Это находится в районе под названием {W{hh%3$s{x.": {
    "en": "It's located in an area called {W{hh%3$s{x.",
    "ua": "Це знаходиться в місцевості під назвою {W{hh%3$s{x."
+  },
+  "У тебя задание - вылечить %1$s!": {
+   "en": "Your task is to heal %1$s!",
+   "ua": "Твоє завдання -- вилікувати %1$s!"
+  },
+  "Место, где пациента видели в последний раз - %1$s": {
+   "en": "The patient was last seen in %1$s",
+   "ua": "Востаннє пацієнта бачили тут: %1$s"
+  },
+  "Это находится в районе под названием {hh%1$s{hx.": {
+   "en": "That is in the area called {hh%1$s{hx.",
+   "ua": "Це в місцевості під назвою {hh%1$s{hx."
+  },
+  "Вылечить %1$s из %2$s (%3$s).": {
+   "en": "Heal %1$s from %2$s (%3$s).",
+   "ua": "Вилікувати %1$s з %2$s (%3$s)."
   }
  },
  "plug-ins/quest/kidnapquest/kidnapquest.cpp": {
@@ -19457,6 +19497,22 @@
   "Я поручаю тебе наказать {W%3$#C4{G, совершивш%3$Gее|его|ую множество злодеяний.": {
    "en": "I'm charging you with punishing {W%3$#C4{G, who has committed countless atrocities.",
    "ua": "Я доручаю тобі покарати {W%3$#C4{G, що вчин%3$Gило|ив|ила безліч лиходійств."
+  },
+  "У тебя задание - уничтожить %1$s!": {
+   "en": "Your task is to destroy %1$s!",
+   "ua": "Твоє завдання -- знищити %1$s!"
+  },
+  "Место, где жертву видели в последний раз - %1$s": {
+   "en": "The victim was last seen in %1$s",
+   "ua": "Востаннє жертву бачили тут: %1$s"
+  },
+  "Это находится в районе под названием {hh%1$s{hx.": {
+   "en": "That is in the area called {hh%1$s{hx.",
+   "ua": "Це в місцевості під назвою {hh%1$s{hx."
+  },
+  "Уничтожить %1$s из %2$s (%3$s).": {
+   "en": "Destroy %1$s from %2$s (%3$s).",
+   "ua": "Знищити %1$s з %2$s (%3$s)."
   }
  },
  "plug-ins/quest/locatequest/locatequest.cpp": {
@@ -20153,6 +20209,20 @@
   "Ты просыпаешься от внезапной боли.": {
    "en": "You wake up from a sudden pain.",
    "ua": "Ти прокидаєшся від раптового болю."
+  }
+ },
+ "plug-ins/quest/core/quest.cpp": {
+  "Твое задание {YВЫПОЛНЕНО{x!": {
+   "en": "Your task is {YCOMPLETE{x!",
+   "ua": "Твоє завдання {YВИКОНАНО{x!"
+  },
+  "Вернись за вознаграждением, до того как выйдет время!": {
+   "en": "Come back for your reward before time runs out!",
+   "ua": "Повернися по нагороду, доки не вийшов час!"
+  },
+  "Вернуться к квестору за наградой.": {
+   "en": "Return to the quest giver for your reward.",
+   "ua": "Повернутися до квестодавця по нагороду."
   }
  }
 }


### PR DESCRIPTION
The EN/UA half of [dreamland_code#983](https://github.com/dreamland-mud/dreamland_code/pull/983).
**Both must ride the same reboot** — not for safety, but because without this the
wrapping in #983 is inert. A `_()`-wrapped string with no catalog entry renders
byte-identically to the original, so half that PR would ship doing nothing. That
exact trap cost `code#970` eighteen of its thirty-seven sites.

## Contents

17 entries across four file keys:

| file key | entries |
|---|---|
| `plug-ins/quest/core/quest.cpp` | 3 — **new key**; the two "task complete" sentences that used to be duplicated in seven quest models |
| `plug-ins/quest/killquest/killquest.cpp` | 4 |
| `plug-ins/quest/healquest/healquest.cpp` | 4 |
| `plug-ins/quest/staffquest/staffquest.cpp` | 6 |

Two of the staffquest entries carry a `$w` code rather than `$n4`: the hand-over is
a `TO_ROOM` broadcast, and `$w` resolves per recipient so each onlooker reads the
item name in their own language.

## The Russian keys are unchanged wording

Byte for byte, **spaced single hyphens included**. The project's typography rule
would make those `" -- "`, but the key must match the literal in the source, and the
source deliberately preserves what a Russian player already sees. Follow-up, not
an oversight.

## Verification

- `lint-catalog-gaps.py --corpus cpp`: **0 gaps**, down from the 17 this PR fills.
  Baseline before #983 was also 0, so these are exactly the new strings and nothing else.
- Placeholder parity, mixed Latin/Cyrillic inside a word, and forbidden punctuation
  checked on all 34 translations: **0 problems**.
- `lint-l10n.py` reports 1 HARD, in `plug-ins/comm/configs.cpp` — pre-existing, not
  touched here.
- `lint-catalog-width.py --file quest`: no new hits; the two it reports are rainbow
  and gqchannel, both pre-existing.
- The file was re-serialised with the exact original format (`indent=1`,
  `ensure_ascii=False`, insertion order kept). Proved by round-tripping the unmodified
  file byte-for-byte first — the diff is **70 lines, all insertions**.

## Deploy

Catalog loads at boot. Rides the next reboot with #983.