### PR TITLE
HOTFIX: unlock template placeholder-order SIGSEGV (revert PR653 burgundy reorder)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -8055,8 +8055,8 @@
    "ua": "%1$^C1 відмикає ключем %2$O4 і відкриває %2$O4."
   },
   "%^C1 отпирает %O5 и открывает %N4.": {
-   "en": "%^C1 unlocks and opens %N4 with %O5.",
-   "ua": "%^C1 відпирає і відчиняє %N4 %O5."
+   "en": "%^C1 uses %O5 to unlock and open %N4.",
+   "ua": "%^C1 відмикає %O5 і відчиняє %N4."
   },
   "%^N1 щелкает.": {
    "en": "%^N1 clicks.",
@@ -8099,8 +8099,8 @@
    "ua": "Ти відмикаєш %1$O4 %2$O5 і відчиняєш %1$O4."
   },
   "Ты отпираешь %O5 и открываешь %N4.": {
-   "en": "You unlock and open %N4 with %O5.",
-   "ua": "Ти відпираєш і відчиняєш %N4 %O5."
+   "en": "You use %O5 to unlock and open %N4.",
+   "ua": "Ти відмикаєш %O5 і відкриваєш %N4."
   },
   "Ты отпираешь ключом %1$O4 и открываешь %1$P2.": {
    "en": "You unlock %1$O4 with the key and open it.",
@@ -8151,12 +8151,12 @@
    "ua": "%^w клацає."
   },
   "Ты отпираешь %O5 и открываешь %w.": {
-   "en": "You unlock and open %w with %O5.",
-   "ua": "Ти відпираєш і відчиняєш %w %O5."
+   "en": "You use %O5 to unlock and open %w.",
+   "ua": "Ти відмикаєш %O5 і відкриваєш %w."
   },
   "%^C1 отпирает %O5 и открывает %w.": {
-   "en": "%^C1 unlocks and opens %w with %O5.",
-   "ua": "%^C1 відпирає і відчиняє %w %O5."
+   "en": "%^C1 uses %O5 to unlock and open %w.",
+   "ua": "%^C1 відмикає %O5 і відчиняє %w."
   }
  },
  "plug-ins/comm/use.cpp": {


### PR DESCRIPTION
PR #653 reordered %w/%O5 in the door-unlock templates; args bind positionally, so %O5 got the doorname pointer and deref'd it as an Object -> crash on every door unlock (cores 16:36, 16:40). Restores %O5-before-%w order. 🤖 Generated with [Claude Code](https://claude.com/claude-code)