### PR TITLE
Add refit quest-trader article to DefaultQuestMaster catalog

### DIFF
--- a/legacy-behaviors/DefaultQuestMaster.xml
+++ b/legacy-behaviors/DefaultQuestMaster.xml
@@ -120,6 +120,11 @@
         <questpoint>50</questpoint>
       </price>
     </node>
+    <node type="RefitQuestArticle">
+      <name>refit</name>
+      <rname>перековка</rname>
+      <descr>Подогнать личные вещи Героя под свой уровень после перерождения</descr>
+    </node>
     <node type="OwnerQuestArticle">
       <vnum>109</vnum>
       <name>owner</name>


### PR DESCRIPTION
Registers the `RefitQuestArticle` (`перековка` / `refit`) node so the quest trader offers the remort-fit service. Dynamic pricing → no `<price>` element. Rides the same reboot as the C++ class (dreamland_code#1013).

🤖 Generated with [Claude Code](https://claude.com/claude-code)