### PR TITLE
refactor(arcadian): retype 8 effect nodes to FeniaWordEffectWE stub

### DIFF
--- a/languages/arcadian.xml
+++ b/languages/arcadian.xml
@@ -96,7 +96,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
     <position>sleep</position>
   </command>
   <effects>
-    <node name="beer_armor" type="BeerArmorWE">
+    <node name="beer_armor" type="FeniaWordEffectWE">
       <frequency>3</frequency>
       <global>true</global>
       <meaning l="en">toughness</meaning>
@@ -106,7 +106,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="beer_elemental" type="BeerElementalWE">
+    <node name="beer_elemental" type="FeniaWordEffectWE">
       <frequency>2</frequency>
       <global>true</global>
       <meaning l="en">summoning a beer elemental</meaning>
@@ -116,7 +116,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="water2beer" type="WaterToBeerWE">
+    <node name="water2beer" type="FeniaWordEffectWE">
       <frequency>2</frequency>
       <global>true</global>
       <meaning l="en">turning water into beer</meaning>
@@ -125,7 +125,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="water2wine" type="WaterToWineWE">
+    <node name="water2wine" type="FeniaWordEffectWE">
       <frequency>2</frequency>
       <global>true</global>
       <meaning l="en">turning water into wine</meaning>
@@ -134,7 +134,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="wine_awake" type="WineAwakeWE">
+    <node name="wine_awake" type="FeniaWordEffectWE">
       <frequency>1</frequency>
       <global>true</global>
       <meaning l="en">brewing an invigorating drink</meaning>
@@ -144,7 +144,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="wine_calm" type="WineCalmWE">
+    <node name="wine_calm" type="FeniaWordEffectWE">
       <frequency>1</frequency>
       <global>true</global>
       <meaning l="en">brewing a calming drink</meaning>
@@ -154,7 +154,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="wine_refresh" type="WineRefreshWE">
+    <node name="wine_refresh" type="FeniaWordEffectWE">
       <frequency>3</frequency>
       <global>true</global>
       <meaning l="en">brewing a refreshing drink</meaning>
@@ -164,7 +164,7 @@ The word with the secret of {csummoning a beer elemental{x is spoken over a barr
       <object>true</object>
       <offensive>false</offensive>
     </node>
-    <node name="wine_sleep" type="WineSleepWE">
+    <node name="wine_sleep" type="FeniaWordEffectWE">
       <frequency>1</frequency>
       <global>true</global>
       <meaning l="en">brewing a sleeping draught</meaning>


### PR DESCRIPTION
Retypes all 8 arcadian `<effects>` nodes to the single `FeniaWordEffectWE` stub. **PAIR with dreamland_code PR #1032** -- same boot. Only `type=` changes; name/meaning/minEffectiveVolume/frequency untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)