### PR TITLE
Translate the Fenia killquest scenario

### DIFF
--- a/config/translations/autoquest.json
+++ b/config/translations/autoquest.json
@@ -1,0 +1,94 @@
+{
+ "autoquest/kill/onCreate": {
+  "%1$^C1 говорит тебе '{GУ меня есть для тебя срочное поручение!{x'": {
+   "en": "%1$^C1 tells you '{GI have an urgent task for you!{x'",
+   "ua": "%1$^C1 каже тобі '{GУ мене є для тебе термінове доручення!{x'"
+  },
+  "%1$^C1 говорит тебе '{GСпокойствие нашего Мира было нарушено!{x'": {
+   "en": "%1$^C1 tells you '{GThe peace of our World has been disturbed!{x'",
+   "ua": "%1$^C1 каже тобі '{GСпокій нашого Світу було порушено!{x'"
+  },
+  "%1$^C1 говорит тебе '{GЯ поручаю тебе наказать {W%2$#C4{G, совершивш%2$Gее|его|ую множество злодеяний.{x'": {
+   "en": "%1$^C1 tells you '{GI'm charging you with punishing {W%2$#C4{G, who has committed countless atrocities.{x'",
+   "ua": "%1$^C1 каже тобі '{GЯ доручаю тобі покарати {W%2$#C4{G, що вчин%2$Gило|ив|ила безліч лиходійств.{x'"
+  },
+  "%1$^C1 говорит тебе '{GТемные силы нашего Мира ослаблены действиями {W%2$#C2{G.{x'": {
+   "en": "%1$^C1 tells you '{GThe dark forces of our World have been weakened by the deeds of {W%2$#C2{G.{x'",
+   "ua": "%1$^C1 каже тобі '{GТемні сили нашого Світу ослаблені діяннями {W%2$#C2{G.{x'"
+  },
+  "%1$^C1 говорит тебе '{GТебе поручается убить %2$P2!{x'": {
+   "en": "%1$^C1 tells you '{GYou are ordered to kill %2$C4!{x'",
+   "ua": "%1$^C1 каже тобі '{GТобі доручається вбити %2$C4!{x'"
+  },
+  "%1$^C1 говорит тебе '{GРавновесие нашего Мира было нарушено!{x'": {
+   "en": "%1$^C1 tells you '{GThe balance of our World has been disturbed!{x'",
+   "ua": "%1$^C1 каже тобі '{GРівновагу нашого Світу порушено!{x'"
+  },
+  "%1$^C1 говорит тебе '{GВ этом винов%2$Gно|ен|на {W%2$#C1{G, я поручаю тебе наказать %2$P2.{x'": {
+   "en": "%1$^C1 tells you '{G{W%2$#C1{G is guilty of this, so I'm tasking you with punishing them.{x'",
+   "ua": "%1$^C1 каже тобі '{GУ цьому вин%2$Gне|ен|на|ні {W%2$#C1{G, тож доручаю тобі покарати %2$C4.{x'"
+  },
+  "%1$^C1 говорит тебе '{GМесто, где %2$P2 видели в последний раз -- {W%3$s{G!{x'": {
+   "en": "%1$^C1 tells you '{GThe place where %2$C4 was last seen -- {W%3$s{G!{x'",
+   "ua": "%1$^C1 каже тобі '{GМісце, де %2$C4 бачили востаннє -- {W%3$s{G!{x'"
+  },
+  "%1$^C1 говорит тебе '{GЭто находится в районе под названием {W{hh%2$s{hx{G.{x'": {
+   "en": "%1$^C1 tells you '{GIt is located in an area called {W{hh%2$s{hx{G.{x'",
+   "ua": "%1$^C1 каже тобі '{GЦе знаходиться в районі під назвою {W{hh%2$s{hx{G.{x'"
+  },
+  "%1$^C1 говорит тебе '{GУ тебя есть {Y%2$d{G мину%2$Iта|ты|т на выполнение задания.{x'": {
+   "en": "%1$^C1 tells you '{GYou have {Y%2$d{G minute%2$gs||s to complete the task.{x'",
+   "ua": "%1$^C1 каже тобі '{GУ тебе є {Y%2$d{G хвилин%2$Iа|и| на виконання завдання.{x'"
+  }
+ },
+ "autoquest/kill/onTargetDeath": {
+  "Твое задание {YВЫПОЛНЕНО{x!": {
+   "en": "Your quest is {YCOMPLETE{x!",
+   "ua": "Твоє завдання {YВИКОНАНО{x!"
+  },
+  "Вернись за вознаграждением к давшему тебе задание до того, как истечет время!": {
+   "en": "Return to whoever gave you the quest for your reward before time runs out!",
+   "ua": "Повернись за винагородою до того, хто дав тобі завдання, поки не сплив час!"
+  },
+  "{YПоздравляю! Ты выполнил%1$Gо||а задание своего согруппника.{x": {
+   "en": "{YCongratulations! You've completed your groupmate's task.{x",
+   "ua": "{YВітаю! Ти виконал%1$Gо||а завдання свого спільника.{x"
+  },
+  "{Y%1$^C1 помог%1$Gло||ла тебе выполнить задание, поспеши к квестору за наградой.{x": {
+   "en": "{Y%1$^C1 helped you complete the task, hurry to the quest giver for your reward.{x",
+   "ua": "{Y%1$^C1 допом%1$Gогло|іг|огла тобі виконати завдання, поспіши до квестодавця по нагороду.{x"
+  },
+  "{YПоздравляю! Но это убийство было поручено другому.{x": {
+   "en": "{YCongratulations! But this kill was assigned to someone else.{x",
+   "ua": "{YВітаю! Але це вбивство було доручено іншому.{x"
+  },
+  "{YКто-то другой выполнил порученное тебе задание.{x": {
+   "en": "{YSomeone else has completed the quest assigned to you.{x",
+   "ua": "{YХтось інший виконав доручене тобі завдання.{x"
+  },
+  "{YЖертва умерла своей смертью.{x": {
+   "en": "{YThe victim died of natural causes.{x",
+   "ua": "{YЖертва померла своєю смертю.{x"
+  }
+ },
+ "autoquest/kill/onInfo": {
+  "У тебя задание -- уничтожить %1$s!": {
+   "en": "Your task is to destroy %1$s!",
+   "ua": "Твоє завдання -- знищити %1$s!"
+  },
+  "Место, где жертву видели в последний раз -- %1$s": {
+   "en": "The victim was last seen in %1$s",
+   "ua": "Востаннє жертву бачили тут: %1$s"
+  },
+  "Это находится в районе под названием {hh%1$s{hx.": {
+   "en": "That is in the area called {hh%1$s{hx.",
+   "ua": "Це в місцевості під назвою {hh%1$s{hx."
+  }
+ },
+ "autoquest/kill/onShortInfo": {
+  "Уничтожить %1$s из %2$s (%3$s).": {
+   "en": "Destroy %1$s from %2$s (%3$s).",
+   "ua": "Знищити %1$s з %2$s (%3$s)."
+  }
+ }
+}


### PR DESCRIPTION
21 EN/UA entries for the four `autoquest/kill/*` codesource keys.

A Fenia file keys the catalog by its own path, so none of the `killquest.cpp` / `victimbehavior.cpp` values carried over automatically -- these are ported by hand.

The questor's `говорит тебе` frame is now inside the key and therefore translated; in C++ it was hardcoded Russian wrapped around an already-translated brief.

Two fixes carried in: a Latin `o` inside the Ukrainian `виконал%Go||а` (mixed script in one word), and a missing closing `{x` that leaked yellow into the prompt.

Must be live BEFORE the engine flip, or EN/UA players read Russian in the gap.

Reviewed adversarially: `reviews/2026-08-16-autoquest-killquest-fenia-port.md`, VERDICT RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)