### PR TITLE
Run killquest on the Fenia engine

### DIFF
--- a/quests/KillQuest.xml
+++ b/quests/KillQuest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <feniaId>1</feniaId>
-  <engine>cpp</engine>
+  <engine>fenia</engine>
   <priority>10</priority>
   <shortDesc>Убийство</shortDesc>
   <shortDesc l="en">Assassination</shortDesc>


### PR DESCRIPTION
The deploy step of autoquest step 5: flips `KillQuest.xml` to `<engine>fenia</engine>`.

Hooks merged (fenia#506), catalog live (world#592). In-flight C++ KillQuests keep completing on the C++ class, so nobody mid-quest is disturbed.

**Exercised live before merge:** request generated a quest with the full brief in English (catalog resolves end to end), `quest find` built a speedwalk from `onHelpLocation`, cancel cleared the marked victim. `onReward`/`onTargetDeath` fire on a kill -- verified against source in the review, players exercise them now.

Rollback: this word back to `cpp` + `quest set reload`, hot.

Review: `reviews/2026-08-16-autoquest-killquest-fenia-port.md`, RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)