### PR TITLE
Capitalize gore death-cry names; add nexus haze translation

### DIFF
--- a/config/translations/global.json
+++ b/config/translations/global.json
@@ -31,11 +31,11 @@
    "ua": "Щось дуже важке з гуркотом падає десь неподалік."
   },
   "Отрубленная молодецким ударом голова %1$C2 падает тебе под ноги.": {
-   "en": "%1$C2's head, struck clean off, drops at your feet.",
+   "en": "%1$^C2's head, struck clean off, drops at your feet.",
    "ua": "Відтята хвацьким ударом голова %1$C2 падає тобі під ноги."
   },
   "Отрубленная молодецким ударом голова %1$C2 взлетает ввысь, бурно фонтанируя {1{Rкровью.{2": {
-   "en": "%1$C2's head, struck clean off, flies up high, fountaining {1{Rblood.{2",
+   "en": "%1$^C2's head, struck clean off, flies up high, fountaining {1{Rblood.{2",
    "ua": "Відтята хвацьким ударом голова %1$C2 злітає вгору, буйно фонтануючи {1{Rкров'ю.{2"
   },
   "Из разрубленного надвое тела %1$C2 выпадает все еще пульсирующее сердце.": {
@@ -43,11 +43,11 @@
    "ua": "З розрубаного навпіл тіла %1$C2 випадає все ще пульсуюче серце."
   },
   "Отсеченная последним ударом лапа %1$C2 падает рядом с телом.": {
-   "en": "%1$C2's paw, severed by that last blow, falls beside the body.",
+   "en": "%1$^C2's paw, severed by that last blow, falls beside the body.",
    "ua": "Відтята останнім ударом лапа %1$C2 падає поряд із тілом."
   },
   "Отсеченная последним ударом рука %1$C2 падает рядом с телом.": {
-   "en": "%1$C2's arm, severed by that last blow, falls beside the body.",
+   "en": "%1$^C2's arm, severed by that last blow, falls beside the body.",
    "ua": "Відтята останнім ударом рука %1$C2 падає поряд із тілом."
   },
   "Тело %1$C2 с перерубленными ногами валится как подкошенное.": {
@@ -67,35 +67,35 @@
    "ua": "З розрізаних грудей %1$C2 випадає все ще пульсуюче серце."
   },
   "Голова %1$C2 лопается от %2$N2, расплескивая мозги во все стороны.": {
-   "en": "%1$C2's head bursts, splattering brains in all directions.",
+   "en": "%1$^C2's head bursts, splattering brains in all directions.",
    "ua": "Голова %1$C2 лопається, розхлюпуючи мізки на всі боки."
   },
   "{1{CЗамороженная{2 лапа %1$C2 отваливается от тела.": {
-   "en": "%1$C2's {1{Cfrozen{2 paw drops away from the body.",
+   "en": "%1$^C2's {1{Cfrozen{2 paw drops away from the body.",
    "ua": "{1{CЗаморожена{2 лапа %1$C2 відвалюється від тіла."
   },
   "{1{CЗамороженная{2 рука %1$C2 отваливается от тела.": {
-   "en": "%1$C2's {1{Cfrozen{2 arm drops away from the body.",
+   "en": "%1$^C2's {1{Cfrozen{2 arm drops away from the body.",
    "ua": "{1{CЗаморожена{2 рука %1$C2 відвалюється від тіла."
   },
   "{1{CЗамороженная{2 нога %1$C2 отваливается от тела.": {
-   "en": "%1$C2's {1{Cfrozen{2 leg drops away from the body.",
+   "en": "%1$^C2's {1{Cfrozen{2 leg drops away from the body.",
    "ua": "{1{CЗаморожена{2 нога %1$C2 відвалюється від тіла."
   },
   "{1{cКровь{2 %1$C2, холодная как сердца разработчиков, окатывает тебя с головы до ног!": {
-   "en": "%1$C2's {1{cblood,{2 cold as a developer's heart, drenches you head to foot!",
+   "en": "%1$^C2's {1{cblood,{2 cold as a developer's heart, drenches you head to foot!",
    "ua": "{1{cКров{2 %1$C2, холодна як серця розробників, обдає тебе з голови до ніг!"
   },
   "{1{cКровь{2 %1$C2, холодная как сердца разработчиков, окатывает %2$C4 с головы до ног!": {
-   "en": "%1$C2's {1{cblood,{2 cold as a developer's heart, drenches %2$C4 head to foot!",
+   "en": "%1$^C2's {1{cblood,{2 cold as a developer's heart, drenches %2$C4 head to foot!",
    "ua": "{1{cКров{2 %1$C2, холодна як серця розробників, обдає %2$C4 з голови до ніг!"
   },
   "Горячая {1{Rкровь{2 %1$C2 окатывает тебя с головы до ног!": {
-   "en": "%1$C2's hot {1{Rblood{2 drenches you head to foot!",
+   "en": "%1$^C2's hot {1{Rblood{2 drenches you head to foot!",
    "ua": "Гаряча {1{Rкров{2 %1$C2 обдає тебе з голови до ніг!"
   },
   "Горячая {1{Rкровь{2 %1$C2 окатывает %2$C4 с головы до ног!": {
-   "en": "%1$C2's hot {1{Rblood{2 drenches %2$C4 head to foot!",
+   "en": "%1$^C2's hot {1{Rblood{2 drenches %2$C4 head to foot!",
    "ua": "Гаряча {1{Rкров{2 %1$C2 обдає %2$C4 з голови до ніг!"
   }
  },

--- a/config/translations/spell.json
+++ b/config/translations/spell.json
@@ -1,5 +1,9 @@
 {
  "spell/nexus/runVict": {
+  "Сквозь дымку портала проглядывается {1{W%s{2 в {1{Y%N6{2.": {
+   "en": "Through the portal's haze, you can make out {1{W%s{2 in {1{Y%N6{2.",
+   "ua": "Крізь серпанок порталу проглядається {1{W%s{2 у {1{Y%N6{2."
+  },
   "%^C3 удаётся избежать твоих транспортных чар.": {
    "en": "%^C3 manages to avoid your transportation magic.",
    "ua": "%^C3 вдається уникнути твоїх транспортних чарів."


### PR DESCRIPTION
global.json: 12 sentence-start EN dismember messages get the `^` capitalize marker (`%1$C2`→`%1$^C2`); mid-sentence ones untouched. spell.json: nexus haze line added so its newly-`._()`-wrapped template resolves EN/UA instead of falling back to Russian.

Reported via typo command by Dementia. Adversarial review: RELEASE, reviews/2026-08-31-transport-l10n-and-gore-capitalize-rereview.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)