### PR TITLE
atlas (help 224): Naris Chain to Redferne via Southern Midgaard

### DIFF
--- a/commands/fenia/map.xml
+++ b/commands/fenia/map.xml
@@ -25,7 +25,7 @@ From the streets of Midgaard, you can reach places such as:
 {Y%A%{x {hh2078Graveyard{x, with a descent to {hh1865Chapel{x
 {R%A%{x {hh2079Dangerous Neighborhood{x and {hh1845Prison{x
 
-If you fly from the Temple Square, you'll find yourself in the {hh2047Skies of Midgaard{x, from where you can get to {hh2048Astral Plane{x({R%A%{x) and the domains of the Githanki. And if you climb up the Naris Chain, you can reach {hh2022Redferne Residence{x, {hh2093Dylan Area{x({Y%A%{x), and {hh2023Divided Souls{x({R%A%{x), with an exit to the {hh1527Bangzui Gardens{x({R%A%{x).
+If you fly from the Temple Square, you'll find yourself in the {hh2047Skies of Midgaard{x, from where you can get to {hh2048Astral Plane{x({R%A%{x) and the domains of the Githanki. Across the Dark River lies {hh5086Southern Midgaard{x, home to the recall temples, the Prison, and the South Gate; from its crossroads the Naris Chain climbs to {hh2022Redferne Residence{x, {hh2093Dylan Area{x({Y%A%{x), and {hh2023Divided Souls{x({R%A%{x), with an exit to the {hh1527Bangzui Gardens{x({R%A%{x).
 
 Lovers of dungeon exploration will be able to descend from Midgaard to {hh1849Metro{x, with stops at the Zoo, {hh1850Prairie{x, and {hh1851Descent to Hell{x({R%A%{x), and in {hh1856Sewers{x({Y%A%{x), with a passage to the vast and mysterious {hh1854UnderDark{x.
 
@@ -101,7 +101,7 @@ P.S. All major cities are surrounded by {hh50suburbs{x, where mansions of wealth
 {Y%A%{x {hh2078Кладбище{x, со спуском в {hh1865Подземелье Часовни{x
 {R%A%{x {hh2079Опасный Район{x и {hh1845Тюрьма{x
 
-Если взлететь от Храмовой Площади, окажешься на {hh2047Небесах Мидгаарда{x, откуда можно добраться до {hh2048Астрала{x({R%A%{x) и владений гитианки. А если взобраться вверх по цепи Нариса, можно попасть в {hh2022Резиденцию Редферна{x, {hh2093Зону Дилана{x({Y%A%{x) и {hh2023Разделенные Души{x({R%A%{x), с выходом в {hh1527Бангзуйские Сады{x({R%A%{x).
+Если взлететь от Храмовой Площади, окажешься на {hh2047Небесах Мидгаарда{x, откуда можно добраться до {hh2048Астрала{x({R%A%{x) и владений гитианки. За Темной Рекой раскинулся {hh5086Южный Мидгаард{x с храмами возврата, Тюрьмой и Южными Воротами; с его перекрестка вверх по цепи Нариса можно попасть в {hh2022Резиденцию Редферна{x, {hh2093Зону Дилана{x({Y%A%{x) и {hh2023Разделенные Души{x({R%A%{x), с выходом в {hh1527Бангзуйские Сады{x({R%A%{x).
 
 Любители исследовать подземелья смогут спуститься из Мидгаарда в {hh1849Метрополитен{x, с остановками в Зоопарке, {hh1850Прериях{x и {hh1851Аду{x({R%A%{x), и в {hh1856Канализацию{x({Y%A%{x), с проходом в огромное и таинственное {hh1854Подземье{x.
 
@@ -178,7 +178,7 @@ P.S. Все крупные города окружены {hh50пригорода
 {Y%A%{x {hh2078Кладовище{x, з входом у {hh1865Підземелля Каплиці{x
 {R%A%{x {hh2079Небезпечний Район{x і {hh1845Вʼязниця{x
 
-Якщо здійнятись від Храмової Площі, опинишся на {hh2047Небесах Мідгаарда{x, звідки можливо дістатися до {hh2048Астралу{x({R%A%{x) і володінь гітіанки. А якщо піднятися вгору за ланцюгом Нарису, можна потрапити в {hh2022Резиденцію Редферна{x, {hh2093Зону Ділана{x({Y%A%{x) і {hh2023Розділені Душі{x({R%A%{x), з виходом у {hh1527Бангзуйські Сади{x({R%A%{x).
+Якщо здійнятись від Храмової Площі, опинишся на {hh2047Небесах Мідгаарда{x, звідки можливо дістатися до {hh2048Астралу{x({R%A%{x) і володінь гітіанки. За Темною Рікою розкинувся {hh5086Південний Мідгаард{x з храмами повернення, Тюрмою і Південними Воротами; з його перехрестя вгору за ланцюгом Нарису можна потрапити в {hh2022Резиденцію Редферна{x, {hh2093Зону Ділана{x({Y%A%{x) і {hh2023Розділені Душі{x({R%A%{x), з виходом у {hh1527Бангзуйські Сади{x({R%A%{x).
 
 Любителі досліджувати підземелля зможуть спуститися з Мідгаарда в {hh1849Метро{x, з зупинками у Зоопарку, {hh1850Прерії{x і {hh1851Пеклі{x({R%A%{x), і в {hh1856Каналізацію{x({Y%A%{x), з проходом в велетенське і таємниче {hh1854Підземʼя{x.
 


### PR DESCRIPTION
Kvoro: correct the Midgaard atlas section — the Naris Chain crossroads is in Southern Midgaard ({hh5086), not the old city. EN/RU/UA. 🤖 Generated with [Claude Code](https://claude.com/claude-code)