### PR TITLE
Name the real command in the "use is a synonym for" lists

### DIFF
--- a/commands/use.xml
+++ b/commands/use.xml
@@ -18,9 +18,9 @@ Some objects in the world can be used for different purposes. {hh238Shovels{x ca
 Finding a suitable two-handed axe, you can cut down a tree in the forest, from which you can then make a fire, or maybe even craft a wooden golem Pinocchio or something more useful. Without special skills, woodcutting takes a long time. An already cut area in the forest can no longer serve as {hh546cover{x for rangers. Also, an axe can be used to chop suitable wooden objects on the ground, including {hh191totems{x of druids.
 
 {CEnchanted Items{x For {hh121enchanted items{x, this command is a synonym for other, more specialized commands, namely:
-%A% for {hh2143enchanted wands{x, it is a synonym for *strike*
-%A% for {hh2144enchanted staves{x, it is a synonym for *wave*
-%A% for {hh2145scrolls{x, it is a synonym for *read*
+%A% for {hh2143enchanted wands{x, it is a synonym for *zap*
+%A% for {hh2144enchanted staves{x, it is a synonym for *brandish*
+%A% for {hh2145scrolls{x, it is a synonym for *recite*
 %A% for potions, it is a synonym for *quaff*
 </text>
     <text l="ru">%FMT% *%CMD%* _%OBJ%_
@@ -47,10 +47,10 @@ Finding a suitable two-handed axe, you can cut down a tree in the forest, from w
 Знайшовши відповідну двуручну сокиру, можна зрубати в лісі дерево, з якого потім можна розвести багаття, а може навіть змайструвати деревʼяного голема Буратіно чи щось більш корисне. Без спеціальних навичок рубка лісу займає довгий час. Вирубана ділянка лісу більше не може служити {hh546укриттям{x для рейнджерів. Також сокирою можна розрубати відповідний деревʼяний обʼєкт на землі, включаючи {hh191тотеми{x друїдів.
 
 {CЧарівні Предмети{x Для {hh121чарівних предметів{x ця команда є синонімом інших, більш вузько-спеціалізованих команд, а саме:
-%A% для {hh2143чарівних жезлів{x це синонім для *вразити*
-%A% для {hh2144чарівних посохів{x це синонім для *махнути*
+%A% для {hh2143чарівних жезлів{x це синонім для *зачарування*
+%A% для {hh2144чарівних посохів{x це синонім для *розмахнути*
 %A% для {hh2145сувоїв{x це синонім для *зачитати*
-%A% для зіль це синонім для *випити*
+%A% для зіль це синонім для *осушити*
 </text>
     <title l="en">{CThings: {xuse</title>
     <title l="ru">{CВещи: {xиспользовать</title>

--- a/helps/group.xml
+++ b/helps/group.xml
@@ -3,7 +3,7 @@
   <node id="121" level="-1" type="Help" labels="items">
     <extra l="en">brandish pills potions quaff recite scrolls staves 'using magic items' vials wands zap</extra>
     <extra l="ru">глотать 'использование волшебных предметов' лекарство 'магические предметы' осушить пилюли поразить посохи пузырек снадобье снадобья свитки таблетки жезлы взмахнуть зачитать зелья 'читать свиток'</extra>
-    <extra l="ua">ковтати 'використання чарівних предметів' ліки 'магічні предмети' осушити пігулки зачарування посохи пузирок зілля настій сувої таблетки жезли змахнути зачитати настої 'читати сувій'</extra>
+    <extra l="ua">ковтати 'використання чарівних предметів' ліки 'магічні предмети' осушити пігулки зачарування посохи пузирок зілля настій сувої таблетки жезли розмахнути зачитати настої 'читати сувій'</extra>
     <keyword l="en">'magical items'</keyword>
     <keyword l="ru">'волшебные предметы'</keyword>
     <keyword l="ua">'чарівні предмети'</keyword>
@@ -29,7 +29,7 @@ Read a magic scroll. Specifying a target is not mandatory -- it all depends on t
 %FMT% *zap* _target_
 Brandish the magic wand you are holding. If no target is specified but you are fighting someone, your opponent will be used as the target for harmful spells.
 
-%FMT% *wave*
+%FMT% *brandish*
 Strike the ground with the magic staff you are holding. The spells on the staff may affect everyone nearby!
 
 Staves and wands may contain multiple charges. When the charges run out, these magic items become useless. However, wizards and witches know the secret of recharging wands and staves (the {hh600recharge{x skill).
@@ -83,7 +83,7 @@ Staves and wands may contain multiple charges. When the charges run out, these m
 %FMT% *зачарування* _ціль_
 Махнути чарівним жезлом, який ти тримаєш у руці. Якщо ціль явно не вказана, але ти з кимось бʼєшся, твій противник буде використаний як мішень для шкідливих заклинань.
 
-%FMT% *змахнути*
+%FMT% *розмахнути*
 Вдарити об землю чарівним посохом, який ти тримаєш у руці. Заклинання на посоху можуть подіяти на всіх навколишніх!
 
 Посохи і жезли можуть містити кілька зарядів. Коли заряди вичерпаються, ці чарівні предмети стають марними. Однак чарівники і відьми знають секрет повторного заряджання жезлів і посохів (вміння {hh600перезарядка{x).


### PR DESCRIPTION
Found by the review of #583. Russian was correct in both files; **English and Ukrainian drifted**.

Verified against the engine, not the help text: `plug-ins/comm/use.cpp:31-59` dispatches `use` by item type straight into `interpret_cmd` -- potion→`quaff`, scroll→`recite`, wand→`zap`, staff→`brandish`. So these four really are the commands `use` stands in for.

**`commands/use.xml`**

| lang | was | now | why |
|---|---|---|---|
| en | `strike` | `zap` | no such command |
| en | `wave` | `brandish` | 🛑 `wave` is a **social**; no command word starts with it, and socials resolve after command lookup fails, so the reader genuinely waved at the room |
| en | `read` | `recite` | real command, wrong one -- `read.cpp` reads extra descriptions |
| ua | `вразити` | `зачарування` | matched nothing |
| ua | `махнути` | `розмахнути` | matched nothing |
| ua | `випити` | `осушити` | `осушити` is the command `use` dispatches to and the canonical direct word |

**`helps/group.xml`** -- EN `%FMT% *wave*` -> `*brandish*`, UA `%FMT% *змахнути*` -> `*розмахнути*`, and the UA extra keyword follows so the article stays findable by the word the body prints. `змахнути` now has zero occurrences in the repo.

The pattern: the translator *translated* the Russian command name instead of *copying* the target command's name in that language. Russian is the only slot written from the command, which is why it is the only correct one.

### Correction, made before merging rather than after

An earlier draft of this description called `випити` a **wrong command for a potion**. That is not true on the current server. `plug-ins/liquid/drink_commands.cpp:803-830` hands `drink` on an `ITEM_POTION` off to quaff by object id; that landed in dreamland_code #963 on 2026-08-11 and has been live since the 08-14 boot. So `випити <зілля>` does quaff the potion. My live probe only exercised the no-argument path, which proves the alias binding and nothing about potions. The edit stands on its own merits -- `осушити` is what `use` actually calls -- but the severity claim was overstated.