### PR TITLE
tune(gear-advisor): raise combatcast proc _global 1.0 -> 10.0

### DIFF
--- a/fight/spell_combat_value.json
+++ b/fight/spell_combat_value.json
@@ -1,7 +1,7 @@
 {
   "_doc": "Relative combat value per spell for the gear advisor's proc scorer (service advice). Items that cast an offensive/heal/buff spell in combat declare <props>combatcast</props>; ga_score computes procScore = SUM over casts of value(spell) * chance/100 * count * (itemLevel/_level_ref) * _global, and it supersedes the flat +50 for proc items. Value covers dealing damage AND negating the opponent's (a self-heal is effective DPS in attrition; heals already carry a 0.75 over-heal discount). Keys starting with _ are knobs/meta, not spells. _global scales procs vs stats; _level_ref is the item level that scores at 1.0x (higher-level procs cast harder). Both are Kit-tuned live on Dementia. See COMBAT_PROC_SCORING.md.",
 
-  "_global": 1.0,
+  "_global": 10.0,
   "_level_ref": 50.0,
 
   "harm": 90,


### PR DESCRIPTION
Raises the combatcast proc scorer's `_global` from 1.0 to 10.0 so proc value matches real per-round DPS now that procs actually fire (code#1128). Calibrated in melee-damroll currency (dr weight 12) against demonfire@10% (was 6.56, target ~72) and fireball@15% armbands (~116); both converge to global ~11, set 10 conservatively. Per-spell value table + `_level_ref` unchanged. Full 71-entry item scan sane (top ~147, no runaway). Boot-loaded config -- rides the code#1128 reboot so scorer and firing land together. Number is boot-tunable; validate live on Dementia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku