### PR TITLE
Add the missing Paths line to five god help articles

### DIFF
--- a/religions/bast.xml
+++ b/religions/bast.xml
@@ -12,6 +12,7 @@
 
 The goddess {hh969Bast{x loves all cats and protects them. Legend has it that those who dare to kill more than 50 felines in a lifetime will be struck by a terrible curse -- they will be hunted until rebirth by the ancient spirit of the feline =Avenger=...
 
+%A% =Paths:= {CFreedom{x
 %A% =Gifts:= Bast's mark will shield your tender skin (or fur) from fire, {x lend your movements {hh739feline swiftness{x. Bast will help a cat {x cornered, but if you dare to touch any creature of the feline family, {x her wrath will turn on you!
 %A% =Restrictions:= only {hh166felars{x, not allowed for {hh1494Hunters{x
 
@@ -21,6 +22,7 @@ The goddess {hh969Bast{x loves all cats and protects them. Legend has it that th
 
 Богиня {hh969Баст{x любит всех кошек и защищает их. По легенде на тех, кто посмеет убить более 50 кошачьих за жизнь, падет жуткое проклятие -- их станет до самого перерождения преследовать древний дух кошачьего =Мстителя=...
 
+%A% =Пути:= {CСвобода{x
 %A% =Дары:= знак Баст защитит твою нежную кожу (или шерстку) от огня, {x придаст твоим движениям {hh739кошачью быстроту{x. Баст поможет кошке, {x загнанной в угол, но если ты посмеешь тронуть любое существо семейства кошачьих, {x ее гнев обратится на тебя!
 %A% =Ограничения:= только {hh166фелары{x, нельзя {hh1494Охотникам{x
 
@@ -30,6 +32,7 @@ The goddess {hh969Bast{x loves all cats and protects them. Legend has it that th
 
 Богиня {hh969Баст{x любить усіх кішок і захищає їх. За легендою, на тих, хто насмілиться вбити більш ніж 50 котячих за життя, впаде жахливе прокляття -- їх аж до самого переродження переслідуватиме давній дух котячого =Месника=...
 
+%A% =Шляхи:= {CСвобода{x
 %A% =Дари:= знак Баст захистить твою ніжну шкіру (або хутро) від вогню, {x надасть твоїм рухам {hh739котячої спритності{x. Баст допоможе кішці, {x загнаній у куток, але якщо ти насмілишся торкнутись будь-якої істоти котячого роду, {x її гнів звернеться на тебе!
 %A% =Обмеження:= тільки {hh166фелари{x, не можна {hh1494Мисливцям{x
 

--- a/religions/erevan ilesere.xml
+++ b/religions/erevan ilesere.xml
@@ -10,6 +10,7 @@
 
 This is a completely unpredictable deity who changes his appearance at will -- so opinions on what he (it?) looks like differ wildly. Followers of Erevan's cult consider him a dark elf of male sex whose height varies from one inch to two meters. Erevan invariably wears at least one green article of clothing, and his symbol is a star with asymmetric rays.
 
+%A% =Paths:= {YSociety{x
 %A% =Gifts:= In battle the tattoo will {hh657heal{x you and {hh739speed{x you, and may douse your enemies with {hh746colorful sprays{x. Sometimes Erevan unexpectedly possesses you and strikes your enemy from behind.
 %A% =Sacrifices:= Erevan Ilesere likes offerings only from stolen goods. Of magical items he prefers those containing healing and haste spells.
 %A% =Restrictions:= not for the {hh30lawful{x
@@ -20,6 +21,7 @@ Learning anything about this cult from its mocking followers is rather difficult
 
 Это полностью непредсказуемое божество, меняющее свой внешний вид, как ему заблагорассудится -- поэтому мнения о том, как он (оно?) выглядит, сильно расходятся. Последователи культа Эревана считают его темным эльфом мужского пола, чей рост варьируется от одного дюйма до двух метров. Эреван неизменно носит как минимум один зеленый предмет одежды, а его символ -- звезда с ассиметричными лучами.
 
+%A% =Пути:= {YОбщество{x
 %A% =Дары:= В бою татуировка будет {hh657лечить{x тебя и {hh739ускорять{x, а противников может обдать {hh746цветными брызгами{x. Иногда Эреван неожиданно вселяется в тебя и исподтишка наносит удар твоему противнику.
 %A% =Жертвоприношения:= Эреван Илесир любит подношения исключительно из ворованых вещей. Из волшебных предметов предпочитает те, что содержат заклинания лечения и ускорения.
 %A% =Ограничения:= не для {hh30законопослушных{x
@@ -30,6 +32,7 @@ Learning anything about this cult from its mocking followers is rather difficult
 
 Це цілком непередбачуване божество, що змінює свій вигляд, як йому заманеться -- тому думки щодо того, як він (воно?) виглядає, дуже розходяться. Послідовники культу Еревана вважають його темним ельфом чоловічої статі, чий зріст варіюється від одного дюйма до двох метрів. Ереван незмінно носить принаймні один зелений предмет одягу, а його символ -- зірка з асиметричними променями.
 
+%A% =Шляхи:= {YСуспільство{x
 %A% =Дари:= У бою татуювання буде {hh657лікувати{x тебе і {hh739пришвидшувати{x, а противників може обдати {hh746барвистими бризками{x. Іноді Ереван несподівано вселяється в тебе і нишком завдає удару твоєму противнику.
 %A% =Жертвоприношення:= Ереван Ілесір любить підношення виключно з вкрадених речей. З чарівних предметів надає перевагу тим, що містять заклинання лікування і пришвидшення.
 %A% =Обмеження:= не для {hh30законослухняних{x

--- a/religions/godiva.xml
+++ b/religions/godiva.xml
@@ -13,18 +13,21 @@
     <keyword l="ua"></keyword>
     <text l="en">{CGodiva{x is the goddess of ancient legends and myths, keeper of secrets and the powerful mysteries of the past. Mortals know very little about this goddess. They say that at the dawn of the Third Epoch Godiva helped the terrible {hh1569Mephisto{x create the clan of {hh1500Phantoms{x and endowed its members with ancient knowledge of the anatomy of all races, the physics and chemistry of this world, as well as legends and lore about all the powerful {hh42artifacts{x, making the Phantoms invincible fighters and inevitable assassins.
 
+%A% =Paths:= {CFreedom{x
 %A% =Gifts:= the mark of Godiva will shroud your {hh1015equipment{x in a phantom veil, {x impenetrable to outside eyes, and grant a spectral aura to your blade, {x so that no one can {hh812disarm{x you
 
 %SA% %H% {hh81Eight Paths{x, {hh80epochs{x
 </text>
     <text l="ru">{CГодива{x -- богиня древних легенд и мифов, хранительница секретов и могущественных тайн прошлого. Про эту богиню смертным известно совсем немногое. Говорят, что на заре Третьей Эпохи Годива помогла ужасному {hh1569Мефисто{x создать клан {hh1500Призраков{x и наделила его членов древними знаниями об анатомии всех рас, физике и химии этого мира, а также легендами и преданиями обо всех могущественных {hh42артефактах{x, сделав Призраков непобедимыми бойцами и неотвратимыми убийцами.
 
+%A% =Пути:= {CСвобода{x
 %A% =Дары:= знак Годивы окутает твою {hh1015экипировку{x призрачным покрывалом, {x непроницаемым для посторонних глаз, и дарует призрачную ауру твоему клинку, {x чтобы никто не смог тебя {hh812обезоружить{x
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
     <text l="ua">{CГодіва{x -- богиня давніх легенд і міфів, охоронниця таємниць і могутніх загадок минулого. Смертним відомо зовсім небагато про цю богиню. Кажуть, що на зорі Третьої Епохи Годіва допомогла жахливому {hh1569Мефісто{x створити клан {hh1500Привидів{x та наділила його членів давніми знаннями про анатомію всіх рас, фізику та хімію цього світу, а також легендами й переказами про всі могутні {hh42артефакти{x, зробивши Привидів непереможними бійцями та невідворотними вбивцями.
 
+%A% =Шляхи:= {CСвобода{x
 %A% =Дари:= знак Годіви огорне твою {hh1015екіпіровку{x примарним покривалом, {x непроникним для сторонніх очей, і дарує примарну ауру твоєму клинку, {x щоб ніхто не зміг тебе {hh812роззброїти{x
 
 %SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x

--- a/religions/hera.xml
+++ b/religions/hera.xml
@@ -8,6 +8,7 @@
   <help id="970" level="-1" type="ReligionHelp">
     <text l="en">{CHera{x -- goddess of hatred and curses, blinding mortals with rage and poisoning them with jealousy and envy. Legend holds that Hera was not always this way, but the endless string of her husband Zeus's adulteries poisoned her soul with jealousy and malice. One of Hera's most terrible creations is her frenzied son {hh966Ares,{x god of war and bloodshed. Mortals and other gods return Hera's hatred in kind; followers of her cult are rare, and temples of Hera -- heraions -- are nearly gone across the breadth of {hh224Thera{x.
 
+%A% =Paths:= {CFreedom{x
 %A% =Gifts:= in battle Hera's mark will {hh548curse{x, {hh705slow{x, {hh831blind{x and infect your enemies with {hh614plague{x
 %A% =Restrictions:= {hh33non-good{x only
 %A% =Sacrifices:= Hera prefers magical items with curse-group spells. Of drinks, she likes wines best.
@@ -18,6 +19,7 @@ One of the last heraions has survived at the site of the cult's origin on Mount 
 </text>
     <text l="ru">{CГера{x -- богиня ненависти и проклятий, ослепляющая смертных гневом и отравляющая их ревностью и завистью. По легенде, Гера не всегда была такой, но бесконечная череда адюльтеров ее мужа, Зевса, отравила ее душу ревностью и злобой. Одно из самых страшных детищ Геры -- ее неистовый сын {hh966Арес,{x бог войны и кровопролития. Смертные и другие боги отвечают на ненависть Геры взаимностью, последователи ее культа редки, и храмов Геры, герейонов, на просторах {hh224Тэры{x почти не осталось.
 
+%A% =Пути:= {CСвобода{x
 %A% =Дары:= в бою знак Геры {hh548проклянет{x, {hh705замедлит{x, {hh831ослепит{x и заразит {hh614чумой{x твоих противников
 %A% =Ограничения:= только {hh33не-добрые{x
 %A% =Жертвоприношения:= Гера предпочитает волшебные предметы с заклинаниями группы проклятий. Из напитков больше всего любит вина.
@@ -28,6 +30,7 @@ One of the last heraions has survived at the site of the cult's origin on Mount 
 </text>
     <text l="ua">{CГера{x -- богиня ненависті і прокльонів, що засліплює смертних гнівом і отруює їх ревнощами та заздрістю. За легендою, Гера не завжди була такою, але нескінченна низка адюльтерів її чоловіка Зевса отруїла її душу ревнощами і злобою. Одне з найстрашніших породінь Гери -- її несамовитий син {hh966Арес,{x бог війни і кровопролиття. Смертні та інші боги відповідають на ненависть Гери взаємністю, послідовники її культу нечисленні, і храмів Гери -- гереонів -- на просторах {hh224Тери{x майже не залишилося.
 
+%A% =Шляхи:= {CСвобода{x
 %A% =Дари:= у бою знак Гери {hh548проклене{x, {hh705сповільнить{x, {hh831осліпить{x і заразить {hh614чумою{x твоїх противників
 %A% =Обмеження:= тільки {hh33недобрі{x
 %A% =Жертвоприношення:= Гера надає перевагу чарівним предметам із заклинаннями групи прокльонів. З напоїв найбільше любить вина.

--- a/religions/karmina.xml
+++ b/religions/karmina.xml
@@ -10,6 +10,7 @@
     <keyword l="ua"></keyword>
     <text l="en">{CKarmina{x is the bloodthirsty goddess-patron of the ancient order of {hh144vampires{x. Few mortals have survived an encounter with her; only one description from an ancient chronicle survives: "I see a skinny, flat-nosed, bald girl with a strange expression on her face. Clear blue eyes peer from under a high forehead adorned with a strange scar. She smiles, and I catch a glint on her even, slightly pointed fangs. The tattered shroud she is wrapped in is stained with dirt and blood all mixed together. And then she suddenly stretches out her arm, gives me the fig and runs off laughing. Or rather rides off... on skis?!?!"
 
+%A% =Paths:= {CFreedom{x
 %A% =Gifts:= the mark of Karmina will increase damage in vampire {hh836form{x, sate the {hh539thirst for blood{x and increase damage from the {hh552bone dagger{x, and will also allow you to sometimes drain blood for pure pleasure
 %A% =Restrictions:= only {hh144vampires{x
 
@@ -17,6 +18,7 @@
 </text>
     <text l="ru">{CКармина{x -- кровожадная богиня-покровительница древнего сословия {hh144вампиров{x. Мало кто из смертных выжил после встречи с ней, сохранилось лишь одно описание из древней летописи: "Я вижу худенькую, плосконосую и лысую девочку со странным выражением лица. Ясные голубые глаза глядят из-под высокого лба, на котором красуется странный шрам. Она улыбается, и я замечаю блик на ее ровных, слегка заостренных клыках. Рваный саван, в который она замотана, испачкан грязью и кровью вперемешку. И тут она внезапно вытягивает руку, показывает мне фигу и хохоча убегает. Точнее уезжает... на лыжах?!?!"
 
+%A% =Пути:= {CСвобода{x
 %A% =Дары:= знак Кармины усилит урон в {hh836форме{x вампира, утолит {hh539жажду крови{x и увеличит повреждения от {hh552костяного кинжала{x, а также позволит иногда сосать кровь ради чистого удовольствия
 %A% =Ограничения:= только {hh144вампиры{x
 
@@ -24,6 +26,7 @@
 </text>
     <text l="ua">{CКарміна{x -- кровожерлива богиня-покровителька давнього стану {hh144вампірів{x. Мало хто зі смертних вижив після зустрічі з нею; збереглося лише один опис із давнього літопису: "Я бачу худеньку, плосконосу і лису дівчинку зі дивним виразом обличчя. Ясні блакитні очі дивляться з-під високого чола, на якому красується дивний шрам. Вона посміхається, і я помічаю відблиск на її рівних, злегка загострених іклах. Драний саван, у який вона загорнута, заплямований брудом і кровʼю вперемішку. І тут вона раптово простягає руку, показує мені дулю та реготом тікає. Точніше відʼїжджає... на лижах?!?!"
 
+%A% =Шляхи:= {CСвобода{x
 %A% =Дари:= знак Карміни посилить шкоду в {hh836формі{x вампіра, вгамує {hh539спрагу крові{x та збільшить ушкодження від {hh552кістяного кинджала{x, а також дозволить іноді ссати кров заради чистого задоволення
 %A% =Обмеження:= тільки {hh144вампіри{x
 


### PR DESCRIPTION
Hera, Karmina, Bast, Godiva, Erevan Ilesere were missing the `%A% =Paths:=` line other gods have. Values from the engine (.tmp.religion.isPathX): Hera/Karmina/Bast/Godiva -> Freedom (isPathFreedom); Erevan Ilesere -> Society (isPathSociety, matches Athena). All three languages. Reported by Imlik, card 5qymL4oi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)