### PR TITLE
l10n(eqset): EN/UA for set skill grant/revoke messages

### DIFF
--- a/config/translations/behavior.json
+++ b/config/translations/behavior.json
@@ -11,6 +11,14 @@
   "Ты надел%1$Gо||а уже {c%2$d{x из {C%3$d{x предметов {hh67комплекта{x '{C%4$N1{x'.": {
    "en": "You've already worn {c%2$d{x of {C%3$d{x items in the {hh67set{x '{C%4$N1{x'.",
    "ua": "Ти наді%1$Gло|в|ла вже {c%2$d{x із {C%3$d{x предметів {hh67комплекту{x '{C%4$N1{x'."
+  },
+  "Вместе с набором к тебе приходят новые умения.": {
+   "en": "Along with the set, new skills come to you.",
+   "ua": "Разом із набором до тебе приходять нові вміння."
+  },
+  "Чудом обретенное умение выветривается из твоей памяти без следа.": {
+   "en": "The miraculously acquired skill evaporates from your memory without a trace.",
+   "ua": "Дивом здобуте вміння вивітрюється з твоєї пам'яті без сліду."
   }
  },
  "behavior/jew": {


### PR DESCRIPTION
Phase 3 of #2758 added two player-facing lines to `behavior/eqset` (grantSkills / revokeSkills) that were RU-only in the catalog. Fill EN+UA. Revoke line reuses the established `giveTemporary` translation shared by ~58 items.

Verified byte-exact against source via `l10n-catalog-add.py --verify-source`; `lint-catalog-gaps` shows no remaining eqset gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)