### PR TITLE
Show non-spell affects in the web affect panel

### DIFF
--- a/card-skills/sconce.xml
+++ b/card-skills/sconce.xml
@@ -35,4 +35,8 @@ An ancient skill of card fighters to stun an opponent with a precise blow of a s
   <name l="en">sconce</name>
   <name l="ru">канделябр</name>
   <name l="ua">канделябр</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Sconce</webLabel>
+  <webLabel l="ru">Канделябр</webLabel>
+  <webLabel l="ua">Канделябр</webLabel>
 </skill>

--- a/clan-skills/clanrecall.xml
+++ b/clan-skills/clanrecall.xml
@@ -136,4 +136,8 @@
   <name l="en">clanrecall</name>
   <name l="ru">кланвозврат</name>
   <name l="ua">кланповернення</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">ClanRcl</webLabel>
+  <webLabel l="ru">КлВозвр</webLabel>
+  <webLabel l="ua">КлПоверн</webLabel>
 </skill>

--- a/clan-skills/fade.xml
+++ b/clan-skills/fade.xml
@@ -62,4 +62,8 @@ Unlike the skill {hh798to hide{x, this skill allows hiding in a much wider range
   <name l="en">fade</name>
   <name l="ru">спрятаться</name>
   <name l="ua">сховатися</name>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Fade</webLabel>
+  <webLabel l="ru">Спрят</webLabel>
+  <webLabel l="ua">Мляв</webLabel>
 </skill>

--- a/clan-skills/guard call.xml
+++ b/clan-skills/guard call.xml
@@ -76,4 +76,8 @@ The total number of {hh15followers{x is also limited -- see {y{hchelp charm{x.
   <name l="en">guard call</name>
   <name l="ru">стража</name>
   <name l="ua">виклик вартових</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Guards</webLabel>
+  <webLabel l="ru">Стража</webLabel>
+  <webLabel l="ua">Вартові</webLabel>
 </skill>

--- a/clan-skills/hunter beacon.xml
+++ b/clan-skills/hunter beacon.xml
@@ -35,4 +35,8 @@
   <name l="en">hunter beacon</name>
   <name l="ru">охотничий маяк</name>
   <name l="ua">мисливський маяк</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Beacon</webLabel>
+  <webLabel l="ru">Маяк</webLabel>
+  <webLabel l="ua">Маяк</webLabel>
 </skill>

--- a/clan-skills/hunter snare.xml
+++ b/clan-skills/hunter snare.xml
@@ -32,4 +32,8 @@
   <name l="en">hunter snare</name>
   <name l="ru">охотничий капкан</name>
   <name l="ua">мисливський капкан</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">HuntSnare</webLabel>
+  <webLabel l="ru">Капкан</webLabel>
+  <webLabel l="ua">Капкан</webLabel>
 </skill>

--- a/clan-skills/panthers.xml
+++ b/clan-skills/panthers.xml
@@ -74,4 +74,8 @@ The strength of the summoned clan creature depends on your {hh3clan rank{x.
   <name l="en">panthers</name>
   <name l="ru">пантеры</name>
   <name l="ua">пантери</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Panthers</webLabel>
+  <webLabel l="ru">Пантеры</webLabel>
+  <webLabel l="ua">Пантери</webLabel>
 </skill>

--- a/clan-skills/soul lust.xml
+++ b/clan-skills/soul lust.xml
@@ -29,7 +29,7 @@
     </node>
   </organizations>
   <webColumn>cln</webColumn>
-  <webLabel l="en">Shroud</webLabel>
-  <webLabel l="ru">Плащ</webLabel>
-  <webLabel l="ua">Плащ</webLabel>
+  <webLabel l="en">SoulLust</webLabel>
+  <webLabel l="ru">ЖаждаДуш</webLabel>
+  <webLabel l="ua">ЖадобаДуш</webLabel>
 </skill>

--- a/clan-skills/squire.xml
+++ b/clan-skills/squire.xml
@@ -90,4 +90,8 @@ The strength of the summoned clan creature depends on your {hh3clan rank{x.
   <name l="en">squire</name>
   <name l="ru">оруженосец</name>
   <name l="ua">зброєносець</name>
+  <webColumn>cln</webColumn>
+  <webLabel l="en">Squire</webLabel>
+  <webLabel l="ru">Оружнос</webLabel>
+  <webLabel l="ua">Зброєнос</webLabel>
 </skill>

--- a/clan-skills/testskill.xml
+++ b/clan-skills/testskill.xml
@@ -21,4 +21,5 @@
   <name l="en">testskill</name>
   <name l="ru">тестовое умение</name>
   <name l="ua">тестова навичка</name>
+  <webColumn>none</webColumn>
 </skill>

--- a/generic-skills/bear call.xml
+++ b/generic-skills/bear call.xml
@@ -76,4 +76,8 @@ Summons two strong bears to assist you.
   <name l="en">bear call</name>
   <name l="ru">медведи</name>
   <name l="ua">ведмеді</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">BearCall</webLabel>
+  <webLabel l="ru">Медведи</webLabel>
+  <webLabel l="ua">Ведмеді</webLabel>
 </skill>

--- a/generic-skills/blackjack.xml
+++ b/generic-skills/blackjack.xml
@@ -58,4 +58,8 @@ Success depends on the thief's level and dexterity, the victim's constitution, t
   <name l="en">blackjack</name>
   <name l="ru">оглушить</name>
   <name l="ua">оглушити</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Blackjack</webLabel>
+  <webLabel l="ru">Оглушен</webLabel>
+  <webLabel l="ua">Оглушен</webLabel>
 </skill>

--- a/generic-skills/bloodlet.xml
+++ b/generic-skills/bloodlet.xml
@@ -52,4 +52,8 @@ In human form, a vampire can intentionally incite blood thirst. To do this, one 
   <name l="en">bloodlet</name>
   <name l="ru">кровопускание</name>
   <name l="ua">кровопускання</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Bleeding</webLabel>
+  <webLabel l="ru">Кровь</webLabel>
+  <webLabel l="ua">Кров</webLabel>
 </skill>

--- a/generic-skills/camouflage.xml
+++ b/generic-skills/camouflage.xml
@@ -66,4 +66,8 @@ Camouflage allows the character to hide in the forest, field, or mountains.
   <name l="ru">замаскироваться</name>
   <name l="ua">замаскуватися</name>
   <raceBonuses registry="race">satyr</raceBonuses>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Camo</webLabel>
+  <webLabel l="ru">Камуфл</webLabel>
+  <webLabel l="ua">Камуфл</webLabel>
 </skill>

--- a/generic-skills/camp.xml
+++ b/generic-skills/camp.xml
@@ -44,4 +44,8 @@ The skill of rangers to set up a camp and {hh249light a fire{x in the wild {hh86
   <name l="en">camp</name>
   <name l="ru">лагерь</name>
   <name l="ua">табір</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Camp</webLabel>
+  <webLabel l="ru">Лагерь</webLabel>
+  <webLabel l="ua">Табір</webLabel>
 </skill>

--- a/generic-skills/critical strike.xml
+++ b/generic-skills/critical strike.xml
@@ -54,4 +54,8 @@
   <name l="en">critical strike</name>
   <name l="ru">критический удар</name>
   <name l="ua">критичний удар</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Crit</webLabel>
+  <webLabel l="ru">Крит</webLabel>
+  <webLabel l="ua">Крит</webLabel>
 </skill>

--- a/generic-skills/detect hide.xml
+++ b/generic-skills/detect hide.xml
@@ -63,4 +63,8 @@ It is also granted by some {hh121potions, scrolls{x and rare artifacts.</text>
   <name l="en">detect hide</name>
   <name l="ru">замечать скрытое</name>
   <name l="ua">знаходити приховане</name>
+  <webColumn>det</webColumn>
+  <webLabel l="en">DetHide</webLabel>
+  <webLabel l="ru">ЗамечСкр</webLabel>
+  <webLabel l="ua">ЗнахПрих</webLabel>
 </skill>

--- a/generic-skills/dirt kicking.xml
+++ b/generic-skills/dirt kicking.xml
@@ -89,4 +89,8 @@ You can get rid of the dirt in your eyes by {hh296washing{x.
   <name l="en">dirt kicking</name>
   <name l="ru">бросок грязью</name>
   <name l="ua">кидок брудом</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Dirt</webLabel>
+  <webLabel l="ru">Грязь</webLabel>
+  <webLabel l="ua">Бруд</webLabel>
 </skill>

--- a/generic-skills/dominate.xml
+++ b/generic-skills/dominate.xml
@@ -58,4 +58,8 @@ You cannot dominate players (there are other skills for this), as well as the un
   <name l="en">dominate</name>
   <name l="ru">доминировать</name>
   <name l="ua">домінувати</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Dominate</webLabel>
+  <webLabel l="ru">Доминир</webLabel>
+  <webLabel l="ua">Домінув</webLabel>
 </skill>

--- a/generic-skills/explode.xml
+++ b/generic-skills/explode.xml
@@ -49,4 +49,8 @@ Samurai know the secret of exploding some material. They throw the material on t
   <name l="en">explode</name>
   <name l="ru">динамит</name>
   <name l="ua">диніт</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Smoke</webLabel>
+  <webLabel l="ru">Дым</webLabel>
+  <webLabel l="ua">Дим</webLabel>
 </skill>

--- a/generic-skills/hara kiri.xml
+++ b/generic-skills/hara kiri.xml
@@ -44,4 +44,8 @@ The samurai can avoid {hh5065disgrace{x by disemboweling himself in a ritual act
   <name l="en">hara kiri</name>
   <name l="ru">харакири</name>
   <name l="ua">харакірі</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">HaraKiri</webLabel>
+  <webLabel l="ru">Харакири</webLabel>
+  <webLabel l="ua">Харакірі</webLabel>
 </skill>

--- a/generic-skills/hazukure.xml
+++ b/generic-skills/hazukure.xml
@@ -28,4 +28,8 @@ This penalty begins to apply after reaching level 20 -- young samurai are yet to
   <name l="en">hazukure</name>
   <name l="ru">хадзукурэ</name>
   <name l="ua">хадзукуре</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Hazukure</webLabel>
+  <webLabel l="ru">Хадзукурэ</webLabel>
+  <webLabel l="ua">Хадзукуре</webLabel>
 </skill>

--- a/generic-skills/herbs.xml
+++ b/generic-skills/herbs.xml
@@ -62,4 +62,8 @@ The skill to find rare herbs, which restore health, and for experts in natural m
   <name l="en">herbs</name>
   <name l="ru">травы</name>
   <name l="ua">трави</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Herbs</webLabel>
+  <webLabel l="ru">Травы</webLabel>
+  <webLabel l="ua">Трави</webLabel>
 </skill>

--- a/generic-skills/katana.xml
+++ b/generic-skills/katana.xml
@@ -49,4 +49,8 @@ This craft is taught in no guild: a samurai must first earn its secret through a
   <name l="en">katana</name>
   <name l="ru">катана</name>
   <name l="ua">катана</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Katana</webLabel>
+  <webLabel l="ru">Катана</webLabel>
+  <webLabel l="ua">Катана</webLabel>
 </skill>

--- a/generic-skills/lay hands.xml
+++ b/generic-skills/lay hands.xml
@@ -42,4 +42,8 @@ A paladin can heal the needy by laying on hands. This activity is quite exhausti
   <name l="en">lay hands</name>
   <name l="ru">наложение рук</name>
   <name l="ua">накладання рук</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">LayHands</webLabel>
+  <webLabel l="ru">НаложРук</webLabel>
+  <webLabel l="ua">НаклРук</webLabel>
 </skill>

--- a/generic-skills/lion call.xml
+++ b/generic-skills/lion call.xml
@@ -76,4 +76,8 @@ This skill is similar to {hh646bear summon{x, and calls two lions to your aid.
   <name l="en">lion call</name>
   <name l="ru">львы</name>
   <name l="ua">леви</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">LionCall</webLabel>
+  <webLabel l="ru">Львы</webLabel>
+  <webLabel l="ua">Леви</webLabel>
 </skill>

--- a/generic-skills/make arrow.xml
+++ b/generic-skills/make arrow.xml
@@ -46,4 +46,5 @@ Making wooden arrows is the most basic skill available to rangers. They also kno
   <name l="en">make arrow</name>
   <name l="ru">изготовление стрел</name>
   <name l="ua">виготовлення стріл</name>
+  <webColumn>none</webColumn>
 </skill>

--- a/generic-skills/misogi.xml
+++ b/generic-skills/misogi.xml
@@ -47,4 +47,8 @@
   <name l="en">misogi</name>
   <name l="ru">мисоги</name>
   <name l="ua">місогі</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Misogi</webLabel>
+  <webLabel l="ru">Мисоги</webLabel>
+  <webLabel l="ua">Місогі</webLabel>
 </skill>

--- a/generic-skills/recall.xml
+++ b/generic-skills/recall.xml
@@ -130,4 +130,8 @@ Recall {Rdoes not work,{x if:
   <name l="en">recall</name>
   <name l="ru">возврат</name>
   <name l="ua">повернення</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Recall</webLabel>
+  <webLabel l="ru">Возврат</webLabel>
+  <webLabel l="ua">Поверн</webLabel>
 </skill>

--- a/generic-skills/settraps.xml
+++ b/generic-skills/settraps.xml
@@ -64,4 +64,8 @@ A foe under a {hh896detect trap{x spell senses the tripwire and steps around it,
   <name l="en">settraps</name>
   <name l="ru">ловушка</name>
   <name l="ua">пастка</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Traps</webLabel>
+  <webLabel l="ru">Ловушка</webLabel>
+  <webLabel l="ua">Пастка</webLabel>
 </skill>

--- a/generic-skills/shapeshift.xml
+++ b/generic-skills/shapeshift.xml
@@ -63,4 +63,8 @@ During the transformation, the druid retains all equipment worn, except for weap
   <name l="en">shapeshift</name>
   <name l="ru">перекинуться</name>
   <name l="ua">перекинутися</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Shape</webLabel>
+  <webLabel l="ru">Перекин</webLabel>
+  <webLabel l="ua">Перекин</webLabel>
 </skill>

--- a/generic-skills/soothe.xml
+++ b/generic-skills/soothe.xml
@@ -51,4 +51,5 @@ Experienced rangers and druids can influence the mind of {hh998aggressive{x crea
   <name l="en">soothe</name>
   <name l="ru">укротить</name>
   <name l="ua">вгамувати</name>
+  <webColumn>none</webColumn>
 </skill>

--- a/generic-skills/strangle.xml
+++ b/generic-skills/strangle.xml
@@ -57,4 +57,8 @@ Success depends on the ninja's {hh37agility{x, {hh36constitution{x, and the {hh2
   <name l="en">strangle</name>
   <name l="ru">придушить</name>
   <name l="ua">придушити</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Strangle</webLabel>
+  <webLabel l="ru">Удушье</webLabel>
+  <webLabel l="ua">Задуха</webLabel>
 </skill>

--- a/generic-skills/temper.xml
+++ b/generic-skills/temper.xml
@@ -56,4 +56,5 @@ The degree of enhancement, duration, and chance of success depend on many factor
   <name l="en">temper</name>
   <name l="ru">закалить</name>
   <name l="ua">закалити</name>
+  <webColumn>none</webColumn>
 </skill>

--- a/generic-skills/vampiric touch.xml
+++ b/generic-skills/vampiric touch.xml
@@ -59,4 +59,8 @@ The vampire touches the victim's neck, and they fall into a terrible nightmare. 
   <name l="en">vampiric touch</name>
   <name l="ru">прикосновение вампира</name>
   <name l="ua">дотик вампіра</name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">VampTouch</webLabel>
+  <webLabel l="ru">Кошмары</webLabel>
+  <webLabel l="ua">Жахіття</webLabel>
 </skill>

--- a/other-skills/accuracy.xml
+++ b/other-skills/accuracy.xml
@@ -21,4 +21,8 @@
   <name l="en">accuracy</name>
   <name l="ru">меткость</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Accuracy</webLabel>
+  <webLabel l="ru">Меткость</webLabel>
+  <webLabel l="ua">Влучність</webLabel>
 </skill>

--- a/other-skills/ahuramazda shroud.xml
+++ b/other-skills/ahuramazda shroud.xml
@@ -6,4 +6,8 @@
   <name l="en">ahuramazda shroud</name>
   <name l="ru">покров Ахурамазды</name>
   <name l="ua"></name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">AhuraShr</webLabel>
+  <webLabel l="ru">ПокрАхур</webLabel>
+  <webLabel l="ua">ПокрАхур</webLabel>
 </skill>

--- a/other-skills/alala courage.xml
+++ b/other-skills/alala courage.xml
@@ -6,4 +6,8 @@
   <name l="en">alala courage</name>
   <name l="ru">отвага Алалы</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AlalaCrg</webLabel>
+  <webLabel l="ru">ОтвагАлал</webLabel>
+  <webLabel l="ua">ВідвАлал</webLabel>
 </skill>

--- a/other-skills/allanon watchfulness.xml
+++ b/other-skills/allanon watchfulness.xml
@@ -6,4 +6,8 @@
   <name l="en">allanon watchfulness</name>
   <name l="ru">наблюдательность Алланона</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AllanonW</webLabel>
+  <webLabel l="ru">НаблАллан</webLabel>
+  <webLabel l="ua">СпостАлл</webLabel>
 </skill>

--- a/other-skills/altar.xml
+++ b/other-skills/altar.xml
@@ -6,4 +6,8 @@
   <name l="en">altar</name>
   <name l="ru">алтарь</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Altar</webLabel>
+  <webLabel l="ru">Алтарь</webLabel>
+  <webLabel l="ua">Вівтар</webLabel>
 </skill>

--- a/other-skills/ancient rage.xml
+++ b/other-skills/ancient rage.xml
@@ -15,4 +15,8 @@
   <name l="en">ancient rage</name>
   <name l="ru">древняя ярость</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AncRage</webLabel>
+  <webLabel l="ru">ДревЯрост</webLabel>
+  <webLabel l="ua">ДавняЛють</webLabel>
 </skill>

--- a/other-skills/ares amok.xml
+++ b/other-skills/ares amok.xml
@@ -6,4 +6,8 @@
   <name l="en">ares amok</name>
   <name l="ru">безумие Ареса</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AresAmok</webLabel>
+  <webLabel l="ru">БезумАрес</webLabel>
+  <webLabel l="ua">ШалАреса</webLabel>
 </skill>

--- a/other-skills/athena wisdom.xml
+++ b/other-skills/athena wisdom.xml
@@ -6,4 +6,8 @@
   <name l="en">athena wisdom</name>
   <name l="ru">мудрость Афины</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AthenaW</webLabel>
+  <webLabel l="ru">МудрАфин</webLabel>
+  <webLabel l="ua">МудрАфін</webLabel>
 </skill>

--- a/other-skills/azazel curse.xml
+++ b/other-skills/azazel curse.xml
@@ -6,4 +6,8 @@
   <name l="en">azazel curse</name>
   <name l="ru">проклятие Азазеля</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">AzCurse</webLabel>
+  <webLabel l="ru">ПроклАзаз</webLabel>
+  <webLabel l="ua">ПроклАзаз</webLabel>
 </skill>

--- a/other-skills/azazel fire.xml
+++ b/other-skills/azazel fire.xml
@@ -6,4 +6,8 @@
   <name l="en">azazel fire</name>
   <name l="ru">пламя Азазеля</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AzFire</webLabel>
+  <webLabel l="ru">ПламАзаз</webLabel>
+  <webLabel l="ua">ПолумАзаз</webLabel>
 </skill>

--- a/other-skills/azazel heal.xml
+++ b/other-skills/azazel heal.xml
@@ -6,4 +6,8 @@
   <name l="en">azazel heal</name>
   <name l="ru">здоровье Азазеля</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AzHeal</webLabel>
+  <webLabel l="ru">ЗдорАзаз</webLabel>
+  <webLabel l="ua">ЗдорАзаз</webLabel>
 </skill>

--- a/other-skills/azazel word.xml
+++ b/other-skills/azazel word.xml
@@ -6,4 +6,8 @@
   <name l="en">azazel word</name>
   <name l="ru">слово Азазеля</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">AzWord</webLabel>
+  <webLabel l="ru">СловАзаз</webLabel>
+  <webLabel l="ua">СловАзаз</webLabel>
 </skill>

--- a/other-skills/backguard.xml
+++ b/other-skills/backguard.xml
@@ -14,4 +14,8 @@
   <name l="en">backguard</name>
   <name l="ru">настороженность</name>
   <name l="ua"></name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">BackGrd</webLabel>
+  <webLabel l="ru">Насторож</webLabel>
+  <webLabel l="ua">Насторож</webLabel>
 </skill>

--- a/other-skills/beer armor.xml
+++ b/other-skills/beer armor.xml
@@ -23,4 +23,8 @@
   <name l="en">beer armor</name>
   <name l="ru">пивная броня</name>
   <name l="ua"></name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">BeerArm</webLabel>
+  <webLabel l="ru">ПивБроня</webLabel>
+  <webLabel l="ua">ПивБроня</webLabel>
 </skill>

--- a/other-skills/clumsiness.xml
+++ b/other-skills/clumsiness.xml
@@ -6,4 +6,8 @@
   <name l="en">clumsiness</name>
   <name l="ru">неуклюжесть</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Clumsy</webLabel>
+  <webLabel l="ru">Неуклюж</webLabel>
+  <webLabel l="ua">Незграбн</webLabel>
 </skill>

--- a/other-skills/corrosion.xml
+++ b/other-skills/corrosion.xml
@@ -27,4 +27,5 @@ Items cannot be protected from corrosion, but its effect can be removed with the
   <name l="en">corrosion</name>
   <name l="ru">коррозия</name>
   <name l="ua"></name>
+  <webColumn>none</webColumn>
 </skill>

--- a/other-skills/cow calm.xml
+++ b/other-skills/cow calm.xml
@@ -11,4 +11,8 @@
   <name l="en">cow calm</name>
   <name l="ru">коровья невозмутимость</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">CowCalm</webLabel>
+  <webLabel l="ru">КорНевозм</webLabel>
+  <webLabel l="ua">КорСпокій</webLabel>
 </skill>

--- a/other-skills/cow inspiration.xml
+++ b/other-skills/cow inspiration.xml
@@ -11,4 +11,8 @@
   <name l="en">cow inspiration</name>
   <name l="ru">коровье вдохновение</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">CowInspir</webLabel>
+  <webLabel l="ru">КорВдохн</webLabel>
+  <webLabel l="ua">КорНатхн</webLabel>
 </skill>

--- a/other-skills/cow lust.xml
+++ b/other-skills/cow lust.xml
@@ -11,4 +11,8 @@
   <name l="en">cow lust</name>
   <name l="ru">коровье бешенство</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">CowLust</webLabel>
+  <webLabel l="ru">КорБешенс</webLabel>
+  <webLabel l="ua">КорШал</webLabel>
 </skill>

--- a/other-skills/creativity.xml
+++ b/other-skills/creativity.xml
@@ -24,4 +24,8 @@
   <name l="en">creativity</name>
   <name l="ru">жажда творить</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Creative</webLabel>
+  <webLabel l="ru">ЖаждаТвор</webLabel>
+  <webLabel l="ua">ЖагаТвор</webLabel>
 </skill>

--- a/other-skills/deforestation.xml
+++ b/other-skills/deforestation.xml
@@ -27,4 +27,5 @@ Slightly damaged trees (for instance, notched) will heal their wounds in time, w
   <name l="en">deforestation</name>
   <name l="ru">обезлесение</name>
   <name l="ua"></name>
+  <webColumn>none</webColumn>
 </skill>

--- a/other-skills/dwarkin mastery.xml
+++ b/other-skills/dwarkin mastery.xml
@@ -6,4 +6,8 @@
   <name l="en">dwarkin mastery</name>
   <name l="ru">мастерство Дворкина</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">DwarkinM</webLabel>
+  <webLabel l="ru">МастДворк</webLabel>
+  <webLabel l="ua">МайстДвор</webLabel>
 </skill>

--- a/other-skills/eruption.xml
+++ b/other-skills/eruption.xml
@@ -8,4 +8,5 @@
   <name l="en">eruption</name>
   <name l="ru">извержение</name>
   <name l="ua"></name>
+  <webColumn>none</webColumn>
 </skill>

--- a/other-skills/faery blessing.xml
+++ b/other-skills/faery blessing.xml
@@ -9,4 +9,8 @@
   <name l="en">faery blessing</name>
   <name l="ru">благословение фей</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">FaeryBls</webLabel>
+  <webLabel l="ru">БлагФей</webLabel>
+  <webLabel l="ua">БлагФей</webLabel>
 </skill>

--- a/other-skills/fatigue.xml
+++ b/other-skills/fatigue.xml
@@ -40,4 +40,8 @@ Fatigue usually passes quickly and your body returns to normal. In some cases fa
   <name l="en">fatigue</name>
   <name l="ru">усталость</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Fatigue</webLabel>
+  <webLabel l="ru">Усталость</webLabel>
+  <webLabel l="ua">Втома</webLabel>
 </skill>

--- a/other-skills/fervor.xml
+++ b/other-skills/fervor.xml
@@ -36,4 +36,8 @@ At the same time your reaction speed increases, reducing the {hh120lag{x after u
   <name l="en">fervor</name>
   <name l="ru">задор</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Fervor</webLabel>
+  <webLabel l="ru">Задор</webLabel>
+  <webLabel l="ua">Запал</webLabel>
 </skill>

--- a/other-skills/frostbite.xml
+++ b/other-skills/frostbite.xml
@@ -6,4 +6,8 @@
   <name l="en">frostbite</name>
   <name l="ru">укус зимы</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Frostbite</webLabel>
+  <webLabel l="ru">Обморож</webLabel>
+  <webLabel l="ua">Обморож</webLabel>
 </skill>

--- a/other-skills/gratitude.xml
+++ b/other-skills/gratitude.xml
@@ -9,4 +9,8 @@
   <name l="en">gratitude</name>
   <name l="ru">благодарность</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Gratitude</webLabel>
+  <webLabel l="ru">Благодар</webLabel>
+  <webLabel l="ua">Вдячність</webLabel>
 </skill>

--- a/other-skills/heat.xml
+++ b/other-skills/heat.xml
@@ -10,4 +10,8 @@
   <name l="en">heat</name>
   <name l="ru">пожар</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Heat</webLabel>
+  <webLabel l="ru">Пожар</webLabel>
+  <webLabel l="ua">Пожежа</webLabel>
 </skill>

--- a/other-skills/incandescent.xml
+++ b/other-skills/incandescent.xml
@@ -37,4 +37,5 @@ The spell {hh633protection from high temperatures{x will prevent items from heat
   <name l="en">incandescent</name>
   <name l="ru">накал</name>
   <name l="ua"></name>
+  <webColumn>none</webColumn>
 </skill>

--- a/other-skills/kind cognition.xml
+++ b/other-skills/kind cognition.xml
@@ -6,4 +6,8 @@
   <name l="en">kind cognition</name>
   <name l="ru">познание Кинд</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">KindCogn</webLabel>
+  <webLabel l="ru">ПознанКинд</webLabel>
+  <webLabel l="ua">ПізнанКінд</webLabel>
 </skill>

--- a/other-skills/leo vigilance.xml
+++ b/other-skills/leo vigilance.xml
@@ -6,4 +6,8 @@
   <name l="en">leo vigilance</name>
   <name l="ru">бдительность Лео</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">LeoVigil</webLabel>
+  <webLabel l="ru">БдитЛео</webLabel>
+  <webLabel l="ua">ПильнЛео</webLabel>
 </skill>

--- a/other-skills/lloth snare.xml
+++ b/other-skills/lloth snare.xml
@@ -10,4 +10,8 @@
   <name l="en">lloth snare</name>
   <name l="ru">тенета Ллот</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Snare</webLabel>
+  <webLabel l="ru">Тенета</webLabel>
+  <webLabel l="ua">Тенета</webLabel>
 </skill>

--- a/other-skills/logging area.xml
+++ b/other-skills/logging area.xml
@@ -8,4 +8,5 @@
   <name l="en">logging area</name>
   <name l="ru">лесозаготовка</name>
   <name l="ua"></name>
+  <webColumn>none</webColumn>
 </skill>

--- a/other-skills/nicotine rush.xml
+++ b/other-skills/nicotine rush.xml
@@ -6,4 +6,8 @@
   <name l="en">nicotine rush</name>
   <name l="ru">никотиновый приход</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Nicotine</webLabel>
+  <webLabel l="ru">Никотин</webLabel>
+  <webLabel l="ua">Нікотин</webLabel>
 </skill>

--- a/other-skills/nofate development.xml
+++ b/other-skills/nofate development.xml
@@ -6,4 +6,8 @@
   <name l="en">nofate development</name>
   <name l="ru">разработка НоФейт</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">NoFateDev</webLabel>
+  <webLabel l="ru">РазрНоФейт</webLabel>
+  <webLabel l="ua">РозрНоФейт</webLabel>
 </skill>

--- a/other-skills/perfume.xml
+++ b/other-skills/perfume.xml
@@ -10,4 +10,8 @@
   <name l="en">perfume</name>
   <name l="ru">благоухание</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Perfume</webLabel>
+  <webLabel l="ru">Благоух</webLabel>
+  <webLabel l="ua">Пахощі</webLabel>
 </skill>

--- a/other-skills/poured liquid.xml
+++ b/other-skills/poured liquid.xml
@@ -8,4 +8,8 @@
   <name l="en">poured liquid</name>
   <name l="ru">вылитая жидкость</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Doused</webLabel>
+  <webLabel l="ru">Облит</webLabel>
+  <webLabel l="ua">Облитий</webLabel>
 </skill>

--- a/other-skills/sacrifice.xml
+++ b/other-skills/sacrifice.xml
@@ -6,4 +6,8 @@
   <name l="en">sacrifice</name>
   <name l="ru">жертвоприношение</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Sacrifice</webLabel>
+  <webLabel l="ru">Жертва</webLabel>
+  <webLabel l="ua">Жертва</webLabel>
 </skill>

--- a/other-skills/set amazon.xml
+++ b/other-skills/set amazon.xml
@@ -9,4 +9,8 @@
   <name l="en">set amazon</name>
   <name l="ru">стремительность амазонки</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Amazon</webLabel>
+  <webLabel l="ru">Амазонка</webLabel>
+  <webLabel l="ua">Амазонка</webLabel>
 </skill>

--- a/other-skills/set ashigaru.xml
+++ b/other-skills/set ashigaru.xml
@@ -9,4 +9,8 @@
   <name l="en">set ashigaru</name>
   <name l="ru">сила асигару</name>
   <name l="ua">сила асігару</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Ashigaru</webLabel>
+  <webLabel l="ru">Асигару</webLabel>
+  <webLabel l="ua">Асігару</webLabel>
 </skill>

--- a/other-skills/set berserker.xml
+++ b/other-skills/set berserker.xml
@@ -9,4 +9,8 @@
   <name l="en">set berserker</name>
   <name l="ru">ярость берсерка</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Berserkr</webLabel>
+  <webLabel l="ru">ЯрБерсрк</webLabel>
+  <webLabel l="ua">ЛютьБерс</webLabel>
 </skill>

--- a/other-skills/set davy jones.xml
+++ b/other-skills/set davy jones.xml
@@ -9,4 +9,8 @@
   <name l="en">set davy jones</name>
   <name l="ru">награда Дэви Джонса</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">DavyJones</webLabel>
+  <webLabel l="ru">ДэвиДжон</webLabel>
+  <webLabel l="ua">ДевіДжон</webLabel>
 </skill>

--- a/other-skills/set defender.xml
+++ b/other-skills/set defender.xml
@@ -9,4 +9,8 @@
   <name l="en">set defender</name>
   <name l="ru">стойкость защитника</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Defender</webLabel>
+  <webLabel l="ru">Защитник</webLabel>
+  <webLabel l="ua">Захисник</webLabel>
 </skill>

--- a/other-skills/set fathers.xml
+++ b/other-skills/set fathers.xml
@@ -9,4 +9,8 @@
   <name l="en">set fathers</name>
   <name l="ru">отцовское наследство</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Fathers</webLabel>
+  <webLabel l="ru">Отцовск</webLabel>
+  <webLabel l="ua">Батьківс</webLabel>
 </skill>

--- a/other-skills/set gloomstalker.xml
+++ b/other-skills/set gloomstalker.xml
@@ -9,4 +9,8 @@
   <name l="en">set gloomstalker</name>
   <name l="ru">тени мрака</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Gloom</webLabel>
+  <webLabel l="ru">ТениМрака</webLabel>
+  <webLabel l="ua">ТініМорок</webLabel>
 </skill>

--- a/other-skills/set hoplite.xml
+++ b/other-skills/set hoplite.xml
@@ -9,4 +9,8 @@
   <name l="en">set hoplite</name>
   <name l="ru">скорость гоплита</name>
   <name l="ua">швидкість гопліта</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Hoplite</webLabel>
+  <webLabel l="ru">Гоплит</webLabel>
+  <webLabel l="ua">Гопліт</webLabel>
 </skill>

--- a/other-skills/set master thief.xml
+++ b/other-skills/set master thief.xml
@@ -9,4 +9,8 @@
   <name l="en">set master thief</name>
   <name l="ru">мастер воровства</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">MastThief</webLabel>
+  <webLabel l="ru">МастВор</webLabel>
+  <webLabel l="ua">МайстКрад</webLabel>
 </skill>

--- a/other-skills/set morris dancer.xml
+++ b/other-skills/set morris dancer.xml
@@ -39,4 +39,8 @@ Set level: 3 Number of items: 4
   <name l="en">set morris dancer</name>
   <name l="ru">танцор морриса</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Morris</webLabel>
+  <webLabel l="ru">Моррис</webLabel>
+  <webLabel l="ua">Морріс</webLabel>
 </skill>

--- a/other-skills/set myrmidon.xml
+++ b/other-skills/set myrmidon.xml
@@ -9,4 +9,8 @@
   <name l="en">set myrmidon</name>
   <name l="ru">сила мирмидонянина</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Myrmidon</webLabel>
+  <webLabel l="ru">Мирмидон</webLabel>
+  <webLabel l="ua">Мірмідон</webLabel>
 </skill>

--- a/other-skills/set myrvale noriva.xml
+++ b/other-skills/set myrvale noriva.xml
@@ -42,4 +42,8 @@ Set level: 78 Number of items: 12
   <name l="en">set myrvale noriva</name>
   <name l="ru">мирвейл Норива</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Noriva</webLabel>
+  <webLabel l="ru">Норива</webLabel>
+  <webLabel l="ua">Норіва</webLabel>
 </skill>

--- a/other-skills/set pixie.xml
+++ b/other-skills/set pixie.xml
@@ -9,4 +9,8 @@
   <name l="en">set pixie</name>
   <name l="ru">доспехи пикси</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Pixie</webLabel>
+  <webLabel l="ru">Пикси</webLabel>
+  <webLabel l="ua">Піксі</webLabel>
 </skill>

--- a/other-skills/set secret of sidhe.xml
+++ b/other-skills/set secret of sidhe.xml
@@ -33,4 +33,8 @@ Set level: 68 Number of items: 5
   <name l="en">set secret of sidhe</name>
   <name l="ru">секрет Сидхов</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">SidheSec</webLabel>
+  <webLabel l="ru">СекрСидх</webLabel>
+  <webLabel l="ua">СекрСідх</webLabel>
 </skill>

--- a/other-skills/set shevale reykaris.xml
+++ b/other-skills/set shevale reykaris.xml
@@ -39,4 +39,8 @@ Set level: 85 Number of items: 9
   <name l="en">set shevale reykaris</name>
   <name l="ru">шивейл Рейкарис</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Reykaris</webLabel>
+  <webLabel l="ru">Рейкарис</webLabel>
+  <webLabel l="ua">Рейкаріс</webLabel>
 </skill>

--- a/other-skills/set travellers joy.xml
+++ b/other-skills/set travellers joy.xml
@@ -33,4 +33,8 @@ Set level: 14 Number of items: 4
   <name l="en">set travellers joy</name>
   <name l="ru">отрада путешественника</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Traveller</webLabel>
+  <webLabel l="ru">Путешес</webLabel>
+  <webLabel l="ua">Мандрівн</webLabel>
 </skill>

--- a/other-skills/set wood nymph.xml
+++ b/other-skills/set wood nymph.xml
@@ -9,4 +9,8 @@
   <name l="en">set wood nymph</name>
   <name l="ru">оберег древесных нимф</name>
   <name l="ua">оберіг мавок</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">WoodNymph</webLabel>
+  <webLabel l="ru">ДревНимф</webLabel>
+  <webLabel l="ua">Мавки</webLabel>
 </skill>

--- a/other-skills/sidhe armor.xml
+++ b/other-skills/sidhe armor.xml
@@ -24,4 +24,8 @@
   <name l="en">sidhe armor</name>
   <name l="ru">броня сидхов</name>
   <name l="ua"></name>
+  <webColumn>pro</webColumn>
+  <webLabel l="en">SidheArm</webLabel>
+  <webLabel l="ru">БронСидх</webLabel>
+  <webLabel l="ua">БронСідх</webLabel>
 </skill>

--- a/other-skills/stuck item.xml
+++ b/other-skills/stuck item.xml
@@ -8,4 +8,8 @@
   <name l="en">stuck item</name>
   <name l="ru">застрявший предмет</name>
   <name l="ua"></name>
+  <webColumn>mal</webColumn>
+  <webLabel l="en">Stuck</webLabel>
+  <webLabel l="ru">Застряло</webLabel>
+  <webLabel l="ua">Застрягло</webLabel>
 </skill>

--- a/other-skills/swim.xml
+++ b/other-skills/swim.xml
@@ -8,4 +8,8 @@
   <name l="en">swim</name>
   <name l="ru">плавание</name>
   <name l="ua"></name>
+  <webColumn>trv</webColumn>
+  <webLabel l="en">Swim</webLabel>
+  <webLabel l="ru">Плавание</webLabel>
+  <webLabel l="ua">Плавання</webLabel>
 </skill>

--- a/other-skills/synesthesia.xml
+++ b/other-skills/synesthesia.xml
@@ -14,4 +14,5 @@
   <name l="en">synesthesia</name>
   <name l="ru">синестезия</name>
   <name l="ua">сінестезія</name>
+  <webColumn>none</webColumn>
 </skill>

--- a/other-skills/tirna freedom.xml
+++ b/other-skills/tirna freedom.xml
@@ -6,4 +6,8 @@
   <name l="en">tirna freedom</name>
   <name l="ru">свобода Тирны</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">TirnaFree</webLabel>
+  <webLabel l="ru">СвобТирны</webLabel>
+  <webLabel l="ua">ВоляТірни</webLabel>
 </skill>

--- a/other-skills/turlok fury.xml
+++ b/other-skills/turlok fury.xml
@@ -6,4 +6,8 @@
   <name l="en">turlok fury</name>
   <name l="ru">ярость Турлока</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">TurlokFur</webLabel>
+  <webLabel l="ru">ЯростТурл</webLabel>
+  <webLabel l="ua">ЛютьТурл</webLabel>
 </skill>

--- a/other-skills/varda blessing.xml
+++ b/other-skills/varda blessing.xml
@@ -6,4 +6,8 @@
   <name l="en">varda blessing</name>
   <name l="ru">благословение Варды</name>
   <name l="ua"></name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">VardaBls</webLabel>
+  <webLabel l="ru">БлагВарды</webLabel>
+  <webLabel l="ua">БлагВарди</webLabel>
 </skill>

--- a/race-aptitudes/search stones.xml
+++ b/race-aptitudes/search stones.xml
@@ -49,4 +49,5 @@ Find stones:
       <level>25</level>
     </node>
   </races>
+  <webColumn>none</webColumn>
 </skill>

--- a/scripts/lint-affect-labels.py
+++ b/scripts/lint-affect-labels.py
@@ -4,24 +4,77 @@ Lint the web-client affect-panel curation.
 
 The panel (plug-ins/web/impl.cpp AffectsWebPromptListener) shows every active affect,
 picking its column + short label from the skill profile fields <webColumn>/<webLabel>.
-A skill that applies a lasting affect but has no <webColumn> still shows -- auto-classified
-(offensive -> mal, else -> enh) and labelled from its own <name> -- so nothing is silently
-missing, but it lands in a guessed column with an un-abbreviated label.
+A skill with no <webColumn> still shows -- auto-classified (offensive spell -> mal,
+everything else -> enh) and labelled from its own <name>. To keep an internal or
+tracking affect out of the panel, say so explicitly: <webColumn>none</webColumn>.
 
-This script lists those skills so the gap is a visible TODO, not a silent omission.
+Three checks:
+  1. <webColumn> holds a legal value                          (hard error)
+  2. no two skills share a (column, label) pair per language  (hard error --
+     the panel de-dups on exactly that key, so the second one vanishes)
+  3. skills still riding the auto-classify fallback           (advisory)
+
+A skill is panel-relevant if it declares <affect type=...>, or a Fenia script names
+it in `af.type = "..."` / `.Affect("...")`, or the engine applies it via
+`postaffect_to_char(ch, gsn_x, ...)` / `af.type = gsn_x`. The Fenia and C++ halves
+only run when dreamland_fenia / dreamland_fenia_public / dreamland_code sit next to
+this repo -- without them the lint under-reports, and says so.
+
 Run from the dreamland_world repo root:  python3 scripts/lint-affect-labels.py
 """
 import os, re, sys
 
-DIRS = ["generic-skills", "clan-skills", "other-skills", "race-aptitudes", "card-skills"]
+DIRS = ["generic-skills", "clan-skills", "other-skills", "race-aptitudes",
+        "card-skills", "craft-skills"]
 VALID = {"pro", "det", "trv", "enh", "mal", "cln", "none"}
+LANGS = ("en", "ru", "ua")
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 col_re = re.compile(r"<webColumn>([^<]*)</webColumn>")
 name_re = re.compile(r'<name l="en">([^<]*)</name>')
+lab_re = re.compile(r'<webLabel l="([^"]*)">([^<]*)</webLabel>')
+fenia_re = re.compile(r'af\.type\s*=\s*"([^"]+)"|\.Affect\(\s*"([^"]+)"')
+cpp_re = re.compile(r'postaffect_to_char\s*\(\s*[^,]+,\s*gsn_(\w+)'
+                    r'|\.type\s*=\s*gsn_(\w+)')
+
+
+def _scan(repo, regex, suffixes, convert):
+    """Affect names a sibling repo applies. Empty set if that repo isn't checked out."""
+    base = os.path.join(os.path.dirname(root), repo)
+    if not os.path.isdir(base):
+        return set()
+    found = set()
+    for dirpath, dirnames, files in os.walk(base):
+        dirnames[:] = [d for d in dirnames if d != ".git"]
+        for f in files:
+            if suffixes and not f.endswith(suffixes):
+                continue
+            try:
+                txt = open(os.path.join(dirpath, f), encoding="utf-8", errors="replace").read()
+            except OSError:
+                continue
+            for m in regex.finditer(txt):
+                found.add(convert(m.group(1) or m.group(2)))
+    return found
+
+
+# Fenia names affects by skill name; C++ by gsn_ symbol, where _ stands for a space.
+applied = set()
+missing_repos = []
+for repo, regex, sfx, conv in (
+        ("dreamland_fenia", fenia_re, None, lambda s: s),
+        ("dreamland_fenia_public", fenia_re, None, lambda s: s),
+        ("dreamland_code", cpp_re, (".cpp", ".h"), lambda s: s.replace("_", " ")),
+):
+    if not os.path.isdir(os.path.join(os.path.dirname(root), repo)):
+        missing_repos.append(repo)
+        continue
+    applied |= _scan(repo, regex, sfx, conv)
 
 uncurated, bad_col, curated = [], [], 0
+labels = {}      # (column, lang, lowercased label) -> first skill that claimed it
+collisions = []
 
 for d in DIRS:
     dp = os.path.join(root, d)
@@ -30,35 +83,60 @@ for d in DIRS:
     for fn in sorted(os.listdir(dp)):
         if not fn.endswith(".xml"):
             continue
-        p = os.path.join(dp, fn)
-        txt = open(p, encoding="utf-8", errors="replace").read()
-        # Only skills that apply a lasting affect are panel-relevant.
-        if "<affect type=" not in txt:
-            continue
         rel = os.path.join(d, fn)
+        txt = open(os.path.join(dp, fn), encoding="utf-8", errors="replace").read()
+        names = name_re.findall(txt)
+        en = names[-1] if names else "?"
+        # Panel-relevant: declares an affect handler, or Fenia applies an affect of this name.
+        if "<affect type=" not in txt and en not in applied:
+            continue
+
         m = col_re.search(txt)
         if not m:
-            names = name_re.findall(txt)
-            uncurated.append((rel, names[-1] if names else "?"))
+            uncurated.append((rel, en))
             continue
         curated += 1
         col = m.group(1).strip()
         if col not in VALID:
             bad_col.append((rel, col))
+            continue
+        if col == "none":
+            continue
+
+        for lang, lab in lab_re.findall(txt):
+            if lang not in LANGS or not lab.strip():
+                continue
+            # Case-sensitive on purpose: mirrors AffectPanelColumns::add exactly,
+            # so this never reports a collision the panel does not actually have.
+            key = (col, lang, lab.strip())
+            if key in labels:
+                collisions.append((rel, labels[key], col, lang, lab.strip()))
+            else:
+                labels[key] = rel
 
 print("Affect-panel curation lint")
 print("  curated skills (have <webColumn>): %d" % curated)
 print("  uncurated affect skills (auto-classified): %d" % len(uncurated))
+if missing_repos:
+    print("  NOTE: not checked out next to this repo, so affects applied there are")
+    print("        invisible to this lint: %s" % ", ".join(missing_repos))
 
 if bad_col:
     print("\nINVALID <webColumn> values (must be pro/det/trv/enh/mal/cln/none):")
     for rel, col in bad_col:
         print("  %-45s %r" % (rel, col))
 
+if collisions:
+    print("\nDUPLICATE (column, label) -- the panel de-dups on this key, so one of the two")
+    print("never renders. Give one of them a different <webLabel>:")
+    for rel, other, col, lang, lab in collisions:
+        print("  %-45s %s/%s %r  collides with %s" % (rel, col, lang, lab, other))
+
 if uncurated:
-    print("\nUncurated affect skills -- add <webColumn>+<webLabel> for a proper column/label:")
+    print("\nUncurated affect skills -- add <webColumn>+<webLabel> for a proper column/label,")
+    print("or <webColumn>none</webColumn> if it should stay out of the panel:")
     for rel, en in uncurated:
         print("  %-45s (%s)" % (rel, en))
 
-# Non-zero exit only on hard errors (invalid column); uncurated is advisory.
-sys.exit(1 if bad_col else 0)
+# Non-zero exit on hard errors (invalid column, colliding labels); uncurated is advisory.
+sys.exit(1 if (bad_col or collisions) else 0)


### PR DESCRIPTION
Fixes two player bug reports: the `пожар` (heat) and `благодарность` (gratitude) affects never appeared in the web client's affect panel or in `mudprompt`.

Same cause for both: `AffectsWebPromptListener` dropped every affect whose skill had no `<webColumn>` and was not a castable spell. 98 affect-applying skills were invisible that way. Three of them set `AFF_BLIND` themselves, so `bitOwnedBySpell()` also suppressed the raw fallback chip — a fire-blinded player saw an empty panel.

- curates 98 skills with `<webColumn>` + short trilingual `<webLabel>`
- 13 object/room-only or internal ones get an explicit `<webColumn>none</webColumn>`
- fixes two pre-existing `(column, label)` collisions (`soul lust` carried `shadow shroud`'s labels verbatim; `set berserker` UA vs `berserk`) — the panel de-dups on that key, so one of each pair never rendered
- `lint-affect-labels.py`: adds the collision check, sees Fenia- and C++-applied affects, covers `craft-skills`, and its docstring no longer claims uncurated affects show when they did not

Engine-side default flip ships separately in `dreamland_code`; a non-empty `<webColumn>` already skips the dropping branch, so this alone fixes both reports on the current binary.