### PR TITLE
quest: new 'charm' autoquest type (feniaId 9)

### DIFF
--- a/config/translations/autoquest.json
+++ b/config/translations/autoquest.json
@@ -1386,5 +1386,75 @@
       "en": "%1$^C1 says through gritted teeth: '{gHelping the dragon? Maybe you're a dragon yourself?{x'.",
       "ua": "%1$^C1 крізь зуби каже: '{gДраконові допомагаєш? Може, ти й са%2$Gмо|м|ма дракон?{x'."
     }
+  },
+  "autoquest/charm/onCreate": {
+    "%1$^C1 говорит тебе '{GУ меня есть для тебя деликатное поручение!{x'": {
+      "en": "%1$^C1 tells you '{GI have a delicate task for you!{x'",
+      "ua": "%1$^C1 каже тобі '{GУ мене є для тебе делікатне доручення!{x'"
+    },
+    "%1$^C1 говорит тебе '{GОчаруй {W%2$#C4{G своими чарами и приведи %2$P2 ко мне.{x'": {
+      "en": "%1$^C1 tells you '{GBeguile {W%2$#C4{G with your own charms and bring %2$C4 to me.{x'",
+      "ua": "%1$^C1 каже тобі '{GЗачаруй {W%2$#C4{G своїми чарами і приведи %2$C4 до мене.{x'"
+    },
+    "%1$^C1 говорит тебе '{GЦель должна прийти ко мне сама -- под твоими чарами и живой.{x'": {
+      "en": "%1$^C1 tells you '{GThe target must walk to me on its own -- charmed, and alive.{x'",
+      "ua": "%1$^C1 каже тобі '{GЦіль має прийти до мене сама -- під твоїми чарами і живою.{x'"
+    },
+    "%1$^C1 говорит тебе '{GМесто, где %2$P2 видели в последний раз -- {W%3$s{G!{x'": {
+      "en": "%1$^C1 tells you '{GThe place where %2$C4 was last seen -- {W%3$s{G!{x'",
+      "ua": "%1$^C1 каже тобі '{GМісце, де %2$C4 бачили востаннє -- {W%3$s{G!{x'"
+    },
+    "%1$^C1 говорит тебе '{GЭто находится в районе под названием {W{hh%2$s{hx{G.{x'": {
+      "en": "%1$^C1 tells you '{GIt is located in an area called {W{hh%2$s{hx{G.{x'",
+      "ua": "%1$^C1 каже тобі '{GЦе знаходиться в районі під назвою {W{hh%2$s{hx{G.{x'"
+    },
+    "%1$^C1 говорит тебе '{GУ тебя есть {Y%2$d{G мину%2$Iта|ты|т на выполнение задания.{x'": {
+      "en": "%1$^C1 tells you '{GYou have {Y%2$d{G minute%2$gs||s to complete the task.{x'",
+      "ua": "%1$^C1 каже тобі '{GУ тебе є {Y%2$d{G хвилин%2$Iа|и| на виконання завдання.{x'"
+    }
+  },
+  "autoquest/charm/onTargetSpec": {
+    "Твое задание {YВЫПОЛНЕНО{x!": {
+      "en": "Your quest is {YCOMPLETE{x!",
+      "ua": "Твоє завдання {YВИКОНАНО{x!"
+    },
+    "Попроси награду у давшего тебе задание, пока не истекло время!": {
+      "en": "Ask whoever gave you the quest for your reward before time runs out!",
+      "ua": "Попроси нагороду в того, хто дав тобі завдання, поки не сплив час!"
+    }
+  },
+  "autoquest/charm/onTargetDeath": {
+    "{YТы убил%1$Gо||а того, кого нужно было очаровать. Задание провалено.{x": {
+      "en": "{YYou have killed the one you were meant to charm. The quest is failed.{x",
+      "ua": "{YТи вби%1$Gло|в|ла того, кого треба було зачарувати. Завдання провалено.{x"
+    },
+    "{YТвоя цель погибла. Задание провалено.{x": {
+      "en": "{YYour target has died. The quest is failed.{x",
+      "ua": "{YТвоя ціль загинула. Завдання провалено.{x"
+    }
+  },
+  "autoquest/charm/onInfo": {
+    "У тебя задание -- очаровать %1$s!": {
+      "en": "Your task is to charm %1$s!",
+      "ua": "Твоє завдання -- зачарувати %1$s!"
+    },
+    "Место, где цель видели в последний раз -- %1$s": {
+      "en": "The target was last seen in %1$s",
+      "ua": "Востаннє ціль бачили тут: %1$s"
+    },
+    "Это находится в районе под названием {hh%1$s{hx.": {
+      "en": "That is in the area called {hh%1$s{hx.",
+      "ua": "Це в місцевості під назвою {hh%1$s{hx."
+    },
+    "Очарованную цель приведи к %1$s -- %2$s.": {
+      "en": "Lead the charmed target to %1$s -- %2$s.",
+      "ua": "Зачаровану ціль приведи до %1$s -- %2$s."
+    }
+  },
+  "autoquest/charm/onShortInfo": {
+    "Очаровать и привести %1$s из %2$s (%3$s).": {
+      "en": "Charm and deliver %1$s from %2$s (%3$s).",
+      "ua": "Зачарувати і привести %1$s з %2$s (%3$s)."
+    }
   }
 }

--- a/helps/quest.xml
+++ b/helps/quest.xml
@@ -257,6 +257,8 @@ You can sew {hh19pockets{x onto the quest bag for convenient item sorting.
   
 {C%A%{x {WHolding Robbery Victims Harmless{x: help a victim of robbers by punishing the thief and returning the stolen goods to their owner. Some thieves prudently stash their loot in chests.
 
+{C%A%{x {WCharming{x: beguile the target with your own magic and lead it, still charmed, back to the questor who gave you the task. Offered only to those who know a suitable ability: {hh729charm person{x, {hh687attract other{x, {hh819dominate{x or {hh175befriend{x.
+
 {C%A%{x {WCollecting Lost Items{x: using the {hh707locate object{x or {hh885find item{x spells, help absent-minded folk find their lost belongings.
 
 {C%A%{x {WClear the Rabble{x: rid an area of an infestation of various charlatans, preachers and other undesirable elements. These villains periodically drop special quest items (portraits, leaflets, fragments of existence, and others): collect them all to receive bonus experience. This quest is also conveniently completed in a group.
@@ -277,6 +279,8 @@ You can sew {hh19pockets{x onto the quest bag for convenient item sorting.
   
 {C%A%{x {WПомощь жертвам ограблений{x: помочь пострадавшему от рук грабителей, покарав вора и вернув награбленное владельцу. Некоторые воры предусмотрительно ныкают добро в сундуки.
 
+{C%A%{x {WОчарование{x: очаровать указанную цель собственными чарами и привести ее, все еще очарованную, к давшему задание квестору. Выдается только тем, кто владеет подходящим умением: {hh729очарование{x, {hh687пленить{x, {hh819доминировать{x или {hh175подружиться{x.
+
 {C%A%{x {WСбор потерянных вещей{x: воспользовавшись заклинаниями {hh707поиск предмета{x или {hh885найти предмет{x, помочь растяпам найти утраченные вещи.
 
 {C%A%{x {WБанду геть{x: избавить местность от нашествия различных шарлатанов, проповедников и других нежелательных элементов. Из этих злодеев периодически выпадают специальные квестовые предметы (портреты, листовки, кусочки бытия и прочие): собери их все, чтобы получить дополнительный опыт. Это задание тоже удобно выполнять группой.
@@ -296,6 +300,8 @@ You can sew {hh19pockets{x onto the quest bag for convenient item sorting.
 {C%A%{x {WЗасідки та Викрадення{x: допомогти матері, що ридає, яка зневірилася знайти своє чадо, або ж, навпаки, доставити соковите немовля на сніданок упирю. По дорозі можуть чекати сюрпризи. Конвойований прийме з твоїх рук і використає за призначенням {hh121зілля та пілюлі{x: це дозволить йому не {hh833таранити двері{x лобами або {hh575злетіти{x коли треба.
   
 {C%A%{x {WДопомога Жертвам Пограбувань{x: допомогти потерпілому від рук грабіжників, покарати злодія і повернути награбоване власнику. Деякі злодії передбачливо ховають добро в скрині.
+
+{C%A%{x {WЗачарування{x: зачарувати вказану ціль власними чарами і привести її, все ще зачаровану, до квестора, що дав завдання. Отримують лише ті, хто володіє відповідним вмінням: {hh729зачарування{x, {hh687привабити іншого{x, {hh819домінувати{x або {hh175потоваришувати{x.
 
 {C%A%{x {WЗбір Загублених Речей{x: скориставшись заклинаннями {hh707пошук предмета{x або {hh885знайти предмет{x, допомогти розтяпам знайти втрачені речі.
 

--- a/quests/CharmQuest.xml
+++ b/quests/CharmQuest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Quest>
+  <feniaId>9</feniaId>
+  <engine>fenia</engine>
+  <priority>2</priority>
+  <shortDesc>Очарование</shortDesc>
+  <shortDesc l="en">Charming</shortDesc>
+  <shortDesc l="ua">Зачарування</shortDesc>
+  <difficulty>средней сложности</difficulty>
+  <difficulty l="en">moderate</difficulty>
+  <difficulty l="ua">середньої складності</difficulty>
+  <skills>
+    <node>charm person</node>
+    <node>attract other</node>
+    <node>dominate</node>
+    <node>befriend</node>
+  </skills>
+</Quest>


### PR DESCRIPTION
New Fenia-engine autoquest type: charm a marked target with your own ability, lead it charmed to the questor. Charmer-only applicability, escort-to-questor completion, finite swim affect (guarded on gaveSwim so natural swimmers are untouched), fish targets excluded, help article 127 extended. Fable RELEASE (reviews/2026-08-19-charm-quest-type.md, 3 rounds). REBOOT-GATED: C++ rebuild first, then cs post the 8 charm Fenia files + utils/mob:charm reload. Non-blocking playtest watch-items in the review (dominate 1% corner, befriend lockout, world pollution).