### PR TITLE
remove fear: fix UA calque «позбавити від страху» → «позбавити страху»

### DIFF
--- a/generic-skills/remove fear.xml
+++ b/generic-skills/remove fear.xml
@@ -24,7 +24,7 @@
   <help id="2026" level="-1" type="SkillHelp">
     <keyword l="en">'remove fear'</keyword>
     <keyword l="ru">'избавить страх'</keyword>
-    <keyword l="ua">'позбавити страх'</keyword>
+    <keyword l="ua">'позбавити страху' 'позбавити від страху'</keyword>
     <text l="en">%FMT% *%SPELL%* _%VICT%_
 
 Allows removing the effect of the {hh740fear{x spell from the target.
@@ -35,7 +35,7 @@ Allows removing the effect of the {hh740fear{x spell from the target.
 </text>
     <text l="ua">%FMT% *%SPELL%* _%VICT%_
 
-Дозволяє позбавити ціль від дії заклинання {hh740страх{x.
+Дозволяє позбавити ціль дії заклинання {hh740страх{x.
 </text>
   </help>
   <mana>40</mana>
@@ -44,7 +44,7 @@ Allows removing the effect of the {hh740fear{x spell from the target.
   </mob>
   <name l="en">remove fear</name>
   <name l="ru">избавить от страха</name>
-  <name l="ua">позбавити від страху</name>
+  <name l="ua">позбавити страху</name>
   <spell type="DefaultSpell">
     <damtype>none</damtype>
     <flags>prayer</flags>


### PR DESCRIPTION
«позбавити» takes the genitive directly; «позбавити ВІД» is the RU «избавить ОТ» calque. Fixed the UA spell name + help government, and the keyword's own case bug — keeping **both** cast phrases (`'позбавити страху' 'позбавити від страху'`) so old casts still resolve. Debt card iNqDT5Ck (C1). The areas5.json onEquip echo the card mentioned doesn't exist (stale). RU untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)