### PR TITLE
questmaster: finer quest-buy-gold step (500 gold / 100 qp)

### DIFF
--- a/legacy-behaviors/DefaultQuestMaster.xml
+++ b/legacy-behaviors/DefaultQuestMaster.xml
@@ -176,14 +176,14 @@
       </lifePrice>
     </node>
     <node type="GoldQuestArticle">
-      <amount>5000</amount>
+      <amount>500</amount>
       <name>gold</name>
       <rname>золото</rname>
-      <descr>5000 золотых монет</descr>
-      <descr l="en">5000 gold coins</descr>
-      <descr l="ua">5000 золотих монет</descr>
+      <descr>500 золотых монет</descr>
+      <descr l="en">500 gold coins</descr>
+      <descr l="ua">500 золотих монет</descr>
       <price type="QuestPointPrice">
-        <questpoint>1000</questpoint>
+        <questpoint>100</questpoint>
       </price>
     </node>
   </services>


### PR DESCRIPTION
The **DefaultQuestMaster** gold article -- inherited by every standard questmaster in the world -- sold a fixed 5000 gold for 1000 qp. Now 500 gold / 100 qp (same 5:1 rate, 10x finer, buy in small steps -- idea by Samuro). Pairs with the tcwnn questmaster override (dreamland_areas#488). Rides the next reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)