### PR TITLE
arcadian brew: register the affect handler (non-empty affect)

### DIFF
--- a/other-skills/arcadian brew.xml
+++ b/other-skills/arcadian brew.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skill type="BasicSkill">
-  <affect type="DefaultAffectHandler"/>
+  <affect type="DefaultAffectHandler">
+    <removeObj>Наваждение в %1$O6 рассеивается, и жидкость вновь становится обычной водой.</removeObj>
+  </affect>
   <help id="5105" level="-1" type="SkillHelp" labels="items">
     <keyword l="en">'arcadian brew'</keyword>
     <keyword l="ru">'арканское варево'</keyword>


### PR DESCRIPTION
Empty <affect/> didn't register the handler; add <removeObj> (mirrors incandescent). Closes the deploy gap where onRemoveObj couldn't bind. Fixes 14090 follow-up.