### PR TITLE
translations: fix %1%^C1 placeholder in blackjack shadow recho

### DIFF
--- a/config/translations/skillcommand.json
+++ b/config/translations/skillcommand.json
@@ -294,9 +294,9 @@
    "en": "You slug your own shadow across the forehead with all your might.",
    "ua": "Ти з усієї сили б'єш власну тінь по лобі."
   },
-  "%1%^C1 изо всех сил бь%1$nет|ют по лбу свою тень.": {
-   "en": "%1%^C1 hit%1$ns| their own shadow across the forehead with all their might.",
-   "ua": "%1%^C1 щосили б'%1$nє|ють по лобі власну тінь."
+  "%1$^C1 изо всех сил бь%1$nет|ют по лбу свою тень.": {
+   "en": "%1$^C1 hit%1$ns| their own shadow across the forehead with all their might.",
+   "ua": "%1$^C1 щосили б'%1$nє|ють по лобі власну тінь."
   },
   "%^O1 распахивает {Dпризрачные {Cкрылья{x над твоей головой, перемещая тебя на долю секунды назад во времени!": {
    "en": "%^O1 spreads {Dghostly {Cwings{x wide over your head, shifting you a split second back in time!",


### PR DESCRIPTION
Corrects the malformed key + en/ua for the blackjack shadow-hit recho, in lockstep with the Fenia source fix. Review: RELEASE.