### PR TITLE
Fix the Ukrainian label for fade in the affect panel

### DIFF
--- a/clan-skills/fade.xml
+++ b/clan-skills/fade.xml
@@ -65,5 +65,5 @@ Unlike the skill {hh798to hide{x, this skill allows hiding in a much wider range
   <webColumn>trv</webColumn>
   <webLabel l="en">Fade</webLabel>
   <webLabel l="ru">Спрят</webLabel>
-  <webLabel l="ua">Мляв</webLabel>
+  <webLabel l="ua">Тінь</webLabel>
 </skill>

--- a/config/affectpanel.json
+++ b/config/affectpanel.json
@@ -20,7 +20,7 @@
         "sneak":      { "en": "Sneak",  "ru": "Подкр",  "ua": "Крадьк" },
         "flying":     { "en": "Fly",    "ru": "Полет",  "ua": "Політ" },
         "pass_door":  { "en": "PassDr", "ru": "Прозр",  "ua": "КрізьД" },
-        "fade":       { "en": "Fade",   "ru": "Спрят",  "ua": "Мляв" },
+        "fade":       { "en": "Fade",   "ru": "Спрят",  "ua": "Тінь" },
         "camouflage": { "en": "Camo",   "ru": "Камуфл", "ua": "Камуфл" }
     },
     "pro": {


### PR DESCRIPTION
`fade`'s UA chip read **Мляв** (sluggish). The skill's own removal message is `Ты перестаешь прятаться во Тьме` — it is shadow concealment. Now **Тінь**, in both `config/affectpanel.json` and `clan-skills/fade.xml` so the chip reads the same whether it arrives through the paf or the raw bit.

Rides the next reboot: code#995 is building on live, so `plug reload most` is closed until then.