### PR TITLE
Buff myrvale noriva + shevale reykaris set bonuses

### DIFF
--- a/behaviors/set myrvale noriva.xml
+++ b/behaviors/set myrvale noriva.xml
@@ -12,8 +12,18 @@
 </props>
   <affects>
     <node>
-      <apply to="slevel">3</apply>
+      <apply to="slevel">4</apply>
       <bits table="res_flags">weapon spell</bits>
+    </node>
+    <node>
+      <apply to="hit">75</apply>
+      <bits table="affect_flags">regeneration</bits>
+    </node>
+    <node>
+      <apply to="saves">-10</apply>
+    </node>
+    <node>
+      <apply to="beats">-5</apply>
     </node>
   </affects>
   <target>obj</target>

--- a/behaviors/set shevale reykaris.xml
+++ b/behaviors/set shevale reykaris.xml
@@ -12,8 +12,17 @@
 </props>
   <affects>
     <node>
-      <apply to="slevel">3</apply>
+      <apply to="slevel">4</apply>
       <bits table="res_flags">weapon spell</bits>
+    </node>
+    <node>
+      <apply to="hit">75</apply>
+    </node>
+    <node>
+      <apply to="saves">-10</apply>
+    </node>
+    <node>
+      <apply to="beats">-5</apply>
     </node>
   </affects>
   <target>obj</target>

--- a/other-skills/set myrvale noriva.xml
+++ b/other-skills/set myrvale noriva.xml
@@ -13,7 +13,7 @@
     <keyword l="ua"></keyword>
     <text l="en">Mir'vale Noriva is one of the three junior houses inhabiting the island of {hh1431Drakiri{x. Members of this house specialize in the healing arts and also take an interest in botany. Their symbol is an open hand above a burning ring. House Noriva is responsible for training and instructing the healers of Drakiri.
 
-The clothing set of this house is available to the cleric class. When all items are assembled together, the cleric gains protection from weapons and spells, and his prayers acquire exceptional power.
+The clothing set of this house is available to the cleric class. When all items are assembled together, the cleric gains protection from weapons and spells, wards against hostile magic, and his prayers grow swifter and more powerful. The living warmth of the house keeps his wounds ever closing, and in the thick of battle its sign may flare -- a hand over a burning ring -- and mend him.
 
 Set level: 78 Number of items: 12
 
@@ -21,7 +21,7 @@ Set level: 78 Number of items: 12
 </text>
     <text l="ru">Мир'вейл Норива -- один из трех младших домов, населяющих остров {hh1431Дракири{x. Члены этого дома специализируются в лекарском искусстве, а также интересуются ботаникой. Их символ -- открытая рука над пылающим кольцом. Дом Норива отвечает за обучение и тренировку лекарей Дракири.
 
-Комплект одежды этого дома доступен классу клериков. Когда все предметы собраны воедино, клерик получает защиту от оружия и заклинаний, а его молитвы приобретают особую силу.
+Комплект одежды этого дома доступен классу клериков. Когда все предметы собраны воедино, клирик получает защиту от оружия и заклинаний, оберег от враждебной магии, а его молитвы становятся быстрее и сильнее. Живое тепло дома не дает его ранам открыться, а в разгар битвы знак дома -- ладонь над пылающим кольцом -- может вспыхнуть и исцелить его.
 
 Уровень комплекта: 78 Количество предметов: 12
 
@@ -29,7 +29,7 @@ Set level: 78 Number of items: 12
 </text>
     <text l="ua">Мірʼвейл Норіва -- один з трьох молодших домів, що населяють острів {hh1431Дракірі{x. Члени цього дому спеціалізуються на лікарському мистецтві, а також цікавляться ботанікою. Їхній символ -- відкрита долоня над палаючим кільцем. Дім Норіва відповідає за навчання та тренування лікарів Дракірі.
 
-Комплект одягу цього дому доступний класу кліриків. Коли всі предмети зібрані докупи, клерик отримує захист від зброї та заклинань, а його молитви набувають особливої сили.
+Комплект одягу цього дому доступний класу кліриків. Коли всі предмети зібрані докупи, клірик отримує захист від зброї та заклинань, оберіг від ворожої магії, а його молитви стають швидшими й сильнішими. Живе тепло дому не дає його ранам відкритися, а в розпал битви знак дому -- долоня над палаючим кільцем -- може спалахнути й зцілити його.
 
 Рівень комплекту: 78 Кількість предметів: 12
 

--- a/other-skills/set shevale reykaris.xml
+++ b/other-skills/set shevale reykaris.xml
@@ -10,7 +10,7 @@
     <keyword l="ua"></keyword>
     <text l="en">Shi'vale Reykaris is one of the three elder houses inhabiting the island of {hh1431Drakiri{x. This house specializes in dark magic and necromancy. The symbol of Reykaris is a humanoid skull with eye sockets blazing with fire.
 
-The Reykaris house set is available to the necromancer class. When all items are assembled together, the necromancer gains protection from weapons and spells, and his spells acquire exceptional power.
+The Reykaris house set is available to the necromancer class. When all items are assembled together, the necromancer gains protection from weapons and spells, wards against hostile magic, and his spells grow swifter and more powerful.
 
 Set level: 85 Number of items: 9
 
@@ -18,7 +18,7 @@ Set level: 85 Number of items: 9
 </text>
     <text l="ru">Ши'вейл Рейкарис -- один из трех старших домов, населяющих остров {hh1431Дракири{x. Этот дом специализируется в темной магии и некромантии. Символ Рейкарис -- череп гуманоида с пылающими огнем глазницами.
 
-Комплект одежд дома Рейкарис доступен классу некромантов. Когда все предметы собраны воедино, некромант получает защиту от оружия и заклинаний, а его заклинания приобретают особую силу.
+Комплект одежд дома Рейкарис доступен классу некромантов. Когда все предметы собраны воедино, некромант получает защиту от оружия и заклинаний, оберег от враждебной магии, а его заклинания становятся быстрее и сильнее.
 
 Уровень комплекта: 85 Количество предметов: 9
 
@@ -26,7 +26,7 @@ Set level: 85 Number of items: 9
 </text>
     <text l="ua">Шіʼвейл Рейкаріс -- один з трьох старших домів, що населяють острів {hh1431Дракірі{x. Цей дім спеціалізується на темній магії та некромантії. Символ Рейкаріс -- череп гуманоїда з палаючими вогнем очницями.
 
-Комплект одягу дому Рейкаріс доступний класу некромантів. Коли всі предмети зібрані докупи, некромант отримує захист від зброї та заклинань, а його заклинання набувають особливої сили.
+Комплект одягу дому Рейкаріс доступний класу некромантів. Коли всі предмети зібрані докупи, некромант отримує захист від зброї та заклинань, оберіг від ворожої магії, а його заклинання стають швидшими й сильнішими.
 
 Рівень комплекту: 85 Кількість предметів: 9
 


### PR DESCRIPTION
Completion-bonus buff for the two drakyri house sets (slevel 3->4, saves -10, beats -5, hit +75; Noriva also gets regeneration). Closes ~half the gap to an artifact kit without a per-piece arms race. Help updated x3 langs. Designed on fable (`reviews/2026-09-03-noriva-set-buff.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)