### PR TITLE
Trilingual descr for all quest-trader articles

### DIFF
--- a/legacy-behaviors/DefaultQuestMaster.xml
+++ b/legacy-behaviors/DefaultQuestMaster.xml
@@ -6,6 +6,8 @@
       <name>orb</name>
       <rname>шар</rname>
       <descr>Хрустальный шар</descr>
+      <descr l="en">Crystal orb</descr>
+      <descr l="ua">Кришталева куля</descr>
       <price type="QuestPointPrice">
         <questpoint>50</questpoint>
       </price>
@@ -14,6 +16,8 @@
       <name>piercing</name>
       <rname>пирсинг</rname>
       <descr>Прокалывание ушей</descr>
+      <descr l="en">Ear piercing</descr>
+      <descr l="ua">Проколювання вух</descr>
       <price type="QuestPointPrice">
         <questpoint>50</questpoint>
       </price>
@@ -23,6 +27,8 @@
       <name>colourless</name>
       <rname>бесцветный рестринг</rname>
       <descr>Рестринг купон</descr>
+      <descr l="en">Restring coupon</descr>
+      <descr l="ua">Купон рестрингу</descr>
       <price type="QuestPointPrice">
         <questpoint>50</questpoint>
       </price>
@@ -32,6 +38,8 @@
       <name>coupon</name>
       <rname>цветной рестринг</rname>
       <descr>{YР{Bе{Gс{Rт{Cр{Mи{Bн{Cг{x {rк{yу{gп{bо{mн{x</descr>
+      <descr l="en">{RR{Ye{Gs{Ct{Br{Mi{Rn{Yg {Gc{Co{Bu{Mp{Ro{Yn{x</descr>
+      <descr l="ua">{RК{Yу{Gп{Cо{Bн {Mр{Rе{Yс{Gт{Cр{Bи{Mн{Rг{Yу{x</descr>
       <price type="QuestPointPrice">
         <questpoint>200</questpoint>
       </price>
@@ -40,6 +48,8 @@
       <name>slot</name>
       <rname>слот</rname>
       <descr>Личный слот: одна любая вещь напоказ</descr>
+      <descr l="en">Personal slot: one item worn just for show</descr>
+      <descr l="ua">Особистий слот: одна річ напоказ</descr>
       <price type="QuestPointPrice">
         <questpoint>200</questpoint>
       </price>
@@ -48,6 +58,8 @@
       <name>mark</name>
       <rname>знак</rname>
       <descr>Знак твоей религии</descr>
+      <descr l="en">Mark of your religion</descr>
+      <descr l="ua">Знак твоєї релігії</descr>
       <price type="QuestPointPrice">
         <questpoint>200</questpoint>
       </price>
@@ -56,6 +68,8 @@
       <name>constitution</name>
       <rname>сложение</rname>
       <descr>+1 сложение</descr>
+      <descr l="en">+1 constitution</descr>
+      <descr l="ua">+1 до статури</descr>
       <price type="QuestPointPrice">
         <questpoint>150</questpoint>
       </price>
@@ -65,6 +79,8 @@
       <name>ring</name>
       <rname>кольцо</rname>
       <descr>Кольцо Героя</descr>
+      <descr l="en">Hero's Ring</descr>
+      <descr l="ua">Перстень Героя</descr>
       <price type="QuestPointPrice">
         <questpoint>1000</questpoint>
       </price>
@@ -76,6 +92,8 @@
       <name>weapon</name>
       <rname>оружие</rname>
       <descr>Оружие Героя</descr>
+      <descr l="en">Hero's Weapon</descr>
+      <descr l="ua">Зброя Героя</descr>
       <price type="QuestPointPrice">
         <questpoint>1000</questpoint>
       </price>
@@ -87,6 +105,8 @@
       <name>girth</name>
       <rname>пояс</rname>
       <descr>Пояс Героя</descr>
+      <descr l="en">Hero's Girth</descr>
+      <descr l="ua">Пояс Героя</descr>
       <price type="QuestPointPrice">
         <questpoint>1000</questpoint>
       </price>
@@ -97,6 +117,8 @@
       <name>keyring</name>
       <rname>брелок</rname>
       <descr>Прикрепить брелок для ключей к Поясу Героя</descr>
+      <descr l="en">Attach a keyring to the Hero's Girth</descr>
+      <descr l="ua">Причепити брелок для ключів до Пояса Героя</descr>
       <price type="QuestPointPrice">
         <questpoint>200</questpoint>
       </price>
@@ -106,6 +128,8 @@
       <name>bag</name>
       <rname>сумка</rname>
       <descr>Дорожная сумка Героя</descr>
+      <descr l="en">Hero's Travelling Bag</descr>
+      <descr l="ua">Дорожня сумка Героя</descr>
       <price type="QuestPointPrice">
         <questpoint>500</questpoint>
       </price>
@@ -116,6 +140,8 @@
       <name>pockets</name>
       <rname>карманы</rname>
       <descr>Нашить карманы на Сумку Героя</descr>
+      <descr l="en">Sew pockets onto the Hero's Bag</descr>
+      <descr l="ua">Нашити кишені на Сумку Героя</descr>
       <price type="QuestPointPrice">
         <questpoint>50</questpoint>
       </price>
@@ -124,12 +150,16 @@
       <name>refit</name>
       <rname>перековка</rname>
       <descr>Подогнать личные вещи Героя под свой уровень после перерождения</descr>
+      <descr l="en">Refit the Hero's personal gear to your level after a remort</descr>
+      <descr l="ua">Підігнати особисті речі Героя під свій рівень після переродження</descr>
     </node>
     <node type="OwnerQuestArticle">
       <vnum>109</vnum>
       <name>owner</name>
       <rname>талон</rname>
       <descr>Талон на единоличное владение вещью</descr>
+      <descr l="en">Coupon for sole ownership of an item</descr>
+      <descr l="ua">Талон на одноосібне володіння річчю</descr>
       <price type="QuestPointPrice">
         <questpoint>1000</questpoint>
       </price>
@@ -143,10 +173,11 @@
       <name>gold</name>
       <rname>золото</rname>
       <descr>5000 золотых монет</descr>
+      <descr l="en">5000 gold coins</descr>
+      <descr l="ua">5000 золотих монет</descr>
       <price type="QuestPointPrice">
         <questpoint>1000</questpoint>
       </price>
     </node>
   </services>
 </behavior>
-


### PR DESCRIPTION
EN/UA `<descr l=...>` siblings for all 16 DefaultQuestMaster articles. Pairs with dreamland_code#1014. Bare RU descr is the fallback. Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)