### PR TITLE
Translate and enable the Fenia staffquest

### DIFF
--- a/config/translations/autoquest.json
+++ b/config/translations/autoquest.json
@@ -90,5 +90,79 @@
    "en": "Destroy %1$s from %2$s (%3$s).",
    "ua": "Знищити %1$s з %2$s (%3$s)."
   }
+ },
+ "autoquest/staff/onCreate": {
+  "%1$^C1 говорит тебе '{G%2$s{x'": {
+   "en": "%1$^C1 tells you '{G%2$s{x'",
+   "ua": "%1$^C1 каже тобі '{G%2$s{x'"
+  },
+  "%1$^C1 говорит тебе '{GИз королевской сокровищницы похитили {W%2$s{G!{x'": {
+   "en": "%1$^C1 tells you '{G{W%2$s{G was stolen from the royal treasury!{x'",
+   "ua": "%1$^C1 каже тобі '{GЗ королівської скарбниці викрали {W%2$s{G!{x'"
+  },
+  "%1$^C1 говорит тебе '{GПридворные волшебники определили, где спрятано украденное сокровище.{x'": {
+   "en": "%1$^C1 tells you '{GThe court wizards have determined where the stolen treasure is hidden.{x'",
+   "ua": "%1$^C1 каже тобі '{GПридворні чарівники визначили, де сховано викрадений скарб.{x'"
+  },
+  "%1$^C1 говорит тебе '{GТебе поручается доставить его мне!{x'": {
+   "en": "%1$^C1 tells you '{GYou've been ordered to deliver it to me!{x'",
+   "ua": "%1$^C1 каже тобі '{GТобі доручається доставити це мені!{x'"
+  },
+  "%1$^C1 говорит тебе '{GМесто, где оно спрятано, называется {W%2$s{G.{x'": {
+   "en": "%1$^C1 tells you '{GThe place where it's hidden is called {W%2$s{G.{x'",
+   "ua": "%1$^C1 каже тобі '{GМісце, де воно сховане, зветься {W%2$s{G.{x'"
+  },
+  "%1$^C1 говорит тебе '{GИ находится это место в районе под названием -- {W{hh%2$s{hx{G.{x'": {
+   "en": "%1$^C1 tells you '{GAnd this place is located in the area called -- {W{hh%2$s{hx{G.{x'",
+   "ua": "%1$^C1 каже тобі '{GІ знаходиться це місце в районі під назвою -- {W{hh%2$s{hx{G.{x'"
+  },
+  "%1$^C1 говорит тебе '{GУ тебя есть {Y%2$d{G мину%2$Iта|ты|т на выполнение задания.{x'": {
+   "en": "%1$^C1 tells you '{GYou have {Y%2$d{G minute%2$gs||s to complete the task.{x'",
+   "ua": "%1$^C1 каже тобі '{GУ тебе є {Y%2$d{G хвилин%2$Iа|и| на виконання завдання.{x'"
+  }
+ },
+ "autoquest/staff/onInfo": {
+  "У тебя задание -- вернуть %1$s.": {
+   "en": "Your task is to bring back %1$s.",
+   "ua": "Твоє завдання -- повернути %1$s."
+  },
+  "Место, где спрятано сокровище, называется %1$s.": {
+   "en": "The place where the treasure is hidden is called %1$s.",
+   "ua": "Місце, де сховано скарб, зветься %1$s."
+  },
+  "И находится это место в районе под названием {hh%1$s{hx.": {
+   "en": "And that place is in the area called {hh%1$s{hx.",
+   "ua": "А розташоване воно в місцевості під назвою {hh%1$s{hx."
+  }
+ },
+ "autoquest/staff/onShortInfo": {
+  "Доставить квестору %1$s из %2$s (%3$s).": {
+   "en": "Deliver %1$s from %2$s (%3$s) to the quest giver.",
+   "ua": "Доставити квестодавцю %1$s з %2$s (%3$s)."
+  }
+ },
+ "autoquest/staff/onTargetGet": {
+  "%1$^O1 загорается голубым пламенем.": {
+   "en": "%1$^O1 bursts into blue flame.",
+   "ua": "%1$^O1 спалахує блакитним полум'ям."
+  },
+  "Мерцающая аура окружает %1$O4.": {
+   "en": "A flickering aura surrounds %1$O4.",
+   "ua": "Мерехтлива аура оточує %1$O4."
+  },
+  "%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2.": {
+   "en": "%1$^O1 doesn't belong to you, so you drop it.",
+   "ua": "%1$^O1 тобі не належить, тож ти кидаєш %1$O4."
+  }
+ },
+ "autoquest/staff/onReward": {
+  "Ты передаешь %1$s %2$C3.": {
+   "en": "You hand %1$s to %2$C3.",
+   "ua": "Ти передаєш %1$s %2$C3."
+  },
+  "%1$^C1 передает %2$s %3$C3.": {
+   "en": "%1$^C1 hands %2$s to %3$C3.",
+   "ua": "%1$^C1 передає %2$s %3$C3."
+  }
  }
 }

--- a/quests/StaffQuest.xml
+++ b/quests/StaffQuest.xml
@@ -2,7 +2,7 @@
 <Quest>
   <objVnum>28107</objVnum>
   <feniaId>2</feniaId>
-  <engine>cpp</engine>
+  <engine>fenia</engine>
   <priority>1</priority>
   <scenarios>
     <node name="chest" type="StaffScenario">


### PR DESCRIPTION
16 EN/UA catalog entries for `autoquest/staff/*`, plus the engine flip to `<engine>fenia</engine>` for StaffQuest.

Translations re-homed from the C++ `.cpp` keys to the Fenia file paths (a Fenia file keys the catalog by its own path). Questor lines fold the `говорит тебе` frame into the key so it translates.

In-flight C++ StaffQuests keep completing on the C++ class. Rollback: engine word back to `cpp` + `quest set reload`.

Review: `reviews/2026-08-17-autoquest-staffquest-fenia-port.md` (RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)