### PR TITLE
Write the where command help and open it to players

### DIFF
--- a/commands/where.xml
+++ b/commands/where.xml
@@ -4,7 +4,40 @@
   <aliases l="ua">тут</aliases>
   <cat>info</cat>
   <extra>keep_hide ghost</extra>
-  <help id="1009" level="102" type="CommandHelp">
+  <help id="1009" level="-1" type="CommandHelp" labels="world">
+    <extra l="en">nearby location 'who is here'</extra>
+    <extra l="ru">рядом местоположение 'кто здесь'</extra>
+    <extra l="ua">поруч місцезнаходження 'хто тут'</extra>
+    <text l="en">%FMT% *%CMD%*
+Shows the area you are currently in and lists the other players who share it, each with the room they are in, so you can see who is around without walking the whole zone.
+
+%FMT% *%CMD%* _name_
+Locates a particular player or creature within your area. The command searches only your current area, not the whole world, and will not reveal anyone who has hidden or turned invisible.
+
+In the {hh2133web client{x every room name in the listing is clickable and sends you along a {hh2170path{x straight to it.
+
+%SA% %H% {hh2170path{x
+</text>
+    <text l="ru">%FMT% *%CMD%*
+Показывает область, в которой ты сейчас находишься, и перечисляет других игроков в ней, у каждого -- комнату, где он стоит, чтобы ты видел, кто рядом, не обходя всю зону.
+
+%FMT% *%CMD%* _имя_
+Находит определенного игрока или существо в пределах твоей области. Команда ищет только в твоей текущей области, а не по всему миру, и не покажет тех, кто спрятался или стал невидимым.
+
+В {hh2133веб-клиенте{x каждое название комнаты в списке кликабельно и отправляет тебя к ней командой {hh2170путь{x.
+
+%SA% %H% {hh2170путь{x
+</text>
+    <text l="ua">%FMT% *%CMD%*
+Показує область, у якій ти зараз перебуваєш, і перелічує інших гравців у ній, у кожного -- кімнату, де він стоїть, щоб ти бачив, хто поруч, не обходячи всю зону.
+
+%FMT% *%CMD%* _імʼя_
+Знаходить певного гравця чи істоту в межах твоєї області. Команда шукає лише в твоїй поточній області, а не по всьому світу, і не покаже тих, хто сховався чи став невидимим.
+
+У {hh2133веб-клієнті{x кожна назва кімнати у списку клікабельна й відправляє тебе до неї командою {hh2170шлях{x.
+
+%SA% %H% {hh2170шлях{x
+</text>
   </help>
   <hint l="en">find out where you are and who is nearby</hint>
   <hint l="ru">узнать, где находишься, и кто рядом</hint>


### PR DESCRIPTION
help 1009 (where/где/де) was an empty CommandHelp stub at level 102 -- unreadable by players, and {hh1009 links were dead. Lowered to level -1, wrote the body in all three languages, added extra keywords + world label, cross-linked {hh2170path{x and {hh2133web client{x. Card qBhh06Bj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)