### PR TITLE
services: register sage 'advice' service (free, self-target)

### DIFF
--- a/behaviors/services.json
+++ b/behaviors/services.json
@@ -28,6 +28,7 @@
 
  // sage services
  { "name": "identify", "nameRus": "опознани|е|я|ю|е|ем|и", "nameUkr": "упізнанн|я|я|ю|я|ям|і", "price_gold": 40, "price_qp": 0, "spell": "identify", "behaviors": "sage", "target": "object", "npc_ok": 0}, 
- { "name": "locate", "nameRus": "локатор||а|у||ом|е", "nameUkr": "локатор||а|у||ом|і", "price_gold": 200, "price_qp": 0, "spell": "", "behaviors": "sage", "target": "string", "npc_ok": 0} 
- 
+ { "name": "locate", "nameRus": "локатор||а|у||ом|е", "nameUkr": "локатор||а|у||ом|і", "price_gold": 200, "price_qp": 0, "spell": "", "behaviors": "sage", "target": "string", "npc_ok": 0},
+ { "name": "advice", "nameRus": "совет||а|у||ом|е", "nameUkr": "порад|а|и|і|у|ою|і", "price_gold": 0, "price_qp": 0, "spell": "", "behaviors": "sage", "target": "char", "npc_ok": 0}
+
 ]


### PR DESCRIPTION
Adds the 'advice' service to services.json so the sage offers it. Pairs with dreamland_fenia #583 (handler) + dreamland_code #1047 (ch.gearAdvice). Loads at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)