### PR TITLE
Remort help (1064): hero gear survives to Lost and Found + refit

### DIFF
--- a/commands/remort.xml
+++ b/commands/remort.xml
@@ -11,7 +11,7 @@
     <keyword l="ua">переродження</keyword>
     <text l="en">%FMT% *%CMD%* _password_ 
 
-When you remort, your soul gains a new, young body, and you start all over again. Only {Rname and gender{x cannot be changed. All the items you had with you at the time of the remort will disappear without a trace along with the body. Only the money in your {hh1086bank{x account and the quest points you earned will be saved. Therefore, if you don't want to lose valuable items, take care of a personal chest or your own home in advance (%H% {hh11gods' mercy{x, {hh50construction{x).
+When you remort, your soul gains a new, young body, and you start all over again. Only {Rname and gender{x cannot be changed. All the items you had with you at the time of the remort will disappear without a trace along with the body. The one exception is your personal hero gear -- quest girth, ring, weapon and bag -- that you are wearing or carrying: instead of vanishing it goes to the Lost and Found office in Midgaard, where you can reclaim it and refit it to your new level at the {hh125quest-trader{x ({y{hcquest buy refit{x). Only the money in your {hh1086bank{x account and the quest points you earned will be saved. Therefore, if you don't want to lose valuable items, take care of a personal chest or your own home in advance (%H% {hh11gods' mercy{x, {hh50construction{x).
 
 You can start a new life only after reaching level 100. You can live an unlimited number of lives, but lives after the tenth will not provide any additional advantages and will still be considered the tenth.
 
@@ -44,7 +44,7 @@ Command *lives* provides info about current life's bonuses. On each remort, the 
 </text>
     <text l="ru">%FMT% *%CMD%* _пароль_ 
 
-При реморте твоя душа обретает новое, молодое тело, и ты начинаешь все заново. Изменить нельзя лишь {Rимя и пол{x. Все вещи, что ты имел{Sfа{Sx при себе на момент реморта, исчезнут бесследно вместе с телом. Деньги на счету в {hh1086банке{x сохранятся за вычетом небольшого налога, также сохранятся и заработанные квестовые очки. Чтобы не потерять накопленные вещи, можно перед перерождением сложить их в сумку и спрятать в укромном месте -- или даже {hh238закопать{x. 
+При реморте твоя душа обретает новое, молодое тело, и ты начинаешь все заново. Изменить нельзя лишь {Rимя и пол{x. Все вещи, что ты имел{Sfа{Sx при себе на момент реморта, исчезнут бесследно вместе с телом. Исключение -- надетые и несомые личные вещи Героя (пояс, кольцо, оружие и сумка): вместо исчезновения они попадают в бюро находок в Мидгаарде, откуда их можно забрать и перековать под новый уровень у {hh125квестового торговца{x ({y{hcквест купить перековка{x). Деньги на счету в {hh1086банке{x сохранятся за вычетом небольшого налога, также сохранятся и заработанные квестовые очки. Чтобы не потерять накопленные вещи, можно перед перерождением сложить их в сумку и спрятать в укромном месте -- или даже {hh238закопать{x. 
 
 Начать новую жизнь можно только по достижении 100 уровня. Всего можно прожить неограниченное количество жизней, однако жизни после десятой не дадут никаких дополнительных преимуществ, и будут все так же считаться за десятую.
 
@@ -82,7 +82,7 @@ Command *lives* provides info about current life's bonuses. On each remort, the 
 </text>
     <text l="ua">%FMT% *%CMD%* _пароль_ 
 
-При реморті твоя душа отримує нове, молоде тіло, і ти починаєш усе заново. Можна змінити лише {Rімʼя і стать{x. Усі речі, які ти мав{Sfа{Sx при собі на момент реморта, зникнуть безслідно разом з тілом. Збережуться лише гроші на рахунку в {hh1086банку{x і зароблені квестові очки. Тому, якщо не хочеш втратити цінні для тебе речі, заздалегідь подбай про іменний сундук або власний будинок (%H% {hh11милість богів{x, {hh50будівництво{x).
+При реморті твоя душа отримує нове, молоде тіло, і ти починаєш усе заново. Можна змінити лише {Rімʼя і стать{x. Усі речі, які ти мав{Sfа{Sx при собі на момент реморта, зникнуть безслідно разом з тілом. Виняток -- надіті й носимі особисті речі Героя (пояс, перстень, зброя і сумка): замість зникнення вони потрапляють у бюро знахідок у Мідгаарді, звідки ти зможеш їх забрати і перекувати під новий рівень у {hh125квестового торговця{x ({y{hcквест купити перековка{x). Збережуться лише гроші на рахунку в {hh1086банку{x і зароблені квестові очки. Тому, якщо не хочеш втратити цінні для тебе речі, заздалегідь подбай про іменний сундук або власний будинок (%H% {hh11милість богів{x, {hh50будівництво{x).
 
 Почати нове життя можна тільки після досягнення 100 рівня. Можна прожити необмежену кількість життів, але життя після десятого не нададуть ніяких додаткових переваг і вважатимуться все ще за десяте.
 

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -17294,9 +17294,13 @@
    "en": "Failed to save your profile: tell the Gods!",
    "ua": "Не вдалося зберегти твій профайл: повідом Богам!"
   },
-  "Вещи можно сохранить в именном сундуке или собственном доме ({y{hcсправка цены{x, {y{hcсправка строительство{x)": {
-   "en": "Items can be stored in a named chest or your own house ({y{hchelp prices{x, {y{hchelp construction{x)",
-   "ua": "Речі можна зберегти в іменній скрині або власному домі ({y{hcдовідка ціни{x, {y{hcдовідка будівництво{x)"
+  "Личные вещи Героя (надетые и в инвентаре) не пропадут: они попадут в бюро находок в Мидгаарде, откуда их можно забрать и перековать под новый уровень ({y{hcквест купить перековка{x).": {
+   "en": "Your worn and carried personal Hero items are not lost: they are sent to the Lost and Found office in Midgaard, where you can reclaim them and refit them to your new level ({y{hcquest buy refit{x).",
+   "ua": "Надіті й носимі особисті речі Героя не пропадуть: вони потраплять у бюро знахідок у Мідгаарді, звідки їх можна забрати і перекувати під новий рівень ({y{hcквест купити перековка{x)."
+  },
+  "Остальные вещи можно сохранить в именном сундуке или собственном доме ({y{hcсправка цены{x, {y{hcсправка строительство{x)": {
+   "en": "Other items can be stored in a named chest or your own house ({y{hchelp prices{x, {y{hchelp construction{x)",
+   "ua": "Решту речей можна зберегти в іменній скрині або власному домі ({y{hcдовідка ціни{x, {y{hcдовідка будівництво{x)"
   },
   "Если хочешь начать новую жизнь, набери {yпереродиться{x пароль.": {
    "en": "If you want to start a new life, type {yreborn{x password.",
@@ -18662,6 +18666,10 @@
   }
  },
  "plug-ins/wearlocation/defaultwearlocation.cpp": {
+  "Это твоя геройская вещь -- перекуй ее под свой уровень у {hh125квестового торговца{x: {y{hcквест купить перековка{x.": {
+   "en": "This is your Hero item -- refit it to your level at the {hh125quest-trader{x: {y{hcquest buy refit{x.",
+   "ua": "Це твоя геройська річ -- перекуй її під свій рівень у {hh125квестового торговця{x: {y{hcквест купити перековка{x."
+  },
   "%1$^C1 теперь носит %2$O4 при себе.": {
    "en": "%1$^C1 now keeps %2$O4 on them.",
    "ua": "%1$^C1 тепер носить %2$O4 при собі."


### PR DESCRIPTION
Trilingual note in remort help 1064: hero gear now goes to the Midgaard Lost and Found on remort and can be refit at the quest-trader. Pairs with dreamland_code feat/remort-preserve-hero-gear.