### PR TITLE
l10n(fountain): EN/UA for onLook drink hint

### DIFF
--- a/config/translations/behaviors.json
+++ b/config/translations/behaviors.json
@@ -3344,5 +3344,11 @@
    "en": "Want an interesting task? Type {y{hcquest request{x.",
    "ua": "Хочеш отримати цікаве завдання? Напиши {y{hcквест попросити{x."
   }
+ },
+ "behaviors/fountain/onLook": {
+  "Напиться отсюда: {y{hcпить{x.": {
+   "en": "Drink from here: {y{hcdrink{x.",
+   "ua": "Напитися звідси: {y{hcпити{x."
+  }
  }
 }


### PR DESCRIPTION
EN/UA catalog entries for the fountain onLook hint. Loads at next reboot (new key; EN/UA fall back to RU source until then). Reviewed with the Fenia change: VERDICT RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)