### PR TITLE
autoquest: flip BigQuest to fenia engine

### DIFF
--- a/quests/BigQuest.xml
+++ b/quests/BigQuest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Quest>
   <feniaId>4</feniaId>
-  <engine>cpp</engine>
+  <engine>fenia</engine>
   <priority>1</priority>
   <shortDesc>Банду геть</shortDesc>
   <shortDesc l="en">Down with the Gang</shortDesc>


### PR DESCRIPTION
Big's Fenia port is complete and its C++ dependency (#1004: neutral gangster death role + per-language mob dressers) is live. This flips `<engine>` so `quest request` routes big through the Fenia handlers.

Pairs with dreamland_fenia#511 (band traits). Deployed via per-file checkout + `quest set reload`, same as the kill/staff/butcher/heal/locate flips.