### PR TITLE
affects: observation -> detects column, capitalized label

### DIFF
--- a/generic-skills/farsight.xml
+++ b/generic-skills/farsight.xml
@@ -68,8 +68,4 @@ The binoculars that {hh2127newcomers{x can acquire on the {hh1560Galeon{x operat
     <target>ignore</target>
     <type>none</type>
   </spell>
-  <webColumn>det</webColumn>
-  <webLabel l="en">Observ</webLabel>
-  <webLabel l="ru">Диагн</webLabel>
-  <webLabel l="ua">Спостер</webLabel>
 </skill>

--- a/generic-skills/observation.xml
+++ b/generic-skills/observation.xml
@@ -54,4 +54,8 @@ This prayer grants you the ability to see someone's illnesses, negative conditio
     <target>char_self</target>
     <type>defensive</type>
   </spell>
+  <webColumn>det</webColumn>
+  <webLabel l="en">Observ</webLabel>
+  <webLabel l="ru">Диагн</webLabel>
+  <webLabel l="ua">Спостер</webLabel>
 </skill>


### PR DESCRIPTION
observation had no <webColumn> (auto-classified to enhance, lowercase). Its det column + capitalized labels were mis-placed on farsight (which grants no affect). Moved to observation, removed the dead pair from farsight. Reboot-gated (skill defs load at boot).

Closes Bugs 6a8dd5c9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)