### PR TITLE
set behaviors: add English descriptions (18 sets)

### DIFF
--- a/behaviors/set amazon.xml
+++ b/behaviors/set amazon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh5081amazon set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh5081набор амазонки{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh5081набір амазонки{x.</description>
   <help id="5081" level="-1" type="BehaviorHelp">

--- a/behaviors/set ashigaru.xml
+++ b/behaviors/set ashigaru.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh298ashigaru set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh298набор асигару{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh298набір асигару{x.</description>
   <help id="298" level="-1" type="BehaviorHelp">

--- a/behaviors/set berserker.xml
+++ b/behaviors/set berserker.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh5079berserker set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh5079набор берсерка{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh5079набір берсерка{x.</description>
   <help id="5079" level="-1" type="BehaviorHelp">

--- a/behaviors/set davy jones.xml
+++ b/behaviors/set davy jones.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of Davy Jones's reward.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x награды Дэви Джонса.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x нагороди Дейві Джонса.</description>
   <id>14</id>

--- a/behaviors/set defender.xml
+++ b/behaviors/set defender.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh5077defender set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh5077набор защитника{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh5077набір захисника{x.</description>
   <help id="5077" level="-1" type="BehaviorHelp">

--- a/behaviors/set fathers.xml
+++ b/behaviors/set fathers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh5073fathers' heritage{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh5073отцовское наследство{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh5073батьківську спадщину{x.</description>
   <help id="5073" level="-1" type="BehaviorHelp">

--- a/behaviors/set gloomstalker.xml
+++ b/behaviors/set gloomstalker.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh5083gloomstalker set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh5083набор охотника тьмы{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh5083набір мисливця тьми{x.</description>
   <help id="5083" level="-1" type="BehaviorHelp">

--- a/behaviors/set hoplite.xml
+++ b/behaviors/set hoplite.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh299hoplite set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh299набор гоплита{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh299набір гопліта{x.</description>
   <help id="299" level="-1" type="BehaviorHelp">

--- a/behaviors/set master scout.xml
+++ b/behaviors/set master scout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of the master of camouflage.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x мастера камуфляжа.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x майстра камуфляжу.</description>
   <id>17</id>

--- a/behaviors/set master thief.xml
+++ b/behaviors/set master thief.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of the master of thievery.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x мастера воровства.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x майстра крадійства.</description>
   <id>10</id>

--- a/behaviors/set morris dancer.xml
+++ b/behaviors/set morris dancer.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of the morris dancer.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x танцора морриса.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x танцівника морріса.</description>
   <id>8</id>

--- a/behaviors/set myrmidon.xml
+++ b/behaviors/set myrmidon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh5075myrmidon set{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh5075набор мирмидонянина{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh5075набір мірмідонянина{x.</description>
   <help id="5075" level="-1" type="BehaviorHelp">

--- a/behaviors/set myrvale noriva.xml
+++ b/behaviors/set myrvale noriva.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of Myrvale Noriva.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x мирвейл Норива.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x мірвейл Норіва.</description>
   <id>1</id>

--- a/behaviors/set pixie.xml
+++ b/behaviors/set pixie.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh290pixie armor{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh290доспехи пикси{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh290обладунки піксі{x.</description>
   <help id="290" level="110" type="BehaviorHelp">

--- a/behaviors/set secret of sidhe.xml
+++ b/behaviors/set secret of sidhe.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x, the secret of the Sidhe.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x секрет Сидхов.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x секрет Сідхів.</description>
   <id>6</id>

--- a/behaviors/set shevale reykaris.xml
+++ b/behaviors/set shevale reykaris.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of Shevale Reykaris.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x шивейл Рейкарис.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x шивейл Рейкарис.</description>
   <id>5</id>

--- a/behaviors/set travellers joy.xml
+++ b/behaviors/set travellers joy.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
-  <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x отраду путешественника.</description>
+  <description l="en">{hh990Wear{x it to assemble the {hh67set{x of traveller's joy.</description>
+  <description l="ru">{hh990Надень{x, чтобы собрать {hh67комплект{x отрады путешественника.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh67комплект{x розраду мандрівника.</description>
   <id>7</id>
   <nameEn>traveller's joy</nameEn>

--- a/behaviors/set wood nymph.xml
+++ b/behaviors/set wood nymph.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <behavior type="DefaultBehavior">
   <cmd></cmd>
+  <description l="en">{hh990Wear{x it to assemble the {hh301wood nymphs' ward{x.</description>
   <description l="ru">{hh990Надень{x, чтобы собрать {hh301оберег древесных нимф{x.</description>
   <description l="ua">{hh990Одягни{x, щоб зібрати {hh301оберіг деревних німф{x.</description>
   <help id="301" level="-1" type="BehaviorHelp">


### PR DESCRIPTION
Fill the missing l="en" set-hint description on all 18 set behaviors (EN players saw the RU fallback), plus a RU genitive fix in traveller's joy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)