### PR TITLE
Translate the kidnap quest's mobs and items into English and Ukrainian

### DIFF
--- a/quests/KidnapQuest.xml
+++ b/quests/KidnapQuest.xml
@@ -13,11 +13,25 @@
 Его настоящее имя Боб Марлей. Среди похитителей детей он хорошо известен 
 под кличкой Бармалей. 
 		    </desc>
+        <desc l="en">A huge fat man with red eyes. His skin is black as night.
+He LOVES little children... with butter.
+His real name is Bob Marley. Among child-snatchers he is far better known
+by the nickname Barmaley.</desc>
+        <desc l="ua">Це здоровенний товстий мужик з червоними очима. Шкіра в нього чорна, як ніч.
+Він ДУЖЕ любить маленьких дітей... з маслом.
+Справжнє його імення -- Боб Марлей. Серед викрадачів дітей він добре відомий
+під кличкою Бармалей.</desc>
         <longDesc>Злобный Бармалей ищет маленьких детей.</longDesc>
+        <longDesc l="en">An evil Barmaley is looking for little children.</longDesc>
+        <longDesc l="ua">Злобний Бармалей шукає маленьких дітей.</longDesc>
         <name>бармалей barmaley bob marley</name>
+        <name l="en">barmaley bob marley bandit</name>
+        <name l="ua">бармалей бандит викрадач</name>
         <race>human</race>
         <sex>male</sex>
         <shortDesc>Бармале|й|я|ю|я|м|е</shortDesc>
+        <shortDesc l="en">Barmaley</shortDesc>
+        <shortDesc l="ua">Бармале|й|я|ю|я|єм|ї</shortDesc>
       </bandit>
       <kid>
         <align>null</align>
@@ -28,10 +42,29 @@
 Но сегодня она забыла бидончик дома, поэтому деньги пропила и никак не может 
 вспомнить дорогу домой.
 		    </desc>
+        <desc l="en">Before you stands a symbol of purity and innocence. She loves her mummy
+very much. Every morning at six she skips off for the milk, jingling the
+coins at the bottom of her little can and humming a cheerful song.
+Everyone around is still asleep, and she is glad of the sun and wakes them
+all with her happy ringing voice. But today she left the can at home, so
+she drank the money away and cannot for the life of her remember the way
+back.</desc>
+        <desc l="ua">Перед тобою символ чистоти й непорочності. Вона дуже любить свою мамцю.
+Щоранку о шостій вона підстрибом біжить по молоко, дзвенячи копійками на дні
+бідончика й наспівуючи веселу пісеньку. Довкола ще всі сплять, а вона радіє
+сонечку й будить усіх своїм дзвінким голосочком.
+Але сьогодні вона забула бідончик удома, тому гроші пропила і ніяк не може
+згадати дорогу додому.</desc>
         <longDesc>Пышные белые банты и накрахмаленное платьице громко плачет.</longDesc>
+        <longDesc l="en">Lush white bows and a starched little dress are crying loudly.</longDesc>
+        <longDesc l="ua">Пишні білі банти та накрохмалена сукенка гучно плачуть.</longDesc>
         <name>girl девочка дочка daughter дочурка</name>
+        <name l="en">girl daughter child</name>
+        <name l="ua">дівчинка дочка донька дитина</name>
         <sex>female</sex>
         <shortDesc>мамин|а|ой|ой|у|ой|ой дочк|а|и|е|у|ой|е</shortDesc>
+        <shortDesc l="en">mummy's little girl</shortDesc>
+        <shortDesc l="ua">мамин|а|ої|ій|у|ою|ій доч|ка|ки|ці|ку|кою|ці</shortDesc>
       </kid>
       <kings>
         <node>1501</node>
@@ -52,9 +85,15 @@
       </kings>
       <mark>
         <desc>Пустой бидон жаждет молока.</desc>
+        <desc l="en">An empty milk can thirsts for milk.</desc>
+        <desc l="ua">Порожній бідон прагне молока.</desc>
         <extra>hum</extra>
         <name>бидончик can bidon</name>
+        <name l="en">can milk churn</name>
+        <name l="ua">бідончик бідон молоко</name>
         <shortDesc>бидончи|к|ка|ком|к|ком|ке</shortDesc>
+        <shortDesc l="en">a milk can</shortDesc>
+        <shortDesc l="ua">бідончи|к|ка|ку|к|ком|ку</shortDesc>
         <wear>hold</wear>
         <gender>m</gender>
         <material>iron</material>
@@ -73,11 +112,36 @@
 комплектуется персональным пейджером для моментальной связи с другими
 супернянями в случае невозможности самостоятельного контроля ситуации.
 		    </desc>
+        <desc l="en">Do not underestimate this eternally sleepy nanny. She comes from the
+special forces of supernannies, trained to watch over and control
+excessively restless children, and to protect them as well. Her list of
+special skills includes eternal drowsiness to dull the vigilance of
+potential child-snatchers, while her excellent combat skills cover both
+hand-to-hand fighting and every kind of weapon, with particular attention
+paid to the exotic sort (stools, rolling pins and other improvised
+material). Every supernanny carries a personal pager for instant contact
+with the other supernannies should she prove unable to handle the
+situation alone.</desc>
+        <desc l="ua">Не варто недооцінювати цю вічно сонну няню. Вона родом зі спецпідрозділу
+супернянь, спеціально тренованих для нагляду й контролю за надміру
+непосидючими дітьми, а також для їхнього захисту. До переліку особливих
+навичок входить вічна сонливість для притуплення пильності потенційних
+викрадачів дітей, а відмінні бойові навички охоплюють як рукопашний бій, так
+і володіння всіма видами зброї, з особливою увагою до екзотичних (як-от
+табуретки, качалки та інший підручний матеріал). Кожна суперняня
+комплектується персональним пейджером для миттєвого виклику інших супернянь
+на випадок, коли ситуацію вже не вдається тримати самотужки.</desc>
         <longDesc>Вечно сонная няня похоже сейчас в бодрствующем состоянии.</longDesc>
+        <longDesc l="en">The eternally sleepy nanny appears to be awake right now.</longDesc>
+        <longDesc l="ua">Вічно сонна няня, схоже, зараз у стані неспання.</longDesc>
         <name>supernanny nanny суперняня няня</name>
+        <name l="en">supernanny nanny nurse</name>
+        <name l="ua">суперняня няня нянька</name>
         <race>human</race>
         <sex>female</sex>
         <shortDesc>супернян|я|и|е|ю|ей|е</shortDesc>
+        <shortDesc l="en">a supernanny</shortDesc>
+        <shortDesc l="ua">супернян|я|і|і|ю|ею|і</shortDesc>
       </bandit>
       <kid>
         <align>null</align>
@@ -86,11 +150,25 @@
 слишком далеко от дремлющей няни. Хватай его под мышку и скорее двигай
 отсюда, пока няня не проснулась.
                     </desc>
+        <desc l="en">An extremely lively little creature, ready like a young kitten to run and jump
+after every ray of sunlight. Naturally, this one has hopped much too far from
+its dozing nanny. Grab it under your arm and get moving out of here before she
+wakes up.</desc>
+        <desc l="ua">Надзвичайно жвава жива істота, готова, мов молоде котеня, бігати й стрибати
+за кожним сонячним промінчиком. Звична справа, що ця істота застрибала
+занадто далеко від дрімотної няні. Хапай його під пахву й мерщій рухай
+звідси, поки няня не прокинулась.</desc>
         <longDesc>Жизнерадостный ребенок лучится здесь улыбками.</longDesc>
+        <longDesc l="en">A cheerful child beams with smiles here.</longDesc>
+        <longDesc l="ua">Життєрадісний малюк аж світиться тут усмішками.</longDesc>
         <name>ребенок child kid</name>
+        <name l="en">child kid boy</name>
+        <name l="ua">дитина малюк хлопчик</name>
         <race>human</race>
         <sex>male</sex>
         <shortDesc>жизнерадостн|ый|ого|ому|ого|ым|ом| ребен|ок|ка|ку|ка|ком|ке|</shortDesc>
+        <shortDesc l="en">a cheerful child</shortDesc>
+        <shortDesc l="ua">життєрадісн|ий|ого|ому|ого|им|ому малю|к|ка|ку|ка|ком|ку</shortDesc>
       </kid>
       <kings>
         <node>8303</node>
@@ -122,8 +200,14 @@
       </kings>
       <mark>
         <desc>Детская лошадка - качалка пустует здесь.</desc>
+        <desc l="en">A child's rocking horse stands idle here.</desc>
+        <desc l="ua">Дитяча конячка-гойдалка стоїть тут без діла.</desc>
         <name>детская лошадка качалка child rocking horse</name>
+        <name l="en">rocking horse child toy</name>
+        <name l="ua">конячка гойдалка дитяча іграшка</name>
         <shortDesc>детск|ая|ой|ой|ую|ой|ой лошадк|а|и|е|у|ой|е - качалк|а|и|е|у|ой|е</shortDesc>
+        <shortDesc l="en">a child's rocking horse</shortDesc>
+        <shortDesc l="ua">дитяч|а|ої|ій|у|ою|ій коняч|ка|ки|ці|ку|кою|ці-гойдал|ка|ки|ці|ку|кою|ці</shortDesc>
         <gender>f</gender>
         <material>wood</material>
       </mark>
@@ -239,11 +323,25 @@
 Похоже, этот рыцарь уверен, что для борьбы со злом любые методы хороши.
 Например -- уничтожить зло, пока оно еще не в состоянии дать сдачи.
 		    </desc>
+        <desc l="en">He is cleanly shaven. His plate armour glitters in the sun.
+Nothing will stand against his faith, his honour and his dignity.
+This knight seems certain that any method is good in the fight with evil.
+For instance -- destroy evil while it is not yet able to hit back.</desc>
+        <desc l="ua">Він гладенько поголений. Його лати виблискують на сонці.
+Ніщо не встоїть перед його вірою, честю та гідністю.
+Схоже, цей лицар певен, що для боротьби зі злом усі методи годяться.
+Наприклад -- знищити зло, поки воно ще не здатне дати здачі.</desc>
         <longDesc>Рыцарь в сверкающих доспехах зыркает в поисках дракона.</longDesc>
+        <longDesc l="en">A knight in glittering armour glares about in search of a dragon.</longDesc>
+        <longDesc l="ua">Лицар у блискучих обладунках зиркає в пошуках дракона.</longDesc>
         <name>knight killer рыцарь убийца</name>
+        <name l="en">knight killer dragonslayer</name>
+        <name l="ua">лицар вбивця драконів</name>
         <race>human</race>
         <sex>male</sex>
         <shortDesc>рыцар|ь|я|ю|я|ем|е-убийц|а|ы|е|у|ей|е драконов</shortDesc>
+        <shortDesc l="en">a dragonslayer knight</shortDesc>
+        <shortDesc l="ua">лицар||я|ю|я|ем|еві-вбивц|я|і|і|ю|ею|і драконів</shortDesc>
       </bandit>
       <kid>
         <align>null</align>
@@ -252,11 +350,26 @@
 что выдает в нем очень сильный испуг. Не стоит подходить близко, если у тебя 
 нет огнетушителя!
                     </desc>
+        <desc l="en">An ordinary dragon, only ti-i-iny. It hatched not long ago and has
+found itself in a completely unfamiliar place for the first time. Smoke
+curls from the little dragon's nostrils, which gives away just how badly
+frightened it is. Better not come close unless you have a fire
+extinguisher!</desc>
+        <desc l="ua">Звичайний дракон, тільки кри-и-ихітний. Він нещодавно вилупився і вперше
+опинився в геть незнайомому місці. З ніздрів дракончика клубочиться дим,
+що виказує в ньому дуже сильний переляк. Не варто підходити близько, якщо в
+тебе немає вогнегасника!</desc>
         <longDesc>Хныкающий маленький дракончик (hatchling), похоже, потерялся..</longDesc>
+        <longDesc l="en">A whimpering little hatchling seems to have got lost..</longDesc>
+        <longDesc l="ua">Скиглявий маленький дракончик (hatchling), схоже, загубився..</longDesc>
         <name>драконенок hatchling dragon</name>
+        <name l="en">hatchling dragon baby</name>
+        <name l="ua">дракончик драконя дракон</name>
         <race>dragon</race>
         <sex>male</sex>
         <shortDesc>драконен|ок|ка|ку|ка|ком|ке</shortDesc>
+        <shortDesc l="en">a dragon hatchling</shortDesc>
+        <shortDesc l="ua">дракончи|к|ка|ку|ка|ком|ку</shortDesc>
       </kid>
       <kings>
         <node>2205</node>
@@ -274,9 +387,15 @@
       </kings>
       <mark>
         <desc>Безопасная игрушка маленького дракона лежит здесь.</desc>
+        <desc l="en">A safe toy for a little dragon lies here.</desc>
+        <desc l="ua">Безпечна іграшка маленького дракона лежить тут.</desc>
         <extra>glow</extra>
         <name>огнетушитель fire extinguisher</name>
+        <name l="en">fire extinguisher</name>
+        <name l="ua">вогнегасник гасник</name>
         <shortDesc>огнетушител|ь|я|ю|ь|ем|е</shortDesc>
+        <shortDesc l="en">a fire extinguisher</shortDesc>
+        <shortDesc l="ua">вогнегасни|к|ка|ку|к|ком|ку</shortDesc>
         <wear>hold</wear>
         <gender>m</gender>
         <material>iron</material>
@@ -290,11 +409,25 @@
 что он не оставлЯл оружие с тех пор как родилсЯ.
 Он гатов помериться силами скаждым!
 		    </desc>
+        <desc l="en">You see infront of youself a short, musculer man.
+The scars all over his body proov
+that he aint put down a weapon since the day he was borned.
+He is redy to mesure strenth with anywon!</desc>
+        <desc l="ua">Ти бачеш перед сабою невисокково, мускулістово чоловіка.
+Кілька шрамів на його тілі доказують,
+що він не покидав зброю з тіх пір, як народивсЯ.
+Він гатовий помірятись силами зкожним!</desc>
         <longDesc>Свирепый войн ищет, из кого бы сделать себе подобного.</longDesc>
+        <longDesc l="en">A feirce worrior is looking for someone to make into his own likeness.</longDesc>
+        <longDesc l="ua">Лютий войн шукає, з кого б зробити сабі подібного.</longDesc>
         <name>воин warrior</name>
+        <name l="en">warrior fighter</name>
+        <name l="ua">воїн войн вояка</name>
         <race>human</race>
         <sex>male</sex>
         <shortDesc>Свиреп|ый|ого|ому|ого|ым|ом вои|н|на|ну|на|ном|не</shortDesc>
+        <shortDesc l="en">a fierce warrior</shortDesc>
+        <shortDesc l="ua">Лют|ий|ого|ому|ого|им|ому во|їн|їна|їну|їна|їном|їні</shortDesc>
       </bandit>
       <kid>
         <align>null</align>
@@ -303,10 +436,24 @@
 Однако, шальной огонек в его глазах говорит о том, что их обладатель
 неприемлет муштру и любое проявление порядка и субординации.
 		    </desc>
+        <desc l="en">A typical young punk of conscription age. One look tells you he is fit
+for active service. Tall, muscular. Yet the reckless spark in his eyes
+says that their owner will not put up with drill, nor with any other
+display of order and subordination.</desc>
+        <desc l="ua">Типовий шибеник призовного віку. З першого погляду
+зрозуміло, що до стройової служби він придатний. Високий, мускулистий.
+Однак навіжений вогник у його очах каже, що їхній власник
+не терпить муштри й будь-якого прояву порядку та субординації.</desc>
         <longDesc>Сорванец пытается отыскать рекра Хаоса.</longDesc>
+        <longDesc l="en">An urchin is trying to track down a recruter of Chaos.</longDesc>
+        <longDesc l="ua">Шибеник намагається розшукати рекра Хаосу.</longDesc>
         <name>сорванец urchin сын</name>
+        <name l="en">urchin son lad</name>
+        <name l="ua">шибеник сорванець син</name>
         <sex>male</sex>
         <shortDesc>сорван|ец|ца|цу|ца|цом|це</shortDesc>
+        <shortDesc l="en">an urchin</shortDesc>
+        <shortDesc l="ua">шибени|к|ка|ку|ка|ком|ку</shortDesc>
       </kid>
       <kings>
         <node>1501</node>
@@ -327,8 +474,14 @@
       </kings>
       <mark>
         <desc>Вожделенная бумажка (white ticket) пылится здесь.</desc>
+        <desc l="en">A much-coveted slip of paper (a white ticket) gathers dust here.</desc>
+        <desc l="ua">Жадана папірчина (white ticket) припадає тут пилом.</desc>
         <name>белый билет white ticket</name>
+        <name l="en">white ticket paper</name>
+        <name l="ua">білий квиток білет папірець</name>
         <shortDesc>бел|ый|ого|ому|ый|ым|ом биле|т|та|ту|т|том|те</shortDesc>
+        <shortDesc l="en">a white ticket</shortDesc>
+        <shortDesc l="ua">біл|ий|ого|ому|ий|им|ому квит|ок|ка|ку|ок|ком|ку</shortDesc>
         <wear>take hold</wear>
         <gender>m</gender>
         <material>paper</material>
@@ -345,11 +498,32 @@
 ты сегодня успел натворить. Однако спокойствие, главное спокойствие и
 самоуверенность... нос отворачивается от тебя.
 		    </desc>
+        <desc l="en">A typical smug mug in an armoured case daubed with state coats of arms;
+the mug practically has "go on, take a swing at me and we will work you
+over with the whole barracks" written across it in capital letters. The
+nose on that mug is very busy, it is sniffing out the traces of crime.
+With horror you notice that one of the nostrils is aimed your way, and
+everything you managed to get up to today flashes through your head like
+a kaleidoscope. Still, calm, the main thing is calm and
+self-assurance... the nose turns away from you.</desc>
+        <desc l="ua">Типова нахабна пика в броньованому футлярі, розмальованому державними
+гербами, на пиці ну прямо великими літерами написано "ну давай, зацідь мені
+і ми відметелимо тебе всією казармою". Ніс на цій пиці дуже зайнятий, він
+винюхує сліди злочинності. Ти з жахом помічаєш, що одна з ніздрів
+спрямована в твій бік, у голові калейдоскопом мелькають справи, які
+ти сьогодні встиг накоїти. Однак спокій, головне спокій і
+самовпевненість... ніс відвертається від тебе.</desc>
         <longDesc>Доблестный страж закона ищет клиентов для своего заведения.</longDesc>
+        <longDesc l="en">A valiant guardian of the law is looking for clients for his establishment.</longDesc>
+        <longDesc l="ua">Доблесний страж закону шукає клієнтів для свого закладу.</longDesc>
         <name>guard страж</name>
+        <name l="en">guard law lawman cop</name>
+        <name l="ua">страж закону вартовий</name>
         <race>human</race>
         <sex>male</sex>
         <shortDesc>страж||а|у|а|ем|е| закона</shortDesc>
+        <shortDesc l="en">a guardian of the law</shortDesc>
+        <shortDesc l="ua">страж||а|у|а|ем|еві закону</shortDesc>
       </bandit>
       <kid>
         <align>null</align>
@@ -360,10 +534,28 @@
 тип ухмыляется жуткой улыбкой, от которой у всякого здравомыслящего существа
 появляется невиданная прыть в ногах.
                     </desc>
+        <desc l="en">A grim character. Deep-set little eyes have latched onto you like a pair of
+ticks in a death grip. You feel an unpleasant chill run down your spine in a
+wave. "With one like this it is dangerous not just to turn your back, but to
+blink at all" -- the thought flickers past. Sensing your uncertainty, the
+character smirks a ghastly smile, the kind that lends any sensible creature an
+unheard-of turn of speed in the legs.</desc>
+        <desc l="ua">Похмурий тип. Глибоко посаджені дрібні очиці, наче два кліщі, вчепилися в
+тебе мертвою хваткою. Ти відчуваєш неприємний холодок, що хвилею пробіг
+по спині. "До такого не те що спиною повертатися небезпечно, а й від кліпання
+краще утриматись" -- майне думка. Відчувши твою невпевненість, цей
+тип вишкіряється моторошною посмішкою, від якої у всякої притомної істоти
+береться небачена прудкість у ногах.</desc>
         <longDesc>Хмурый урка бросает на тебя недобрый взгляд.</longDesc>
+        <longDesc l="en">A sullen crook throws you an unkind look.</longDesc>
+        <longDesc l="ua">Похмурий урка кидає на тебе недобрий погляд.</longDesc>
         <name>урка urka</name>
+        <name l="en">crook urka thug</name>
+        <name l="ua">урка блатний зек</name>
         <sex>male</sex>
         <shortDesc>урк|а|и|е|у|ой|е</shortDesc>
+        <shortDesc l="en">a crook</shortDesc>
+        <shortDesc l="ua">ур|ка|ки|ці|ку|кою|ці</shortDesc>
       </kid>
       <kings>
         <node>14030</node>
@@ -384,9 +576,15 @@
       </kings>
       <mark>
         <desc>Поддельный паспорт лежит здесь.</desc>
+        <desc l="en">A forged passport lies here.</desc>
+        <desc l="ua">Підроблений паспорт лежить тут.</desc>
         <extra>dark</extra>
         <name>паспорт passport fake</name>
+        <name l="en">passport fake forged</name>
+        <name l="ua">паспорт підроблений фальшивка</name>
         <shortDesc>паспорт||а|у||ом|е</shortDesc>
+        <shortDesc l="en">a forged passport</shortDesc>
+        <shortDesc l="ua">паспорт||а|у||ом|і</shortDesc>
         <wear>hold</wear>
         <gender>m</gender>
         <material>paper</material>
@@ -464,11 +662,32 @@
 ты сегодня успел натворить. Однако спокойствие, главное спокойствие и
 самоуверенность... нос отворачивается от тебя.
 		    </desc>
+        <desc l="en">A typical smug mug in an armoured case daubed with state coats of arms;
+the mug practically has "go on, take a swing at me and we will work you
+over with the whole barracks" written across it in capital letters. The
+nose on that mug is very busy, it is sniffing out the traces of crime.
+With horror you notice that one of the nostrils is aimed your way, and
+everything you managed to get up to today flashes through your head like
+a kaleidoscope. Still, calm, the main thing is calm and
+self-assurance... the nose turns away from you.</desc>
+        <desc l="ua">Типова нахабна пика в броньованому футлярі, розмальованому державними
+гербами, на пиці ну прямо великими літерами написано "ну давай, зацідь мені
+і ми відметелимо тебе всією казармою". Ніс на цій пиці дуже зайнятий, він
+винюхує сліди злочинності. Ти з жахом помічаєш, що одна з ніздрів
+спрямована в твій бік, у голові калейдоскопом мелькають справи, які
+ти сьогодні встиг накоїти. Однак спокій, головне спокій і
+самовпевненість... ніс відвертається від тебе.</desc>
         <longDesc>Доблестный страж закона ищет клиентов для своего заведения.</longDesc>
+        <longDesc l="en">A valiant guardian of the law is looking for clients for his establishment.</longDesc>
+        <longDesc l="ua">Доблесний страж закону шукає клієнтів для свого закладу.</longDesc>
         <name>guard страж</name>
+        <name l="en">guard law lawman cop</name>
+        <name l="ua">страж закону вартовий</name>
         <race>human</race>
         <sex>male</sex>
         <shortDesc>страж||а|у|а|ем|е| закона</shortDesc>
+        <shortDesc l="en">a guardian of the law</shortDesc>
+        <shortDesc l="ua">страж||а|у|а|ем|еві закону</shortDesc>
       </bandit>
       <kid>
         <align>null</align>
@@ -479,10 +698,28 @@
 тип ухмыляется жуткой улыбкой, от которой у всякого здравомыслящего существа
 появляется невиданная прыть в ногах.
                     </desc>
+        <desc l="en">A grim character. Deep-set little eyes have latched onto you like a pair of
+ticks in a death grip. You feel an unpleasant chill run down your spine in a
+wave. "With one like this it is dangerous not just to turn your back, but to
+blink at all" -- the thought flickers past. Sensing your uncertainty, the
+character smirks a ghastly smile, the kind that lends any sensible creature an
+unheard-of turn of speed in the legs.</desc>
+        <desc l="ua">Похмурий тип. Глибоко посаджені дрібні очиці, наче два кліщі, вчепилися в
+тебе мертвою хваткою. Ти відчуваєш неприємний холодок, що хвилею пробіг
+по спині. "До такого не те що спиною повертатися небезпечно, а й від кліпання
+краще утриматись" -- майне думка. Відчувши твою невпевненість, цей
+тип вишкіряється моторошною посмішкою, від якої у всякої притомної істоти
+береться небачена прудкість у ногах.</desc>
         <longDesc>Хмурый урка бросает на тебя недобрый взгляд.</longDesc>
+        <longDesc l="en">A sullen crook throws you an unkind look.</longDesc>
+        <longDesc l="ua">Похмурий урка кидає на тебе недобрий погляд.</longDesc>
         <name>урка urka</name>
+        <name l="en">crook urka thug</name>
+        <name l="ua">урка блатний зек</name>
         <sex>male</sex>
         <shortDesc>урк|а|и|е|у|ой|е</shortDesc>
+        <shortDesc l="en">a crook</shortDesc>
+        <shortDesc l="ua">ур|ка|ки|ці|ку|кою|ці</shortDesc>
       </kid>
       <kings>
         <node>13246</node>
@@ -498,9 +735,15 @@
       </kings>
       <mark>
         <desc>Поддельный паспорт лежит здесь.</desc>
+        <desc l="en">A forged passport lies here.</desc>
+        <desc l="ua">Підроблений паспорт лежить тут.</desc>
         <extra>dark</extra>
         <name>паспорт passport fake</name>
+        <name l="en">passport fake forged</name>
+        <name l="ua">паспорт підроблений фальшивка</name>
         <shortDesc>паспорт||а|у||ом|е</shortDesc>
+        <shortDesc l="en">a forged passport</shortDesc>
+        <shortDesc l="ua">паспорт||а|у||ом|і</shortDesc>
         <wear>hold</wear>
         <gender>m</gender>
         <material>paper</material>

--- a/quests/KidnapQuest.xml
+++ b/quests/KidnapQuest.xml
@@ -22,7 +22,7 @@ by the nickname Barmaley.</desc>
 Справжнє його імення -- Боб Марлей. Серед викрадачів дітей він добре відомий
 під кличкою Бармалей.</desc>
         <longDesc>Злобный Бармалей ищет маленьких детей.</longDesc>
-        <longDesc l="en">An evil Barmaley is looking for little children.</longDesc>
+        <longDesc l="en">Evil Barmaley is looking for little children.</longDesc>
         <longDesc l="ua">Злобний Бармалей шукає маленьких дітей.</longDesc>
         <name>бармалей barmaley bob marley</name>
         <name l="en">barmaley bob marley bandit</name>
@@ -155,8 +155,8 @@ after every ray of sunlight. Naturally, this one has hopped much too far from
 its dozing nanny. Grab it under your arm and get moving out of here before she
 wakes up.</desc>
         <desc l="ua">Надзвичайно жвава жива істота, готова, мов молоде котеня, бігати й стрибати
-за кожним сонячним промінчиком. Звична справа, що ця істота застрибала
-занадто далеко від дрімотної няні. Хапай його під пахву й мерщій рухай
+за кожним сонячним промінчиком. Звична справа, що ця істота пострибала
+геть далеко від дрімотної няні. Хапай її під пахву й мерщій рухай
 звідси, поки няня не прокинулась.</desc>
         <longDesc>Жизнерадостный ребенок лучится здесь улыбками.</longDesc>
         <longDesc l="en">A cheerful child beams with smiles here.</longDesc>
@@ -325,7 +325,7 @@ wakes up.</desc>
 		    </desc>
         <desc l="en">He is cleanly shaven. His plate armour glitters in the sun.
 Nothing will stand against his faith, his honour and his dignity.
-This knight seems certain that any method is good in the fight with evil.
+This knight seems certain that any method is good in the fight against evil.
 For instance -- destroy evil while it is not yet able to hit back.</desc>
         <desc l="ua">Він гладенько поголений. Його лати виблискують на сонці.
 Ніщо не встоїть перед його вірою, честю та гідністю.


### PR DESCRIPTION
Every bandit, kid and item the kidnap quest spawns rendered Russian to every reader. Not a fallback failure: `QuestMobileAppearence` and `QuestItemAppearence` held single values, so `getForLang()` had nothing to fall back to.

Those fields became `XMLMultiString` in #982 (live since reboot #63), so this is **data only** -- 66 `l="en"` / `l="ua"` siblings across the six scenarios. **243 insertions, 0 deletions, 0 Russian bytes changed.**

### Checks run

- Round-trip parse against the pre-edit file: 0 pre-existing values altered, 132 new values (66 EN + 66 UA).
- All 18 Ukrainian `shortDesc` pads rendered through a port of `Flexer::flexAux` and read as words in all six cases.
- No English `shortDesc` carries a `|`.
- Every new character encodes in KOI8-U; no `--`-class punctuation strays, no guillemets, no XML entities in element text.
- No new line exceeds 78 characters (the existing Russian maximum).

### Content notes

- Russian keyword lists keep every token. Targeting joins all language slots, so the new lists only grow what a player can type.
- The urchin scenario's warrior cannot spell, on purpose -- English and Ukrainian keep him illiterate.
- `urka` and `urka2` carry byte-identical data and get the same translation.
- Ukrainian avoids the modifier apostrophe; its engine handling is still unsettled.

### Deploy

Loads at boot. No `plug reload most` before the next reboot.