### PR TITLE
Number the EN missile-dodge victim template so it stops throwing

### DIFF
--- a/config/translations/utils.json
+++ b/config/translations/utils.json
@@ -1287,7 +1287,7 @@
    "ua": "Ти різко викидаєш руку убік і дивом ловиш %O4 %C2 на льоту!"
   },
   "Ты чудом уворачиваешься, и %s %C2 пролетает мимо!": {
-   "en": "You dodge by sheer miracle, and %C2's %s flies right past you!",
+   "en": "You dodge by sheer miracle, and %2$C2's %1$s flies right past you!",
    "ua": "Ти дивом ухиляєшся, і %s %C2 пролітає повз!"
   },
   "%1$^O1 пада%1$nет|ют %2$s в районе {g%3$s{x.": {


### PR DESCRIPTION
Unnumbered reversed EN template made an EN victim's dodge throw (no message). Number it %2$C2's %1$s. RU/UA unaffected. Surfaced by the l10n dodge fix. Typos card AXqNSTVz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)