### PR TITLE
translations: fix %1%^C1 shadow-recho placeholders + dedup trip

### DIFF
--- a/config/translations/skillcommand.json
+++ b/config/translations/skillcommand.json
@@ -130,9 +130,9 @@
    "en": "You unsuccessfully try to knock your own shadow off its feet.",
    "ua": "Ти безуспішно намагаєшся збити з ніг свою тінь."
   },
-  "%1%^C1 безуспешно пыта%1$nется|ются сбить с ног свою тень.": {
-   "en": "%1%^C1 unsuccessfully tr%1$nies|y to knock their own shadow off its feet.",
-   "ua": "%1%^C1 безуспішно намага%1$nється|ються збити з ніг свою тінь."
+  "%1$^C1 безуспешно пыта%1$nется|ются сбить с ног свою тень.": {
+   "en": "%1$^C1 unsuccessfully tr%1$nies|y to knock their own shadow off its feet.",
+   "ua": "%1$^C1 безуспішно намага%1$nється|ються збити з ніг свою тінь."
   },
   "Сначала тебе само%1$Gму|му|й|им нужно встать на ноги.": {
    "en": "First you need to get back on your feet yourself.",
@@ -1498,9 +1498,9 @@
    "en": "You futilely try to grab your own shadow.",
    "ua": "Ти безуспішно намагаєшся вхопити свою тінь."
   },
-  "%1%^C1 безуспешно пыта%1$nется|ются схватить свою тень.": {
-   "en": "%1%^C1 futilely tr%1$nies|y to grab their own shadow.",
-   "ua": "%1%^C1 безуспішно намага%1$nється|ються вхопити свою тінь."
+  "%1$^C1 безуспешно пыта%1$nется|ются схватить свою тень.": {
+   "en": "%1$^C1 futilely tr%1$nies|y to grab their own shadow.",
+   "ua": "%1$^C1 безуспішно намага%1$nється|ються вхопити свою тінь."
   },
   "{WЛовко ухватившись, ты стаскиваешь %1$C4 из седла!{x": {
    "en": "{WWith a deft grab, you drag %1$C4 out of the saddle!{x",
@@ -2562,9 +2562,9 @@
    "en": "You pretend to be Tyler Durden and slug yourself in the face with all your might.",
    "ua": "Ти вдаєш із себе Тайлера Дердена і щосили б'єш себе по обличчю."
   },
-  "%1%^C1 притворя%1$nется|ются Тайлером Дерденом и изо всех сил бь%1$nет|ют себя по лицу.": {
-   "en": "%1%^C1 pretend%1$ns| to be Tyler Durden and slug%1$ns| themselves in the face with all their might.",
-   "ua": "%1%^C1 вида%1$nє|ють себе за Тайлера Дердена і щосили б'%1$nє|ють себе по обличчю."
+  "%1$^C1 притворя%1$nется|ются Тайлером Дерденом и изо всех сил бь%1$nет|ют себя по лицу.": {
+   "en": "%1$^C1 pretend%1$ns| to be Tyler Durden and slug%1$ns| themselves in the face with all their might.",
+   "ua": "%1$^C1 вида%1$nє|ють себе за Тайлера Дердена і щосили б'%1$nє|ють себе по обличчю."
   },
   "{RВнезапный удар в лицо заставляет тебя приземлиться!{x": {
    "en": "{RA sudden punch to the face sends you sprawling to the ground!{x",
@@ -3397,10 +3397,6 @@
   "Ты отчаянно подсекаешь собственную тень.": {
    "en": "You desperately try to trip your own shadow.",
    "ua": "Ти відчайдушно підсікаєш власну тінь."
-  },
-  "%1%^C1 отчаянно подсека%1$nет|ют собственную тень.": {
-   "en": "%1%^C1 desperately trip%1$ns| their own shadow.",
-   "ua": "%1%^C1 відчайдушно підсіка%1$nє|ють власну тінь."
   },
   "%1$^C1 прочно сто%1$nит|ят на четырех копытах, подсечка тут не поможет.": {
    "en": "%1$^C1 stand%1$ns| firm on four hooves -- a leg-sweep won't help here.",


### PR DESCRIPTION
Fixes bash/grab/smash shadow-recho keys+en/ua in lockstep with Fenia; removes a stale duplicate trip entry the fix exposed. Review: RELEASE. JSON valid, no duplicate keys.