### PR TITLE
Translate and enable the Fenia butcherquest

### DIFF
--- a/config/translations/autoquest.json
+++ b/config/translations/autoquest.json
@@ -164,5 +164,93 @@
    "en": "%1$^C1 hands %2$s to %3$C3.",
    "ua": "%1$^C1 передає %2$s %3$C3."
   }
+ },
+ "autoquest/butcher/onCreate": {
+  "%1$^C1 говорит тебе '{GУ меня есть для тебя срочное поручение!{x'": {
+   "en": "%1$^C1 tells you '{GI have an urgent task for you!{x'",
+   "ua": "%1$^C1 каже тобі '{GУ мене є для тебе термінове доручення!{x'"
+  },
+  "%1$^C1 говорит тебе '{G{W%2$s{G из местности {W{hh%3$s{hx{G хочет подать к столу {W%4$d{G кус%4$Iок|ка|ков мяса {W%5$s{G из местности {W{hh%6$s{hx{G.{x'": {
+   "en": "%1$^C1 tells you '{G{W%2$s{G from the region {W{hh%3$s{hx{G wants {W%4$d{G piece%4$gs||s of {W%5$s{G meat from the region {W{hh%6$s{hx{G served at the table.{x'",
+   "ua": "%1$^C1 каже тобі '{G{W%2$s{G з місцевості {W{hh%3$s{hx{G хоче, щоб подали до столу {W%4$d{G шмат%4$Iок|ки|ків м'яса {W%5$s{G з місцевості {W{hh%6$s{hx{G.{x'"
+  },
+  "%1$^C1 говорит тебе '{GДоставь мясо заказчику и вернись сюда за вознаграждением.{x'": {
+   "en": "%1$^C1 tells you '{GDeliver the meat to the customer and come back here for your reward.{x'",
+   "ua": "%1$^C1 каже тобі '{GДостав м'ясо замовнику і повернись сюди за винагородою.{x'"
+  },
+  "%1$^C1 говорит тебе '{GУ тебя есть {Y%2$d{G мину%2$Iта|ты|т на выполнение задания.{x'": {
+   "en": "%1$^C1 tells you '{GYou have {Y%2$d{G minute%2$gs||s to complete the task.{x'",
+   "ua": "%1$^C1 каже тобі '{GУ тебе є {Y%2$d{G хвилин%2$Iа|и| на виконання завдання.{x'"
+  }
+ },
+ "autoquest/butcher/onInfo": {
+  "%1$s из {hh%2$s{hx просит тебя доставить к столу %3$d кус%3$Iок|ка|ков мяса %4$s из местности {hh%5$s{hx.": {
+   "en": "%1$s from {hh%2$s{hx asks you to bring %3$d piece%3$gs||s of %4$s meat from the area of {hh%5$s{hx to the table.",
+   "ua": "%1$s з {hh%2$s{hx просить тебе подати до столу %3$d шмат%3$Iок|ки|ків м'яса %4$s з місцевості {hh%5$s{hx."
+  },
+  "Доставлено кусков: %1$d.": {
+   "en": "Pieces delivered: %1$d.",
+   "ua": "Доставлено шматків: %1$d."
+  },
+  "Заказ уже неактуален.": {
+   "en": "The order is no longer valid.",
+   "ua": "Замовлення вже неактуальне."
+  }
+ },
+ "autoquest/butcher/onShortInfo": {
+  "%1$s из %2$s заказал %3$d кус%3$Iок|ка|ков мяса %4$s из %5$s.": {
+   "en": "%1$s from %2$s ordered %3$d piece%3$gs||s of %4$s meat from %5$s.",
+   "ua": "%1$s з %2$s замовив %3$d шмат%3$Iок|ки|ків м'яса %4$s з %5$s."
+  },
+  "Заказ повара.": {
+   "en": "A cook's order.",
+   "ua": "Замовлення кухаря."
+  }
+ },
+ "autoquest/butcher/onTargetGive": {
+  "%1$^C1 говорит тебе '{GЧто ты мне приволок%2$Gло|л|ла! Это даже не мясо!{x'": {
+   "en": "%1$^C1 tells you '{GWhat did you drag in for me?! This isn't even meat!{x'",
+   "ua": "%1$^C1 каже тобі '{GЩо ти мені притяг%2$Gло||ла|ли! Це навіть не м'ясо!{x'"
+  },
+  "%1$^C1 говорит тебе '{GУжас, с кого ты это среза%2$Gло|л|ла?!{x'": {
+   "en": "%1$^C1 tells you '{GGood grief, who did you carve this off of?!{x'",
+   "ua": "%1$^C1 каже тобі '{GЖах, з кого ти це зріза%2$Gло|в|ла|ли?!{x'"
+  },
+  "%1$^C1 говорит тебе '{GХороший кусок, но я заказыва%1$Gло|л|ла мясо %2$s.{x'": {
+   "en": "%1$^C1 tells you '{GGood cut, but I ordered %2$s meat.{x'",
+   "ua": "%1$^C1 каже тобі '{GГарний шматок, але я замовля%1$Gло|в|ла|ли м'ясо %2$s.{x'"
+  },
+  "%1$^C1 говорит тебе '{GЭти звери водятся в %2$s, а не в %3$s.{x'": {
+   "en": "%1$^C1 tells you '{GThose animals live in %2$s, not in %3$s.{x'",
+   "ua": "%1$^C1 каже тобі '{GЦі звірі водяться в %2$s, а не в %3$s.{x'"
+  },
+  "%1$^C1 говорит тебе '{GСпасибо за помощь! Вернись к квестору за наградой.{x'": {
+   "en": "%1$^C1 tells you '{GThanks for the help! Go back to the questor for your reward.{x'",
+   "ua": "%1$^C1 каже тобі '{GДякую за допомогу! Повернися до квестора за нагородою.{x'"
+  },
+  "%1$^C1 говорит тебе '{GХватит, родн%2$Gое|ой|ая.{x'": {
+   "en": "%1$^C1 tells you '{GThat's enough, dear.{x'",
+   "ua": "%1$^C1 каже тобі '{GДосить, рідн%2$Gе|ий|а|і.{x'"
+  },
+  "%1$^C1 говорит тебе '{GМаловато будет...{x'": {
+   "en": "%1$^C1 tells you '{GThat won't quite cut it...{x'",
+   "ua": "%1$^C1 каже тобі '{GЗамало буде...{x'"
+  },
+  "%1$^C1 куда-то прячет %2$O4.": {
+   "en": "%1$^C1 hides %2$O4 somewhere.",
+   "ua": "%1$^C1 кудись ховає %2$O4."
+  }
+ },
+ "autoquest/butcher/onTargetDeath": {
+  "{YЗаказ отменен в связи с кончиной заказчика.{x": {
+   "en": "{YThe order has been cancelled due to the customer's untimely demise.{x",
+   "ua": "{YЗамовлення скасовано у зв'язку зі смертю замовника.{x"
+  }
+ },
+ "autoquest/butcher/onTargetGreet": {
+  "%1$^C1 выжидающе смотрит на тебя.": {
+   "en": "%1$^C1 looks at you expectantly.",
+   "ua": "%1$^C1 вичікувально дивиться на тебе."
+  }
  }
 }

--- a/quests/ButcherQuest.xml
+++ b/quests/ButcherQuest.xml
@@ -6,7 +6,7 @@
     <node>кухарка</node>
   </cooks>
   <feniaId>3</feniaId>
-  <engine>cpp</engine>
+  <engine>fenia</engine>
   <priority>1</priority>
   <races>
     <node>hoofed</node>


### PR DESCRIPTION
19 EN/UA catalog entries for `autoquest/butcher/*`, plus the engine flip to `<engine>fenia</engine>` for ButcherQuest.

Re-homed from the C++ `.cpp` keys; questor and cook lines fold the `говорит тебе` frame into the key. Rollback: engine word back to `cpp` + `quest set reload`.

Review: `reviews/2026-08-17-autoquest-butcherquest-fenia-port.md` (RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)