### PR TITLE
clans: add english and ukrainian rank titles for all clans

### DIFF
--- a/clans/battlerager.xml
+++ b/clans/battlerager.xml
@@ -49,228 +49,336 @@
     <node name="all">
       <node>
         <female>рекрут</female>
+        <english>recruit</english>
+        <ukrainian>рекрут</ukrainian>
         <male>рекрут</male>
       </node>
       <node>
         <female>камикадзе</female>
+        <english>kamikaze</english>
+        <ukrainian>камікадзе</ukrainian>
         <male>камикадзе</male>
       </node>
       <node>
         <female>варвар</female>
+        <english>barbarian</english>
+        <ukrainian>варвар</ukrainian>
         <male>варвар</male>
       </node>
       <node>
         <female>безумец</female>
+        <english>madman</english>
+        <ukrainian>божевільний</ukrainian>
         <male>безумец</male>
       </node>
       <node>
         <female>берсеркер</female>
+        <english>berserker</english>
+        <ukrainian>берсерк</ukrainian>
         <male>берсеркер</male>
       </node>
       <node>
         <female>БИЧ</female>
+        <english>scourge</english>
+        <ukrainian>бич</ukrainian>
         <male>БИЧ</male>
       </node>
       <node>
         <female>атеист</female>
+        <english>atheist</english>
+        <ukrainian>атеїст</ukrainian>
         <male>атеист</male>
       </node>
       <node>
         <female>убийца магов</female>
+        <english>mage slayer</english>
+        <ukrainian>вбивця магів</ukrainian>
         <male>убийца магов</male>
       </node>
       <node>
         <female>инквизитор</female>
+        <english>inquisitor</english>
+        <ukrainian>інквізитор</ukrainian>
         <male>инквизитор</male>
       </node>
     </node>
     <node name="ninja">
       <node>
         <female>кандидатка</female>
+        <english>candidate</english>
+        <ukrainian>кандидат</ukrainian>
         <male>кандидат</male>
       </node>
       <node>
         <female>лазутчица</female>
+        <english>infiltrator</english>
+        <ukrainian>лазутчик</ukrainian>
         <male>лазутчик</male>
       </node>
       <node>
         <female>крадущаяся</female>
+        <english>prowler</english>
+        <ukrainian>скрадливий</ukrainian>
         <male>крадущийся</male>
       </node>
       <node>
         <female>диверсант</female>
+        <english>saboteur</english>
+        <ukrainian>диверсант</ukrainian>
         <male>диверсант</male>
       </node>
       <node>
         <female>шпионка</female>
+        <english>spy</english>
+        <ukrainian>шпигун</ukrainian>
         <male>шпион</male>
       </node>
       <node>
         <female>невидимка</female>
+        <english>unseen</english>
+        <ukrainian>невидимка</ukrainian>
         <male>невидимка</male>
       </node>
       <node>
         <female>ночная бестия</female>
+        <english>night warrior</english>
+        <ukrainian>нічний воїн</ukrainian>
         <male>ночной воин</male>
       </node>
       <node>
         <female>убийца магов</female>
+        <english>mage slayer</english>
+        <ukrainian>вбивця магів</ukrainian>
         <male>убийца магов</male>
       </node>
       <node>
         <female>инквизитор</female>
+        <english>inquisitor</english>
+        <ukrainian>інквізитор</ukrainian>
         <male>инквизитор</male>
       </node>
     </node>
     <node name="ranger">
       <node>
         <female>скаут</female>
+        <english>scout</english>
+        <ukrainian>скаут</ukrainian>
         <male>скаут</male>
       </node>
       <node>
         <female>дриада</female>
+        <english>rover</english>
+        <ukrainian>волоцюга</ukrainian>
         <male>шатун</male>
       </node>
       <node>
         <female>браконьерша</female>
+        <english>poacher</english>
+        <ukrainian>браконьєр</ukrainian>
         <male>браконьер</male>
       </node>
       <node>
         <female>зверолов</female>
+        <english>trapper</english>
+        <ukrainian>звіролов</ukrainian>
         <male>зверолов</male>
       </node>
       <node>
         <female>лесничий</female>
+        <english>forester</english>
+        <ukrainian>лісничий</ukrainian>
         <male>лесничий</male>
       </node>
       <node>
         <female>сумрак леса</female>
+        <english>forest dusk</english>
+        <ukrainian>сутінь лісу</ukrainian>
         <male>сумрак леса</male>
       </node>
       <node>
         <female>нимфа</female>
+        <english>wood spirit</english>
+        <ukrainian>лісовик</ukrainian>
         <male>леший</male>
       </node>
       <node>
         <female>убийца магов</female>
+        <english>mage slayer</english>
+        <ukrainian>вбивця магів</ukrainian>
         <male>убийца магов</male>
       </node>
       <node>
         <female>инквизитор</female>
+        <english>inquisitor</english>
+        <ukrainian>інквізитор</ukrainian>
         <male>инквизитор</male>
       </node>
     </node>
     <node name="samurai">
       <node>
         <female>ронин</female>
+        <english>ronin</english>
+        <ukrainian>ронін</ukrainian>
         <male>ронин</male>
       </node>
       <node>
         <female>камикадзе</female>
+        <english>kamikaze</english>
+        <ukrainian>камікадзе</ukrainian>
         <male>камикадзе</male>
       </node>
       <node>
         <female>мастер поединков</female>
+        <english>duel master</english>
+        <ukrainian>майстер двобоїв</ukrainian>
         <male>мастер поединков</male>
       </node>
       <node>
         <female>повелительница мечей</female>
+        <english>lord of swords</english>
+        <ukrainian>повелитель мечів</ukrainian>
         <male>повелитель мечей</male>
       </node>
       <node>
         <female>муза войны</female>
+        <english>spirit of war</english>
+        <ukrainian>дух війни</ukrainian>
         <male>дух войны</male>
       </node>
       <node>
         <female>стратег</female>
+        <english>strategist</english>
+        <ukrainian>стратег</ukrainian>
         <male>стратег</male>
       </node>
       <node>
         <female>сегун</female>
+        <english>shogun</english>
+        <ukrainian>сьогун</ukrainian>
         <male>сегун</male>
       </node>
       <node>
         <female>убийца магов</female>
+        <english>mage slayer</english>
+        <ukrainian>вбивця магів</ukrainian>
         <male>убийца магов</male>
       </node>
       <node>
         <female>инквизитор</female>
+        <english>inquisitor</english>
+        <ukrainian>інквізитор</ukrainian>
         <male>инквизитор</male>
       </node>
     </node>
     <node name="thief">
       <node>
         <female>карманник</female>
+        <english>pickpocket</english>
+        <ukrainian>кишенькар</ukrainian>
         <male>карманник</male>
       </node>
       <node>
         <female>осторожная</female>
+        <english>wary</english>
+        <ukrainian>обережний</ukrainian>
         <male>осторожный</male>
       </node>
       <node>
         <female>вор</female>
+        <english>thief</english>
+        <ukrainian>крадій</ukrainian>
         <male>вор</male>
       </node>
       <node>
         <female>налетчица</female>
+        <english>raider</english>
+        <ukrainian>нальотник</ukrainian>
         <male>налетчик</male>
       </node>
       <node>
         <female>мокрушница</female>
+        <english>hitman</english>
+        <ukrainian>мокрушник</ukrainian>
         <male>мокрушник</male>
       </node>
       <node>
         <female>разбойница</female>
+        <english>cutthroat</english>
+        <ukrainian>горлоріз</ukrainian>
         <male>головорез</male>
       </node>
       <node>
         <female>мастер теней</female>
+        <english>master of shadows</english>
+        <ukrainian>майстер тіней</ukrainian>
         <male>мастер теней</male>
       </node>
       <node>
         <female>убийца магов</female>
+        <english>mage slayer</english>
+        <ukrainian>вбивця магів</ukrainian>
         <male>убийца магов</male>
       </node>
       <node>
         <female>инквизитор</female>
+        <english>inquisitor</english>
+        <ukrainian>інквізитор</ukrainian>
         <male>инквизитор</male>
       </node>
     </node>
     <node name="warrior">
       <node>
         <female>рекрут</female>
+        <english>recruit</english>
+        <ukrainian>рекрут</ukrainian>
         <male>рекрут</male>
       </node>
       <node>
         <female>дикарка</female>
+        <english>barbarian</english>
+        <ukrainian>варвар</ukrainian>
         <male>варвар</male>
       </node>
       <node>
         <female>воительница</female>
+        <english>warrior</english>
+        <ukrainian>войовник</ukrainian>
         <male>воитель</male>
       </node>
       <node>
         <female>фурия</female>
+        <english>berserker</english>
+        <ukrainian>берсерк</ukrainian>
         <male>берсеркер</male>
       </node>
       <node>
         <female>ветеран</female>
+        <english>veteran</english>
+        <ukrainian>ветеран</ukrainian>
         <male>ветеран</male>
       </node>
       <node>
         <female>вихрь стали</female>
+        <english>whirlwind of steel</english>
+        <ukrainian>вихор сталі</ukrainian>
         <male>вихрь стали</male>
       </node>
       <node>
         <female>мастер боя</female>
+        <english>battle master</english>
+        <ukrainian>майстер бою</ukrainian>
         <male>мастер боя</male>
       </node>
       <node>
         <female>убийца магов</female>
+        <english>mage slayer</english>
+        <ukrainian>вбивця магів</ukrainian>
         <male>убийца магов</male>
       </node>
       <node>
         <female>инквизитор</female>
+        <english>inquisitor</english>
+        <ukrainian>інквізитор</ukrainian>
         <male>инквизитор</male>
       </node>
     </node>

--- a/clans/chaos.xml
+++ b/clans/chaos.xml
@@ -59,38 +59,56 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>дитя хаоса</female>
+      <english>child of chaos</english>
+      <ukrainian>дитя хаосу</ukrainian>
       <male>дитя хаоса</male>
     </node>
     <node>
       <female>адепт хаоса</female>
+      <english>adept of chaos</english>
+      <ukrainian>адепт хаосу</ukrainian>
       <male>адепт хаоса</male>
     </node>
     <node>
       <female>агент хаоса</female>
+      <english>agent of chaos</english>
+      <ukrainian>агент хаосу</ukrainian>
       <male>агент хаоса</male>
     </node>
     <node>
       <female>вассал хаоса</female>
+      <english>vassal of chaos</english>
+      <ukrainian>васал хаосу</ukrainian>
       <male>вассал хаоса</male>
     </node>
     <node>
       <female>баронесса хаоса</female>
+      <english>baron of chaos</english>
+      <ukrainian>барон хаосу</ukrainian>
       <male>барон хаоса</male>
     </node>
     <node>
       <female>жрица хаоса</female>
+      <english>priest of chaos</english>
+      <ukrainian>жрець хаосу</ukrainian>
       <male>жрец хаоса</male>
     </node>
     <node>
       <female>княгиня хаоса</female>
+      <english>prince of chaos</english>
+      <ukrainian>князь хаосу</ukrainian>
       <male>князь хаоса</male>
     </node>
     <node>
       <female>несущая хаос</female>
+      <english>chaosbringer</english>
+      <ukrainian>носій хаосу</ukrainian>
       <male>несущий хаос</male>
     </node>
     <node>
       <female>повелительница</female>
+      <english>sovereign</english>
+      <ukrainian>повелитель</ukrainian>
       <male>повелитель</male>
     </node>
   </titles>

--- a/clans/flowers.xml
+++ b/clans/flowers.xml
@@ -33,14 +33,20 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>хиппи</female>
+      <english>hippie</english>
+      <ukrainian>хіпі</ukrainian>
       <male>хиппи</male>
     </node>
     <node>
       <female>просветленная</female>
+      <english>enlightened</english>
+      <ukrainian>просвітлений</ukrainian>
       <male>просветленный</male>
     </node>
     <node>
       <female>просветленная</female>
+      <english>enlightened</english>
+      <ukrainian>просвітлений</ukrainian>
       <male>просветленный</male>
     </node>
   </titles>

--- a/clans/ghost.xml
+++ b/clans/ghost.xml
@@ -36,14 +36,20 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>посвященная</female>
+      <english>initiate</english>
+      <ukrainian>посвячений</ukrainian>
       <male>посвященный</male>
     </node>
     <node>
       <female>посвященная</female>
+      <english>initiate</english>
+      <ukrainian>посвячений</ukrainian>
       <male>посвященный</male>
     </node>
     <node>
       <female>посвященная</female>
+      <english>initiate</english>
+      <ukrainian>посвячений</ukrainian>
       <male>посвященный</male>
     </node>
   </titles>

--- a/clans/invader.xml
+++ b/clans/invader.xml
@@ -69,38 +69,56 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>зомби</female>
+      <english>zombie</english>
+      <ukrainian>зомбі</ukrainian>
       <male>зомби</male>
     </node>
     <node>
       <female>меняющаяся</female>
+      <english>shifter</english>
+      <ukrainian>мінливий</ukrainian>
       <male>меняющийся</male>
     </node>
     <node>
       <female>кобра</female>
+      <english>asp</english>
+      <ukrainian>аспід</ukrainian>
       <male>аспид</male>
     </node>
     <node>
       <female>чертовка</female>
+      <english>imp</english>
+      <ukrainian>чорт</ukrainian>
       <male>черт</male>
     </node>
     <node>
       <female>демоница</female>
+      <english>demon</english>
+      <ukrainian>демон</ukrainian>
       <male>демон</male>
     </node>
     <node>
       <female>смерть</female>
+      <english>doom</english>
+      <ukrainian>фатум</ukrainian>
       <male>рок</male>
     </node>
     <node>
       <female>черный ангел</female>
+      <english>dark angel</english>
+      <ukrainian>чорний янгол</ukrainian>
       <male>черный ангел</male>
     </node>
     <node>
       <female>княгиня тьмы</female>
+      <english>prince of darkness</english>
+      <ukrainian>князь пітьми</ukrainian>
       <male>князь тьмы</male>
     </node>
     <node>
       <female>властительница</female>
+      <english>overlord</english>
+      <ukrainian>володар</ukrainian>
       <male>властелин</male>
     </node>
   </titles>

--- a/clans/knight.xml
+++ b/clans/knight.xml
@@ -52,38 +52,56 @@
       <titles>
         <node>
           <female>ученик</female>
+          <english>apprentice</english>
+          <ukrainian>учень</ukrainian>
           <male>ученик</male>
         </node>
         <node>
           <female>послушница</female>
+          <english>novice</english>
+          <ukrainian>послушник</ukrainian>
           <male>послушник</male>
         </node>
         <node>
           <female>аколит</female>
+          <english>acolyte</english>
+          <ukrainian>аколіт</ukrainian>
           <male>аколит</male>
         </node>
         <node>
           <female>посвященная</female>
+          <english>initiate</english>
+          <ukrainian>посвячений</ukrainian>
           <male>посвященный</male>
         </node>
         <node>
           <female>познающая</female>
+          <english>seeker</english>
+          <ukrainian>шукач</ukrainian>
           <male>познающий</male>
         </node>
         <node>
           <female>адепт</female>
+          <english>adept</english>
+          <ukrainian>адепт</ukrainian>
           <male>адепт</male>
         </node>
         <node>
           <female>Жрица</female>
+          <english>archmage</english>
+          <ukrainian>архімаг</ukrainian>
           <male>Архимаг</male>
         </node>
         <node>
           <female>Изгоняющая Зло</female>
+          <english>banisher of evil</english>
+          <ukrainian>гонитель зла</ukrainian>
           <male>Изгоняющий Зло</male>
         </node>
         <node>
           <female>Королева</female>
+          <english>king</english>
+          <ukrainian>король</ukrainian>
           <male>Король</male>
         </node>
       </titles>
@@ -95,38 +113,56 @@
       <titles>
         <node>
           <female>ученик</female>
+          <english>apprentice</english>
+          <ukrainian>учень</ukrainian>
           <male>ученик</male>
         </node>
         <node>
           <female>посвященная</female>
+          <english>initiate</english>
+          <ukrainian>посвячений</ukrainian>
           <male>посвященный</male>
         </node>
         <node>
           <female>врачевательница</female>
+          <english>healer</english>
+          <ukrainian>лікар</ukrainian>
           <male>лекарь</male>
         </node>
         <node>
           <female>целительница</female>
+          <english>restorer</english>
+          <ukrainian>цілитель</ukrainian>
           <male>целитель</male>
         </node>
         <node>
           <female>настоятель</female>
+          <english>prior</english>
+          <ukrainian>настоятель</ukrainian>
           <male>настоятель</male>
         </node>
         <node>
           <female>проповедница</female>
+          <english>preacher</english>
+          <ukrainian>проповідник</ukrainian>
           <male>проповедник</male>
         </node>
         <node>
           <female>Пророк</female>
+          <english>prophet</english>
+          <ukrainian>пророк</ukrainian>
           <male>Пророк</male>
         </node>
         <node>
           <female>Несущая Свет</female>
+          <english>lightbringer</english>
+          <ukrainian>носій світла</ukrainian>
           <male>Несущий Свет</male>
         </node>
         <node>
           <female>Королева</female>
+          <english>king</english>
+          <ukrainian>король</ukrainian>
           <male>Король</male>
         </node>
       </titles>
@@ -138,38 +174,56 @@
       <titles>
         <node>
           <female>ученик</female>
+          <english>apprentice</english>
+          <ukrainian>учень</ukrainian>
           <male>ученик</male>
         </node>
         <node>
           <female>оруженосец</female>
+          <english>squire</english>
+          <ukrainian>зброєносець</ukrainian>
           <male>оруженосец</male>
         </node>
         <node>
           <female>воительница</female>
+          <english>warrior</english>
+          <ukrainian>воїн</ukrainian>
           <male>воин</male>
         </node>
         <node>
           <female>ветеран</female>
+          <english>veteran</english>
+          <ukrainian>ветеран</ukrainian>
           <male>ветеран</male>
         </node>
         <node>
           <female>мастер</female>
+          <english>master</english>
+          <ukrainian>майстер</ukrainian>
           <male>мастер</male>
         </node>
         <node>
           <female>наставница</female>
+          <english>mentor</english>
+          <ukrainian>наставник</ukrainian>
           <male>наставник</male>
         </node>
         <node>
           <female>Элита</female>
+          <english>elite</english>
+          <ukrainian>еліта</ukrainian>
           <male>Элита</male>
         </node>
         <node>
           <female>Карающая Зло</female>
+          <english>punisher of evil</english>
+          <ukrainian>каратель зла</ukrainian>
           <male>Карающий Зло</male>
         </node>
         <node>
           <female>Королева</female>
+          <english>king</english>
+          <ukrainian>король</ukrainian>
           <male>Король</male>
         </node>
       </titles>
@@ -201,38 +255,56 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>ученик</female>
+      <english>apprentice</english>
+      <ukrainian>учень</ukrainian>
       <male>ученик</male>
     </node>
     <node>
       <female>оруженосец</female>
+      <english>squire</english>
+      <ukrainian>зброєносець</ukrainian>
       <male>оруженосец</male>
     </node>
     <node>
       <female>посвященная</female>
+      <english>initiate</english>
+      <ukrainian>посвячений</ukrainian>
       <male>посвященный</male>
     </node>
     <node>
       <female>сестра</female>
+      <english>brother</english>
+      <ukrainian>брат</ukrainian>
       <male>брат</male>
     </node>
     <node>
       <female>графиня</female>
+      <english>count</english>
+      <ukrainian>граф</ukrainian>
       <male>граф</male>
     </node>
     <node>
       <female>герцогиня</female>
+      <english>duke</english>
+      <ukrainian>герцог</ukrainian>
       <male>герцог</male>
     </node>
     <node>
       <female>леди</female>
+      <english>lord</english>
+      <ukrainian>лорд</ukrainian>
       <male>лорд</male>
     </node>
     <node>
       <female>миледи</female>
+      <english>cardinal</english>
+      <ukrainian>кардинал</ukrainian>
       <male>кардинал</male>
     </node>
     <node>
       <female>Королева</female>
+      <english>king</english>
+      <ukrainian>король</ukrainian>
       <male>Король</male>
     </node>
   </titles>

--- a/clans/lion.xml
+++ b/clans/lion.xml
@@ -70,38 +70,56 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>коготь</female>
+      <english>fang</english>
+      <ukrainian>ікло</ukrainian>
       <male>клык</male>
     </node>
     <node>
       <female>кошка</female>
+      <english>pursuer</english>
+      <ukrainian>переслідувач</ukrainian>
       <male>преследующий</male>
     </node>
     <node>
       <female>ярость</female>
+      <english>predator</english>
+      <ukrainian>хижак</ukrainian>
       <male>хищник</male>
     </node>
     <node>
       <female>львенок</female>
+      <english>cub</english>
+      <ukrainian>левеня</ukrainian>
       <male>львенок</male>
     </node>
     <node>
       <female>химера</female>
+      <english>sphinx</english>
+      <ukrainian>сфінкс</ukrainian>
       <male>сфинкс</male>
     </node>
     <node>
       <female>амазонка</female>
+      <english>warrior</english>
+      <ukrainian>воїн</ukrainian>
       <male>воин</male>
     </node>
     <node>
       <female>львица</female>
+      <english>lion</english>
+      <ukrainian>лев</ukrainian>
       <male>лев</male>
     </node>
     <node>
       <female>видящая</female>
+      <english>seer</english>
+      <ukrainian>провидець</ukrainian>
       <male>видящий</male>
     </node>
     <node>
       <female>валькирия</female>
+      <english>lord</english>
+      <ukrainian>владика</ukrainian>
       <male>владыка</male>
     </node>
   </titles>

--- a/clans/ruler.xml
+++ b/clans/ruler.xml
@@ -58,38 +58,56 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>постигающая</female>
+      <english>learner</english>
+      <ukrainian>пізнавач</ukrainian>
       <male>постигающий</male>
     </node>
     <node>
       <female>патрульная</female>
+      <english>patroller</english>
+      <ukrainian>патрульний</ukrainian>
       <male>патрульный</male>
     </node>
     <node>
       <female>постовая</female>
+      <english>sentry</english>
+      <ukrainian>вартовий</ukrainian>
       <male>постовой</male>
     </node>
     <node>
       <female>охранница</female>
+      <english>guard</english>
+      <ukrainian>охоронець</ukrainian>
       <male>охранник</male>
     </node>
     <node>
       <female>миротворица</female>
+      <english>peacemaker</english>
+      <ukrainian>миротворець</ukrainian>
       <male>миротворец</male>
     </node>
     <node>
       <female>блюстительница</female>
+      <english>warden</english>
+      <ukrainian>наглядач</ukrainian>
       <male>блюститель</male>
     </node>
     <node>
       <female>покровительница</female>
+      <english>patron</english>
+      <ukrainian>покровитель</ukrainian>
       <male>покровитель</male>
     </node>
     <node>
       <female>творящая из хаоса</female>
+      <english>shaper of chaos</english>
+      <ukrainian>творець із хаосу</ukrainian>
       <male>творящий из хаоса</male>
     </node>
     <node>
       <female>хранительница равновесия</female>
+      <english>keeper of balance</english>
+      <ukrainian>хранитель рівноваги</ukrainian>
       <male>хранитель равновесия</male>
     </node>
   </titles>

--- a/clans/shalafi.xml
+++ b/clans/shalafi.xml
@@ -68,38 +68,56 @@
       <titles>
         <node>
           <female>избранная</female>
+          <english>chosen</english>
+          <ukrainian>обраний</ukrainian>
           <male>избранный</male>
         </node>
         <node>
           <female>искательница</female>
+          <english>seeker</english>
+          <ukrainian>шукач</ukrainian>
           <male>искатель</male>
         </node>
         <node>
           <female>мыслительница</female>
+          <english>thinker</english>
+          <ukrainian>мислитель</ukrainian>
           <male>мыслитель</male>
         </node>
         <node>
           <female>оккультистка</female>
+          <english>occultist</english>
+          <ukrainian>окультист</ukrainian>
           <male>оккультист</male>
         </node>
         <node>
           <female>ведунья</female>
+          <english>warlock</english>
+          <ukrainian>відун</ukrainian>
           <male>ведун</male>
         </node>
         <node>
           <female>чудотворящая</female>
+          <english>miracle worker</english>
+          <ukrainian>чудотворець</ukrainian>
           <male>чудотворец</male>
         </node>
         <node>
           <female>аскетка</female>
+          <english>ascetic</english>
+          <ukrainian>аскет</ukrainian>
           <male>аскет</male>
         </node>
         <node>
           <female>Гуру</female>
+          <english>guru</english>
+          <ukrainian>гуру</ukrainian>
           <male>Гуру</male>
         </node>
         <node>
           <female>Сатори</female>
+          <english>satori</english>
+          <ukrainian>саторі</ukrainian>
           <male>Сатори</male>
         </node>
       </titles>   
@@ -111,38 +129,56 @@
       <titles>
         <node>
           <female>одарённая</female>
+          <english>gifted</english>
+          <ukrainian>обдарований</ukrainian>
           <male>одарённый</male>
         </node>
         <node>
           <female>скиталица</female>
+          <english>wanderer</english>
+          <ukrainian>блукач</ukrainian>
           <male>скиталец</male>
         </node>
         <node>
           <female>философиня</female>
+          <english>philosopher</english>
+          <ukrainian>філософ</ukrainian>
           <male>философ</male>
         </node>
         <node>
           <female>созерцательница</female>
+          <english>contemplator</english>
+          <ukrainian>споглядач</ukrainian>
           <male>созерцатель</male>
         </node>
         <node>
           <female>сталкерша</female>
+          <english>stalker</english>
+          <ukrainian>сталкер</ukrainian>
           <male>сталкер</male>
         </node>
         <node>
           <female>мистик</female>
+          <english>mystic</english>
+          <ukrainian>містик</ukrainian>
           <male>мистик</male>
         </node>
         <node>
           <female>шаманка</female>
+          <english>shaman</english>
+          <ukrainian>шаман</ukrainian>
           <male>шаман</male>
         </node>
         <node>
           <female>Йогиня</female>
+          <english>yogi</english>
+          <ukrainian>йогін</ukrainian>
           <male>Йогин</male>
         </node>
         <node>
           <female>Бодхи</female>
+          <english>bodhi</english>
+          <ukrainian>бодхі</ukrainian>
           <male>Бодхи</male>
         </node>
       </titles>	    
@@ -154,38 +190,56 @@
       <titles>
         <node>
           <female>прирождённая</female>
+          <english>natural</english>
+          <ukrainian>природжений</ukrainian>
           <male>прирождённый</male>
         </node>
         <node>
           <female>страждущая</female>
+          <english>sufferer</english>
+          <ukrainian>стражденний</ukrainian>
           <male>страждущий</male>
         </node>
         <node>
           <female>мудрая</female>
+          <english>sage</english>
+          <ukrainian>мудрець</ukrainian>
           <male>мудрец</male>
         </node>
         <node>
           <female>апатеистка</female>
+          <english>apatheist</english>
+          <ukrainian>апатеїст</ukrainian>
           <male>апатеист</male>
         </node>
         <node>
           <female>чародейка</female>
+          <english>sorcerer</english>
+          <ukrainian>чаклун</ukrainian>
           <male>чародей</male>
         </node>
         <node>
           <female>кудесница</female>
+          <english>wizard</english>
+          <ukrainian>чарівник</ukrainian>
           <male>кудесник</male>
         </node>
         <node>
           <female>катарсис</female>
+          <english>catharsis</english>
+          <ukrainian>катарсис</ukrainian>
           <male>катарсис</male>
         </node>
         <node>
           <female>Будда</female>
+          <english>buddha</english>
+          <ukrainian>будда</ukrainian>
           <male>Будда</male>
         </node>
         <node>
           <female>Самадхи</female>
+          <english>samadhi</english>
+          <ukrainian>самадхі</ukrainian>
           <male>Самадхи</male>
         </node>
       </titles>		    
@@ -201,38 +255,56 @@
   <titles type="ClanTitlesByLevel">
     <node>
       <female>одаренная</female>
+      <english>gifted</english>
+      <ukrainian>обдарований</ukrainian>
       <male>одаренный</male>
     </node>
     <node>
       <female>искательница</female>
+      <english>seeker</english>
+      <ukrainian>шукач</ukrainian>
       <male>искатель</male>
     </node>
     <node>
       <female>мистика</female>
+      <english>mystic</english>
+      <ukrainian>містик</ukrainian>
       <male>мистик</male>
     </node>
     <node>
       <female>астрологиня</female>
+      <english>astrologer</english>
+      <ukrainian>астролог</ukrainian>
       <male>астролог</male>
     </node>
     <node>
       <female>ясновидящая</female>
+      <english>clairvoyant</english>
+      <ukrainian>ясновидець</ukrainian>
       <male>ясновидящий</male>
     </node>
     <node>
       <female>дервиш</female>
+      <english>dervish</english>
+      <ukrainian>дервіш</ukrainian>
       <male>дервиш</male>
     </node>
     <node>
       <female>наставница</female>
+      <english>mentor</english>
+      <ukrainian>наставник</ukrainian>
       <male>наставник</male>
     </node>
     <node>
       <female>повелительница магии</female>
+      <english>lord of magic</english>
+      <ukrainian>повелитель магії</ukrainian>
       <male>повелитель магии</male>
     </node>
     <node>
       <female>верховный маг</female>
+      <english>high mage</english>
+      <ukrainian>верховний маг</ukrainian>
       <male>верховный маг</male>
     </node>
   </titles>


### PR DESCRIPTION
336 rank forms (168 EN + 168 UA), lowercase, gender-neutral, one per clan rank node. Pairs with dreamland_code #1042 (lang-aware ClanTitles::build) and dreamland_fenia whois. Loads at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)