### PR TITLE
Fill empty UA name + EN/UA help labels for the spores affect

### DIFF
--- a/other-skills/spores.xml
+++ b/other-skills/spores.xml
@@ -6,9 +6,9 @@
   <dammsg mg="m"></dammsg>
   <group registry="skillGroup">nature</group>
   <help id="196" level="-1" type="SkillHelp">
-    <extra l="en"></extra>
+    <extra l="en">hallucinogenic spores</extra>
     <extra l="ru">галлюциногенные споры</extra>
-    <extra l="ua"></extra>
+    <extra l="ua">галюциногенні спори</extra>
     <text l="en">Fungal spores arising in the brain as a result of eating {hh197hallucinogenic mushrooms{x.
 </text>
     <text l="ru">Грибные споры, возникающие в мозгу в результате поедания {hh197галлюциногенных грибов{x.
@@ -18,7 +18,7 @@
   </help>
   <name l="en">spores</name>
   <name l="ru">грибные споры</name>
-  <name l="ua"></name>
+  <name l="ua">грибні спори</name>
   <spell type="DefaultSpell">
     <damtype>none</damtype>
     <flags>magic</flags>


### PR DESCRIPTION
Fixes an in-game report (Bromir): the character affect panel pulled the spores affect name, which had an empty `<name l="ua">`, so Ukrainian players saw the RU/EN fallback. Also fills the two empty EN/UA `<extra>` help search labels for help 196.

Data-only, per Kit's call: the spell (infected mushroom / грибочек) and the affect (spores / грибные споры) stay two linked concepts via {hh196}/{hh197}. Reboot-gated (skill defs load at boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)