### PR TITLE
help: bash is ~2x more common than pierce/slash in damage-types article

### DIFF
--- a/helps/immort.xml
+++ b/helps/immort.xml
@@ -250,7 +250,7 @@ Gods can hide their true level or even take on the appearance of mortals. You ca
 %A% =Immunity= immune: hits of this affect type deal {Wno{x damage at all, and spells fail completely. Immunities are very rare.
 
 {CAFFECT TYPES{x
-%A% =Weapon=: most physical effects that deal "ordinary" damage (for example, stabs or heavy blows). Magic weapons or weapon {hh96flags{x have their own affect types -- usually elemental ones.
+%A% =Weapon=: most physical effects that deal "ordinary" damage. It splits into three types you can resist on their own -- =bash= (heavy, crushing blows), =pierce= (stabs) and =slash= (cuts). Bash is by far the most common in the world, about twice as common as pierce or slash, so resisting it protects you most often. Magic weapons or weapon {hh96flags{x have their own affect types -- usually elemental ones.
 %A% =Magic=: effects of combat magic -- but not prayers
 %A% =Prayers=: effects of most cleric and paladin prayers
 %A% =Elements=: the effects of fire (e.g. {hh625fireball{x), cold (e.g. {hh610chill touch{x), electricity/shock (e.g. {hh579lightning bolt{x), acid, energy, light, sound, water/drowning, and mental attacks.
@@ -270,7 +270,7 @@ Many creatures (mobs) in the world already have innate immunities or vulnerabili
 %A% =Иммунитет= иммун: удары этим типом воздействий не нанесут вообще {Wникакого{x урона, а заклинания полностью провалятся. Иммуны бывают очень редко.
 
 {CТИПЫ ВОЗДЕЙСТВИЙ{x
-%A% =Оружие=: большинство физических воздействий, наносящих "обычные" повреждения (например, уколы или тяжелые удары). Магическое оружие или {hh96флаги{x оружия имеют свои собственные типы воздействий -- обычно, элементальные.
+%A% =Оружие=: большинство физических воздействий, наносящих "обычные" повреждения. Оно делится на три типа, к которым можно получить отдельную сопротивляемость -- =дробящий= (тяжелые удары), =колющий= (уколы) и =рубящий= (порезы). Дробящий -- самый частый в мире, примерно вдвое чаще колющего или рубящего, так что сопротивляемость к нему пригодится чаще всего. Магическое оружие или {hh96флаги{x оружия имеют свои собственные типы воздействий -- обычно, элементальные.
 %A% =Магия=: эффекты боевой магии -- но не молитв
 %A% =Молитвы=: эффекты большинства молитв клериков и паладинов 
 %A% =Элементы=: эффекты воздействий элементов огня (например, {hh625шар огня{x), холода (например, {hh610ледяного касания{x), электричества/шока (например, {hh579молнии{x), кислоты, энергии, света, звука, воды/утопления, а также ментальных атак.
@@ -290,7 +290,7 @@ Many creatures (mobs) in the world already have innate immunities or vulnerabili
 %A% =Імунітет= імун: удари цим типом впливу не завдадуть узагалі {Wжодної{x шкоди, а заклинання повністю провалюються. Імуни бувають дуже рідко.
 
 {CТИПИ ВПЛИВІВ{x
-%A% =Зброя=: більшість фізичних впливів, що завдають "звичайних" ушкоджень (наприклад, уколи чи важкі удари). Магічна зброя або {hh96прапори{x зброї мають свої власні типи впливів -- зазвичай елементальні.
+%A% =Зброя=: більшість фізичних впливів, що завдають "звичайних" ушкоджень. Вона ділиться на три типи, до яких можна отримати окрему опірність -- =важкий удар= (дроблення), =прокол= (уколи) та =розсічення= (порізи). Важкий удар -- найпоширеніший у світі, приблизно вдвічі частіший за прокол чи розсічення, тож опірність до нього стане в пригоді найчастіше. Магічна зброя або {hh96прапори{x зброї мають свої власні типи впливів -- зазвичай елементальні.
 %A% =Магія=: ефекти бойової магії -- але не молитов
 %A% =Молитви=: ефекти більшості молитов кліриків і паладинів
 %A% =Елементи=: ефекти впливу вогню (наприклад, {hh625вогняної кулі{x), холоду (наприклад, {hh610льодяного дотику{x), електрики/шоку (наприклад, {hh579удару блискавки{x), кислоти, енергії, світла, звуку, води/утоплення, а також ментальних атак.


### PR DESCRIPTION
Adds the physical-damage sub-type breakdown to help 'damage types' (immort.xml node 101), all three languages.

- Names bash/pierce/slash as separately resistable physical sub-types (mechanic verified in `plug-ins/fight_core/immunity.cpp`, see DAMTYPE_MODEL.md section 1).
- States the frequency fact from DAMTYPE_MODEL.md section 5: bash is the most common physical damage in the world, ~2x pierce or slash, so resisting it protects most often.
- Text-only, no help-ID change (edits existing node) -> no collision risk. Hot-reloads via `plug reload most`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)