### PR TITLE
Document service advice (gear sage) and #autobuff

### DIFF
--- a/behaviors/sage.xml
+++ b/behaviors/sage.xml
@@ -17,6 +17,9 @@ Same as the {hh603identify{x spell, shows all the item's stats.
 
 %FMT% *service* *locator* _string_
 Same as the {hh707locator{x spell, shows the locations of all items that have that string in their keywords.
+
+%FMT% *service* *advice* _slot_
+Weighs everything you wear against the best you could realistically obtain for your level and class and tells you in a single figure how well equipped you are, names your weakest slots, and points to who carries a better item and where to look. It costs {C50 quest points{x, charged only when the sage actually has advice to give. Add a _slot_ to appraise just one wear spot, mindful of paired slots and a second weapon in hand. A companion to the {hh65item search{x on the website.
 </text>
     <text l="ru">По всему миру можно найти =мудрецов=, которые предоставляют {hh275платные услуги{x по {hh603опознанию{x и поиску предметов -- например, Отто в Мидгаарде.
 
@@ -25,6 +28,9 @@ Same as the {hh707locator{x spell, shows the locations of all items that have th
 
 %FMT% *услуга* *локатор* _строка_
 Аналогично заклинанию {hh707локатора{x, показывает местонахождения всех вещей, которые имеют эту строку в ключевых словах.
+
+%FMT% *услуга* *совет* _слот_
+Взвешивает все, что на тебе надето, против лучшего, что ты реально можешь добыть на своем уровне и классе, и говорит одним числом, насколько хорошо ты снаряжен, называет самые слабые слоты и подсказывает, у кого вещь получше и где ее искать. Стоит {C50 очков квестов{x, и только когда мудрецу действительно есть что посоветовать. Добавь _слот_, чтобы оценить одну ячейку снаряжения, с оглядкой на парные слоты и второе оружие в руке. Дополняет {hh65поиск предметов{x на сайте.
 </text>
     <text l="ua">По всьому світу можна знайти =мудреців=, які надають {hh275платні послуги{x з {hh603ідентифікації{x та пошуку предметів -- наприклад, Отто в Мідгаарді.
 
@@ -33,6 +39,9 @@ Same as the {hh707locator{x spell, shows the locations of all items that have th
 
 %FMT% *послуга* *локатор* _рядок_
 Аналогічно заклинанню {hh707локатора{x, показує місцезнаходження всіх речей, які мають цей рядок у ключових словах.
+
+%FMT% *послуга* *порада* _слот_
+Зважує все, що на тобі надіто, проти найкращого, що ти реально можеш здобути на своєму рівні й класі, і каже одним числом, наскільки добре ти споряджений, називає найслабші слоти й підказує, у кого річ краща і де її шукати. Коштує {C50 очок квестів{x, і лише коли мудрецю справді є що порадити. Додай _слот_, щоб оцінити одну комірку спорядження, з оглядом на парні слоти й другу зброю в руці. Доповнює {hh65пошук предметів{x на сайті.
 </text>
     <title l="en">{CPaid services: {xsages</title>
     <title l="ru">{CПлатные услуги: {xмудрецы</title>

--- a/helps/help.xml
+++ b/helps/help.xml
@@ -3510,6 +3510,7 @@ Some items can be {hh1024picked up{x, while others cannot be moved at all. Items
 
 To find out where to get good items, you can use the =search tool= on the website:
 %A% {y{hlhttps://dreamland.rocks/searcher.html{x
+Or ask any {hh276sage{x in the world for {yservice advice{x -- it appraises the gear you wear and tells you which slots to upgrade next.
 
 {CITEM TYPES{x
 Items come in many types. You can find out an item's type using {hh603identify{x.
@@ -3539,6 +3540,7 @@ Items come in many types. You can find out an item's type using {hh603identify{x
 
 Чтобы узнать, где взять хорошие предметы, можно использовать =поисковик= на сайте:
 %A% {y{hlhttps://dreamland.rocks/searcher.html{x
+Или попроси у любого {hh276мудреца{x в мире {yуслугу совет{x -- он оценит твое снаряжение и подскажет, какие слоты пора улучшить.
 
 {CТИПЫ ПРЕДМЕТОВ{x
 Предметы бывают многих типов. Узнать тип предмета можно с помощью {hh603опознания{x.
@@ -3568,6 +3570,7 @@ Items come in many types. You can find out an item's type using {hh603identify{x
 
 Щоб дізнатися, де взяти хороші предмети, можна скористатися =пошуковиком= на сайті:
 %A% {y{hlhttps://dreamland.rocks/searcher.html{x
+Або попроси в будь-якого {hh276мудреця{x у світі {yпослугу порада{x -- він оцінить спорядження, що на тобі, і підкаже, які слоти пора покращити.
 
 {CТИПИ ПРЕДМЕТІВ{x
 Предмети бувають різних типів. Дізнатися тип предмета можна за допомогою {hh603розпізнавання{x.
@@ -4288,6 +4291,7 @@ It is also recommended to disable colours:
 
 The web client has several special internal commands for conveniently setting up hotkeys and so on.
 %FMT% *#help* -- shows help on the internal commands of the web client
+%FMT% *#autobuff* -- casts your useful buffs on yourself, one by one (also the autobuff button and the ~ key)
 
 {CSCREEN READER MODE{x
 For visually impaired players there is a special mode: type {hc{yhelp screenreader{x.
@@ -4323,6 +4327,7 @@ Enables or disables sending a special character sequence (telnet go ahead) after
 
 В веб-клиенте есть несколько специальных внутренних команд, чтобы удобнее настраивать быстрые клавиши и т.п.
 %FMT% *#help* -- выводит справку по внутренним командам веб-клиента
+%FMT% *#autobuff* -- сам накладывает на тебя полезные бафы, по очереди (также кнопка автобаф и клавиша ~)
 
 {CРЕЖИМ ДЛЯ НЕЗРЯЧИХ{x
 Для незрячих игроков есть специальный режим: набери {hc{yсправка скринридер{x.
@@ -4358,6 +4363,7 @@ Enables or disables sending a special character sequence (telnet go ahead) after
 
 У веб-клієнті є кілька спеціальних внутрішніх команд, щоб зручніше налаштовувати гарячі клавіші тощо.
 %FMT% *#help* -- виводить довідку по внутрішніх командах веб-клієнта
+%FMT% *#autobuff* -- сам накладає на тебе корисні бафи, по черзі (також кнопка автобаф і клавіша ~)
 
 {CРЕЖИМ ДЛЯ НЕЗРЯЧИХ{x
 Для незрячих гравців є спеціальний режим: набери {hc{yдовідка скринридер{x.


### PR DESCRIPTION
Help support for the gear-sage + autobuff change: sage 276 gains the service advice block (3 langs, 50qp), items 65 cross-links it next to the website searcher, web-client 2133 documents #autobuff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)