### PR TITLE
l10n(command): en/ua for service 'nothing to repair'

### DIFF
--- a/config/translations/command.json
+++ b/config/translations/command.json
@@ -555,6 +555,10 @@
   "Похоже, здесь никто не слышал об услуге под названием {g%s.{x": {
    "en": "Looks like nobody here has heard of a service called {g%s.{x",
    "ua": "Схоже, тут ніхто не чув про послугу під назвою {g%s.{x"
+  },
+  "Я не вижу на тебе ничего, что я мог%G||ла бы отремонтировать.": {
+   "en": "I don't see anything on you that I could repair.",
+   "ua": "Я не бачу на тобі нічого, що можу відремонтувати."
   }
  },
  "command/suicide/runFunc": {


### PR DESCRIPTION
Catalog entry for the repair-all refusal now rendered via viewer.print(._()) (paired fenia PR). Reboot/plug-reload-most-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)