### PR TITLE
Give each autoquest type a stable Fenia id

### DIFF
--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
+  <feniaId>4</feniaId>
   <priority>1</priority>
   <shortDesc>Банду геть</shortDesc>
   <shortDesc l="en">Down with the Gang</shortDesc>

--- a/quests/ButcherQuest.xml
+++ b/quests/ButcherQuest.xml
@@ -5,6 +5,7 @@
     <node>cook</node>
     <node>кухарка</node>
   </cooks>
+  <feniaId>3</feniaId>
   <priority>1</priority>
   <races>
     <node>hoofed</node>

--- a/quests/HealQuest.xml
+++ b/quests/HealQuest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
+  <feniaId>5</feniaId>
   <priority>2</priority>
   <scenarios>
     <node name="blindness" type="HealScenario">

--- a/quests/KidnapQuest.xml
+++ b/quests/KidnapQuest.xml
@@ -3,6 +3,7 @@
   <banditVnum>28101</banditVnum>
   <markVnum>28100</markVnum>
   <princeVnum>28100</princeVnum>
+  <feniaId>8</feniaId>
   <priority>3</priority>
   <scenarios>
     <node name="bidon" type="KidnapBidonScenario">

--- a/quests/KillQuest.xml
+++ b/quests/KillQuest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
+  <feniaId>1</feniaId>
   <priority>10</priority>
   <shortDesc>Убийство</shortDesc>
   <shortDesc l="en">Assassination</shortDesc>

--- a/quests/LocateQuest.xml
+++ b/quests/LocateQuest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <itemVnum>28108</itemVnum>
+  <feniaId>7</feniaId>
   <priority>1</priority>
   <scenarios>
     <node name="alchemist" type="LocateAlchemistScenario">

--- a/quests/StaffQuest.xml
+++ b/quests/StaffQuest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <objVnum>28107</objVnum>
+  <feniaId>2</feniaId>
   <priority>1</priority>
   <scenarios>
     <node name="chest" type="StaffScenario">

--- a/quests/StealQuest.xml
+++ b/quests/StealQuest.xml
@@ -9,6 +9,7 @@
     <node>28103</node>
     <node>28105</node>
   </chests>
+  <feniaId>6</feniaId>
   <priority>4</priority>
   <shortDesc>Помощь жертвам ограблений</shortDesc>
   <shortDesc l="en">Helping Robbery Victims</shortDesc>


### PR DESCRIPTION
Pairs with dreamland_code#998. `<feniaId>` is the key of that type's entry in the Fenia DB, so it is declared here explicitly and must never be reused or renumbered: an id that moved would re-point Fenia scripts written for one quest type at another.

Kill 1, Staff 2, Butcher 3, Big 4, Heal 5, Steal 6, Locate 7, Kidnap 8.

Harmless on the current binary — an unknown node is logged as unparsed and ignored — so the order between the two repos does not matter. `QuestManager::load` on the new binary logs an error if two types ever end up sharing an id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)