### PR TITLE
l10n: re-key 61 spell-catalog entries for per-viewer deity name

### DIFF
--- a/config/translations/spell.json
+++ b/config/translations/spell.json
@@ -808,57 +808,57 @@
   }
  },
  "spell/liturgy/runVict": {
-  "Твоя литургия {1{C%N3{2 принесла тебе только защиту.": {
-   "en": "Your liturgy to {1{C%N3{2 brought you only protection.",
-   "ua": "Твоя літургія {1{C%N3{2 принесла тобі лише захист."
-  },
   "Тебе потребуется больше здоровья, энергии и движений для литургии.": {
    "en": "You will need more health, energy, and moves for the liturgy.",
    "ua": "Тобі знадобиться більше здоров'я, енергії та рухів для літургії."
-  },
-  "%^C1 поет заунывную литургию, прося {1{C%N4{2 о помощи.": {
-   "en": "%^C1 sings a mournful liturgy, begging {1{C%N4{2 for help.",
-   "ua": "%^C1 співає тужливу літургію, благаючи {1{C%N4{2 про допомогу."
-  },
-  "%^C1 разгнева%1$Gло|л|ла {1{C%N4{2 своей настырностью!": {
-   "en": "%^C1 angers {1{C%N4{2 with their persistence!",
-   "ua": "%^C1 розгніва%1$Gло|в|ла {1{C%N4{2 своєю настирливістю!"
-  },
-  "Отвечая на литургию %C2, сила {1{C%N2{2 меняет исход боя!": {
-   "en": "In answer to %C2's liturgy, the power of {1{C%N2{2 changes the outcome of the battle!",
-   "ua": "У відповідь на літургію %C2, сила {1{C%N2{2 змінює результат бою!"
-  },
-  "Отвечая на литургию, {1{C%N1{2 одаряет %C4 своей силой!": {
-   "en": "Answering the liturgy, {1{C%N1{2 blesses %C4 with their power!",
-   "ua": "Відповідаючи на літургію, {1{C%N1{2 наділяє %C4 своєю силою!"
-  },
-  "Отвечая на твою литургию, сила {1{C%N2{2 меняет исход боя!": {
-   "en": "Answering your liturgy, the power of {1{C%N2{2 changes the outcome of the battle!",
-   "ua": "Відповідаючи на твою літургію, сила {1{C%N2{2 змінює результат бою!"
-  },
-  "Отвечая на твою литургию, сила {1{C%N2{2 снисходит на тебя!": {
-   "en": "Answering your liturgy, the power of {1{C%N2{2 descends upon you!",
-   "ua": "Відповідаючи на твою літургію, сила {1{C%N2{2 сходить на тебе!"
-  },
-  "Похоже, {1{C%N3{2 сейчас не до твоей литургии.": {
-   "en": "It looks like {1{C%N3{2 has no time for your liturgy right now.",
-   "ua": "Схоже, {1{C%N3{2 зараз не до твоєї літургії."
   },
   "Твои мускулы перестают тебе повиноваться...": {
    "en": "Your muscles stop obeying you...",
    "ua": "Твої м'язи перестають тобі підкорятися..."
   },
-  "Ты поешь заунывную литургию, прося {1{C%N4{2 о помощи.": {
-   "en": "You sing a mournful liturgy, asking {1{C%N4{2 for help.",
-   "ua": "Ти співаєш тужливу літургію, просячи {1{C%N4{2 про допомогу."
-  },
-  "Ты разгнева%1$Gло|л|ла {1{C%N4{2 своей настырностью!": {
-   "en": "You've angered {1{C%N4{2 with your persistence!",
-   "ua": "Ти розгніва%1$Gло|в|ла {1{C%N4{2 своєю настирливістю!"
-  },
   "До тебя доносятся чьи-то заунывные религиозные песнопения.": {
    "en": "Somebody's mournful religious chanting drifts over to you.",
    "ua": "До тебе долинає чиєсь тужливе релігійне співання."
+  },
+  "Ты поешь заунывную литургию, прося {1{C%s{2 о помощи.": {
+   "en": "You sing a mournful liturgy, asking {1{C%s{2 for help.",
+   "ua": "Ти співаєш тужливу літургію, просячи {1{C%s{2 про допомогу."
+  },
+  "%^C1 поет заунывную литургию, прося {1{C%s{2 о помощи.": {
+   "en": "%^C1 sings a mournful liturgy, begging {1{C%s{2 for help.",
+   "ua": "%^C1 співає тужливу літургію, благаючи {1{C%s{2 про допомогу."
+  },
+  "Ты разгнева%1$Gло|л|ла {1{C%s{2 своей настырностью!": {
+   "en": "You've angered {1{C%s{2 with your persistence!",
+   "ua": "Ти розгніва%1$Gло|в|ла {1{C%s{2 своєю настирливістю!"
+  },
+  "%^C1 разгнева%1$Gло|л|ла {1{C%s{2 своей настырностью!": {
+   "en": "%^C1 angers {1{C%s{2 with their persistence!",
+   "ua": "%^C1 розгніва%1$Gло|в|ла {1{C%s{2 своєю настирливістю!"
+  },
+  "Похоже, {1{C%s{2 сейчас не до твоей литургии.": {
+   "en": "It looks like {1{C%s{2 has no time for your liturgy right now.",
+   "ua": "Схоже, {1{C%s{2 зараз не до твоєї літургії."
+  },
+  "Твоя литургия {1{C%s{2 принесла тебе только защиту.": {
+   "en": "Your liturgy to {1{C%s{2 brought you only protection.",
+   "ua": "Твоя літургія {1{C%s{2 принесла тобі лише захист."
+  },
+  "Отвечая на твою литургию, сила {1{C%s{2 меняет исход боя!": {
+   "en": "Answering your liturgy, the power of {1{C%s{2 changes the outcome of the battle!",
+   "ua": "Відповідаючи на твою літургію, сила {1{C%s{2 змінює результат бою!"
+  },
+  "Отвечая на литургию %C2, сила {1{C%s{2 меняет исход боя!": {
+   "en": "In answer to %C2's liturgy, the power of {1{C%s{2 changes the outcome of the battle!",
+   "ua": "У відповідь на літургію %C2, сила {1{C%s{2 змінює результат бою!"
+  },
+  "Отвечая на твою литургию, сила {1{C%s{2 снисходит на тебя!": {
+   "en": "Answering your liturgy, the power of {1{C%s{2 descends upon you!",
+   "ua": "Відповідаючи на твою літургію, сила {1{C%s{2 сходить на тебе!"
+  },
+  "Отвечая на литургию, {1{C%s{2 одаряет %C4 своей силой!": {
+   "en": "Answering the liturgy, {1{C%s{2 blesses %C4 with their power!",
+   "ua": "Відповідаючи на літургію, {1{C%s{2 наділяє %C4 своєю силою!"
   }
  },
  "spell/mental knife/runVict": {
@@ -1070,10 +1070,6 @@
    "en": "%1$^C1 touches %2$O3, and %2$O1 %2$nbecomes|become wrapped in a {1{Bblue aura{2 of enchantment.",
    "ua": "%1$^C1 торкається %2$O3, і %2$O1 %2$nогортається|огортаються {1{Bсиньою аурою{2 зачарування."
   },
-  "Волею {1{C%N2{2 ты наделяешь %O4 чудесной силой!": {
-   "en": "By the will of {1{C%N2{2, you imbue %O4 with wondrous power!",
-   "ua": "Волею {1{C%N2{2 ти наділяєш %O4 чудесною силою!"
-  },
   "Твоя жажда творить помогает наделить %O4 дополнительными свойствами.": {
    "en": "Your thirst to create helps imbue %O4 with additional properties.",
    "ua": "Твоя жага творити допомагає наділити %O4 додатковими властивостями."
@@ -1089,6 +1085,10 @@
   "%2$^O1 окутыва%2$nется|ются {1{Bсиней аурой{2 зачарования.": {
    "en": "%2$^O1 %2$nis|are wrapped in {1{Ba blue aura{2 of enchantment.",
    "ua": "%2$^O1 огорта%2$nється|ються {1{Bсиньою аурою{2 зачарування."
+  },
+  "Волею {1{C%s{2 ты наделяешь %O4 чудесной силой!": {
+   "en": "By the will of {1{C%s{2, you imbue %O4 with wondrous power!",
+   "ua": "Волею {1{C%s{2 ти наділяєш %O4 чудесною силою!"
   }
  },
  "spell/shadowblade/runArg": {
@@ -1550,10 +1550,6 @@
    "en": "There's no one here for you to pacify right now.",
    "ua": "Тут зараз нема кого замирювати."
   },
-  "%^C1 взывает к {1{C%N3{2, напевая тихую умиротворяющую мелодию.": {
-   "en": "%^C1 calls upon {1{C%N3{2, humming a quiet, soothing melody.",
-   "ua": "%^C1 звертається до {1{C%N3{2, наспівуючи тиху заспокійливу мелодію."
-  },
   "Волна умиротворения и спокойствия окутывает %C4.": {
    "en": "A wave of peace and calm washes over %C4.",
    "ua": "Хвиля умиротворення і спокою огортає %C4."
@@ -1566,9 +1562,13 @@
    "en": "Growling with wild fury, %C1 flatly refuses to calm down.",
    "ua": "Ричачи від дикої люті, %C1 категорично відмовляється заспокоюватися."
   },
-  "Ты взываешь к {1{C%N3{2, напевая тихую умиротворяющую мелодию.": {
-   "en": "You call upon {1{C%N3{2, humming a quiet, soothing melody.",
-   "ua": "Ти звертаєшся до {1{C%N3{2, наспівуючи тиху заспокійливу мелодію."
+  "Ты взываешь к {1{C%s{2, напевая тихую умиротворяющую мелодию.": {
+   "en": "You call upon {1{C%s{2, humming a quiet, soothing melody.",
+   "ua": "Ти звертаєшся до {1{C%s{2, наспівуючи тиху заспокійливу мелодію."
+  },
+  "%^C1 взывает к {1{C%s{2, напевая тихую умиротворяющую мелодию.": {
+   "en": "%^C1 calls upon {1{C%s{2, humming a quiet, soothing melody.",
+   "ua": "%^C1 звертається до {1{C%s{2, наспівуючи тиху заспокійливу мелодію."
   }
  },
  "spell/deafen/runVict": {
@@ -1760,14 +1760,6 @@
    "en": "This prayer is forbidden for use on other clans' territories.",
    "ua": "Цю молитву заборонено використовувати на чужих кланових територіях."
   },
-  "Именем {1{C%N2{2 %C1 зажигает {1{Wослепительный свет,{2 обращающий врагов в бегство!": {
-   "en": "In the name of {1{C%N2{2, %C1 ignites {1{Wa blinding light{2 that sends enemies fleeing!",
-   "ua": "Іменем {1{C%N2{2 %C1 запалює {1{Wсліплюче світло,{2 що обертає ворогів у втечу!"
-  },
-  "Именем {1{C%N2{2 ты зажигаешь {1{Wослепительный свет,{2 обращающий врагов в бегство!": {
-   "en": "In the name of {1{C%N2{2 you kindle a {1{Wblinding light,{2 sending enemies fleeing!",
-   "ua": "Іменем {1{C%N2{2 ти запалюєш {1{Wсліпуче світло,{2 що обертає ворогів у втечу!"
-  },
   "Ослепительные лучи света заставляют %C4 обратиться в паническое бегство!": {
    "en": "Blinding rays of light send %C4 fleeing in a panic!",
    "ua": "Сліпучі промені світла змушують %C4 кинутися в панічну втечу!"
@@ -1779,6 +1771,14 @@
   "Ты видишь отблеск ослепительного света, заливающего местность неподалеку.": {
    "en": "You catch the glare of a blinding light flooding the land nearby.",
    "ua": "Ти бачиш відблиск сліпучого світла, що заливає місцевість неподалік."
+  },
+  "Именем {1{C%s{2 ты зажигаешь {1{Wослепительный свет,{2 обращающий врагов в бегство!": {
+   "en": "In the name of {1{C%s{2 you kindle a {1{Wblinding light,{2 sending enemies fleeing!",
+   "ua": "Іменем {1{C%s{2 ти запалюєш {1{Wсліпуче світло,{2 що обертає ворогів у втечу!"
+  },
+  "Именем {1{C%s{2 %C1 зажигает {1{Wослепительный свет,{2 обращающий врагов в бегство!": {
+   "en": "In the name of {1{C%s{2, %C1 ignites {1{Wa blinding light{2 that sends enemies fleeing!",
+   "ua": "Іменем {1{C%s{2 %C1 запалює {1{Wсліплюче світло,{2 що обертає ворогів у втечу!"
   }
  },
  "spell/hand of undead/runVict": {
@@ -2618,25 +2618,25 @@
   }
  },
  "spell/aid/runVict": {
-  "%^C2 согревает тепло, дарованное {1{C%N5{2.": {
-   "en": "%^C2 feels the warmth granted by {1{C%N5{2.",
-   "ua": "%^C2 зігрівається теплом, дарованим {1{C%N5{2."
-  },
-  "%^C2 согревает тепло, дарованное {1{C%N5{2. {D[{G%d{D]{x": {
-   "en": "%^C2 is warmed by the warmth granted by {1{C%N5{2. {D[{G%d{D]{x",
-   "ua": "%^C2 зігрівається теплом, дарованим {1{C%N5{2. {D[{G%d{D]{x"
-  },
   "Перед повторным использованием этого заклинания надо немного подождать.": {
    "en": "You need to wait a bit before using this spell again.",
    "ua": "Перед повторним використанням цього заклинання треба трохи почекати."
   },
-  "Тебя согревает тепло, дарованное {1{C%N5{2! {D[{G%d{D]{x": {
-   "en": "Warmth granted by {1{C%N5{2 spreads through you! {D[{G%d{D]{x",
-   "ua": "Тебе зігріває тепло, дароване {1{C%N5{2! {D[{G%d{D]{x"
+  "Тебя согревает тепло, дарованное {1{C%s{2! {D[{G%d{D]{x": {
+   "en": "Warmth granted by {1{C%s{2 spreads through you! {D[{G%d{D]{x",
+   "ua": "Тебе зігріває тепло, дароване {1{C%s{2! {D[{G%d{D]{x"
   },
-  "Тебя согревает тепло, дарованное {1{C%N5{2. {D[{G%d{D]{x": {
-   "en": "Warmth granted by {1{C%N5{2 spreads through you. {D[{G%d{D]{x",
-   "ua": "Тебе зігріває тепло, даровано {1{C%N5{2. {D[{G%d{D]{x"
+  "%^C2 согревает тепло, дарованное {1{C%s{2.": {
+   "en": "%^C2 feels the warmth granted by {1{C%s{2.",
+   "ua": "%^C2 зігрівається теплом, дарованим {1{C%s{2."
+  },
+  "%^C2 согревает тепло, дарованное {1{C%s{2. {D[{G%d{D]{x": {
+   "en": "%^C2 is warmed by the warmth granted by {1{C%s{2. {D[{G%d{D]{x",
+   "ua": "%^C2 зігрівається теплом, дарованим {1{C%s{2. {D[{G%d{D]{x"
+  },
+  "Тебя согревает тепло, дарованное {1{C%s{2. {D[{G%d{D]{x": {
+   "en": "Warmth granted by {1{C%s{2 spreads through you. {D[{G%d{D]{x",
+   "ua": "Тебе зігріває тепло, даровано {1{C%s{2. {D[{G%d{D]{x"
   }
  },
  "spell/desert fist/runVict": {
@@ -2644,17 +2644,9 @@
    "en": "There isn't enough sand here to form a fist.",
    "ua": "Тут недостатньо піску, щоб сформувати кулак."
   },
-  "Ты взываешь к %N3, прося сотворить вихрь песка.": {
-   "en": "You call upon %N3, asking them to conjure a whirl of sand.",
-   "ua": "Ти звертаєшся до %N3, просячи створити вихор піску."
-  },
   "%1$^C1 зачем-то бьет песчаным кулаком себя сам%1$Gого|ого|у!": {
    "en": "%1$^C1 punches themselves with a sandy fist for some reason!",
    "ua": "%1$^C1 чомусь б'є піщаним кулаком себе сам%1$Gого|ого|у!"
-  },
-  "%^C1 взывает к %N3, прося сотворить вихрь песка.": {
-   "en": "%^C1 calls out to %N3, asking for a whirl of sand to be conjured.",
-   "ua": "%^C1 звертається до %N3, просячи сотворити вихор піску."
   },
   "Ты зачем-то бьешь песчаным кулаком себя сам%1$Gого|ого|у!": {
    "en": "You punch yourself with a fist of sand for no reason!",
@@ -2671,6 +2663,14 @@
   "{yВихрь песка,{x созданный тобой, образует огромный кулак и ударяет %2$C4!": {
    "en": "{yThe whirl of sand{x you raised forms a huge fist and slams into %2$C4!",
    "ua": "{yВихор піску,{x створений тобою, утворює величезний кулак і б'є %2$C4!"
+  },
+  "Ты взываешь к %s, прося сотворить вихрь песка.": {
+   "en": "You call upon %s, asking them to conjure a whirl of sand.",
+   "ua": "Ти звертаєшся до %s, просячи створити вихор піску."
+  },
+  "%^C1 взывает к %s, прося сотворить вихрь песка.": {
+   "en": "%^C1 calls out to %s, asking for a whirl of sand to be conjured.",
+   "ua": "%^C1 звертається до %s, просячи сотворити вихор піску."
   }
  },
  "spell/sonic resonance/runVict": {
@@ -2712,17 +2712,17 @@
    "en": "This room is already lit by the glow of the mind.",
    "ua": "Ця кімната вже освітлена сяйвом розуму."
   },
-  "%1$^C1 взывает к {1{C%N3{2, освещая местность вокруг сиянием разума.": {
-   "en": "%1$^C1 calls out to {1{C%N3{2, lighting up the area around with a glow of the mind.",
-   "ua": "%1$^C1 звертається до {1{C%N3{2, освітлюючи місцевість навколо сяйвом розуму."
-  },
-  "Ты взываешь к {1{C%N3{2, освещая местность вокруг сиянием разума.": {
-   "en": "You call upon {1{C%N3{2, lighting up the area with a radiance of the mind.",
-   "ua": "Ти звертаєшся до {1{C%N3{2, освітлюючи місцевість сяйвом розуму."
-  },
   "Ты на мгновение чувствуешь освежающее покалывание, но ощущение быстро пропадает.": {
    "en": "For a moment you feel a refreshing tingle, but the sensation fades quickly.",
    "ua": "На мить ти відчуваєш освіжаюче поколювання, але відчуття швидко минає."
+  },
+  "%1$^C1 взывает к {1{C%s{2, освещая местность вокруг сиянием разума.": {
+   "en": "%1$^C1 calls out to {1{C%s{2, lighting up the area around with a glow of the mind.",
+   "ua": "%1$^C1 звертається до {1{C%s{2, освітлюючи місцевість навколо сяйвом розуму."
+  },
+  "Ты взываешь к {1{C%s{2, освещая местность вокруг сиянием разума.": {
+   "en": "You call upon {1{C%s{2, lighting up the area with a radiance of the mind.",
+   "ua": "Ти звертаєшся до {1{C%s{2, освітлюючи місцевість сяйвом розуму."
   }
  },
  "spell/sanctify lands/runRoom": {
@@ -2880,17 +2880,9 @@
   }
  },
  "spell/enhanced armor/runVict": {
-  "Тебя окружает силовое поле, дарованное {1{C%N5{2.": {
-   "en": "A force field, granted by {1{C%N5{2, surrounds you.",
-   "ua": "Тебе оточує силове поле, дароване {1{C%N5{2."
-  },
   "Тебя окружает силовое поле, помогающее уходить от ударов.": {
    "en": "A force field surrounds you, helping you dodge blows.",
    "ua": "Тебе оточує силове поле, що допомагає ухилятися від ударів."
-  },
-  "%^C4 окружает силовое поле, дарованное {1{C%N5{2.": {
-   "en": "%^C4 is surrounded by a force field granted by {1{C%N5{2.",
-   "ua": "%^C4 оточує силове поле, дароване {1{C%N5{2."
   },
   "%^C4 окружает силовое поле, помогающее уходить от ударов.": {
    "en": "A force field surrounds %C4, helping them dodge blows.",
@@ -2903,6 +2895,14 @@
   "%1$^C1 уже под защитой силового поля.": {
    "en": "%1$^C1 is already protected by enhanced armor.",
    "ua": "%1$^C1 уже під захистом покращеної броні."
+  },
+  "Тебя окружает силовое поле, дарованное {1{C%s{2.": {
+   "en": "A force field, granted by {1{C%s{2, surrounds you.",
+   "ua": "Тебе оточує силове поле, дароване {1{C%s{2."
+  },
+  "%^C4 окружает силовое поле, дарованное {1{C%s{2.": {
+   "en": "%^C4 is surrounded by a force field granted by {1{C%s{2.",
+   "ua": "%^C4 оточує силове поле, дароване {1{C%s{2."
   }
  },
  "spell/curse/runObj": {
@@ -3718,14 +3718,6 @@
   }
  },
  "spell/bless weapon/runObj": {
-  "Именем {1{C%N2{2 %C1 освящает %O4 на борьбу со Злом!": {
-   "en": "In the name of {1{C%N2{2 %C1 consecrates %O4 for the fight against Evil!",
-   "ua": "Іменем {1{C%N2{2 %C1 освячує %O4 на боротьбу зі Злом!"
-  },
-  "Именем {1{C%N2{2 ты освящаешь %O4 на борьбу со Злом!": {
-   "en": "In the name of {1{C%N2{2, you consecrate %O4 for the battle against Evil!",
-   "ua": "Іменем {1{C%N2{2 ти освячуєш %O4 на боротьбу зі Злом!"
-  },
   "%2$^O1 не оружие.": {
    "en": "%2$^O1 is not a weapon.",
    "ua": "%2$^O1 не зброя."
@@ -3741,6 +3733,14 @@
   "Темная сущность %2$O2 отвергает твое освящение.": {
    "en": "The dark essence of %2$O2 rejects your consecration.",
    "ua": "Темна сутність %2$O2 відкидає твоє освячення."
+  },
+  "Именем {1{C%s{2 ты освящаешь %O4 на борьбу со Злом!": {
+   "en": "In the name of {1{C%s{2, you consecrate %O4 for the battle against Evil!",
+   "ua": "Іменем {1{C%s{2 ти освячуєш %O4 на боротьбу зі Злом!"
+  },
+  "Именем {1{C%s{2 %C1 освящает %O4 на борьбу со Злом!": {
+   "en": "In the name of {1{C%s{2 %C1 consecrates %O4 for the fight against Evil!",
+   "ua": "Іменем {1{C%s{2 %C1 освячує %O4 на боротьбу зі Злом!"
   }
  },
  "spell/regrow/runVict": {

--- a/config/translations/spell2.json
+++ b/config/translations/spell2.json
@@ -648,10 +648,6 @@
    "en": "%^C1 flicks their tail, and %O1 bursts forth from the ground.",
    "ua": "%^C1 клацає хвостом, і з землі пробивається %O1."
   },
-  "Милостью %N2 из земли пробивается %O1.": {
-   "en": "By the grace of %N2, %O1 bursts from the ground.",
-   "ua": "Милістю %N2 з землі пробивається %O1."
-  },
   "Создать родник в воздухе не под силу даже самым могучим волшебникам.": {
    "en": "Not even the mightiest wizards can create a spring in midair.",
    "ua": "Створити джерело в повітрі не під силу навіть наймогутнішим чарівникам."
@@ -671,6 +667,10 @@
   "Ты щелкаешь хвостом, и из земли пробивается %O1.": {
    "en": "You flick your tail, and %O1 bursts forth from the ground.",
    "ua": "Ти клацаєш хвостом, і з землі пробивається %O1."
+  },
+  "Милостью %s из земли пробивается %O1.": {
+   "en": "By the grace of %s, %O1 bursts from the ground.",
+   "ua": "Милістю %s з землі пробивається %O1."
   }
  },
  "spell/control weather/runArg": {
@@ -1106,18 +1106,6 @@
    "en": "%^C1 {1{WBANISHES{2 you!",
    "ua": "%^C1 {1{WВИГАНЯЄ{2 тебе!"
   },
-  "%^C1 взывает к {1{C%N3{2, чертя в воздухе символ изгнания нечисти.": {
-   "en": "%^C1 calls upon {1{C%N3{2, tracing a sign of banishment against the unclean in the air.",
-   "ua": "%^C1 звертається до {1{C%N3{2, малюючи в повітрі знак вигнання нечисті."
-  },
-  "В ужасе от мощи {1{C%N2{2 ты обращаешься в бегство!": {
-   "en": "Terrified by the power of {1{C%N2{2, you flee in terror!",
-   "ua": "У жаху від могутності {1{C%N2{2 ти кидаєшся навтіки!"
-  },
-  "В ужасе от мощи {1{C%N2{2, %C1 обращается в паническое бегство!": {
-   "en": "Terrified by the might of {1{C%N2{2, %C1 flees in a blind panic!",
-   "ua": "У жаху від могутності {1{C%N2{2, %C1 кидається навтіки у паніці!"
-  },
   "К сожалению, %C1 -- не нечисть, не демон и не богомерзкий голем.": {
    "en": "Unfortunately, %C1 is not undead, not a demon, and not a godless golem.",
    "ua": "На жаль, %C1 -- не нечисть, не демон і не богомерзький голем."
@@ -1126,13 +1114,25 @@
    "en": "Before %C1 can even react, %C1 vanishes in {1{Wa blinding flash!{2",
    "ua": "Не встигнувши й опам'ятатися, %C1 зникає у {1{Wсліплячому спалаху!{2"
   },
-  "Ты взываешь к {1{C%N3{2, чертя в воздухе символ изгнания нечисти.": {
-   "en": "You call upon {1{C%N3{2, tracing the symbol of banishment against unholy creatures in the air.",
-   "ua": "Ти волаєш до {1{C%N3{2, викреслюючи в повітрі символ вигнання нечисті."
-  },
   "Ты сопротивляешься священному символу изгнания!": {
    "en": "You resist the holy symbol of banishment!",
    "ua": "Ти опираєшся священному символу вигнання!"
+  },
+  "Ты взываешь к {1{C%s{2, чертя в воздухе символ изгнания нечисти.": {
+   "en": "You call upon {1{C%s{2, tracing the symbol of banishment against unholy creatures in the air.",
+   "ua": "Ти волаєш до {1{C%s{2, викреслюючи в повітрі символ вигнання нечисті."
+  },
+  "%^C1 взывает к {1{C%s{2, чертя в воздухе символ изгнания нечисти.": {
+   "en": "%^C1 calls upon {1{C%s{2, tracing a sign of banishment against the unclean in the air.",
+   "ua": "%^C1 звертається до {1{C%s{2, малюючи в повітрі знак вигнання нечисті."
+  },
+  "В ужасе от мощи {1{C%s{2, %C1 обращается в паническое бегство!": {
+   "en": "Terrified by the might of {1{C%s{2, %C1 flees in a blind panic!",
+   "ua": "У жаху від могутності {1{C%s{2, %C1 кидається навтіки у паніці!"
+  },
+  "В ужасе от мощи {1{C%s{2 ты обращаешься в бегство!": {
+   "en": "Terrified by the power of {1{C%s{2, you flee in terror!",
+   "ua": "У жаху від могутності {1{C%s{2 ти кидаєшся навтіки!"
   }
  },
  "spell/mosquito swarm/runVict": {
@@ -1316,33 +1316,9 @@
    "en": "%1$^C1 banishes themselves for some reason!",
    "ua": "%1$^C1 чомусь виганяє себе сам%1$Gого|ого|у!"
   },
-  "%^C1 взывает к {1{C%N3{2, {1{Yизгоняя{2 %C4!": {
-   "en": "%^C1 calls upon {1{C%N3{2, {1{Ybanishing{2 %C4!",
-   "ua": "%^C1 волає до {1{C%N3{2, {1{Yвиганяючи{2 %C4!"
-  },
-  "%^C1 взывает к {1{C%N3{2, {1{Yизгоняя{2 тебя!": {
-   "en": "%^C1 calls upon {1{C%N3{2, {1{Ybanishing{2 you!",
-   "ua": "%^C1 звертається до {1{C%N3{2, {1{Yвиганяючи{2 тебе!"
-  },
   "{1{YСветлая энергия взрывается внутри тебя!{2": {
    "en": "{1{YRadiant energy explodes inside you!{2",
    "ua": "{1{YСвітла енергія вибухає всередині тебе!{2"
-  },
-  "Волею {1{C%N2{2 %C1 {1{RПОЛНОСТЬЮ РАЗВОПЛОЩАЕТ{2 %C4!": {
-   "en": "By the will of {1{C%N2{2, %C1 {1{RCOMPLETELY UNMAKES{2 %C4!",
-   "ua": "Волею {1{C%N2{2 %C1 {1{RПОВНІСТЮ РОЗВТІЛЮЄ{2 %C4!"
-  },
-  "Волею {1{C%N2{2 %C1 {1{RПОЛНОСТЬЮ РАЗВОПЛОЩАЕТ{2 тебя!": {
-   "en": "By the will of {1{C%N2{2, %C1 {1{RCOMPLETELY UNMAKES{2 you!",
-   "ua": "Волею {1{C%N2{2 %C1 {1{RПОВНІСТЮ ЗНЕТІЛЕСНЮЄ{2 тебе!"
-  },
-  "Волею {1{C%N2{2 ты {1{RПОЛНОСТЬЮ РАЗВОПЛОЩАЕШЬ{2 %C4!": {
-   "en": "By the will of {1{C%N2{2 you {1{RCOMPLETELY DISCORPORATE{2 %C4!",
-   "ua": "Волею {1{C%N2{2 ти {1{RПОВНІСТЮ РОЗВТІЛЮЄШ{2 %C4!"
-  },
-  "Ты взываешь к {1{C%N3{2, {1{Yизгоняя{2 %C4!": {
-   "en": "You call upon {1{C%N3{2, {1{Ybanishing{2 %C4!",
-   "ua": "Ти волаєш до {1{C%N3{2, {1{Yвиганяючи{2 %C4!"
   },
   "Ты зачем-то изгоняешь себя сам%1$Gого|ого|у!": {
    "en": "For some reason you banish yourself!",
@@ -1351,6 +1327,30 @@
   "Эта молитва не сможет навредить тебе. Извращен{Smец{Sfка{Sx.": {
    "en": "This prayer can't harm you. Pervert.",
    "ua": "Ця молитва не зможе нашкодити тобі. Збочен{Smець{Sfка{Sx."
+  },
+  "Волею {1{C%s{2 ты {1{RПОЛНОСТЬЮ РАЗВОПЛОЩАЕШЬ{2 %C4!": {
+   "en": "By the will of {1{C%s{2 you {1{RCOMPLETELY DISCORPORATE{2 %C4!",
+   "ua": "Волею {1{C%s{2 ти {1{RПОВНІСТЮ РОЗВТІЛЮЄШ{2 %C4!"
+  },
+  "Волею {1{C%s{2 %C1 {1{RПОЛНОСТЬЮ РАЗВОПЛОЩАЕТ{2 %C4!": {
+   "en": "By the will of {1{C%s{2, %C1 {1{RCOMPLETELY UNMAKES{2 %C4!",
+   "ua": "Волею {1{C%s{2 %C1 {1{RПОВНІСТЮ РОЗВТІЛЮЄ{2 %C4!"
+  },
+  "Волею {1{C%s{2 %C1 {1{RПОЛНОСТЬЮ РАЗВОПЛОЩАЕТ{2 тебя!": {
+   "en": "By the will of {1{C%s{2, %C1 {1{RCOMPLETELY UNMAKES{2 you!",
+   "ua": "Волею {1{C%s{2 %C1 {1{RПОВНІСТЮ ЗНЕТІЛЕСНЮЄ{2 тебе!"
+  },
+  "Ты взываешь к {1{C%s{2, {1{Yизгоняя{2 %C4!": {
+   "en": "You call upon {1{C%s{2, {1{Ybanishing{2 %C4!",
+   "ua": "Ти волаєш до {1{C%s{2, {1{Yвиганяючи{2 %C4!"
+  },
+  "%^C1 взывает к {1{C%s{2, {1{Yизгоняя{2 %C4!": {
+   "en": "%^C1 calls upon {1{C%s{2, {1{Ybanishing{2 %C4!",
+   "ua": "%^C1 волає до {1{C%s{2, {1{Yвиганяючи{2 %C4!"
+  },
+  "%^C1 взывает к {1{C%s{2, {1{Yизгоняя{2 тебя!": {
+   "en": "%^C1 calls upon {1{C%s{2, {1{Ybanishing{2 you!",
+   "ua": "%^C1 звертається до {1{C%s{2, {1{Yвиганяючи{2 тебе!"
   }
  },
  "spell/dispel good/runVict": {
@@ -1816,25 +1816,25 @@
    "en": "For some reason %1$^C1 fires the {1{WRay of Truth{2 at themselves!",
    "ua": "%1$^C1 чомусь випускає {1{WПромінь Істини{2 в себе сам%1$Gого|ого|у!"
   },
-  "%^C1 взывает к {1{C%N3{2, выпуская {1{WЛуч Истины{2 в сторону %C2!": {
-   "en": "%^C1 calls out to {1{C%N3{2, unleashing the {1{WRay of Truth{2 at %C2!",
-   "ua": "%^C1 волає до {1{C%N3{2, вивільняючи {1{WПромінь Істини{2 у бік %C2!"
-  },
-  "%^C1 взывает к {1{C%N3{2, выпуская {1{WЛуч Истины{2 в тебя!": {
-   "en": "%^C1 calls upon {1{C%N3{2, releasing a {1{WRay of Truth{2 at you!",
-   "ua": "%^C1 звертається до {1{C%N3{2, випускаючи {1{WПромінь Істини{2 в тебе!"
-  },
   "{1{WЭнергия Луча Истины взрывается внутри тебя!{2": {
    "en": "{1{WThe energy of the Ray of Truth explodes inside you!{2",
    "ua": "{1{WЕнергія Променя Істини вибухає всередині тебе!{2"
   },
-  "Ты взываешь к {1{C%N3{2, выпуская {1{WЛуч Истины{2 в сторону %C2!": {
-   "en": "You call upon {1{C%N3{2, releasing a {1{WRay of Truth{2 toward %C2!",
-   "ua": "Ти волаєш до {1{C%N3{2, випускаючи {1{WПромінь Істини{2 у бік %C2!"
-  },
   "Ты зачем-то выпускаешь {1{WЛуч Истины{2 в себя сам%1$Gого|ого|у!": {
    "en": "You fire the {1{WRay of Truth{2 at yourself for some reason!",
    "ua": "Ти чомусь випускаєш {1{WПромінь Істини{2 у себе сам%1$Gого|ого|у!"
+  },
+  "Ты взываешь к {1{C%s{2, выпуская {1{WЛуч Истины{2 в сторону %C2!": {
+   "en": "You call upon {1{C%s{2, releasing a {1{WRay of Truth{2 toward %C2!",
+   "ua": "Ти волаєш до {1{C%s{2, випускаючи {1{WПромінь Істини{2 у бік %C2!"
+  },
+  "%^C1 взывает к {1{C%s{2, выпуская {1{WЛуч Истины{2 в сторону %C2!": {
+   "en": "%^C1 calls out to {1{C%s{2, unleashing the {1{WRay of Truth{2 at %C2!",
+   "ua": "%^C1 волає до {1{C%s{2, вивільняючи {1{WПромінь Істини{2 у бік %C2!"
+  },
+  "%^C1 взывает к {1{C%s{2, выпуская {1{WЛуч Истины{2 в тебя!": {
+   "en": "%^C1 calls upon {1{C%s{2, releasing a {1{WRay of Truth{2 at you!",
+   "ua": "%^C1 звертається до {1{C%s{2, випускаючи {1{WПромінь Істини{2 в тебе!"
   }
  },
  "spell/poison/runObj": {
@@ -2298,25 +2298,25 @@
    "en": "%O1 suddenly drops into %C3's hands.",
    "ua": "%O1 раптово падає в руки %C3."
   },
-  "%1$^C1 просит {1{C%2$N4{2 о пропитании, и %1$P4 на ладонь падает %3$O1.": {
-   "en": "%1$^C1 asks {1{C%2$N4{2 for sustenance, and %3$O1 falls into their own palm.",
-   "ua": "%1$^C1 просить {1{C%2$N4{2 про їжу, і %3$O1 падає на власну долоню."
-  },
   "%^C1 прищуривается и выращивает у себя на ладони %O4.": {
    "en": "%^C1 narrows their eyes and grows %O4 in the palm of their hand.",
    "ua": "%^C1 мружиться і вирощує на своїй долоні %O4."
-  },
-  "Волею {1{C%N2{2 тебе в руки падает %O1 на пропитание.": {
-   "en": "By the will of {1{C%N2{2, %O1 falls into your hands for sustenance.",
-   "ua": "Волею {1{C%N2{2 тобі в руки падає %O1 на прожиток."
   },
   "Ты прищуриваешься и выращиваешь у себя на ладони %O4.": {
    "en": "You squint and grow %O4 on your palm.",
    "ua": "Ти мружишся і вирощуєш у себе на долоні %O4."
   },
-  "Ты просишь {1{C%N4{2 о пропитании, и тебе на ладонь падает %O1.": {
-   "en": "You ask {1{C%N4{2 for sustenance, and %O1 falls into your palm.",
-   "ua": "Ти просиш {1{C%N4{2 про харч, і тобі на долоню падає %O1."
+  "Ты просишь {1{C%s{2 о пропитании, и тебе на ладонь падает %O1.": {
+   "en": "You ask {1{C%s{2 for sustenance, and %O1 falls into your palm.",
+   "ua": "Ти просиш {1{C%s{2 про харч, і тобі на долоню падає %O1."
+  },
+  "%1$^C1 просит {1{C%2$s{2 о пропитании, и %1$P4 на ладонь падает %3$O1.": {
+   "en": "%1$^C1 asks {1{C%2$s{2 for sustenance, and %3$O1 falls into their own palm.",
+   "ua": "%1$^C1 просить {1{C%2$s{2 про їжу, і %3$O1 падає на власну долоню."
+  },
+  "Волею {1{C%s{2 тебе в руки падает %O1 на пропитание.": {
+   "en": "By the will of {1{C%s{2, %O1 falls into your hands for sustenance.",
+   "ua": "Волею {1{C%s{2 тобі в руки падає %O1 на прожиток."
   }
  },
  "spell/holy word/runRoom": {
@@ -2340,21 +2340,9 @@
    "en": "You are already inspired.",
    "ua": "Ти вже натхнен%1$Gне|ний|на|ні."
   },
-  "%^C1 произносит тайное Слово {1{C%N2{2, призывая божественную силу!": {
-   "en": "%^C1 utters the secret Word {1{C%N2{2, calling upon divine power!",
-   "ua": "%^C1 промовляє таємне Слово {1{C%N2{2, закликаючи божественну силу!"
-  },
-  "Ты произносишь тайное Слово {1{C%N2{2, призывая божественную силу!": {
-   "en": "You speak the secret Word of {1{C%N2{2, calling forth divine power!",
-   "ua": "Ти промовляєш таємне Слово {1{C%N2{2, прикликаючи божественну силу!"
-  },
   "Ты чувствуешь себя опустошенно.": {
    "en": "You feel utterly drained.",
    "ua": "Ти почуваєшся спустошено."
-  },
-  "Вокруг тебя вспыхивает %s, когда {1{C%N1{2 дарует тебе могущество!": {
-   "en": "Around you flares up %s as {1{C%N1{2 grants you might!",
-   "ua": "Навколо тебе спалахує %s, коли {1{C%N1{2 дарує тобі могутність!"
   },
   "Вокруг %C2 вспыхивает %s!": {
    "en": "Around %C2 flares up %s!",
@@ -2375,6 +2363,18 @@
   "Земля дрожит под ногами, когда ты чувствуешь вмешательство божественных сил.": {
    "en": "The ground trembles underfoot as you feel divine powers intervene.",
    "ua": "Земля дрижить під ногами, коли ти відчуваєш втручання божественних сил."
+  },
+  "Ты произносишь тайное Слово {1{C%s{2, призывая божественную силу!": {
+   "en": "You speak the secret Word of {1{C%s{2, calling forth divine power!",
+   "ua": "Ти промовляєш таємне Слово {1{C%s{2, прикликаючи божественну силу!"
+  },
+  "%^C1 произносит тайное Слово {1{C%s{2, призывая божественную силу!": {
+   "en": "%^C1 utters the secret Word {1{C%s{2, calling upon divine power!",
+   "ua": "%^C1 промовляє таємне Слово {1{C%s{2, закликаючи божественну силу!"
+  },
+  "Вокруг тебя вспыхивает %s, когда {1{C%s{2 дарует тебе могущество!": {
+   "en": "Around you flares up %s as {1{C%s{2 grants you might!",
+   "ua": "Навколо тебе спалахує %s, коли {1{C%s{2 дарує тобі могутність!"
   }
  },
  "spell/farsight/runArg": {
@@ -2438,17 +2438,9 @@
   }
  },
  "spell/protective shield/runVict": {
-  "%^C4 окружает тускло светящийся {1{cохранный щит,{2 дарованный {1{C%N5{2.": {
-   "en": "%^C4 is surrounded by a dimly glowing {1{cwarding shield,{2 granted by {1{C%N5{2.",
-   "ua": "%^C4 оточує тьмяно світний {1{cохоронний щит,{2 дарований {1{C%N5{2."
-  },
   "%^C4 окружает тускло светящийся {1{cохранный щит,{2 отклоняющий резкие толчки и удары.": {
    "en": "%^C4 is surrounded by a dimly glowing {1{cprotective shield,{2 deflecting sharp blows and strikes.",
    "ua": "%^C4 оточує тьмяно світний {1{cохоронний щит,{2 що відхиляє різкі поштовхи та удари."
-  },
-  "Тебя окружает тускло светящийся {1{cохранный щит,{2 дарованный {1{C%N5{2.": {
-   "en": "A dimly glowing {1{cprotective shield,{2 granted by {1{C%N5{2, surrounds you.",
-   "ua": "Тебе оточує тьмяно світний {1{cохоронний щит,{2 дарований {1{C%N5{2."
   },
   "Тебя окружает тускло светящийся {1{cохранный щит,{2 отклоняющий резкие толчки и удары.": {
    "en": "A dimly glowing {1{cwarding shield{2 surrounds you, deflecting sharp blows and strikes.",
@@ -2461,6 +2453,14 @@
   "%1$^C1 уже под воздействием охранного щита.": {
    "en": "%1$^C1 is already affected by protective shield.",
    "ua": "%1$^C1 уже під захистом охоронного щита."
+  },
+  "Тебя окружает тускло светящийся {1{cохранный щит,{2 дарованный {1{C%s{2.": {
+   "en": "A dimly glowing {1{cprotective shield,{2 granted by {1{C%s{2, surrounds you.",
+   "ua": "Тебе оточує тьмяно світний {1{cохоронний щит,{2 дарований {1{C%s{2."
+  },
+  "%^C4 окружает тускло светящийся {1{cохранный щит,{2 дарованный {1{C%s{2.": {
+   "en": "%^C4 is surrounded by a dimly glowing {1{cwarding shield,{2 granted by {1{C%s{2.",
+   "ua": "%^C4 оточує тьмяно світний {1{cохоронний щит,{2 дарований {1{C%s{2."
   }
  },
  "spell/astral projection/runVict": {
@@ -2660,13 +2660,13 @@
    "en": "%^C1 is already under the effect of stardust, that's enough.",
    "ua": "%^C1 вже під дією зоряного пилу, цього досить."
   },
-  "Вокруг %C2 вспыхивает {Wбелая аура{x, дарованная {1{C%N5{2.": {
-   "en": "A {Wwhite aura{x flares up around %C2, granted by {1{C%N5{2.",
-   "ua": "Навколо %C2 спалахує {Wбіла аура{x, дарована {1{C%N5{2."
+  "Вокруг тебя вспыхивает {Wбелая аура{x, дарованная {1{C%s{2.": {
+   "en": "A {Wwhite aura{x flares up around you, granted by {1{C%s{2.",
+   "ua": "Навколо тебе спалахує {Wбіла аура{x, дарована {1{C%s{2."
   },
-  "Вокруг тебя вспыхивает {Wбелая аура{x, дарованная {1{C%N5{2.": {
-   "en": "A {Wwhite aura{x flares up around you, granted by {1{C%N5{2.",
-   "ua": "Навколо тебе спалахує {Wбіла аура{x, дарована {1{C%N5{2."
+  "Вокруг %C2 вспыхивает {Wбелая аура{x, дарованная {1{C%s{2.": {
+   "en": "A {Wwhite aura{x flares up around %C2, granted by {1{C%s{2.",
+   "ua": "Навколо %C2 спалахує {Wбіла аура{x, дарована {1{C%s{2."
   }
  },
  "spell/caustic font/runVict": {
@@ -2754,17 +2754,17 @@
    "en": "This room is already lit with healing light.",
    "ua": "Ця кімната вже освітлена цілющим світлом."
   },
-  "%1$^C1 взывает к {1{C%N3{2, освещая местность вокруг целебным светом.": {
-   "en": "%1$^C1 calls upon {1{C%N3{2, lighting up the area with healing light.",
-   "ua": "%1$^C1 звертається до {1{C%N3{2, освітлюючи місцевість цілющим світлом."
-  },
-  "Ты взываешь к {1{C%N3{2, освещая местность вокруг целебным светом.": {
-   "en": "You call upon {1{C%N3{2, lighting up the area around you with healing light.",
-   "ua": "Ти волаєш до {1{C%N3{2, освітлюючи місцевість навколо цілющим світлом."
-  },
   "Ты на мгновение чувствуешь приятное тепло, но ощущение быстро пропадает.": {
    "en": "For a moment you feel a pleasant warmth, but the sensation fades quickly.",
    "ua": "На мить ти відчуваєш приємне тепло, але відчуття швидко минає."
+  },
+  "%1$^C1 взывает к {1{C%s{2, освещая местность вокруг целебным светом.": {
+   "en": "%1$^C1 calls upon {1{C%s{2, lighting up the area with healing light.",
+   "ua": "%1$^C1 звертається до {1{C%s{2, освітлюючи місцевість цілющим світлом."
+  },
+  "Ты взываешь к {1{C%s{2, освещая местность вокруг целебным светом.": {
+   "en": "You call upon {1{C%s{2, lighting up the area around you with healing light.",
+   "ua": "Ти волаєш до {1{C%s{2, освітлюючи місцевість навколо цілющим світлом."
   }
  },
  "spell/brew/runObj": {
@@ -2794,14 +2794,6 @@
    "en": "A {1{Cmagical shield{2 surrounds you, helping to block blows.",
    "ua": "Тебе оточує {1{Cмагічний щит,{2 що допомагає блокувати удари."
   },
-  "%^C4 окружает священный щит, дарованный {1{C%N5{2.": {
-   "en": "A sacred shield, granted by {1{C%N5{2, surrounds %C4.",
-   "ua": "%^C4 оточує священний щит, дарований {1{C%N5{2."
-  },
-  "Тебя окружает {1{Cсвященный щит,{2 дарованный {1{C%N5{2.": {
-   "en": "A {1{Csacred shield,{2 granted by {1{C%N5{2, surrounds you.",
-   "ua": "Тебе оточує {1{Cсвященний щит,{2 дарований {1{C%N5{2."
-  },
   "Ты уже под воздействием этого заклинания.": {
    "en": "You are already affected by this spell.",
    "ua": "Ти вже під впливом цього закляття."
@@ -2809,6 +2801,14 @@
   "%1$^C1 уже под воздействием этого заклинания.": {
    "en": "%1$^C1 is already affected by this spell.",
    "ua": "%1$^C1 вже під впливом цього закляття."
+  },
+  "Тебя окружает {1{Cсвященный щит,{2 дарованный {1{C%s{2.": {
+   "en": "A {1{Csacred shield,{2 granted by {1{C%s{2, surrounds you.",
+   "ua": "Тебе оточує {1{Cсвященний щит,{2 дарований {1{C%s{2."
+  },
+  "%^C4 окружает священный щит, дарованный {1{C%s{2.": {
+   "en": "A sacred shield, granted by {1{C%s{2, surrounds %C4.",
+   "ua": "%^C4 оточує священний щит, дарований {1{C%s{2."
   }
  },
  "spell/gaseous form/runVict": {
@@ -2958,18 +2958,6 @@
   }
  },
  "spell/frenzy/runVict": {
-  "Волею {1{C%N2{2 глаза %C2 зажигаются диким огнем!": {
-   "en": "By the will of {1{C%N2{2, %C2's eyes ignite with wild fire!",
-   "ua": "Волею {1{C%N2{2 очі %C2 запалюються диким вогнем!"
-  },
-  "Волею {1{C%N2{2 твои глаза зажигаются диким огнем!": {
-   "en": "By the will of {1{C%N2{2, your eyes ignite with wild fire!",
-   "ua": "Волею {1{C%N2{2 твої очі займаються диким вогнем!"
-  },
-  "Волею {1{C%N2{2 твои глаза зажигаются диким огнем.": {
-   "en": "By the will of {1{C%N2{2, your eyes ignite with wild fire.",
-   "ua": "Волею {1{C%N2{2 твої очі займаються диким вогнем."
-  },
   "Глаза %C2 зажигаются диким огнем!": {
    "en": "%C2's eyes blaze with wild fire!",
    "ua": "Очі %C2 спалахують диким вогнем!"
@@ -2989,6 +2977,18 @@
   "Кажется, натура %1$C2 не по душе {1{C%2$s{2.": {
    "en": "It seems the nature of %1$C2 does not please {1{C%2$s{2.",
    "ua": "Здається, вдача %1$C2 не до душі {1{C%2$s{2."
+  },
+  "Волею {1{C%s{2 твои глаза зажигаются диким огнем!": {
+   "en": "By the will of {1{C%s{2, your eyes ignite with wild fire!",
+   "ua": "Волею {1{C%s{2 твої очі займаються диким вогнем!"
+  },
+  "Волею {1{C%s{2 глаза %C2 зажигаются диким огнем!": {
+   "en": "By the will of {1{C%s{2, %C2's eyes ignite with wild fire!",
+   "ua": "Волею {1{C%s{2 очі %C2 запалюються диким вогнем!"
+  },
+  "Волею {1{C%s{2 твои глаза зажигаются диким огнем.": {
+   "en": "By the will of {1{C%s{2, your eyes ignite with wild fire.",
+   "ua": "Волею {1{C%s{2 твої очі займаються диким вогнем."
   }
  },
  "spell/detect undead/runVict": {
@@ -3088,10 +3088,6 @@
   }
  },
  "spell/fly/runVict": {
-  "Волею {1{C%N2{2 ты поднимаешься в воздух! Это чудо!": {
-   "en": "By the will of {1{C%N2{2, you rise into the air! It's a miracle!",
-   "ua": "Волею {1{C%N2{2 ти підіймаєшся в повітря! Це диво!"
-  },
   "Со счастливой ухмылкой %C1 поднимается в воздух, начиная левитировать.": {
    "en": "With a happy grin, %C1 rises into the air, beginning to levitate.",
    "ua": "Зі щасливою посмішкою %C1 підіймається в повітря, починаючи левітувати."
@@ -3107,6 +3103,10 @@
   "Ты и так можешь подняться в воздух.": {
    "en": "You can already take to the air anyway.",
    "ua": "Ти й так можеш піднятися в повітря."
+  },
+  "Волею {1{C%s{2 ты поднимаешься в воздух! Это чудо!": {
+   "en": "By the will of {1{C%s{2, you rise into the air! It's a miracle!",
+   "ua": "Волею {1{C%s{2 ти підіймаєшся в повітря! Це диво!"
   }
  },
  "spell/heal/runVict": {
@@ -3446,13 +3446,13 @@
   }
  },
  "spell/infected mushroom/runArg": {
-  "%1$^C1 просит {1{C%2$N4{2 о просветлении, и %1$P4 на ладонь падает %3$O1.": {
-   "en": "%1$^C1 begs {1{C%2$N4{2 for enlightenment, and %3$O1 falls into the palm of %1$C2.",
-   "ua": "%1$^C1 просить {1{C%2$N4{2 про просвітлення, і на долоню %1$C2 падає %3$O1."
+  "Ты просишь {1{C%s{2 о просветлении, и тебе на ладонь падает %O1.": {
+   "en": "You ask {1{C%s{2 for enlightenment, and %O1 falls into your palm.",
+   "ua": "Ти просиш {1{C%s{2 про просвітлення, і тобі на долоню падає %O1."
   },
-  "Ты просишь {1{C%N4{2 о просветлении, и тебе на ладонь падает %O1.": {
-   "en": "You ask {1{C%N4{2 for enlightenment, and %O1 falls into your palm.",
-   "ua": "Ти просиш {1{C%N4{2 про просвітлення, і тобі на долоню падає %O1."
+  "%1$^C1 просит {1{C%2$s{2 о просветлении, и %1$P4 на ладонь падает %3$O1.": {
+   "en": "%1$^C1 begs {1{C%2$s{2 for enlightenment, and %3$O1 falls into the palm of %1$C2.",
+   "ua": "%1$^C1 просить {1{C%2$s{2 про просвітлення, і на долоню %1$C2 падає %3$O1."
   }
  },
  "spell/ethereal fist/runVict": {


### PR DESCRIPTION
Pairs with the dreamland_fenia god-name fix. 61 entries re-keyed %N<case>->%s in RU key + EN/UA values; nothing else changed (counts 963/1034 unchanged). Fable review covered both halves: RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)