### PR TITLE
grantskills behavior definition (Phase 3c #2853)

### DIFF
--- a/behaviors/grantskills.xml
+++ b/behaviors/grantskills.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<behavior type="DefaultBehavior">
+  <cmd></cmd>
+  <description l="en">Grants temporary skills to the wearer while the item is worn.</description>
+  <description l="ru">Дает временные умения владельцу, пока предмет надет.</description>
+  <description l="ua">Дає тимчасові вміння власнику, поки предмет одягнений.</description>
+  <id>106</id>
+  <nameRus>источник умений</nameRus>
+  <nameUa>джерело вмінь</nameUa>
+  <props>null
+</props>
+  <target>obj</target>
+</behavior>


### PR DESCRIPTION
Phase 3c of perma-affects epic (Trello #2853). Migrates 43 skill-grant items to a generic `grantskills` behavior + per-object props. fable adversarial review RELEASE (round 2) — reviews/2026-08-30-grantskills-behavior-phase3c.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)