### PR TITLE
perception: grant permanent 'detect trap'; help now says always-detects (#2758)

### DIFF
--- a/generic-skills/perception.xml
+++ b/generic-skills/perception.xml
@@ -13,6 +13,7 @@
     </node>
   </classes>
   <dammsg mg="m"></dammsg>
+  <grants registry="skill">'detect trap'</grants>
   <group registry="skillGroup">adventure</group>
   <hard>5</hard>
   <help id="834" level="-1" type="SkillHelp">
@@ -21,15 +22,15 @@
     <extra l="ua">сприйняття</extra>
     <text l="en">The ability to sense hidden exits and secret passages.
 
-The same sharp eye catches danger underfoot: a character with this skill has a chance to spot a {hh655trap{x set by a thief or ninja and to step around hidden snares, pits and deadly tiles without springing them. The keener the eye, the more often it works -- and the more you skirt danger, the sharper it grows. A {hh896detect trap{x spell does the same, but never misses.
+The same sharp eye catches danger underfoot: anyone who has learned this skill always spots a {hh655trap{x set by a thief or ninja and steps around hidden snares, pits and deadly tiles without springing them -- the very same protection a {hh896detect trap{x spell grants.
 </text>
     <text l="ru">Умение почувствовать скрытые выходы и тайные ходы.
 
-Тот же острый глаз замечает опасность под ногами: обладатель этого навыка имеет шанс различить {hh655ловушку{x, расставленную вором или ниндзя, и обойти скрытые силки, ямы и смертельные плиты, не приводя их в действие. Чем острее глаз, тем чаще это удается -- и чем больше ходишь по краю, тем глаз острее. Заклинание {hh896обнаружение ловушек{x делает то же самое, но без промаха.
+Тот же острый глаз замечает опасность под ногами: всякий, кто выучил этот навык, всегда различает {hh655ловушку{x, расставленную вором или ниндзя, и обходит скрытые силки, ямы и смертельные плиты, не приводя их в действие -- та же защита, что дает заклинание {hh896обнаружение ловушек{x.
 </text>
     <text l="ua">Здатність відчувати приховані виходи та таємні проходи.
 
-Те саме гостре око помічає небезпеку під ногами: власник цієї навички має шанс розрізнити {hh655пастку{x, розставлену крадієм чи ніндзя, і обійти приховані сильця, ями та смертельні плити, не приводячи їх у дію. Що гостріше око, то частіше це вдається -- і що більше ходиш по краю, то око гостріше. Закляття {hh896виявлення пасток{x робить те саме, але без промаху.
+Те саме гостре око помічає небезпеку під ногами: кожен, хто вивчив цю навичку, завжди розрізняє {hh655пастку{x, розставлену крадієм чи ніндзя, і обходить приховані сильця, ями та смертельні плити, не приводячи їх у дію -- той самий захист, що дає закляття {hh896виявлення пасток{x.
 </text>
   </help>
   <name l="en">perception</name>


### PR DESCRIPTION
Adds `<grants registry="skill">'detect trap'</grants>` so the passive-affect engine (dreamland_code #1088) keeps a permanent detect-trap affect on any learned holder. Help (en/ru/ua) rewritten from chance-to-spot to always-detects, matching the spell. Loads at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)