### PR TITLE
quest catalog: add the UpgradeQuestArticle node

### DIFF
--- a/legacy-behaviors/DefaultQuestMaster.xml
+++ b/legacy-behaviors/DefaultQuestMaster.xml
@@ -153,6 +153,13 @@
       <descr l="en">Refit the Hero's personal gear to your level after a remort</descr>
       <descr l="ua">Підігнати особисті речі Героя під свій рівень після переродження</descr>
     </node>
+    <node type="UpgradeQuestArticle">
+      <name>upgrade</name>
+      <rname>улучшение</rname>
+      <descr>Улучшить снятую вещь Героя на ступень: пояс, кольцо или оружие</descr>
+      <descr l="en">Upgrade an unequipped Hero item one tier: girth, ring or weapon</descr>
+      <descr l="ua">Покращити зняту річ Героя на щабель: пояс, перстень чи зброю</descr>
+    </node>
     <node type="OwnerQuestArticle">
       <vnum>109</vnum>
       <name>owner</name>


### PR DESCRIPTION
Adds the 'upgrade' service to DefaultQuestMaster (Phase 2, epic eW6dpFPa). Pairs with code #1017. Reboot-gated: names a class the old binary lacks, must boot together.