### PR TITLE
fix(help): summon help 584 matches auto-protection (nosummon retired)

### DIFF
--- a/generic-skills/summon.xml
+++ b/generic-skills/summon.xml
@@ -43,7 +43,6 @@ You can summon characters below your {hh2036spell level{x, but not below your {h
 {cYou can be summoned by:{x
 %A% players in your PK-range
 %A% your clan members
-%A% any other players if you do not have {y{hcconfig nosummon{x turned on
 %A% world mage mobs you try to flee from after an unsuccessful battle
 
 {cCannot be summoned:{x
@@ -53,6 +52,7 @@ You can summon characters below your {hh2036spell level{x, but not below your {h
 %A% clan characters in your PK if you are non-clan
 
 {cHow to protect against summoning:{x
+%A% Anyone outside your {hh32PK-range{x cannot summon you at all -- you are protected automatically (your clan and group aside)
 %A% Increase {hh2035magic protection{x: to summon successfully, a saving throw must be passed
 %A% Find an item or spell {hh570mental block{x</text>
     <text l="ru">%FMT% *%SPELL%* _%VICT%_
@@ -64,7 +64,6 @@ You can summon characters below your {hh2036spell level{x, but not below your {h
 {cТебя могут призвать:{x
 %A% игроки в твоем ПК-интервале
 %A% твои клановики
-%A% любые другие игроки, если у тебя не включено {y{hcнастройки непризыв{x
 %A% мобы-маги по миру, от которых ты попытаешься сбежать после неудачного боя
 
 {cНе получится призвать:{x
@@ -74,6 +73,7 @@ You can summon characters below your {hh2036spell level{x, but not below your {h
 %A% клановых персонажей в твоем ПК, если ты некланов{Smый{Sfая{Sx
 
 {cКак защититься от призыва:{x
+%A% Игроки вне твоего {hh32ПК-интервала{x вообще не могут тебя призвать -- ты защищен автоматически (кроме клана и группы)
 %A% Увеличить {hh2035защиту от магии{x: чтобы успешно призвать, надо пройти спасбросок
 %A% Найти вещь или заклинание {hh570ментального блока{x
 </text>
@@ -86,7 +86,6 @@ You can summon characters below your {hh2036spell level{x, but not below your {h
 {cТебе можуть викликати:{x
 %A% гравці в твоєму ПК-інтервалі
 %A% твої клановики
-%A% будь-які інші гравці, якщо у тебе не увімкнено {y{hcналаштування невиклик{x
 %A% моби-чарівники по світу, від яких ти спробуєш втекти після невдалого бою
 
 {cНе вдасться викликати:{x
@@ -96,6 +95,7 @@ You can summon characters below your {hh2036spell level{x, but not below your {h
 %A% кланових персонажів у твоєму ПК, якщо ти не в клані{Smий{Sfа{Sx
 
 {cЯк захиститися від виклику:{x
+%A% Гравці поза твоїм {hh32ПК-інтервалом{x взагалі не можуть тебе викликати -- ти захищений автоматично (окрім клану та групи)
 %A% Збільшити {hh2035захист від магії{x: щоб успішно викликати, потрібно пройти спасбросок
 %A% Знайти річ або заклинання {hh570ментального блоку{x</text>
   </help>


### PR DESCRIPTION
config nosummon was retired (transportspell.cpp:177); help 584 still advertised it (Simzgnund report). Drop the obsolete bullet EN/RU/UA, add an explicit auto-protection line, keep the help keyword. Reboot/plug-reload gated. Kit-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)