### PR TITLE
Translate the quest target markers for the new target class

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -15357,6 +15357,16 @@
    "ua": "{YТвоє завдання вже неможливо виконати. За кілька хвилин зможеш попросити нове.{x"
   }
  },
+ "plug-ins/quest/core/questtargets.cpp": {
+  "{R[ЦЕЛЬ] {x": {
+   "en": "{R[TARGET] {x",
+   "ua": "{R[ЦІЛЬ] {x"
+  },
+  "{R[ВОР] {x": {
+   "en": "{R[THIEF] {x",
+   "ua": "{R[КРАДІЙ] {x"
+  }
+ },
  "plug-ins/quest/core/xmlattributequestdata.cpp": {
   "Время, отведенное на задание, вышло!": {
    "en": "Time's up for the quest!",


### PR DESCRIPTION
Step 3 moves the [ЦЕЛЬ] and [ВОР] look tags into one generic
plug-ins/quest/core/questtargets.cpp, and the l10n catalog is keyed per source
FILE -- so without these the tags would have gone on rendering, in Russian, to
every English and Ukrainian player.

Same wording as the entries already under killquest/victimbehavior.cpp and
stealquest/mobiles.cpp; those stay where they are until the C++ types they
belong to are deleted, which is the last step of the migration.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)