### PR TITLE
Add trilingual damage-class nouns

### DIFF
--- a/fight/damage_nouns.json
+++ b/fight/damage_nouns.json
@@ -1,0 +1,82 @@
+[
+ {
+  "en": "irresistible damage",
+  "ua": "невідворотна шкода"
+ },
+ {
+  "en": "heavy blow",
+  "ua": "важкий удар"
+ },
+ {
+  "en": "pierce",
+  "ua": "прокол"
+ },
+ {
+  "en": "slash",
+  "ua": "розсічення"
+ },
+ {
+  "en": "burn",
+  "ua": "опік"
+ },
+ {
+  "en": "freezing",
+  "ua": "заморожування"
+ },
+ {
+  "en": "electric shock",
+  "ua": "електрошок"
+ },
+ {
+  "en": "acid",
+  "ua": "кислота"
+ },
+ {
+  "en": "poison",
+  "ua": "отруєння"
+ },
+ {
+  "en": "negative energy",
+  "ua": "темна енергія"
+ },
+ {
+  "en": "holy power",
+  "ua": "святість"
+ },
+ {
+  "en": "force blow",
+  "ua": "силовий удар"
+ },
+ {
+  "en": "mental attack",
+  "ua": "ментальна атака"
+ },
+ {
+  "en": "disease",
+  "ua": "хвороба"
+ },
+ {
+  "en": "drowning",
+  "ua": "сила води"
+ },
+ {
+  "en": "radiant energy",
+  "ua": "промениста енергія"
+ },
+ {
+  "en": "unknown damage",
+  "ua": "невідома шкода"
+ },
+ {
+  "en": "pain and suffering",
+  "ua": "біль і страждання"
+ },
+ {
+  "en": "charm magic",
+  "ua": "магія зачарування"
+ },
+ {
+  "en": "sonic blow",
+  "ua": "звуковий удар"
+ }
+]


### PR DESCRIPTION
20 damage classes x en/ua nominative, 1:1 with damage_table enum. Consumed by magic.cpp damage_noun(). Trello AXqNSTVz. Reviewed (fable): RELEASE.