### PR TITLE
Catalog the autoquest client markers under questtargets.cpp

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -15402,6 +15402,18 @@
   }
  },
  "plug-ins/quest/core/questtargets.cpp": {
+  "{x({YХныкает{x) ": {
+   "en": "{x({YWhimpering{x) ",
+   "ua": "{x({YСкиглить{x) "
+  },
+  "{x({YЖдет кого-то{x) ": {
+   "en": "{x({YWaiting for someone{x) ",
+   "ua": "{x({YЧекає когось{x) "
+  },
+  "{x({YТерпеливо ждет{x) ": {
+   "en": "{x({YWaiting patiently{x) ",
+   "ua": "{x({YТерпляче чекає{x) "
+  },
   "{R[ЦЕЛЬ] {x": {
    "en": "{R[TARGET] {x",
    "ua": "{R[ЦІЛЬ] {x"


### PR DESCRIPTION
l10n leak found in playtest (Dementia, EN): the autoquest client waiting-marker rendered Russian '(Ждет кого-то)' on the EN path. Root cause: the live Fenia quest path emits the marker from `plug-ins/quest/core/questtargets.cpp`, but the catalog only had these strings keyed under the legacy `*quest/mobiles.cpp` files -> RU fallback. Adds the 3 marker strings under questtargets.cpp (EN/UA copied from the legacy entries). Reboot-gated (catalog loads at boot). Part of the quest system's move to Fenia (legacy C++ retirement to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)