### PR TITLE
Catalog: single-name help title formats

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -20477,6 +20477,16 @@
   "Группа умений {c%1$s{x, {c%2$s{x": {
    "en": "Skill group {c%1$s{x, {c%2$s{x",
    "ua": "Група вмінь {c%1$s{x, {c%2$s{x"
+  },
+  "Группа умений {c%1$s{x": {
+   "en": "Skill group {c%1$s{x",
+   "ua": "Група вмінь {c%1$s{x"
+  }
+ },
+ "plug-ins/command/commandhelp.cpp": {
+  "Команда {c%1$s{x": {
+   "en": "Command {c%1$s{x",
+   "ua": "Команда {c%1$s{x"
   }
  },
  "plug-ins/languages/core/language.cpp": {


### PR DESCRIPTION
Companion to the dreamland_code help-title collapse (one name, not two). Adds EN/UA translations for the new single-placeholder title formats: `Группа умений {c%1\$s{x` (skill-group) and `Команда {c%1\$s{x` (command, new per-language title). Both ride the same reboot as the code PR.