### PR TITLE
accuracy skill: fill empty UA name (влучність)

### DIFF
--- a/other-skills/accuracy.xml
+++ b/other-skills/accuracy.xml
@@ -20,7 +20,7 @@
   </help>
   <name l="en">accuracy</name>
   <name l="ru">меткость</name>
-  <name l="ua"></name>
+  <name l="ua">влучність</name>
   <webColumn>enh</webColumn>
   <webLabel l="en">Accuracy</webLabel>
   <webLabel l="ru">Меткость</webLabel>


### PR DESCRIPTION
Empty `<name l="ua">` made the accuracy affect render RU меткость on UA clients. UA form was already in the webLabel. Reboot-gated (skill defs load at boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)