### PR TITLE
autoquest: flip StealQuest to fenia engine

### DIFF
--- a/quests/StealQuest.xml
+++ b/quests/StealQuest.xml
@@ -10,7 +10,7 @@
     <node>28105</node>
   </chests>
   <feniaId>6</feniaId>
-  <engine>cpp</engine>
+  <engine>fenia</engine>
   <priority>4</priority>
   <shortDesc>Помощь жертвам ограблений</shortDesc>
   <shortDesc l="en">Helping Robbery Victims</shortDesc>


### PR DESCRIPTION
Activates the Fenia steal port (incl. [7665] service-mob exclusion). Handlers deployed + verified live; catalog loaded. Persist-then-reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)