### PR TITLE
l10n: EN/UA for protection-good neutral-rejection message

### DIFF
--- a/config/translations/spell.json
+++ b/config/translations/spell.json
@@ -3239,6 +3239,10 @@
   "%^C1 на мгновение окутывается {1{Dтемным щитом,{2 получая защиту от добрых существ.": {
    "en": "%^C1 is momentarily wrapped in a {1{Ddark shield,{2 gaining protection from good creatures.",
    "ua": "%^C1 на мить огортається {1{Dтемним щитом,{2 отримуючи захист від добрих істот."
+  },
+  "Твой нейтралитет не дает тебе получить защиту от добрых существ.": {
+   "en": "Your neutrality prevents you from gaining protection against good beings.",
+   "ua": "Твій нейтралітет не дає тобі отримати захист від добрих істот."
   }
  },
  "spell/inspire/runRoom": {


### PR DESCRIPTION
Adds the neutral-rejection phrase to the spell/protection good/runVict section of spell.json (resolver keys by codesource path). Pairs with the fenia ._() wrap.

Adversarially reviewed on fable: VERDICT RELEASE (round 2). Full review: reviews/2026-08-23-dementia-l10n-leak-batch.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)