### PR TITLE
combat-proc value: deafen 20 -> 30

### DIFF
--- a/fight/spell_combat_value.json
+++ b/fight/spell_combat_value.json
@@ -34,7 +34,7 @@
   "web": 20,
   "entangle": 20,
   "confuse": 20,
-  "deafen": 20,
+  "deafen": 30,
   "fear": 15,
   "calm": 15,
   "faerie fire": 15,


### PR DESCRIPTION
deafen = 50% cast-fail (magic.cpp:274 / ccast.cpp:233): great vs casters, near-zero vs melee. A flat per-spell weight can't condition on target, so 20 (peer with web/entangle/confuse) underpriced the caster case. Bumped to 30 to peer with slow/mind wrench. Not pushed to nuke tier -- it stays a target-conditional debuff.