### PR TITLE
regeneration: curate web-panel column+label (enh/Regen)

### DIFF
--- a/generic-skills/regeneration.xml
+++ b/generic-skills/regeneration.xml
@@ -45,6 +45,10 @@ Regeneration greatly accelerates {hh2130life recovery{x. {hh837Poisoning{x and {
   <name l="en">regeneration</name>
   <name l="ru">регенерация</name>
   <name l="ua">регенерація</name>
+  <webColumn>enh</webColumn>
+  <webLabel l="en">Regen</webLabel>
+  <webLabel l="ru">Реген</webLabel>
+  <webLabel l="ua">Реген</webLabel>
   <spell type="DefaultSpell">
     <damtype>none</damtype>
     <flags>prayer</flags>


### PR DESCRIPTION
Landing follow-up for the gear-grant affect display (dreamland_code#1103). regeneration is gear-granted (marsh.are) and, once gear affects surface in the panel, would double-chip (auto-fallback + raw 'Regen' bit). Curate to exactly match the affectpanel.json raw-bit (enh, Regen/Реген/Реген) so the de-dup collapses it. Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)