### PR TITLE
Catalog EN/UA for the container contents hint (idea 23111)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -6829,6 +6829,14 @@
   "Посмотреть, что сверху: {y{hcизучить %1$s{x.": {
    "en": "To see what is on it: {y{hcexamine %1$s{x.",
    "ua": "Подивитися, що зверху: {y{hcвивчити %1$s{x."
+  },
+  "Сверху что-то лежит, посмотреть: {y{hcизучить %1$s{x.": {
+   "en": "Something is on top, to see it: {y{hcexamine %1$s{x.",
+   "ua": "Зверху щось лежить, подивитися: {y{hcвивчити %1$s{x."
+  },
+  "Внутри что-то есть, заглянуть: {y{hcизучить %1$s{x.": {
+   "en": "There is something inside, to see it: {y{hcexamine %1$s{x.",
+   "ua": "Всередині щось є, зазирнути: {y{hcвивчити %1$s{x."
   }
  },
  "plug-ins/comm/move.cpp": {


### PR DESCRIPTION
Paired with dreamland_code #1117. Two new `plug-ins/comm/look.cpp` catalog entries (EN/UA) for the 'something inside/on top' container hints. Reboot-gated with the code side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)