### PR TITLE
Add questmasterchat behavior def + onSpec translation

### DIFF
--- a/behaviors/questmasterchat.xml
+++ b/behaviors/questmasterchat.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description l="ru">Зазывала: изредка приглашает игроков взять задание (onSpec). Ответы на слова о квесте и tell остаются в C++ QuestMaster, который по-прежнему висит на мобе для определения занятия.</description>
+  <description l="ua">Зазивала: зрідка запрошує гравців узяти завдання (onSpec). Відповіді на слова про квест і tell лишаються в C++ QuestMaster, який досі висить на мобі для визначення заняття.</description>
+  <id>105</id>
+  <nameRus>приглашение на квест</nameRus>
+  <nameUa>запрошення на квест</nameUa>
+  <props>null</props>
+  <target>mob</target>
+</behavior>

--- a/config/translations/behaviors.json
+++ b/config/translations/behaviors.json
@@ -3334,5 +3334,11 @@
    "en": "A blueprint only binds into a tome of recipes.",
    "ua": "Креслення вшивається лише в том рецептів."
   }
+ },
+ "behaviors/questmasterchat/onSpec": {
+  "Хочешь получить интересное задание? Напиши {y{hcквест попросить{x.": {
+   "en": "Want an interesting task? Type {y{hcquest request{x.",
+   "ua": "Хочеш отримати цікаве завдання? Напиши {y{hcквест попросити{x."
+  }
  }
 }


### PR DESCRIPTION
New behavior def `questmasterchat` (id 105, target mob) for the questmaster ambient invite, plus the onSpec invite string EN/UA in `behaviors.json` (ported from the old `questmaster.cpp` catalog so EN/UA players keep a localized invite).

Pairs with dreamland_code#1015, dreamland_fenia (onSpec body), dreamland_areas (14 attaches). Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)