### PR TITLE
l10n: group quest-target tags EN/UA (Zodda)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -15365,6 +15365,14 @@
   "{R[ВОР] {x": {
    "en": "{R[THIEF] {x",
    "ua": "{R[КРАДІЙ] {x"
+  },
+  "{y[ЦЕЛЬ %1$s] {x": {
+   "en": "{y[TARGET %1$s] {x",
+   "ua": "{y[ЦІЛЬ %1$s] {x"
+  },
+  "{y[ВОР %1$s] {x": {
+   "en": "{y[THIEF %1$s] {x",
+   "ua": "{y[КРАДІЙ %1$s] {x"
   }
  },
  "plug-ins/quest/core/xmlattributequestdata.cpp": {


### PR DESCRIPTION
EN/UA catalog for the group-visible quest-target tags added in dreamland_code #1008. Reboot-gated (loads at boot). Part of autoquest epic card eW6dpFPa, checklist 3.