### PR TITLE
arcadian brew: register temporary transmute affect

### DIFF
--- a/config/translations/affect.json
+++ b/config/translations/affect.json
@@ -1390,5 +1390,11 @@
    "en": "Your lips are cracked, and every breath scrapes your parched throat.",
    "ua": "Губи потріскались, і кожен вдих дряпає пересохле горло."
   }
+ },
+ "affect/arcadian brew/onRemoveObj": {
+  "Наваждение в %1$O6 рассеивается, и жидкость вновь становится обычной водой.": {
+   "en": "The glamour in %1$O6 dissipates, and the liquid turns back to ordinary water.",
+   "ua": "Мана в %1$O6 розсіюється, і рідина знову стає звичайною водою."
+  }
  }
 }

--- a/other-skills/arcadian brew.xml
+++ b/other-skills/arcadian brew.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<skill type="BasicSkill">
+  <affect type="DefaultAffectHandler"/>
+  <help id="5105" level="-1" type="SkillHelp" labels="items">
+    <keyword l="en">'arcadian brew'</keyword>
+    <keyword l="ru">'арканское варево'</keyword>
+    <keyword l="ua">'арканське вариво'</keyword>
+    <text l="en">An arcadian word of power can briefly transmute the plain water in a vessel or fountain into wine or beer. The enchantment is temporary: when it fades, the liquid returns to ordinary water.</text>
+    <text l="ru">Арканское слово силы может ненадолго превратить обычную воду в сосуде или фонтане в вино или пиво. Наваждение временно: когда оно спадает, жидкость вновь становится обычной водой.</text>
+    <text l="ua">Арканське слово сили може ненадовго перетворити звичайну воду в посудині чи фонтані на вино або пиво. Мана тимчасова: коли вона спадає, рідина знову стає звичайною водою.</text>
+  </help>
+  <name l="en">arcadian brew</name>
+  <name l="ru">арканское варево</name>
+  <name l="ua">арканське вариво</name>
+  <webColumn>none</webColumn>
+</skill>


### PR DESCRIPTION
New 'arcadian brew' affect type (other-skills, help 5105) + catalog, so water2wine/water2beer transmute a fountain/vessel TEMPORARILY (timed affect reverts to water) instead of permanently. Fixes 14090 + chy4nQ3D. fable RELEASE (round 2). Pairs with dreamland_fenia onRemoveObj + water2wine/beer rework.