### PR TITLE
Translate the big quest's gang mobs and items into English and Ukrainian

### DIFF
--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -493,7 +493,7 @@ to the masses the knowledge of the one correct way of life.</desc>
             <sex>female</sex>
             <shortDesc>ханж|а|и|е|у|ой|е</shortDesc>
             <shortDesc l="en">a bigot</shortDesc>
-            <shortDesc l="ua">ханж|а|і|і|у|ою|і</shortDesc>
+            <shortDesc l="ua">ханж|а|і|і|у|ею|і</shortDesc>
             <race>arial</race>
         </node>
         <node>
@@ -516,7 +516,7 @@ to the masses the knowledge of the one correct way of life.</desc>
             <sex>female</sex>
             <shortDesc>ханж|а|и|е|у|ой|е</shortDesc>
             <shortDesc l="en">a bigot</shortDesc>
-            <shortDesc l="ua">ханж|а|і|і|у|ою|і</shortDesc>
+            <shortDesc l="ua">ханж|а|і|і|у|ею|і</shortDesc>
             <race>arial</race>
         </node>
         <node>
@@ -539,7 +539,7 @@ to the masses the knowledge of the one correct way of life.</desc>
             <sex>male</sex>
             <shortDesc>ханж|а|и|е|у|ой|е</shortDesc>
             <shortDesc l="en">a bigot</shortDesc>
-            <shortDesc l="ua">ханж|а|і|і|у|ою|і</shortDesc>
+            <shortDesc l="ua">ханж|а|і|і|у|ею|і</shortDesc>
             <race>arial</race>
         </node>
       </mobiles>

--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -15,8 +15,14 @@
       <priority>2</priority>
       <item>
         <desc>Частичка окружающей тебя реальности.</desc>
+        <desc l="en">A tiny piece of the reality around you.</desc>
+        <desc l="ua">Часточка реальності, що тебе оточує.</desc>
         <name>piece fabric space частичка кусочек бытия</name>
+        <name l="en">piece fabric space being</name>
+        <name l="ua">часточка шматочок буття тканина</name>
         <shortDesc>кусоч|ек|ка|ку|ек|ком|ке бытия</shortDesc>
+        <shortDesc l="en">a piece of being</shortDesc>
+        <shortDesc l="ua">шматоч|ок|ка|ку|ок|ком|ку буття</shortDesc>
         <gender>m</gender>
         <material>ethereal</material>
       </item>
@@ -25,10 +31,20 @@
             <desc>Эта бага настолько массивна, что вызывает искажение пространственно-временного континуума.
 Уничтожь ее побыстрее, пока не случилось что-то непоправимое.
     </desc>
+            <desc l="en">This bug is so massive that it warps the space-time continuum.
+Destroy it quickly, before something irreparable happens.</desc>
+            <desc l="ua">Ця бага настільки масивна, що спричиняє викривлення просторово-часового
+континууму. Знищ її швидше, доки не сталося чогось непоправного.</desc>
             <longDesc>Толстая бага искривляет здесь пространство.</longDesc>
+            <longDesc l="en">A fat bug is warping space here.</longDesc>
+            <longDesc l="ua">Товста бага викривляє тут простір.</longDesc>
             <name>bug fat anomaly аномалия бага толстая</name>
+            <name l="en">bug fat anomaly</name>
+            <name l="ua">бага товста аномалія</name>
             <sex>female</sex>
             <shortDesc>толст|ая|ой|ой|ую|ой|ой баг|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a fat bug</shortDesc>
+            <shortDesc l="ua">товст|а|ої|ій|у|ою|ій ба|га|ги|зі|гу|гою|зі</shortDesc>
             <race>unique</race>
         </node>
         <node>
@@ -36,20 +52,42 @@
 и пожирает ее. Теперь понятно, кто прогрыз дыру и вывел этих тварей наружу.
 Скорее убей ее!
     </desc>
+            <desc l="en">An impressive mouth with two rows of the sharpest teeth tears the fabric of
+creation and devours it. Now it is clear who gnawed the hole and let these
+creatures out. Kill it, quickly!</desc>
+            <desc l="ua">Вражаючий рот із двома рядами найгостріших зубів рве тканину світобудови
+і пожирає її. Тепер ясно, хто прогриз дірку й випустив цих тварюк назовні.
+Мерщій убий її!</desc>
             <longDesc>Крашащая бага острыми зубами подгрызает основы мироздания.</longDesc>
+            <longDesc l="en">A crashing bug is chewing through the foundations of creation.</longDesc>
+            <longDesc l="ua">Крашуча бага гострими зубами підгризає основи світобудови.</longDesc>
             <name>bug crash anomaly аномалия бага крашащая</name>
+            <name l="en">bug crash anomaly</name>
+            <name l="ua">бага крашуча аномалія</name>
             <sex>female</sex>
             <shortDesc>крашащ|ая|ей|ей|ую|ей|ей баг|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a crashing bug</shortDesc>
+            <shortDesc l="ua">крашуч|а|ої|ій|у|ою|ій ба|га|ги|зі|гу|гою|зі</shortDesc>
             <race>unique</race>
         </node>
         <node>
             <desc>Ты не успеваешь моргнуть, как на ее месте появляется еще две,
 потом их уже четверо, через мгновение -- восемь... Это необходимо остановить!
     </desc>
+            <desc l="en">You do not have time to blink before two more appear in its place,
+then there are four, and a moment later eight... This has to be stopped!</desc>
+            <desc l="ua">Ти не встигаєш кліпнути, як на її місці постає ще дві,
+потім їх уже четверо, за мить -- вісім... Це треба зупинити!</desc>
             <longDesc>Ксерящая бага размножается делением здесь.</longDesc>
+            <longDesc l="en">A xeroxing bug is multiplying by division here.</longDesc>
+            <longDesc l="ua">Ксеруюча бага розмножується тут поділом.</longDesc>
             <name>bug xerox anomaly аномалия бага ксерящая</name>
+            <name l="en">bug xerox anomaly copy</name>
+            <name l="ua">бага ксеруюча аномалія</name>
             <sex>female</sex>
             <shortDesc>ксерящ|ая|ей|ей|ую|ей|ей баг|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a xeroxing bug</shortDesc>
+            <shortDesc l="ua">ксеруюч|а|ої|ій|у|ою|ій ба|га|ги|зі|гу|гою|зі</shortDesc>
             <race>unique</race>
         </node>
       </mobiles>
@@ -69,8 +107,14 @@
       <priority>4</priority>
       <item>
         <desc>Смятая бумажка содержит куплет какой-то песни.</desc>
+        <desc l="en">A crumpled scrap of paper carries a verse of some song.</desc>
+        <desc l="ua">Пожмакана папірчина містить куплет якоїсь пісні.</desc>
         <name>verse куплет бумажка</name>
+        <name l="en">verse paper scrap song</name>
+        <name l="ua">куплет папірчина пісня</name>
         <shortDesc>куплет||а|у||ом|е панк-молебна</shortDesc>
+        <shortDesc l="en">a verse of a punk prayer</shortDesc>
+        <shortDesc l="ua">куплет||а|у||ом|і панк-молебню</shortDesc>
         <gender>m</gender>
         <material>paper</material>
       </item>
@@ -79,20 +123,44 @@
             <desc>Голову хулиганки украшает ярко-зеленый ирокез, а на теле надета майка с непонятной символикой.
 Ты не видишь ничего особенно оскорбительного, но раз тебя послали -- надо выполнять!
 </desc>
+            <desc l="en">A bright green mohawk crowns the hooligan's head, and she wears a t-shirt
+with symbols you cannot make out. You see nothing especially offensive about
+her, but since you were sent -- the job is the job!</desc>
+            <desc l="ua">Голову хуліганки прикрашає яскраво-зелений ірокез, а на тілі -- майка
+з незрозумілою символікою. Ти не бачиш нічого аж такого образливого,
+але раз послали -- треба виконувати!</desc>
             <longDesc>Хулиганка (punk girl) подыскивает подходящий храм, чтобы осквернить его.</longDesc>
+            <longDesc l="en">A punk girl is picking out a suitable temple to defile.</longDesc>
+            <longDesc l="ua">Хуліганка (punk girl) підшукує відповідний храм, щоб осквернити його.</longDesc>
             <name>punk girl хулиганка</name>
+            <name l="en">punk girl hooligan</name>
+            <name l="ua">хуліганка панкерка дівчина</name>
             <sex>female</sex>
             <shortDesc>хулиганк|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a punk girl</shortDesc>
+            <shortDesc l="ua">хуліган|ка|ки|ці|ку|кою|ці</shortDesc>
             <race>draconian</race>
         </node>
         <node>
             <desc>Голову хулигана украшает ярко-зеленый ирокез, а на теле надета майка с непонятной символикой.
 Ты не видишь ничего особенно оскорбительного, но раз тебя послали - надо выполнять!
 </desc>
+            <desc l="en">A bright green mohawk crowns the hooligan's head, and he wears a t-shirt
+with symbols you cannot make out. You see nothing especially offensive about
+him, but since you were sent -- the job is the job!</desc>
+            <desc l="ua">Голову хулігана прикрашає яскраво-зелений ірокез, а на тілі -- майка
+з незрозумілою символікою. Ти не бачиш нічого аж такого образливого,
+але раз послали -- треба виконувати!</desc>
             <longDesc>Хулиган подыскивает подходящий храм, чтобы осквернить его.</longDesc>
+            <longDesc l="en">A punk is picking out a suitable temple to defile.</longDesc>
+            <longDesc l="ua">Хуліган підшукує відповідний храм, щоб осквернити його.</longDesc>
             <name>punk хулиган</name>
+            <name l="en">punk hooligan</name>
+            <name l="ua">хуліган панкер</name>
             <sex>male</sex>
             <shortDesc>хулиган||а|у|а|ом|е</shortDesc>
+            <shortDesc l="en">a punk</shortDesc>
+            <shortDesc l="ua">хуліган||а|у|а|ом|ові</shortDesc>
             <race>draconian</race>
         </node>
       </mobiles>
@@ -117,8 +185,14 @@
       <priority>4</priority>
       <item>
         <desc>Фотография изображает Валькирию при весьма интересных обстоятельствах.</desc>
+        <desc l="en">The photograph shows the Valkyrie in highly interesting circumstances.</desc>
+        <desc l="ua">Світлина зображує Валькірію за вельми цікавих обставин.</desc>
         <name>photo nu фото ню-фото</name>
+        <name l="en">photo nude picture</name>
+        <name l="ua">фото світлина ню-фото</name>
         <shortDesc>ню-фото Валькирии</shortDesc>
+        <shortDesc l="en">a nude photo of the Valkyrie</shortDesc>
+        <shortDesc l="ua">ню-фото Валькірії</shortDesc>
         <gender>n</gender>
         <material>paper</material>
       </item>
@@ -127,20 +201,40 @@
             <desc>Маленькая, но очень проворная феечка с радужными крыльями не пропустит
 ни одного интересного "кадра" -- все они рано или поздно окажутся в ее альбоме.
 </desc>
+            <desc l="en">A small but very nimble little faery with rainbow wings will not miss a
+single interesting "shot" -- sooner or later they all end up in her album.</desc>
+            <desc l="ua">Маленька, але дуже прудка феєчка з райдужними крилами не пропустить
+жодного цікавого "кадру" -- усі вони рано чи пізно опиняться в її альбомі.</desc>
             <longDesc>Папарацци делает быструю зарисовку с натуры.</longDesc>
+            <longDesc l="en">A paparazzo is making a quick sketch from life.</longDesc>
+            <longDesc l="ua">Папараці робить швидкий начерк з натури.</longDesc>
             <name>reporter paparazzi папарацци журналист</name>
+            <name l="en">reporter paparazzi photographer</name>
+            <name l="ua">папараці журналістка репортерка</name>
             <sex>female</sex>
             <shortDesc>папарацци</shortDesc>
+            <shortDesc l="en">a paparazzo</shortDesc>
+            <shortDesc l="ua">папараці</shortDesc>
             <race>faery</race>
         </node>
         <node>
             <desc>Упитанный хоббит с волосатыми ногами вооружен блокнотом
 и ручкой. Он пытливо вглядывается в тебя, но быстро теряет интерес.
 </desc>
+            <desc l="en">A well-fed hobbit with hairy feet is armed with a notebook
+and a pen. He peers at you keenly, but quickly loses interest.</desc>
+            <desc l="ua">Вгодований гобіт з волохатими ногами озброєний записником
+і ручкою. Він допитливо вдивляється в тебе, але швидко втрачає інтерес.</desc>
             <longDesc>Пронырливый журналист выискивает очередную сенсацию.</longDesc>
+            <longDesc l="en">A pushy reporter is sniffing out his next sensation.</longDesc>
+            <longDesc l="ua">Пронозливий журналіст вишукує чергову сенсацію.</longDesc>
             <name>reporter журналист</name>
+            <name l="en">reporter journalist</name>
+            <name l="ua">журналіст репортер</name>
             <sex>male</sex>
             <shortDesc>журналист||а|у|а|ом|е</shortDesc>
+            <shortDesc l="en">a reporter</shortDesc>
+            <shortDesc l="ua">журналіст||а|у|а|ом|ові</shortDesc>
             <race>hobbit</race>
         </node>
       </mobiles>
@@ -158,17 +252,31 @@
         <node>
             <desc>Тебя одолевает желание прикончить его еще до того, как он откроет рот.
 </desc>
+            <desc l="en">You are overcome by the urge to finish him off before he even opens his mouth.</desc>
+            <desc l="ua">Тебе долає бажання прикінчити його ще до того, як він розтулить рота.</desc>
             <longDesc>Проповедник пытается поговорить с тобой о религии.</longDesc>
+            <longDesc l="en">A preacher is trying to talk to you about religion.</longDesc>
+            <longDesc l="ua">Проповідник намагається поговорити з тобою про релігію.</longDesc>
             <name>preacher проповедник</name>
+            <name l="en">preacher missionary</name>
+            <name l="ua">проповідник місіонер</name>
             <sex>male</sex>
             <shortDesc>проповедник||а|у|а|ом|е</shortDesc>
+            <shortDesc l="en">a preacher</shortDesc>
+            <shortDesc l="ua">проповідни|к|ка|ку|ка|ком|кові</shortDesc>
             <race>human</race>
         </node>
       </mobiles>
       <item>
         <desc>Страница вырвана из какой-то священной книги.</desc>
+        <desc l="en">The page has been torn out of some holy book.</desc>
+        <desc l="ua">Сторінка вирвана з якоїсь священної книги.</desc>
         <name>page holy text страница текст</name>
+        <name l="en">page holy text scripture</name>
+        <name l="ua">сторінка текст священний</name>
         <shortDesc>страниц|а|ы|е|у|ей|е священного текста</shortDesc>
+        <shortDesc l="en">a page of a holy text</shortDesc>
+        <shortDesc l="ua">сторін|ка|ки|ці|ку|кою|ці священного тексту</shortDesc>
         <gender>f</gender>
         <material>paper</material>
       </item>
@@ -184,8 +292,14 @@
       <priority>4</priority>
       <item>
         <desc>Струна валяется здесь, жертва излишнего музыкального рвения.</desc>
+        <desc l="en">A string lies here, a victim of excessive musical zeal.</desc>
+        <desc l="ua">Струна валяється тут, жертва надмірного музичного завзяття.</desc>
         <name>broken string порванная струна</name>
+        <name l="en">broken string</name>
+        <name l="ua">струна порвана</name>
         <shortDesc>порванн|ая|ой|ой|ую|ой|ой струн|а|ы|е|у|ой|е</shortDesc>
+        <shortDesc l="en">a broken string</shortDesc>
+        <shortDesc l="ua">порван|а|ої|ій|у|ою|ій струн|а|и|і|у|ою|і</shortDesc>
         <gender>f</gender>
         <material>fiber</material>
       </item>
@@ -194,20 +308,40 @@
             <desc>Девица с длинными нечесаными волосами и в балахоне то ли поет,
 то ли делает домашнее задание по сольфеджио. 
 </desc>
+            <desc l="en">A girl with long uncombed hair and a shapeless robe is either singing
+or doing her solfeggio homework.</desc>
+            <desc l="ua">Дівиця з довгим нечесаним волоссям і в балахоні чи то співає,
+чи то робить домашнє завдання із сольфеджіо.</desc>
             <longDesc>Певица выводит ртом очередную руладу.</longDesc>
+            <longDesc l="en">A singer is working her mouth through another roulade.</longDesc>
+            <longDesc l="ua">Співачка виводить ротом чергову руладу.</longDesc>
             <name>musician singer певица музыкант</name>
+            <name l="en">musician singer</name>
+            <name l="ua">співачка музикантка дівиця</name>
             <sex>female</sex>
             <shortDesc>певиц|а|ы|е|у|ей|е</shortDesc>
+            <shortDesc l="en">a singer</shortDesc>
+            <shortDesc l="ua">співач|ка|ки|ці|ку|кою|ці</shortDesc>
             <race>half-elf</race>
         </node>
         <node>
             <desc>Поглощенный своей гитарой, он не видит ничего вокруг себя, и, зажмурившись,
 производит на свет очередное отвратительное брынь-брынь.
 </desc>
+            <desc l="en">Absorbed in his guitar, he sees nothing around him and, screwing his eyes
+shut, brings another revolting twang into the world.</desc>
+            <desc l="ua">Поглинутий своєю гітарою, він не бачить нічого довкола і, замружившись,
+видає на світ чергове огидне бринь-бринь.</desc>
             <longDesc>Музыкант берет на редкость фальшивый аккорд.</longDesc>
+            <longDesc l="en">A musician strikes a chord of rare falseness.</longDesc>
+            <longDesc l="ua">Музикант бере на диво фальшивий акорд.</longDesc>
             <name>musician музыкант</name>
+            <name l="en">musician guitarist</name>
+            <name l="ua">музикант гітарист</name>
             <sex>male</sex>
             <shortDesc>музыкант||а|у|а|ом|е</shortDesc>
+            <shortDesc l="en">a musician</shortDesc>
+            <shortDesc l="ua">музикант||а|у|а|ом|ові</shortDesc>
             <race>mawg</race>
         </node>
         <node>
@@ -215,10 +349,22 @@
 зажал скрипку под подбородком и что-то там подстраивает. Издаваемые при этом
 звуки просто невыносимы, но в твоих силах это прекратить!
 </desc>
+            <desc l="en">A scrawny type in glasses, with greasy thin hair, has clamped a violin
+firmly under his chin and is tuning something in there. The sounds this
+produces are simply unbearable, but it is in your power to stop it!</desc>
+            <desc l="ua">Худий тип в окулярах і з масним ріденьким волоссям міцно
+затиснув скрипку під підборіддям і щось там підлаштовує. Звуки, що при
+цьому виходять, просто нестерпні, але тобі до снаги це припинити!</desc>
             <longDesc>Скрипач в который раз пытается настроить скрипку.</longDesc>
+            <longDesc l="en">A fiddler is trying to tune his violin for the umpteenth time.</longDesc>
+            <longDesc l="ua">Скрипаль укотре намагається налаштувати скрипку.</longDesc>
             <name>musician fiddler музыкант скрипач</name>
+            <name l="en">musician fiddler violinist</name>
+            <name l="ua">скрипаль музикант</name>
             <sex>male</sex>
             <shortDesc>скрипач||а|у|а|ом|е</shortDesc>
+            <shortDesc l="en">a fiddler</shortDesc>
+            <shortDesc l="ua">скрипал|ь|я|ю|я|ем|еві</shortDesc>
             <race>half-elf</race>
         </node>
       </mobiles>
@@ -239,8 +385,14 @@
       <priority>4</priority>
       <item>
         <desc>Неумело нацарапанная листовка зазывает на концерт рок-менестрелей.</desc>
+        <desc l="en">A clumsily scrawled flyer invites you to a concert of rock minstrels.</desc>
+        <desc l="ua">Невміло надряпана листівка зазиває на концерт рок-менестрелів.</desc>
         <name>flyer листовка</name>
+        <name l="en">flyer leaflet</name>
+        <name l="ua">листівка флаєр</name>
         <shortDesc>листовк|а|и|е|у|ой|е с приглашением на концерт</shortDesc>
+        <shortDesc l="en">a flyer inviting you to a concert</shortDesc>
+        <shortDesc l="ua">листів|ка|ки|ці|ку|кою|ці із запрошенням на концерт</shortDesc>
         <gender>f</gender>
         <material>paper</material>
       </item>
@@ -250,20 +402,42 @@
 свои пасы руками. Тебе необходимо вмешаться, пока под его палочки не попался
 настоящий барабан.
 </desc>
+			<desc l="en">An unusually mobile specimen, as dwarves go, does not stop waving his arms
+about for a second. You need to step in before a real drum ends up under his
+sticks.</desc>
+			<desc l="ua">Надзвичайно рухливий, як на дварфа, екземпляр ні на секунду не припиняє
+свої паси руками. Тобі треба втрутитись, поки під його палички не втрапив
+справжній барабан.</desc>
             <longDesc>Рок-менестрель размахивает барабанными палочками.</longDesc>
+            <longDesc l="en">A rock minstrel is waving his drumsticks about.</longDesc>
+            <longDesc l="ua">Рок-менестрель вимахує барабанними паличками.</longDesc>
             <name>minstrel rock-minstrel менестрель рок-менестрель</name>
+            <name l="en">minstrel rock-minstrel drummer</name>
+            <name l="ua">менестрель рок-менестрель барабанщик</name>
             <sex>male</sex>
             <shortDesc>рок-менестрел|ь|я|ю|я|ем|е</shortDesc>
+            <shortDesc l="en">a rock minstrel</shortDesc>
+            <shortDesc l="ua">рок-менестрел|ь|я|ю|я|ем|еві</shortDesc>
             <race>dwarf</race>
         </node>
         <node>
 			<desc>Коренастый дварф с копной волос и бородой до пояса сверлит тебя тяжелым
 похмельным взглядом. Разделайся с ним поскорее!
 </desc>
+			<desc l="en">A stocky dwarf with a mop of hair and a beard down to his belt drills into
+you with a heavy hungover stare. Deal with him quickly!</desc>
+			<desc l="ua">Кремезний дварф з копицею волосся й бородою до пояса свердлить тебе важким
+похмільним поглядом. Розправся з ним якнайшвидше!</desc>
             <longDesc>Рок-менестрель ищет, об кого бы сломать гитару.</longDesc>
+            <longDesc l="en">A rock minstrel is looking for someone to break a guitar over.</longDesc>
+            <longDesc l="ua">Рок-менестрель шукає, об кого б розтрощити гітару.</longDesc>
             <name>minstrel rock-minstrel менестрель рок-менестрель</name>
+            <name l="en">minstrel rock-minstrel guitarist</name>
+            <name l="ua">менестрель рок-менестрель гітарист</name>
             <sex>male</sex>
             <shortDesc>рок-менестрел|ь|я|ю|я|ем|е</shortDesc>
+            <shortDesc l="en">a rock minstrel</shortDesc>
+            <shortDesc l="ua">рок-менестрел|ь|я|ю|я|ем|еві</shortDesc>
             <race>dwarf</race>
         </node>
       </mobiles>
@@ -287,8 +461,14 @@
       </criteria>
       <item>
         <desc>Маленькая крупица сомнения пытается закрасться в тебя.</desc>
+        <desc l="en">A tiny grain of doubt is trying to creep into you.</desc>
+        <desc l="ua">Маленька крихта сумніву намагається закрастися в тебе.</desc>
         <name>sliver doubt крупица сомнений</name>
+        <name l="en">sliver doubt grain</name>
+        <name l="ua">крихта сумнів дрібка</name>
         <shortDesc>крупиц|а|ы|е|у|ей|е сомнений</shortDesc>
+        <shortDesc l="en">a grain of doubt</shortDesc>
+        <shortDesc l="ua">крихт|а|и|і|у|ою|і сумнівів</shortDesc>
         <gender>f</gender>
         <material>ethereal</material>
       </item>
@@ -298,10 +478,22 @@
 сантиметрах от земли. Ее просветленное лицо отражает решимость нести в массы
 знания о единственно правильном образе жизни. 
 </desc>
+			<desc l="en">An arial in snow-white robes and with snow-white wings hovers a few
+centimetres above the ground. Her enlightened face reflects a resolve to carry
+to the masses the knowledge of the one correct way of life.</desc>
+			<desc l="ua">Аріелла в білосніжних шатах і з білосніжними крилами ширяє за кілька
+сантиметрів від землі. Її просвітлене обличчя відбиває рішучість нести в маси
+знання про єдино правильний спосіб життя.</desc>
             <longDesc>Ханжа готовится прочитать лекцию о вреде mlove.</longDesc>
+            <longDesc l="en">A bigot is preparing to deliver a lecture on the harms of mlove.</longDesc>
+            <longDesc l="ua">Ханжа готується прочитати лекцію про шкоду mlove.</longDesc>
             <name>bigot ханжа</name>
+            <name l="en">bigot prude</name>
+            <name l="ua">ханжа святенниця</name>
             <sex>female</sex>
             <shortDesc>ханж|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a bigot</shortDesc>
+            <shortDesc l="ua">ханж|а|і|і|у|ою|і</shortDesc>
             <race>arial</race>
         </node>
         <node>
@@ -309,10 +501,22 @@
 сантиметрах от земли. Ее просветленное лицо отражает решимость нести в массы
 знания о единственно правильном образе жизни. 
 </desc>
+			<desc l="en">An arial in snow-white robes and with snow-white wings hovers a few
+centimetres above the ground. Her enlightened face reflects a resolve to carry
+to the masses the knowledge of the one correct way of life.</desc>
+			<desc l="ua">Аріелла в білосніжних шатах і з білосніжними крилами ширяє за кілька
+сантиметрів від землі. Її просвітлене обличчя відбиває рішучість нести в маси
+знання про єдино правильний спосіб життя.</desc>
             <longDesc>Ханжа призывает окружающих стать на путь полной трезвости.</longDesc>
+            <longDesc l="en">A bigot is urging everyone around to take the path of total sobriety.</longDesc>
+            <longDesc l="ua">Ханжа закликає присутніх стати на шлях цілковитої тверезості.</longDesc>
             <name>bigot ханжа</name>
+            <name l="en">bigot prude</name>
+            <name l="ua">ханжа святенниця</name>
             <sex>female</sex>
             <shortDesc>ханж|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a bigot</shortDesc>
+            <shortDesc l="ua">ханж|а|і|і|у|ою|і</shortDesc>
             <race>arial</race>
         </node>
         <node>
@@ -320,10 +524,22 @@
 сантиметрах от земли. Его просветленное лицо отражает решимость нести в массы
 знания о единственно правильном образе жизни. 
 </desc>
+			<desc l="en">An arial in snow-white robes and with snow-white wings hovers a few
+centimetres above the ground. His enlightened face reflects a resolve to carry
+to the masses the knowledge of the one correct way of life.</desc>
+			<desc l="ua">Аріал у білосніжних шатах і з білосніжними крилами ширяє за кілька
+сантиметрів від землі. Його просвітлене обличчя відбиває рішучість
+нести в маси знання про єдино правильний спосіб життя.</desc>
             <longDesc>Ханжа хмурится, заметив, что не 100% твоего тела прикрыто броней.</longDesc>
+            <longDesc l="en">A bigot frowns, noticing that not 100% of your body is covered by armour.</longDesc>
+            <longDesc l="ua">Ханжа хмурніє, помітивши, що не 100% твого тіла прикрито бронею.</longDesc>
             <name>bigot ханжа</name>
+            <name l="en">bigot prude</name>
+            <name l="ua">ханжа святенник</name>
             <sex>male</sex>
             <shortDesc>ханж|а|и|е|у|ой|е</shortDesc>
+            <shortDesc l="en">a bigot</shortDesc>
+            <shortDesc l="ua">ханж|а|і|і|у|ою|і</shortDesc>
             <race>arial</race>
         </node>
       </mobiles>


### PR DESCRIPTION
Same leak as #577, next quest along. `BigQuest` spawns 7 quest items and 16 gang members, all named and described in Russian only.

The fields are `QuestItemAppearence` / `QuestMobileAppearence`, `XMLMultiString` since #982 (live since reboot #63), so this is **data only** -- 85 `l="en"` / `l="ua"` siblings across the seven scenarios. **216 insertions, 0 deletions, 0 Russian bytes changed.**

`msgStart`, `msgInfo` and `msgJoin` are deliberately **not** here: they still sit behind `XMLStringVector` / `XMLString`, and lifting them plus fixing `msgInfo`'s `%I` (the Slavic count rule) to `%g` for English is its own reviewable unit.

### Checks run

- Round-trip parse against the pre-edit file: 0 pre-existing values altered, 170 new values (85 EN + 85 UA).
- All 23 Ukrainian `shortDesc` pads rendered through a port of `Flexer::flexAux` and read as words in all six cases.
- No English `shortDesc` carries a `|`.
- Every new character encodes in KOI8-U. No stray Unicode punctuation, no XML entities in element text, no `ʼ`.
- No new line exceeds 78 characters.

### Content notes

- Russian keyword lists keep every token. Targeting joins all language slots, so the new lists only grow what a player can type.
- Ukrainian «бага» declines to «базі» in the dative and locative. That is correct (г → з, as in нога/нозі) even though it looks like the unrelated «база». A wrong pad would be worse than an odd-looking one.
- `mlove` stays untranslated in all three languages, exactly as the Russian already does, although a Ukrainian player types `кохатися`.
- Proper nouns follow established spelling: Валькірія, Аріелла, гобіт.
- The `100%` in the religion2 bigot's long description is a single literal `%`, unchanged from the Russian that already renders it.

### Deploy

Loads at boot. No `plug reload most` before the next reboot.