### PR TITLE
Name the engine each autoquest type runs on

### DIFF
--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <feniaId>4</feniaId>
+  <engine>cpp</engine>
   <priority>1</priority>
   <shortDesc>Банду геть</shortDesc>
   <shortDesc l="en">Down with the Gang</shortDesc>

--- a/quests/ButcherQuest.xml
+++ b/quests/ButcherQuest.xml
@@ -6,6 +6,7 @@
     <node>кухарка</node>
   </cooks>
   <feniaId>3</feniaId>
+  <engine>cpp</engine>
   <priority>1</priority>
   <races>
     <node>hoofed</node>

--- a/quests/HealQuest.xml
+++ b/quests/HealQuest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <feniaId>5</feniaId>
+  <engine>cpp</engine>
   <priority>2</priority>
   <scenarios>
     <node name="blindness" type="HealScenario">

--- a/quests/KidnapQuest.xml
+++ b/quests/KidnapQuest.xml
@@ -4,6 +4,7 @@
   <markVnum>28100</markVnum>
   <princeVnum>28100</princeVnum>
   <feniaId>8</feniaId>
+  <engine>cpp</engine>
   <priority>3</priority>
   <scenarios>
     <node name="bidon" type="KidnapBidonScenario">

--- a/quests/KillQuest.xml
+++ b/quests/KillQuest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <feniaId>1</feniaId>
+  <engine>cpp</engine>
   <priority>10</priority>
   <shortDesc>Убийство</shortDesc>
   <shortDesc l="en">Assassination</shortDesc>

--- a/quests/LocateQuest.xml
+++ b/quests/LocateQuest.xml
@@ -2,6 +2,7 @@
 <Quest>
   <itemVnum>28108</itemVnum>
   <feniaId>7</feniaId>
+  <engine>cpp</engine>
   <priority>1</priority>
   <scenarios>
     <node name="alchemist" type="LocateAlchemistScenario">

--- a/quests/StaffQuest.xml
+++ b/quests/StaffQuest.xml
@@ -2,6 +2,7 @@
 <Quest>
   <objVnum>28107</objVnum>
   <feniaId>2</feniaId>
+  <engine>cpp</engine>
   <priority>1</priority>
   <scenarios>
     <node name="chest" type="StaffScenario">

--- a/quests/StealQuest.xml
+++ b/quests/StealQuest.xml
@@ -10,6 +10,7 @@
     <node>28105</node>
   </chests>
   <feniaId>6</feniaId>
+  <engine>cpp</engine>
   <priority>4</priority>
   <shortDesc>Помощь жертвам ограблений</shortDesc>
   <shortDesc l="en">Helping Robbery Victims</shortDesc>


### PR DESCRIPTION
Every type gets <engine>cpp</engine>, which is what they all do today. It
becomes the switch step 5 onwards flips to `fenia`, one type at a time, with
`quest set reload` and no reboot.

Written now rather than when the first type flips, because the rollback has a
trap otherwise: reload merges rather than replaces, so DELETING the node leaves
the old value in place until the next reboot even though the file reads as if
the type is back on C++. With the word already there, rolling back is editing
it, and the trap is out of reach.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)