### PR TITLE
Name and rate all eight quests in English and Ukrainian

### DIFF
--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -2,7 +2,11 @@
 <Quest>
   <priority>1</priority>
   <shortDesc>Банду геть</shortDesc>
+  <shortDesc l="en">Down with the Gang</shortDesc>
+  <shortDesc l="ua">Банду геть</shortDesc>
   <difficulty>набор опыта</difficulty>
+  <difficulty l="en">for experience</difficulty>
+  <difficulty l="ua">набір досвіду</difficulty>
   <itemVnum>28003</itemVnum>
   <mobileVnum>28012</mobileVnum>
 

--- a/quests/ButcherQuest.xml
+++ b/quests/ButcherQuest.xml
@@ -11,5 +11,9 @@
     <node>rodent</node>
   </races>
   <shortDesc>Заказ Повара</shortDesc>
+  <shortDesc l="en">Cook's Order</shortDesc>
+  <shortDesc l="ua">Замовлення Кухаря</shortDesc>
   <difficulty>средней сложности</difficulty>
+  <difficulty l="en">moderate</difficulty>
+  <difficulty l="ua">середньої складності</difficulty>
 </Quest>

--- a/quests/HealQuest.xml
+++ b/quests/HealQuest.xml
@@ -60,5 +60,9 @@
     </node>
   </scenarios>
   <shortDesc>Лечение болезней</shortDesc>
+  <shortDesc l="en">Curing Diseases</shortDesc>
+  <shortDesc l="ua">Лікування хвороб</shortDesc>
   <difficulty>легкое</difficulty>
+  <difficulty l="en">easy</difficulty>
+  <difficulty l="ua">легке</difficulty>
 </Quest>

--- a/quests/KidnapQuest.xml
+++ b/quests/KidnapQuest.xml
@@ -569,6 +569,10 @@
     </node>
   </scenarios>
   <shortDesc>Засады и похищения</shortDesc>
+  <shortDesc l="en">Ambush and Abduction</shortDesc>
+  <shortDesc l="ua">Засідки та викрадення</shortDesc>
   <difficulty>очень трудное</difficulty>
+  <difficulty l="en">very hard</difficulty>
+  <difficulty l="ua">дуже важке</difficulty>
   <minAutoLevel>40</minAutoLevel>
 </Quest>

--- a/quests/KillQuest.xml
+++ b/quests/KillQuest.xml
@@ -2,5 +2,9 @@
 <Quest>
   <priority>10</priority>
   <shortDesc>Убийство</shortDesc>
+  <shortDesc l="en">Assassination</shortDesc>
+  <shortDesc l="ua">Вбивство</shortDesc>
   <difficulty>средней сложности</difficulty>
+  <difficulty l="en">moderate</difficulty>
+  <difficulty l="ua">середньої складності</difficulty>
 </Quest>

--- a/quests/LocateQuest.xml
+++ b/quests/LocateQuest.xml
@@ -193,5 +193,9 @@
     </node>
   </scenarios>
   <shortDesc>Сбор потерянных вещей</shortDesc>
+  <shortDesc l="en">Lost Property</shortDesc>
+  <shortDesc l="ua">Збір загублених речей</shortDesc>
   <difficulty>средней сложности</difficulty>
+  <difficulty l="en">moderate</difficulty>
+  <difficulty l="ua">середньої складності</difficulty>
 </Quest>

--- a/quests/StaffQuest.xml
+++ b/quests/StaffQuest.xml
@@ -47,5 +47,9 @@
     </node>
   </scenarios>
   <shortDesc>Поиск королевских вещей</shortDesc>
+  <shortDesc l="en">Royal Treasures</shortDesc>
+  <shortDesc l="ua">Пошук королівських речей</shortDesc>
   <difficulty>легкое</difficulty>
+  <difficulty l="en">easy</difficulty>
+  <difficulty l="ua">легке</difficulty>
 </Quest>

--- a/quests/StealQuest.xml
+++ b/quests/StealQuest.xml
@@ -11,6 +11,8 @@
   </chests>
   <priority>4</priority>
   <shortDesc>Помощь жертвам ограблений</shortDesc>
+  <shortDesc l="en">Helping Robbery Victims</shortDesc>
+  <shortDesc l="ua">Допомога пограбованим</shortDesc>
   <thiefs>
     <node>thief</node>
     <node>rogue</node>
@@ -28,4 +30,6 @@
     <node>грабитель</node>
   </thiefs>
   <difficulty>трудное</difficulty>
+  <difficulty l="en">hard</difficulty>
+  <difficulty l="ua">важке</difficulty>
 </Quest>


### PR DESCRIPTION
Data half of dreamland_code#992 — 32 new values, Russian anchors untouched.

Menu rendered in all three languages before committing; longest new name is 24 chars against the `%-25s` column, so nothing shifts. `Банду геть` stays verbatim in RU and UA (already Ukrainian, an author's joke).

🛑 **Must not reach live before dreamland_code#992.**