### PR TITLE
Show lloth snare buff in enhancement affect column

### DIFF
--- a/other-skills/lloth snare.xml
+++ b/other-skills/lloth snare.xml
@@ -9,8 +9,8 @@
   </help>
   <name l="en">lloth snare</name>
   <name l="ru">тенета Ллот</name>
-  <name l="ua"></name>
-  <webColumn>mal</webColumn>
+  <name l="ua">тенета Ллот</name>
+  <webColumn>enh</webColumn>
   <webLabel l="en">Snare</webLabel>
   <webLabel l="ru">Тенета</webLabel>
   <webLabel l="ua">Тенета</webLabel>


### PR DESCRIPTION
Lloth snare is a follower buff but its `webColumn` was `mal` (malevolent/red), so it showed as a debuff on the worshipper's affect panel. Move to `enh` and fill the empty UA name.

Reported in-game by Disabolica (Trello Bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)