### PR TITLE
fix(l10n): UA config change-hint uses %5$s %6$s not the RU pair

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -4990,7 +4990,7 @@
   },
   "\nИспользуй команду {hc{yрежим %s %s{x для изменения.": {
    "en": "\nUse the command {hc{yconfig %3$s %4$s{x to change it.",
-   "ua": "\nВикористовуй команду {hc{yрежим %s %s{x, щоб змінити."
+   "ua": "\nВикористовуй команду {hc{yрежим %5$s %6$s{x, щоб змінити."
   },
   "\r\nПодробнее смотри по команде {yрежим {Dнастройка{w.": {
    "en": "\r\nFor details see the {yconfig {Dsetting{w command.",

--- a/config/translations/spell2.json
+++ b/config/translations/spell2.json
@@ -3763,6 +3763,10 @@
   "Твой нейтралитет не дает тебе получить защиту от злых существ.": {
    "en": "Your neutrality prevents you from gaining protection against evil beings.",
    "ua": "Твій нейтралітет не дає тобі отримати захист від злих істот."
+  },
+  "Твой нейтралитет не дает тебе получить защиту от добрых существ.": {
+   "en": "Your neutrality prevents you from gaining protection against good beings.",
+   "ua": "Твій нейтралітет не дає тобі отримати захист від добрих істот."
   }
  },
  "spell/acid arrow/runVict": {


### PR DESCRIPTION
Trello xkhkGgh7. Smoke-test found a UA player sees the Russian option name (`режим спамбой да`) on `config fightspam`. The 6-arg hint (configs.cpp:88-91, #910) exposes RU(1-2)/EN(3-4)/UA(5-6) pairs; the UA catalog value used un-numbered `%s %s` (=RU pair). Numbered to `%5$s %6$s`. EN already correct. Picks up via `plug reload most` (translations.cpp:82).