### PR TITLE
l10n: catalog EN/UA for chocolate sniff + Wonka dance

### DIFF
--- a/config/translations/areas4.json
+++ b/config/translations/areas4.json
@@ -3103,6 +3103,30 @@
    "ua": "%^O1 випромінює п'янкий запах свіжого какао. Ммммм..."
   }
  },
+ "areas/chocolate.are/obj/50061.onSpec": {
+  "%^C1 внезапно поднимает нос по ветру.": {
+   "en": "%^C1 suddenly lifts their nose to the wind.",
+   "ua": "%^C1 раптом підіймає ніс за вітром."
+  },
+  "%^C1 блаженно улыбается.": {
+   "en": "%^C1 smiles blissfully.",
+   "ua": "%^C1 блаженно посміхається."
+  }
+ },
+ "areas/chocolate.are/mob/50001.onSocial dance": {
+  "Проходи, тут уже открыто.": {
+   "en": "Come on through, it's already open.",
+   "ua": "Проходь, тут уже відчинено."
+  },
+  "%^C1 с улыбкой распахивает перед тобой двери Фабрики.": {
+   "en": "%^C1 with a smile throws open the Factory doors before you.",
+   "ua": "%^C1 з усмішкою розчиняє перед тобою двері Фабрики."
+  },
+  "%^C1 с улыбкой распахивает двери перед %C5.": {
+   "en": "%^C1 with a smile throws open the doors before %C5.",
+   "ua": "%^C1 з усмішкою розчиняє двері перед %C5."
+  }
+ },
  "areas/ruler.are/mob/510.onGive stamp": {
   "%^C1 возвращает %^C3 %O4.": {
    "en": "%^C1 gives %O4 back to %^C3.",


### PR DESCRIPTION
EN/UA catalog entries for the two chocolate handlers fixed in dreamland_fenia#664 (obj 50061.onSpec sniff emotes; mob 50001.onSocial dance door reaction). Reported by Dementia (typo card AXqNSTVz). fable-reviewed (RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)