### PR TITLE
services.json: sage advice takes an optional argument (target optstring)

### DIFF
--- a/behaviors/services.json
+++ b/behaviors/services.json
@@ -29,6 +29,6 @@
  // sage services
  { "name": "identify", "nameRus": "опознани|е|я|ю|е|ем|и", "nameUkr": "упізнанн|я|я|ю|я|ям|і", "price_gold": 40, "price_qp": 0, "spell": "identify", "behaviors": "sage", "target": "object", "npc_ok": 0}, 
  { "name": "locate", "nameRus": "локатор||а|у||ом|е", "nameUkr": "локатор||а|у||ом|і", "price_gold": 200, "price_qp": 0, "spell": "", "behaviors": "sage", "target": "string", "npc_ok": 0},
- { "name": "advice", "nameRus": "совет||а|у||ом|е", "nameUkr": "порад|а|и|і|у|ою|і", "price_gold": 0, "price_qp": 0, "spell": "", "behaviors": "sage", "target": "char", "npc_ok": 0}
+ { "name": "advice", "nameRus": "совет||а|у||ом|е", "nameUkr": "порад|а|и|і|у|ою|і", "price_gold": 0, "price_qp": 0, "spell": "", "behaviors": "sage", "target": "optstring", "npc_ok": 0}
 
 ]


### PR DESCRIPTION
Changes the sage `advice` service `target` from `char` to `optstring` so `service advice <slot>` can pass a wear-slot keyword to the handler, while plain `service advice` still works (optstring accepts an empty argument). Pairs with the `gearAdvice` slotFilter arg (#1061) and the `locateService` optstring branch. One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)