### PR TITLE
Translate the big quest's briefing, info and announcement

### DIFF
--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -333,7 +333,7 @@ and a pen. He peers at you keenly, but quickly loses interest.</desc>
         <node>
           <text>Жители умоляют избавить их от этих зануд.</text>
           <text l="en">The locals are begging to be rid of these bores.</text>
-          <text l="ua">Мешканці благають позбавити їх від цих занудів.</text>
+          <text l="ua">Мешканці благають звільнити їх від цих зануд.</text>
         </node>
         <node>
           <text>Верни несчастным их мир и покой, а я вознагражу тебя.</text>
@@ -343,7 +343,7 @@ and a pen. He peers at you keenly, but quickly loses interest.</desc>
       </msgStart>
       <msgInfo>Необходимо избавить мир от {Y%3$d{w проповедник%3$Iа|ов|ов, которые не дают проходу мирным жителям.</msgInfo>
       <msgInfo l="en">The world must be rid of {Y%3$d{w preacher%3$gs||s giving the peaceful locals no rest.</msgInfo>
-      <msgInfo l="ua">Треба позбавити світ від {Y%3$d{w проповідник%3$Iа|ів|ів, які не дають проходу мирним мешканцям.</msgInfo>
+      <msgInfo l="ua">Треба звільнити світ від {Y%3$d{w проповідник%3$Iа|ів|ів, які не дають проходу мирним мешканцям.</msgInfo>
       <msgJoin>{YТомик священной книги возникает перед тобой, сложенный из всех страниц.{x</msgJoin>
       <msgJoin l="en">{YA volume of the holy book appears before you, assembled from all the pages.{x</msgJoin>
       <msgJoin l="ua">{YТомик священної книги постає перед тобою, складений з усіх сторінок.{x</msgJoin>
@@ -447,7 +447,7 @@ produces are simply unbearable, but it is in your power to stop it!</desc>
       </msgStart>
       <msgInfo>Необходимо избавить мир от {Y%3$d{w музыкант%3$Iа|ов|ов, которые не дают покоя мирным жителям.</msgInfo>
       <msgInfo l="en">The world must be rid of {Y%3$d{w musician%3$gs||s giving the peaceful locals no rest.</msgInfo>
-      <msgInfo l="ua">Треба позбавити світ від {Y%3$d{w музикант%3$Iа|ів|ів, які не дають спокою мирним мешканцям.</msgInfo>
+      <msgInfo l="ua">Треба звільнити світ від {Y%3$d{w музикант%3$Iа|ів|ів, які не дають спокою мирним мешканцям.</msgInfo>
       <msgJoin>{YПорванные струны внезапно свиваются в один какофонический клубок.{x</msgJoin>
       <msgJoin l="en">{YThe broken strings suddenly twist together into one cacophonous tangle.{x</msgJoin>
       <msgJoin l="ua">{YПорвані струни раптом сплітаються в один какофонічний клубок.{x</msgJoin>

--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -92,11 +92,23 @@ then there are four, and a moment later eight... This has to be stopped!</desc>
         </node>
       </mobiles>
       <msgStart> 
-        <node>В местности {W{hh%3$s{hx{G порвалась ткань мироздания, породив на свет различные {Wаномалии{G.</node>
-        <node>Восстанови порядок вещей и вернись ко мне за вознаграждением.</node>
+        <node>
+          <text>В местности {W{hh%3$s{hx{G порвалась ткань мироздания, породив на свет различные {Wаномалии{G.</text>
+          <text l="en">The fabric of creation has torn in {W{hh%3$s{hx{G, letting all kinds of {Wanomalies{G into the world.</text>
+          <text l="ua">У місцевості {W{hh%3$s{hx{G порвалася тканина світобудови, породивши на світ різні {Wаномалії{G.</text>
+        </node>
+        <node>
+          <text>Восстанови порядок вещей и вернись ко мне за вознаграждением.</text>
+          <text l="en">Put the order of things back and return to me for your reward.</text>
+          <text l="ua">Віднови лад речей і повертайся до мене по винагороду.</text>
+        </node>
       </msgStart>
       <msgInfo>Тебе надо уничтожить {Y%3$d{w аномали%3$Iю|и|й, прорвавшихся сюда из дыры в ткани мироздания.</msgInfo>
+      <msgInfo l="en">You must destroy {Y%3$d{w anomal%3$gies|y|ies that broke through the hole in the fabric of creation.</msgInfo>
+      <msgInfo l="ua">Тобі треба знищити {Y%3$d{w аномалі%3$Iю|ї|й, що прорвалися сюди крізь дірку в тканині світобудови.</msgInfo>
       <msgJoin>{YИз разрозненных кусочков внезапно возникает цельный фрагмент бытия.{x</msgJoin>
+      <msgJoin l="en">{YThe scattered pieces suddenly come together into one whole fragment of being.{x</msgJoin>
+      <msgJoin l="ua">{YЗ розрізнених шматочків раптом постає цілісний фрагмент буття.{x</msgJoin>
     </node>
     <node name="religion1" type="BigQuestScenario">
       <criteria>
@@ -165,12 +177,28 @@ him, but since you were sent -- the job is the job!</desc>
         </node>
       </mobiles>
       <msgStart> 
-        <node>Группа {Wхулиганов{G нарушила закон об оскорблении чувств верующих в Атум-Ра!</node>
-        <node>Они скрываются в местности {W{hh%3$s{hx{G. Полное уничтожение -- вот единственный способ призвать их к порядку.</node>
-        <node>Разделайся с ними и вернись сюда за наградой.</node>
+        <node>
+          <text>Группа {Wхулиганов{G нарушила закон об оскорблении чувств верующих в Атум-Ра!</text>
+          <text l="en">A gang of {Whooligans{G has broken the law against offending the faithful of Atum-Ra!</text>
+          <text l="ua">Зграя {Wхуліганів{G порушила закон про образу почуттів вірян Атум-Ра!</text>
+        </node>
+        <node>
+          <text>Они скрываются в местности {W{hh%3$s{hx{G. Полное уничтожение -- вот единственный способ призвать их к порядку.</text>
+          <text l="en">They are hiding out in {W{hh%3$s{hx{G. Total destruction is the only way to bring them to order.</text>
+          <text l="ua">Вони переховуються в місцевості {W{hh%3$s{hx{G. Цілковите знищення -- ось єдиний спосіб закликати їх до порядку.</text>
+        </node>
+        <node>
+          <text>Разделайся с ними и вернись сюда за наградой.</text>
+          <text l="en">Deal with them and come back here for your reward.</text>
+          <text l="ua">Розправся з ними і повертайся сюди по нагороду.</text>
+        </node>
       </msgStart>
       <msgInfo>Тебе необходимо ликвидировать группу из {Y%3$d{w хулиган%3$Iа|ов|ов, нарушивш%3$Iего|их|их закон об оскорблении чувств верующих в Атум-Ра</msgInfo>
+      <msgInfo l="en">You must liquidate a gang of {Y%3$d{w hooligan%3$gs||s who broke the law against offending the faithful of Atum-Ra</msgInfo>
+      <msgInfo l="ua">Тобі необхідно ліквідувати зграю з {Y%3$d{w хуліган%3$Iа|ів|ів, що поруши%3$Iв|ли|ли закон про образу почуттів вірян Атум-Ра</msgInfo>
       <msgJoin>{YВсе куплеты неожиданно складываются в издевательский молебен.{x</msgJoin>
+      <msgJoin l="en">{YAll the verses unexpectedly fall together into one mocking prayer service.{x</msgJoin>
+      <msgJoin l="ua">{YУсі куплети несподівано складаються в глумливий молебень.{x</msgJoin>
     </node>
 
     <node name="defamation" type="BigQuestScenario">
@@ -239,12 +267,28 @@ and a pen. He peers at you keenly, but quickly loses interest.</desc>
         </node>
       </mobiles>
       <msgStart> 
-        <node>Группа независимых {Wжурналистов{G распространяет компрометирующие материалы на Валькирию.</node>
-        <node>Эту возмутительную клевету необходимо остановить! Последний раз их видели в местности {W{hh%3$s{hx{G.</node>
-        <node>Спаси репутацию Валькирии и вернись ко мне за наградой.</node>
+        <node>
+          <text>Группа независимых {Wжурналистов{G распространяет компрометирующие материалы на Валькирию.</text>
+          <text l="en">A band of independent {Wreporters{G is spreading compromising material about the Valkyrie.</text>
+          <text l="ua">Гурт незалежних {Wжурналістів{G поширює компромат на Валькірію.</text>
+        </node>
+        <node>
+          <text>Эту возмутительную клевету необходимо остановить! Последний раз их видели в местности {W{hh%3$s{hx{G.</text>
+          <text l="en">This outrageous slander has to be stopped! They were last seen in {W{hh%3$s{hx{G.</text>
+          <text l="ua">Цей обурливий наклеп треба спинити! Востаннє їх бачили в місцевості {W{hh%3$s{hx{G.</text>
+        </node>
+        <node>
+          <text>Спаси репутацию Валькирии и вернись ко мне за наградой.</text>
+          <text l="en">Save the Valkyrie's reputation and come back to me for your reward.</text>
+          <text l="ua">Врятуй репутацію Валькірії і повертайся до мене по нагороду.</text>
+        </node>
       </msgStart>
       <msgInfo>Тебе предстоит уничтожить {Y%3$d{w журналист%3$Iа|ов|ов, которые распространяют клевету.</msgInfo>
+      <msgInfo l="en">You are to destroy {Y%3$d{w reporter%3$gs||s spreading the slander.</msgInfo>
+      <msgInfo l="ua">Тобі належить знищити {Y%3$d{w журналіст%3$Iа|ів|ів, які поширюють наклеп.</msgInfo>
       <msgJoin>{YВсе фотографии внезапно образуют захватывающий фото-альбом!{x</msgJoin>
+      <msgJoin l="en">{YAll the photographs suddenly form one gripping photo album!{x</msgJoin>
+      <msgJoin l="ua">{YУсі світлини раптом утворюють захопливий фотоальбом!{x</msgJoin>
     </node>
     <node name="vegan" type="BigQuestScenario">
       <priority>4</priority>
@@ -281,12 +325,28 @@ and a pen. He peers at you keenly, but quickly loses interest.</desc>
         <material>paper</material>
       </item>
       <msgStart> 
-        <node>Группа бродячих {Wпроповедников{G пытается обратить всю территорию {W{hh%3$s{hx{G в свою веру.</node>
-        <node>Жители умоляют избавить их от этих зануд.</node>
-        <node>Верни несчастным их мир и покой, а я вознагражу тебя.</node>
+        <node>
+          <text>Группа бродячих {Wпроповедников{G пытается обратить всю территорию {W{hh%3$s{hx{G в свою веру.</text>
+          <text l="en">A band of wandering {Wpreachers{G is trying to convert the whole of {W{hh%3$s{hx{G to their faith.</text>
+          <text l="ua">Гурт мандрівних {Wпроповідників{G намагається навернути всю територію {W{hh%3$s{hx{G у свою віру.</text>
+        </node>
+        <node>
+          <text>Жители умоляют избавить их от этих зануд.</text>
+          <text l="en">The locals are begging to be rid of these bores.</text>
+          <text l="ua">Мешканці благають позбавити їх від цих занудів.</text>
+        </node>
+        <node>
+          <text>Верни несчастным их мир и покой, а я вознагражу тебя.</text>
+          <text l="en">Give the poor souls back their peace and quiet, and I will reward you.</text>
+          <text l="ua">Поверни бідолахам мир і спокій, а я тебе винагороджу.</text>
+        </node>
       </msgStart>
       <msgInfo>Необходимо избавить мир от {Y%3$d{w проповедник%3$Iа|ов|ов, которые не дают проходу мирным жителям.</msgInfo>
+      <msgInfo l="en">The world must be rid of {Y%3$d{w preacher%3$gs||s giving the peaceful locals no rest.</msgInfo>
+      <msgInfo l="ua">Треба позбавити світ від {Y%3$d{w проповідник%3$Iа|ів|ів, які не дають проходу мирним мешканцям.</msgInfo>
       <msgJoin>{YТомик священной книги возникает перед тобой, сложенный из всех страниц.{x</msgJoin>
+      <msgJoin l="en">{YA volume of the holy book appears before you, assembled from all the pages.{x</msgJoin>
+      <msgJoin l="ua">{YТомик священної книги постає перед тобою, складений з усіх сторінок.{x</msgJoin>
     </node>
     <node name="music" type="BigQuestScenario">
       <priority>4</priority>
@@ -369,12 +429,28 @@ produces are simply unbearable, but it is in your power to stop it!</desc>
         </node>
       </mobiles>
       <msgStart> 
-        <node>На мирных жителей местности {W{hh%3$s{hx{G внезапно обрушилась группа начинающих {Wмузыкантов{G!</node>
-        <node>Теперь стало невозможно спать по ночам, да и днем от них нет покоя.</node>
-        <node>Избавь мир от какофонии, а я вознагражу тебя.</node>
+        <node>
+          <text>На мирных жителей местности {W{hh%3$s{hx{G внезапно обрушилась группа начинающих {Wмузыкантов{G!</text>
+          <text l="en">A band of beginner {Wmusicians{G has suddenly descended on the peaceful folk of {W{hh%3$s{hx{G!</text>
+          <text l="ua">На мирних мешканців місцевості {W{hh%3$s{hx{G раптом звалився гурт початківців-{Wмузикантів{G!</text>
+        </node>
+        <node>
+          <text>Теперь стало невозможно спать по ночам, да и днем от них нет покоя.</text>
+          <text l="en">Sleeping at night has become impossible, and there is no peace from them by day either.</text>
+          <text l="ua">Тепер уночі неможливо спати, та й удень від них нема спокою.</text>
+        </node>
+        <node>
+          <text>Избавь мир от какофонии, а я вознагражу тебя.</text>
+          <text l="en">Rid the world of the cacophony, and I will reward you.</text>
+          <text l="ua">Позбав світ какофонії, а я тебе винагороджу.</text>
+        </node>
       </msgStart>
       <msgInfo>Необходимо избавить мир от {Y%3$d{w музыкант%3$Iа|ов|ов, которые не дают покоя мирным жителям.</msgInfo>
+      <msgInfo l="en">The world must be rid of {Y%3$d{w musician%3$gs||s giving the peaceful locals no rest.</msgInfo>
+      <msgInfo l="ua">Треба позбавити світ від {Y%3$d{w музикант%3$Iа|ів|ів, які не дають спокою мирним мешканцям.</msgInfo>
       <msgJoin>{YПорванные струны внезапно свиваются в один какофонический клубок.{x</msgJoin>
+      <msgJoin l="en">{YThe broken strings suddenly twist together into one cacophonous tangle.{x</msgJoin>
+      <msgJoin l="ua">{YПорвані струни раптом сплітаються в один какофонічний клубок.{x</msgJoin>
     </node>
     <node name="rockmusic" type="BigQuestScenario">
       <criteria>
@@ -442,12 +518,28 @@ you with a heavy hungover stare. Deal with him quickly!</desc>
         </node>
       </mobiles>
       <msgStart> 
-        <node>Группа бродячих {Wрок-менестрелей{G готовится дать концерт тяжелой музыки в местности {W{hh%3$s{hx{G.</node>
-        <node>У них нет ни голоса, ни слуха, только безудержное рвение.</node>
-        <node>Уничтожь их до того, как они успеют выступить, а я вознагражу тебя.</node>
+        <node>
+          <text>Группа бродячих {Wрок-менестрелей{G готовится дать концерт тяжелой музыки в местности {W{hh%3$s{hx{G.</text>
+          <text l="en">A band of wandering {Wrock minstrels{G is preparing to give a heavy music concert in {W{hh%3$s{hx{G.</text>
+          <text l="ua">Гурт мандрівних {Wрок-менестрелів{G готується дати концерт важкої музики в місцевості {W{hh%3$s{hx{G.</text>
+        </node>
+        <node>
+          <text>У них нет ни голоса, ни слуха, только безудержное рвение.</text>
+          <text l="en">They have neither voice nor ear, only unstoppable zeal.</text>
+          <text l="ua">У них нема ні голосу, ні слуху, тільки нестримне завзяття.</text>
+        </node>
+        <node>
+          <text>Уничтожь их до того, как они успеют выступить, а я вознагражу тебя.</text>
+          <text l="en">Destroy them before they get to perform, and I will reward you.</text>
+          <text l="ua">Знищ їх, доки вони не встигли виступити, а я тебе винагороджу.</text>
+        </node>
       </msgStart>
       <msgInfo>Необходимо уничтожить {W%3$d{w бродячих рок-менестрел%3$Iя|ей|ей, до того как они устроят концерт.</msgInfo>
+      <msgInfo l="en">You must destroy {W%3$d{w wandering rock minstrel%3$gs||s before they put on their concert.</msgInfo>
+      <msgInfo l="ua">Треба знищити {W%3$d{w мандрівних рок-менестрел%3$Iя|ів|ів, доки вони не влаштували концерт.</msgInfo>
       <msgJoin>{YВсе листовки из пачки складываются вместе, превращаясь в огромный плакат-афишу.{x</msgJoin>
+      <msgJoin l="en">{YEvery flyer in the stack folds together into one enormous poster.{x</msgJoin>
+      <msgJoin l="ua">{YУсі листівки з пачки складаються докупи, обертаючись на величезну афішу.{x</msgJoin>
     </node>
     <node name="religion2" type="BigQuestScenario">
       <priority>4</priority>
@@ -544,12 +636,28 @@ to the masses the knowledge of the one correct way of life.</desc>
         </node>
       </mobiles>
       <msgStart> 
-	    <node>Группа {Wханжей{G наводнила местность {W{hh%3$s{hx{G и оскорбляет чувства верующих в Эроса.</node>
-        <node>Верующие жалуются, что из их жизни скоро окончательно исчезнет разврат и пьянство.</node>
-        <node>Уничтожь ханжей, восстанови равновесие и возвращайся ко мне за наградой.</node>
+	    <node>
+	      <text>Группа {Wханжей{G наводнила местность {W{hh%3$s{hx{G и оскорбляет чувства верующих в Эроса.</text>
+	      <text l="en">A crowd of {Wbigots{G has flooded {W{hh%3$s{hx{G and is offending the faithful of Eros.</text>
+	      <text l="ua">Юрба {Wханжів{G наводнила місцевість {W{hh%3$s{hx{G і ображає почуття вірян Ероса.</text>
+	    </node>
+        <node>
+          <text>Верующие жалуются, что из их жизни скоро окончательно исчезнет разврат и пьянство.</text>
+          <text l="en">The faithful complain that debauchery and drunkenness are about to vanish from their lives for good.</text>
+          <text l="ua">Віряни скаржаться, що з їхнього життя скоро остаточно зникне розпуста й пиятика.</text>
+        </node>
+        <node>
+          <text>Уничтожь ханжей, восстанови равновесие и возвращайся ко мне за наградой.</text>
+          <text l="en">Destroy the bigots, restore the balance and come back to me for your reward.</text>
+          <text l="ua">Знищ ханжів, віднови рівновагу і повертайся до мене по нагороду.</text>
+        </node>
       </msgStart>
       <msgInfo>Уничтожить {W%3$d{w ханж%3$Iу|ей|ей, пока они не замучали окружающих своей праведностью.</msgInfo>
+      <msgInfo l="en">Destroy {W%3$d{w bigot%3$gs||s before they torment everyone around them with their righteousness.</msgInfo>
+      <msgInfo l="ua">Знищити {W%3$d{w ханж%3$Iу|ів|ів, доки вони не замучили довколишніх своєю праведністю.</msgInfo>
 	  <msgJoin>{YВсе крупицы сливаются в солидный булыжник уверенности.{x</msgJoin>
+	  <msgJoin l="en">{YAll the grains merge into one solid cobblestone of certainty.{x</msgJoin>
+	  <msgJoin l="ua">{YУсі крихти зливаються в солідний бруковий камінь упевненості.{x</msgJoin>
     </node>
   </scenarios>
 </Quest>


### PR DESCRIPTION
The last data half of L3. **34 values in English and Ukrainian**: 20 briefing lines, 7 `quest info` lines and 7 room announcements, across the seven scenarios.

Pairs with `dreamland_code#994`, which lifts the three fields to `XMLMultiString`. **Both must ride the same reboot** — and the data must not reach a boot with an older binary, which would render the briefing blank.

### `msgStart` changes shape

Each `<node>текст</node>` becomes a `<node>` holding three `<text>` children, because a vector element has to be a container for moc to dispatch three languages onto one member (see the code PR). **No Russian text changed — only its nesting.** Verified by round-trip parse against the pre-edit file: 0 pre-existing values altered, 68 new.

### 🛑 The English `msgInfo` lines use `%g`, not `%I`

`%I` is `GET_COUNT` — the Slavic 1 / 2-4 / 5+ rule Russian and Ukrainian share. English needs `URANGE(0,n,2)`: zero / one / many. Written with `%I`, an English line reads "21 hooligan".

Every value rendered at n = 0, 1, 2, 5, 11, 21, 22, 25, 101, 111 in all three languages and read as a sentence.

**Reading that output caught three English relative clauses that had to agree with a count** — "1 reporter who are spreading" — now participles that do not: *spreading* / *giving* / *giving*.

For the record: `mobsTotal = number_range(10, 15)`, so the singular slot is unreachable in play. That is also why the Russian can carry «1 аномалию, прорвавшихся» and «1 бродячих рок-менестреля» without anyone noticing. Pre-existing, left alone; Ukrainian mirrors the Russian rather than inventing a fix for a line nobody can see.

### Tooling

`scripts/lint-english-plural.py` now scans `dreamland_world/quests/` as a third source. Quest data is handed straight to `fmt` as a format string, so no catalog-side lint could ever have seen it. Verified against a planted regression: swapping one `%g` back to `%I` makes it report the file, the line, and "21 anomaly".

### Checks

XML parses. 0 Russian values changed. Every new character encodes in KOI8-U. Canonical names used: `Atum-Ra` / `Атум-Ра`, `Eros` / `Ерос`, `Valkyrie` / `Валькірія`.