### PR TITLE
Ukrainian who-list tags (A8) — 23 races + 13 classes data

### DIFF
--- a/professions/anti-paladin.xml
+++ b/professions/anti-paladin.xml
@@ -911,4 +911,5 @@
   </wearModifiers>
   <whoName>A-P</whoName>
   <whoNameRus>А-П</whoNameRus>
+  <whoNameUa>А-П</whoNameUa>
 </Profession>

--- a/professions/cleric.xml
+++ b/professions/cleric.xml
@@ -954,4 +954,5 @@ Note that clerics must choose a {hh1religion{x -- otherwise the {hh2036level{x o
   </wearModifiers>
   <whoName>Cle</whoName>
   <whoNameRus>Кле</whoNameRus>
+  <whoNameUa>Клі</whoNameUa>
 </Profession>

--- a/professions/druid.xml
+++ b/professions/druid.xml
@@ -73,4 +73,5 @@ To use their powers, druids must choose a {hh1religion{x -- and only gods of the
   </wearModifiers>
   <whoName>Dru</whoName>
   <whoNameRus>Дру</whoNameRus>
+  <whoNameUa>Дру</whoNameUa>
 </Profession>

--- a/professions/necromancer.xml
+++ b/professions/necromancer.xml
@@ -941,4 +941,5 @@
   </wearModifiers>
   <whoName>Nec</whoName>
   <whoNameRus>Нек</whoNameRus>
+  <whoNameUa>Нек</whoNameUa>
 </Profession>

--- a/professions/ninja.xml
+++ b/professions/ninja.xml
@@ -905,4 +905,5 @@
   </wearModifiers>
   <whoName>Nin</whoName>
   <whoNameRus>Нин</whoNameRus>
+  <whoNameUa>Нін</whoNameUa>
 </Profession>

--- a/professions/paladin.xml
+++ b/professions/paladin.xml
@@ -910,4 +910,5 @@ Of course, paladins must choose a {hh1religion{x -- otherwise the {hh2036level{x
   </wearModifiers>
   <whoName>Pal</whoName>
   <whoNameRus>Пал</whoNameRus>
+  <whoNameUa>Пал</whoNameUa>
 </Profession>

--- a/professions/ranger.xml
+++ b/professions/ranger.xml
@@ -941,4 +941,5 @@
   </wearModifiers>
   <whoName>Ran</whoName>
   <whoNameRus>Рей</whoNameRus>
+  <whoNameUa>Рей</whoNameUa>
 </Profession>

--- a/professions/samurai.xml
+++ b/professions/samurai.xml
@@ -904,4 +904,5 @@
   </wearModifiers>
   <whoName>Sam</whoName>
   <whoNameRus>Сам</whoNameRus>
+  <whoNameUa>Сам</whoNameUa>
 </Profession>

--- a/professions/thief.xml
+++ b/professions/thief.xml
@@ -933,5 +933,5 @@
   </wearModifiers>
   <whoName>Thi</whoName>
   <whoNameRus>Вор</whoNameRus>
-  <whoNameUa>Кра</whoNameUa>
+  <whoNameUa>Вор</whoNameUa>
 </Profession>

--- a/professions/thief.xml
+++ b/professions/thief.xml
@@ -933,4 +933,5 @@
   </wearModifiers>
   <whoName>Thi</whoName>
   <whoNameRus>Вор</whoNameRus>
+  <whoNameUa>Кра</whoNameUa>
 </Profession>

--- a/professions/vampire.xml
+++ b/professions/vampire.xml
@@ -948,4 +948,5 @@ Every young vampire must undergo a one-time initiation ritual with the Master of
   </wearModifiers>
   <whoName>Vam</whoName>
   <whoNameRus>Вам</whoNameRus>
+  <whoNameUa>Вам</whoNameUa>
 </Profession>

--- a/professions/warlock.xml
+++ b/professions/warlock.xml
@@ -952,4 +952,5 @@ Only men can become warlocks. Female spellcasters become {hh139witches{x.
   </wearModifiers>
   <whoName>WrK</whoName>
   <whoNameRus>Кол</whoNameRus>
+  <whoNameUa>Чак</whoNameUa>
 </Profession>

--- a/professions/warrior.xml
+++ b/professions/warrior.xml
@@ -904,4 +904,5 @@ Warriors get the most out of defensive {hh2021combat{x and {hh1127weapon{x skill
   </wearModifiers>
   <whoName>War</whoName>
   <whoNameRus>Вои</whoNameRus>
+  <whoNameUa>Вої</whoNameUa>
 </Profession>

--- a/professions/witch.xml
+++ b/professions/witch.xml
@@ -943,4 +943,5 @@
   </wearModifiers>
   <whoName>Wit</whoName>
   <whoNameRus>Вед</whoNameRus>
+  <whoNameUa>Від</whoNameUa>
 </Profession>

--- a/races/arial.xml
+++ b/races/arial.xml
@@ -54,6 +54,7 @@ Arials prefer to stay silent about the origins of their race, their ancestral ho
   <nameMlt>ариал|ы|ов|ам|ов|ам|ах</nameMlt>
   <nameWho>Arial</nameWho>
   <nameWhoRus>Ариал</nameWhoRus>
+  <nameWhoUa>Арі</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye wings claws</parts>
   <points>250</points>
   <res>sound</res>

--- a/races/centaur.xml
+++ b/races/centaur.xml
@@ -64,6 +64,7 @@ Centaurs possess an innate ability to strike {hh876two blows{x with their hooves
   <nameMlt>кентавр|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Centa</nameWho>
   <nameWhoRus>Кента</nameWhoRus>
+  <nameWhoUa>Кнт</nameWhoUa>
   <off>bash kick kick_dirt</off>
   <parts>head arms legs heart brains guts hands fingers ear eye tail four_hooves</parts>
   <points>250</points>

--- a/races/cloud giant.xml
+++ b/races/cloud giant.xml
@@ -58,6 +58,7 @@ Their gaseous nature grants them the ability to {hh575fly{x, lets them slip more
   <nameScore>облачн. вел.</nameScore>
   <nameWho>ClGia</nameWho>
   <nameWhoRus>ОбВел</nameWhoRus>
+  <nameWhoUa>Хма</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>slash</res>

--- a/races/dark-elf.xml
+++ b/races/dark-elf.xml
@@ -52,6 +52,7 @@ After the great racial wars, which you can read about in the {hh2088Library{x, t
   <nameScore>темн. эльф</nameScore>
   <nameWho>D-Elf</nameWho>
   <nameWhoRus>Т-Элф</nameWhoRus>
+  <nameWhoUa>Тем</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>charm</res>

--- a/races/drow.xml
+++ b/races/drow.xml
@@ -55,6 +55,7 @@ Like the Dark Elves, drow use a modified form of the dialect {hh2040ahenn{x. The
   <nameScore>дроу</nameScore>
   <nameWho>Drow</nameWho>
   <nameWhoRus>Дроу</nameWhoRus>
+  <nameWhoUa>Дро</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>poison</res>

--- a/races/duergar.xml
+++ b/races/duergar.xml
@@ -48,6 +48,7 @@ Duergar are slightly shorter than humans, with dull gray skin and a bald head ad
   <nameMlt>дуэргар|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Duerg</nameWho>
   <nameWhoRus>Дуэрг</nameWhoRus>
+  <nameWhoUa>Дуе</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>disease</res>

--- a/races/dwarf.xml
+++ b/races/dwarf.xml
@@ -56,6 +56,7 @@ Long years at underground forges have developed in them {hh830infravision{x and 
   <nameMlt>дварф|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Dwarf</nameWho>
   <nameWhoRus>Дварф</nameWhoRus>
+  <nameWhoUa>Два</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>fire</res>

--- a/races/elf.xml
+++ b/races/elf.xml
@@ -60,6 +60,7 @@ Elves have walked the path of Light since time immemorial, but do not be deceive
   <nameMlt>эльф|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Elf</nameWho>
   <nameWhoRus>Эльф</nameWhoRus>
+  <nameWhoUa>Ель</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>charm</res>

--- a/races/faery.xml
+++ b/races/faery.xml
@@ -48,6 +48,7 @@ Every faerie has access to the magic of their race -- {hh554faerie fire{x and {h
   <nameMlt>фе|и|й|ям|й|ями|ях</nameMlt>
   <nameWho>Faery</nameWho>
   <nameWhoRus>Фея</nameWhoRus>
+  <nameWhoUa>Фей</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye wings</parts>
   <points>250</points>
   <res>energy light</res>

--- a/races/felar.xml
+++ b/races/felar.xml
@@ -55,6 +55,7 @@ Unlike everyone else, the goddess Bast gives felars no leeway for killing feline
   <nameMlt>фелар|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Felar</nameWho>
   <nameWhoRus>Фелар</nameWhoRus>
+  <nameWhoUa>Фел</nameWhoUa>
   <off>tail</off>
   <parts>head arms legs heart brains guts hands feet fingers ear eye tail claws fangs</parts>
   <points>250</points>

--- a/races/githyanki.xml
+++ b/races/githyanki.xml
@@ -49,6 +49,7 @@ Silver plays an important role in githyanki culture, and by spending their entir
   <nameScore>гитианки</nameScore>
   <nameWho>Githy</nameWho>
   <nameWhoRus>Гитиа</nameWhoRus>
+  <nameWhoUa>Гіт</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye fangs</parts>
   <points>250</points>
   <res>silver</res>

--- a/races/gnome.xml
+++ b/races/gnome.xml
@@ -46,6 +46,7 @@ Gnomes are weaker than humans and {hh101vulnerable{x to energy attacks. On the o
   <nameMlt>гном|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Gnome</nameWho>
   <nameWhoRus>Гном</nameWhoRus>
+  <nameWhoUa>Гно</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <pracBonus>5</pracBonus>

--- a/races/half-elf.xml
+++ b/races/half-elf.xml
@@ -52,6 +52,7 @@ The fate of half-elves is unenviable -- they are often looked down on and called
   <nameScore>полуэльф</nameScore>
   <nameWho>H-Elf</nameWho>
   <nameWhoRus>ПЭльф</nameWhoRus>
+  <nameWhoUa>Нап</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <size>medium</size>

--- a/races/hobbit.xml
+++ b/races/hobbit.xml
@@ -48,6 +48,7 @@ Hobbit faces are distinguished not by beauty but rather by good nature -- chubby
   <nameMlt>хоббит|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Hobbi</nameWho>
   <nameWhoRus>Хобби</nameWhoRus>
+  <nameWhoUa>Гбт</nameWhoUa>
   <off>dodge fast</off>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>

--- a/races/human.xml
+++ b/races/human.xml
@@ -49,6 +49,7 @@ Humans can pursue any class -- from warrior to vampire. They possess none of the
   <nameScore>человек</nameScore>
   <nameWho>Human</nameWho>
   <nameWhoRus>Челов</nameWhoRus>
+  <nameWhoUa>Люд</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <size>medium</size>
   <wearloc registry="wearlocation">neck_2 neck_1 wrist_r wrist_l body light head legs feet about waist float finger_l second_wield finger_r shield hands arms wield hold face tattoo tat_arms tat_face tat_wrist_l tat_wrist_r hair</wearloc>

--- a/races/kender.xml
+++ b/races/kender.xml
@@ -59,6 +59,7 @@ Kender are the carriers of the great ideas "all property not mine is all mine" a
   <nameMlt>кендер|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Kendr</nameWho>
   <nameWhoRus>Кендр</nameWhoRus>
+  <nameWhoUa>Кен</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>sound</res>

--- a/races/mawg.xml
+++ b/races/mawg.xml
@@ -49,6 +49,7 @@ Mawgs possess an innate ability to sniff out {hh640tracks{x. They dislike {hh166
   <nameWho>Mawg</nameWho>
   <nameWhoFemale>Челоб</nameWhoFemale>
   <nameWhoRus>Чес</nameWhoRus>
+  <nameWhoUa>Псю</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye tail claws fangs</parts>
   <points>250</points>
   <res>poison drowning</res>

--- a/races/rockseer.xml
+++ b/races/rockseer.xml
@@ -48,6 +48,7 @@ Over long centuries of seclusion they forgot {hh2044Quenya{x, the tongue of the 
   <nameMlt>роксир|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Rocks</nameWho>
   <nameWhoRus>Рокси</nameWhoRus>
+  <nameWhoUa>Рок</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>charm</res>

--- a/races/satyr.xml
+++ b/races/satyr.xml
@@ -51,6 +51,7 @@ As native forest dwellers, they do not fear trees but use their help for {hh546c
   <nameMlt>сатир|ы|ов|ам|ов|ами|ах</nameMlt>
   <nameWho>Satyr</nameWho>
   <nameWhoRus>Сатир</nameWhoRus>
+  <nameWhoUa>Сат</nameWhoUa>
   <parts>head arms legs heart brains guts hands fingers ear eye two_hooves horns</parts>
   <points>250</points>
   <res>disease wood</res>

--- a/races/storm giant.xml
+++ b/races/storm giant.xml
@@ -49,6 +49,7 @@ They are far stronger and more enduring than humans, but quite slow, even though
   <nameScore>шторм. вел.</nameScore>
   <nameWho>StGia</nameWho>
   <nameWhoRus>ШтВел</nameWhoRus>
+  <nameWhoUa>Што</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <res>lightning</res>

--- a/races/svirfnebli.xml
+++ b/races/svirfnebli.xml
@@ -48,6 +48,7 @@ In intellect and wisdom svirfnebli yield to few, and they possess good resistanc
   <nameScore>свирфнебли</nameScore>
   <nameWho>Svirf</nameWho>
   <nameWhoRus>Свирф</nameWhoRus>
+  <nameWhoUa>Сві</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye</parts>
   <points>250</points>
   <pracBonus>2</pracBonus>

--- a/races/troll.xml
+++ b/races/troll.xml
@@ -56,6 +56,7 @@ A natural inclination toward Evil has developed in trolls {hh101resistance{x to 
   <nameMlt>тролл|и|ей|ям|ей|ями|ях</nameMlt>
   <nameWho>Troll</nameWho>
   <nameWhoRus>Трол</nameWhoRus>
+  <nameWhoUa>Тро</nameWhoUa>
   <off>berserk</off>
   <parts>head arms legs heart brains guts hands feet fingers ear eye claws fangs</parts>
   <points>250</points>

--- a/races/urukhai.xml
+++ b/races/urukhai.xml
@@ -48,6 +48,7 @@ From childhood they handle nearly all weapon types with skill. They have little 
   <nameScore>урук-хай</nameScore>
   <nameWho>Urkhi</nameWho>
   <nameWhoRus>Урук</nameWhoRus>
+  <nameWhoUa>Уру</nameWhoUa>
   <parts>head arms legs heart brains guts hands feet fingers ear eye claws fangs</parts>
   <points>250</points>
   <size>large</size>


### PR DESCRIPTION
The 36 nameWhoUa/whoNameUa entries read by the engine field (dreamland_code A8 PR). Kit-approved scheme. Ships in the same reboot as the engine field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)