### PR TITLE
Translate the quest-info lines for butcher and big

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -14605,6 +14605,26 @@
   "Уничтожить %1$d преступник%1$Iа|ов|ов из '%2$s' (убито %3$d).": {
    "en": "Destroy %1$d criminal%1$I|s|s from '%2$s' (killed %3$d).",
    "ua": "Знищити %1$d злочинц%1$Iя|ів|ів із '%2$s' (вбито %3$d)."
+  },
+  "Твое задание {YВЫПОЛНЕНО{x!": {
+   "en": "Your task is {YCOMPLETE{x!",
+   "ua": "Твоє завдання {YВИКОНАНО{x!"
+  },
+  "Сообщи об этом квестору командой {yквест сдать{x, до того как выйдет время!": {
+   "en": "Tell the quest giver with {yquest complete{x, before time runs out!",
+   "ua": "Повідом квестодавця командою {yквест завершити{x, доки не вийшов час!"
+  },
+  "Последний раз их видели в местности '{hh%1$s{hx'.": {
+   "en": "They were last seen in the area '{hh%1$s{hx'.",
+   "ua": "Востаннє їх бачили в місцевості '{hh%1$s{hx'."
+  },
+  "Уже убито %1$d, осталось совсем немного.": {
+   "en": "%1$d killed already, not many left.",
+   "ua": "Уже вбито %1$d, лишилося зовсім небагато."
+  },
+  "Сообщить квестору о выполнении задания.": {
+   "en": "Report the finished task to the quest giver.",
+   "ua": "Повідомити квестодавця про виконання завдання."
   }
  },
  "plug-ins/quest/butcherquest/steakcustomer.cpp": {
@@ -19373,6 +19393,18 @@
   "У тебя есть {Y%d{G минут%s на выполнение задания.": {
    "en": "You have {Y%d{G minute%s to complete the task.",
    "ua": "У тебе є {Y%d{G хвилин%s на виконання завдання."
+  },
+  "%1$s из {hh%2$s{hx просит тебя доставить к столу %3$d кус%3$Iок|ка|ков мяса %4$s из местности {hh%5$s{hx.": {
+   "en": "%1$s from {hh%2$s{hx asks you to bring %3$d piece%3$I|s|s of %4$s meat from the area of {hh%5$s{hx to the table.",
+   "ua": "%1$s з {hh%2$s{hx просить тебе подати до столу %3$d шмат%3$Iок|ки|ків м'яса %4$s з місцевості {hh%5$s{hx."
+  },
+  "Доставлено кусков: %1$d.": {
+   "en": "Pieces delivered: %1$d.",
+   "ua": "Доставлено шматків: %1$d."
+  },
+  "%1$s из %2$s заказал %3$d кус%3$Iок|ка|ков мяса %4$s из %5$s.": {
+   "en": "%1$s from %2$s ordered %3$d piece%3$I|s|s of %4$s meat from %5$s.",
+   "ua": "%1$s з %2$s замовив %3$d шмат%3$Iок|ки|ків м'яса %4$s з %5$s."
   }
  },
  "plug-ins/quest/healquest/healquest.cpp": {


### PR DESCRIPTION
The EN/UA half of [dreamland_code#984](https://github.com/dreamland-mud/dreamland_code/pull/984).
Eight entries. Without them the wrapping in #984 is inert.

## Plurals were rendered, not assumed

The counts moved out of `GET_COUNT(n, "ок", "ка", "ков")` and into the format as a
`%3$I` alternation. Ukrainian gets its own three forms (шматок / шматки / шматків).

English uses `|s|s` — empty singular, `s` for the rest. **That is correct only
because `ordered` is bounded to 1..12** by `create()`: the alternation follows the
Russian count rule, so 21 would pick the singular and read "21 piece". Inside the
real range it is right.

Simulated the formatter (`%I` → `GET_COUNT(argInt(), 8, 9, 10)`, alternation
terminated by space per `msgformatter.cpp:347`) and rendered all three languages at
n = 1, 2, 4, 5, 11, 12:

| n | ru | en | ua |
|---|---|---|---|
| 1 | 1 кусок | 1 piece | 1 шматок |
| 2 | 2 куска | 2 pieces | 2 шматки |
| 5 | 5 кусков | 5 pieces | 5 шматків |
| 11 | 11 кусков | 11 pieces | 11 шматків |
| 12 | 12 кусков | 12 pieces | 12 шматків |

Russian matches the old `GET_COUNT` output exactly.

## The command name was looked up, not translated by ear

The bigquest completion line tells the player to type `квест сдать`. Resolved
against `arg_is(cmd, "complete")` (`cquest.cpp:179`) and `grammar/synonyms.json`
(`"complete": ["завершити", "сдать", "завершить"]`): English **`quest complete`**,
Ukrainian **`квест завершити`**. Documenting a word the parser rejects is a known
failure mode on this board, and the compass-alias review caught exactly that class
earlier today.

## Apostrophes

ASCII `'`, matching all **195** existing Ukrainian catalog values. The modifier `ʼ`
appears in **zero** of them — that convention lives in area XML, not here.

## Verification

- `lint-catalog-gaps.py --corpus cpp`: **0 gaps**.
- Round-tripped the unmodified 800KB file byte-for-byte before editing, so the diff
  is **32 lines, all insertions**, with no reformatting.

## Deploy

Catalog loads at boot. Rides the next reboot with #984.