### PR TITLE
Translate the locate quest: catalog frames and item data

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -16537,7 +16537,7 @@
    "ua": "Пропало чимало, але вона буде вдячна тобі, якщо принесеш їй хоча б {Y%1$d{x штук%1$Iу|и|."
   },
   "%1$s просит тебя собрать пачку %2$s, которую ветром расшвыряло по окрестностям. Всего их было {Y%3$d{x штук%3$Iу|и|.": {
-   "en": "%1$s asks you to gather up a bundle of %2$s that the wind scattered across the neighbourhood. There were {Y%3$d{x of them in all.",
+   "en": "%1$s asks you to gather up a bundle of %2$s that the wind scattered across the neighborhood. There were {Y%3$d{x of them in all.",
    "ua": "%1$s просить тебе зібрати пачку %2$s, яку вітром розкидало по околицях. Усього їх було {Y%3$d{x."
   },
   "В лаборатории %1$s взрывом расшвыряло %2$s, в количестве {Y%3$d{x штук%3$Iи||.": {
@@ -16549,7 +16549,7 @@
    "ua": "%1$s просить тебе спробувати їх зібрати."
   },
   "Поставщик не донес %1$s орудия пыток, растеряв их на полпути от %2$s.": {
-   "en": "A supplier failed to deliver instruments of torture to %1$s, losing them halfway from %2$s.",
+   "en": "A supplier failed to deliver instruments of torture to %1$s, scattering them somewhere on the road from %2$s.",
    "ua": "Постачальник не доніс %1$s знаряддя тортур, розгубивши їх на півдорозі від %2$s."
   },
   "Всего их было {Y%1$d{x штук%1$Iи||.": {

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -16489,8 +16489,8 @@
    "ua": "Всього там {W%d{G залізяк. Притягни їх сюди, якщо ти справді такий гарний нишпорка, як про тебе розказують."
   },
   "Да, так вот.. в моей лаборатории прогремел взрыв, и {W$n4{G расшвыряло в разные стороны.": {
-   "en": "Yeah, so... there was an explosion in my lab, and it flung $n4 in every direction.",
-   "ua": "Так, ось... у моїй лабораторії гримнув вибух, і $n4 розкидало в різні боки."
+   "en": "Yeah, so... there was an explosion in my lab, and it flung {W$n4{G in every direction.",
+   "ua": "Так, ось... у моїй лабораторії гримнув вибух, і {W$n4{G розкидало в різні боки."
   },
   "Если я их не соберу, меня казнят, а не то и уволят.": {
    "en": "If I don't collect them, they'll have me executed -- or worse, fired.",
@@ -16527,6 +16527,38 @@
   "Случилось ужасное. С моего рабочего стола сквозняком выдуло в окно пачку {W$n2{G и расшвыряло по окрестностям!": {
    "en": "Something terrible happened. A draft blew a pack of {W$n2{G off my desk and out the window, scattering it all over the neighborhood!",
    "ua": "Сталося щось жахливе. Протягом здуло з мого робочого столу пачку {W$n2{G у вікно і розкидало по околицях!"
+  },
+  "%1$s жалуется на банду грызунов, которые растащили %2$s из ее кладовки.": {
+   "en": "%1$s complains about a gang of rodents that dragged %2$s out of her pantry.",
+   "ua": "%1$s скаржиться на банду гризунів, які розтягли %2$s з її комори."
+  },
+  "Пропало довольно много, но она будет благодарна тебе, если ты принесешь ей хотя бы {Y%1$d{x штук%1$Iу|и|.": {
+   "en": "Quite a lot went missing, but she will be grateful if you bring her at least {Y%1$d{x of them.",
+   "ua": "Пропало чимало, але вона буде вдячна тобі, якщо принесеш їй хоча б {Y%1$d{x штук%1$Iу|и|."
+  },
+  "%1$s просит тебя собрать пачку %2$s, которую ветром расшвыряло по окрестностям. Всего их было {Y%3$d{x штук%3$Iу|и|.": {
+   "en": "%1$s asks you to gather up a bundle of %2$s that the wind scattered across the neighbourhood. There were {Y%3$d{x of them in all.",
+   "ua": "%1$s просить тебе зібрати пачку %2$s, яку вітром розкидало по околицях. Усього їх було {Y%3$d{x."
+  },
+  "В лаборатории %1$s взрывом расшвыряло %2$s, в количестве {Y%3$d{x штук%3$Iи||.": {
+   "en": "An explosion in the laboratory of %1$s scattered %2$s all over, {Y%3$d{x of them in all.",
+   "ua": "У лабораторії %1$s вибухом розкидало %2$s, у кількості {Y%3$d{x штук%3$Iи||."
+  },
+  "%1$s просит тебя попытаться собрать их.": {
+   "en": "%1$s asks you to try and gather them up.",
+   "ua": "%1$s просить тебе спробувати їх зібрати."
+  },
+  "Поставщик не донес %1$s орудия пыток, растеряв их на полпути от %2$s.": {
+   "en": "A supplier failed to deliver instruments of torture to %1$s, losing them halfway from %2$s.",
+   "ua": "Постачальник не доніс %1$s знаряддя тортур, розгубивши їх на півдорозі від %2$s."
+  },
+  "Всего их было {Y%1$d{x штук%1$Iи||.": {
+   "en": "There were {Y%1$d{x of them in all.",
+   "ua": "Усього їх було {Y%1$d{x."
+  },
+  "%1$s просит тебя собрать их и отдать ему.": {
+   "en": "%1$s asks you to gather them up and hand them over.",
+   "ua": "%1$s просить тебе зібрати їх і віддати йому."
   }
  },
  "plug-ins/quest/staffquest/staffquest.cpp": {
@@ -19623,6 +19655,34 @@
   "У тебя есть {Y%3$d{G мину%3$Iта|ты|т, чтобы добраться туда и узнать подробности.": {
    "en": "You have {Y%3$d{G minute%3$I|s|s to get there and find out the details.",
    "ua": "У тебе є {Y%3$d{G хвилин%3$Iа|и|, щоб дістатися туди і дізнатися подробиці."
+  },
+  "%1$s хочет отыскать кое-какие свои вещи.": {
+   "en": "%1$s wants to recover some lost belongings.",
+   "ua": "%1$s хоче відшукати деякі свої речі."
+  },
+  "Тебя с нетерпением ждут в районе %1$s.": {
+   "en": "You are eagerly awaited at %1$s.",
+   "ua": "На тебе з нетерпінням чекають у районі %1$s."
+  },
+  "Это находится в местности под названием {hh%1$s{hx.": {
+   "en": "That is in the area called {hh%1$s{hx.",
+   "ua": "Це в місцевості під назвою {hh%1$s{hx."
+  },
+  "Тобой уже доставлено {Y%1$d{x из них.": {
+   "en": "You have delivered {Y%1$d{x of them so far.",
+   "ua": "Тобою вже доставлено {Y%1$d{x з них."
+  },
+  "Заказчик ждет тебя в районе %1$s.": {
+   "en": "The client is waiting for you at %1$s.",
+   "ua": "Замовник чекає на тебе в районі %1$s."
+  },
+  "Помочь %1$s из %2$s (%3$s) отыскать свои вещи.": {
+   "en": "Help %1$s from %2$s (%3$s) recover their belongings.",
+   "ua": "Допомогти %1$s з %2$s (%3$s) відшукати свої речі."
+  },
+  "Найти %1$d штук%1$Iу|и| %2$s для %3$s из %4$s (%5$s).": {
+   "en": "Find %1$d %2$s for %3$s from %4$s (%5$s).",
+   "ua": "Знайти %1$d штук%1$Iу|и| %2$s для %3$s з %4$s (%5$s)."
   }
  },
  "plug-ins/quest/stealquest/stealquest.cpp": {

--- a/quests/LocateQuest.xml
+++ b/quests/LocateQuest.xml
@@ -15,7 +15,7 @@
           <desc l="ua">Скалка чогось блискучого зблиснула в пилюці.</desc>
           <name>осколок fragment test-tube пробирка</name>
           <name l="en">fragment shard test-tube testtube</name>
-          <name l="ua">уламок скалка пробірки</name>
+          <name l="ua">уламок скалка пробірка</name>
           <shortDesc>оскол|ок|ка|ку|ок|ком|ке пробирки</shortDesc>
           <shortDesc l="en">a fragment of a test-tube</shortDesc>
           <shortDesc l="ua">улам|ок|ка|ку|ок|ком|ку пробірки</shortDesc>
@@ -31,7 +31,7 @@
           <desc l="ua">Клаптик паперу з незрозумілими карлючками лежить тут.</desc>
           <name>обрывок рецепта shred recipe</name>
           <name l="en">shred scrap recipe</name>
-          <name l="ua">уривок клаптик рецепта</name>
+          <name l="ua">уривок клаптик рецепт</name>
           <shortDesc>обрыв|ок|ка|ку|ок|ком|ке рецепта</shortDesc>
           <shortDesc l="en">a shred of a recipe</shortDesc>
           <shortDesc l="ua">урив|ок|ка|ку|ок|ком|ку рецепта</shortDesc>
@@ -65,7 +65,7 @@
           <shortDesc l="ua">пшеничн|е|ого|ому|е|им|ому зерн|о|а|у|о|ом|і</shortDesc>
           <shortMlt>пшеничн|ые|ых|ым|ые|ыми|ых зерн|а|а|ам|а|ами|ах</shortMlt>
           <shortMlt l="en">grains of wheat</shortMlt>
-          <shortMlt l="ua">пшеничн|і|их|им|і|ими|их зерн|а|ен|ам|а|ами|ах</shortMlt>
+          <shortMlt l="ua">пшеничн|і|их|им|і|ими|их зер|на|ен|нам|на|нами|нах</shortMlt>
           <gender>n</gender>
           <material>grain</material>
         </node>
@@ -81,7 +81,7 @@
           <shortDesc l="ua">рисов|е|ого|ому|е|им|ому зерн|о|а|у|о|ом|і</shortDesc>
           <shortMlt>рисов|ые|ых|ым|ые|ыми|ых зерн|а|а|ам|а|ами|ах</shortMlt>
           <shortMlt l="en">grains of rice</shortMlt>
-          <shortMlt l="ua">рисов|і|их|им|і|ими|их зерн|а|ен|ам|а|ами|ах</shortMlt>
+          <shortMlt l="ua">рисов|і|их|им|і|ими|их зер|на|ен|нам|на|нами|нах</shortMlt>
           <gender>n</gender>
           <material>grain</material>
         </node>
@@ -157,7 +157,7 @@
           <shortDesc l="ua">секретн|е|ого|ому|е|им|ому посланн|я|я|ю|я|ям|і</shortDesc>
           <shortMlt>секретн|ые|ых|ым|ые|ыми|ых пис|ьма|ем|ьмам|ьма|ьмами|ьмах</shortMlt>
           <shortMlt l="en">secret letters</shortMlt>
-          <shortMlt l="ua">секретн|і|их|им|і|ими|их посланн|я|ь|ям|я|ями|ях</shortMlt>
+          <shortMlt l="ua">секретн|і|их|им|і|ими|их послан|ня|ь|ням|ня|нями|нях</shortMlt>
           <gender>n</gender>
           <material>paper</material>
         </node>
@@ -179,13 +179,13 @@
           <desc l="ua">Інструмент загадкової конструкції лежить тут.</desc>
           <name>приспособление орудие пытки пыток torture instrument</name>
           <name l="en">torture instrument device</name>
-          <name l="ua">знаряддя тортур пристрій</name>
+          <name l="ua">знаряддя тортури пристрій</name>
           <shortDesc>оруди|е|я|ю|е|ем|и пытки</shortDesc>
           <shortDesc l="en">an instrument of torture</shortDesc>
           <shortDesc l="ua">знарядд|я|я|ю|я|ям|і тортур</shortDesc>
           <shortMlt>оруди|я|й|ям|я|ями|ях пытки</shortMlt>
           <shortMlt l="en">instruments of torture</shortMlt>
-          <shortMlt l="ua">знарядд|я|ь|ям|я|ями|ях тортур</shortMlt>
+          <shortMlt l="ua">знаряд|дя|ь|дям|дя|дями|дях тортур</shortMlt>
           <gender>n</gender>
           <material>iron</material>
         </node>

--- a/quests/LocateQuest.xml
+++ b/quests/LocateQuest.xml
@@ -11,17 +11,33 @@
       <items>
         <node>
           <desc>Кусочек чего-то блестящего мелькнул в пыли.</desc>
+          <desc l="en">A sliver of something glittering catches the light in the dust.</desc>
+          <desc l="ua">Скалка чогось блискучого зблиснула в пилюці.</desc>
           <name>осколок fragment test-tube пробирка</name>
+          <name l="en">fragment shard test-tube testtube</name>
+          <name l="ua">уламок скалка пробірки</name>
           <shortDesc>оскол|ок|ка|ку|ок|ком|ке пробирки</shortDesc>
+          <shortDesc l="en">a fragment of a test-tube</shortDesc>
+          <shortDesc l="ua">улам|ок|ка|ку|ок|ком|ку пробірки</shortDesc>
           <shortMlt>оскол|ки|ков|кам|ки|ками|ках пробирки</shortMlt>
+          <shortMlt l="en">fragments of a test-tube</shortMlt>
+          <shortMlt l="ua">улам|ки|ків|кам|ки|ками|ках пробірки</shortMlt>
           <gender>m</gender>
           <material>glass</material>
         </node>
         <node>
           <desc>Клочок бумаги с непонятными каракулями лежит здесь.</desc>
+          <desc l="en">A scrap of paper covered in unreadable scrawl lies here.</desc>
+          <desc l="ua">Клаптик паперу з незрозумілими карлючками лежить тут.</desc>
           <name>обрывок рецепта shred recipe</name>
+          <name l="en">shred scrap recipe</name>
+          <name l="ua">уривок клаптик рецепта</name>
           <shortDesc>обрыв|ок|ка|ку|ок|ком|ке рецепта</shortDesc>
+          <shortDesc l="en">a shred of a recipe</shortDesc>
+          <shortDesc l="ua">урив|ок|ка|ку|ок|ком|ку рецепта</shortDesc>
           <shortMlt>обрыв|ки|ков|кам|ки|ками|ках рецепта</shortMlt>
+          <shortMlt l="en">shreds of a recipe</shortMlt>
+          <shortMlt l="ua">урив|ки|ків|кам|ки|ками|ках рецепта</shortMlt>
           <gender>m</gender>
           <material>paper</material>
         </node>
@@ -39,33 +55,65 @@
       <items>
         <node>
           <desc>Пшеничное зернышко втоптано в пыль.</desc>
+          <desc l="en">A grain of wheat is trodden into the dust.</desc>
+          <desc l="ua">Пшеничне зернятко втоптане в пилюку.</desc>
           <name>зерно grain пшеничное wheat</name>
+          <name l="en">grain wheat</name>
+          <name l="ua">зерно пшеничне</name>
           <shortDesc>пшеничн|ое|ого|ому|ое|ым|ом зерн|о|а|у|о|ом|е</shortDesc>
+          <shortDesc l="en">a grain of wheat</shortDesc>
+          <shortDesc l="ua">пшеничн|е|ого|ому|е|им|ому зерн|о|а|у|о|ом|і</shortDesc>
           <shortMlt>пшеничн|ые|ых|ым|ые|ыми|ых зерн|а|а|ам|а|ами|ах</shortMlt>
+          <shortMlt l="en">grains of wheat</shortMlt>
+          <shortMlt l="ua">пшеничн|і|их|им|і|ими|их зерн|а|ен|ам|а|ами|ах</shortMlt>
           <gender>n</gender>
           <material>grain</material>
         </node>
         <node>
           <desc>Рисовое зернышко втоптано в пыль.</desc>
+          <desc l="en">A grain of rice is trodden into the dust.</desc>
+          <desc l="ua">Рисове зернятко втоптане в пилюку.</desc>
           <name>зерно grain рисовое rice</name>
+          <name l="en">grain rice</name>
+          <name l="ua">зерно рисове</name>
           <shortDesc>рисов|ое|ого|ому|ое|ым|ом зерн|о|а|у|о|ом|е</shortDesc>
+          <shortDesc l="en">a grain of rice</shortDesc>
+          <shortDesc l="ua">рисов|е|ого|ому|е|им|ому зерн|о|а|у|о|ом|і</shortDesc>
           <shortMlt>рисов|ые|ых|ым|ые|ыми|ых зерн|а|а|ам|а|ами|ах</shortMlt>
+          <shortMlt l="en">grains of rice</shortMlt>
+          <shortMlt l="ua">рисов|і|их|им|і|ими|их зерн|а|ен|ам|а|ами|ах</shortMlt>
           <gender>n</gender>
           <material>grain</material>
         </node>
         <node>
           <desc>Сморщенная картофелина валяется здесь.</desc>
+          <desc l="en">A shrivelled potato lies here.</desc>
+          <desc l="ua">Зморщена картоплина валяється тут.</desc>
           <name>картофелина potato</name>
+          <name l="en">potato</name>
+          <name l="ua">картоплина картопля</name>
           <shortDesc>картофелин|а|ы|е|у|ой|е</shortDesc>
+          <shortDesc l="en">a potato</shortDesc>
+          <shortDesc l="ua">картоплин|а|и|і|у|ою|і</shortDesc>
           <shortMlt>картофел|ь|я|ю|ь|ем|е</shortMlt>
+          <shortMlt l="en">potatoes</shortMlt>
+          <shortMlt l="ua">картопл|я|і|і|ю|ею|і</shortMlt>
           <gender>f</gender>
           <material>plant</material>
         </node>
         <node>
           <desc>Сморщенное яблоко лежит на земле.</desc>
+          <desc l="en">A shrivelled apple lies on the ground.</desc>
+          <desc l="ua">Зморщене яблуко лежить на землі.</desc>
           <name>сушеное яблоко dried apple</name>
+          <name l="en">dried apple</name>
+          <name l="ua">сушене яблуко</name>
           <shortDesc>сушен|ое|ого|ому|ое|ым|ом яблок|о|а|у|о|ом|е</shortDesc>
+          <shortDesc l="en">a dried apple</shortDesc>
+          <shortDesc l="ua">сушен|е|ого|ому|е|им|ому яблук|о|а|у|о|ом|у</shortDesc>
           <shortMlt>сушен|ые|ых|ым|ые|ыми|ых яблок|и||ам|и|ами|ах</shortMlt>
+          <shortMlt l="en">dried apples</shortMlt>
+          <shortMlt l="ua">сушен|і|их|им|і|ими|их яблук|а||ам|а|ами|ах</shortMlt>
           <gender>n</gender>
           <material>plant</material>
         </node>
@@ -83,17 +131,33 @@
       <items>
         <node>
           <desc>Этот скомканный кусок бумаги выглядит ужасно важным.</desc>
+          <desc l="en">This crumpled piece of paper looks terribly important.</desc>
+          <desc l="ua">Цей зіжмаканий шматок паперу виглядає страшенно важливим.</desc>
           <name>важный документ important document</name>
+          <name l="en">important document</name>
+          <name l="ua">важливий документ</name>
           <shortDesc>важн|ый|ого|ому|ый|ым|ом документ||а|у||ом|е</shortDesc>
+          <shortDesc l="en">an important document</shortDesc>
+          <shortDesc l="ua">важлив|ий|ого|ому|ий|им|ому документ||а|у||ом|і</shortDesc>
           <shortMlt>важн|ые|ых|ым|ые|ыми|ых документ|ы|ов|ам|ы|ами|ах</shortMlt>
+          <shortMlt l="en">important documents</shortMlt>
+          <shortMlt l="ua">важлив|і|их|им|і|ими|их документ|и|ів|ам|и|ами|ах</shortMlt>
           <gender>m</gender>
           <material>paper</material>
         </node>
         <node>
           <desc>На полу лежит толстый, запечатанный сургучной печатью конверт (letter).</desc>
+          <desc l="en">A thick envelope sealed with wax lies on the floor (letter).</desc>
+          <desc l="ua">На підлозі лежить товстий, запечатаний сургучевою печаткою конверт (letter).</desc>
           <name>секретное письмо secret letter</name>
+          <name l="en">secret letter</name>
+          <name l="ua">секретне послання</name>
           <shortDesc>секретн|ое|ого|ому|ое|ым|ом письм|о|а|у|о|ом|е</shortDesc>
+          <shortDesc l="en">a secret letter</shortDesc>
+          <shortDesc l="ua">секретн|е|ого|ому|е|им|ому посланн|я|я|ю|я|ям|і</shortDesc>
           <shortMlt>секретн|ые|ых|ым|ые|ыми|ых пис|ьма|ем|ьмам|ьма|ьмами|ьмах</shortMlt>
+          <shortMlt l="en">secret letters</shortMlt>
+          <shortMlt l="ua">секретн|і|их|им|і|ими|их посланн|я|ь|ям|я|ями|ях</shortMlt>
           <gender>n</gender>
           <material>paper</material>
         </node>
@@ -111,9 +175,17 @@
       <items>
         <node>
           <desc>Инструмент загадочной конструкции лежит тут.</desc>
+          <desc l="en">An instrument of mysterious construction lies here.</desc>
+          <desc l="ua">Інструмент загадкової конструкції лежить тут.</desc>
           <name>приспособление орудие пытки пыток torture instrument</name>
+          <name l="en">torture instrument device</name>
+          <name l="ua">знаряддя тортур пристрій</name>
           <shortDesc>оруди|е|я|ю|е|ем|и пытки</shortDesc>
+          <shortDesc l="en">an instrument of torture</shortDesc>
+          <shortDesc l="ua">знарядд|я|я|ю|я|ям|і тортур</shortDesc>
           <shortMlt>оруди|я|й|ям|я|ями|ях пытки</shortMlt>
+          <shortMlt l="en">instruments of torture</shortMlt>
+          <shortMlt l="ua">знарядд|я|ь|ям|я|ями|ях тортур</shortMlt>
           <gender>n</gender>
           <material>iron</material>
         </node>


### PR DESCRIPTION
Catalog half of dreamland_code#988, plus the item data that makes it visible.

**Catalog** — 15 entries for the rewritten `info`/`shortInfo` lines and the four scenario legends. English drops the Russian counter word instead of gluing a plural onto it (the item names are already plural); Ukrainian keeps a counter where the case is unambiguous and drops it where agreement with «було» would be wrong.

Also restores the `{W...{G` highlight around the item name in the alchemist's line — both translations had dropped the pair. Balanced, so a missing highlight rather than a colour leak.

**Data** — EN and UA for all nine locate items: description, keywords, singular and plural name. **Purely additive**: every Russian node is byte-identical and keeps working, since an attribute-less Cyrillic node files under RU. Ukrainian nouns keep the gender the shared `<gender>` field declares. Pad shapes verified to match RU cell-for-cell; EN carries no pads.

Quest-level `<shortDesc>` and `<difficulty>` are still `XMLString` on `QuestRegistrator` and were left alone — their own schema change.

Must ride the same boot as dreamland_code#988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)