### PR TITLE
Rewrite "Services and favours of the gods" help (node 11)

### DIFF
--- a/helps/help.xml
+++ b/helps/help.xml
@@ -81,68 +81,29 @@ And read help often: just type {y?{x followed by any topic you're curious about.
     <keyword l="en">favors god</keyword>
     <keyword l="ru">божественные услуги</keyword>
     <keyword l="ua">божественні послуги</keyword>
-    <text l="en">Sometimes the gods may take pity and do you a {Cfavour{x. Favours cannot be demanded, only requested. The gods may grant them -- or refuse. {hh92Respect{x the gods and express your requests within the framework of your character's {hh31roleplay{x -- that will make it much easier for the gods to agree to help you. By the way, the gods have their own {hh81roleplay{x too -- sometimes when one god refuses, another may agree.
+    <text l="en">Once, a god might take pity and grant you a personal =favour= -- a teleport to your {hh12corpse{x, a lift to where you needed to be, the renaming of a complex item, or a home built to your blueprints. Favours were always at the gods' discretion: you could never demand one, only ask.
 
-If your request is granted, in return the gods will usually ask a price -- sometimes in {hh125quest points{x, sometimes in something else at their discretion.
+Right now almost no active {hh92Immortals{x remain, and there is simply no one to grant personal favours. So don't count on them -- at present they are not rendered at all.
 
-{CTELEPORT AND CORPSE RETRIEVAL{x
-The gods possess the ability to transport one or more characters to any location in the world. They may do so at their own pleasure, but in rare cases they can be asked for it -- for example, if you urgently need to get somewhere. Likewise, the gods can teleport you to your {hh12corpse{x or, conversely, bring the corpse to you. Whether the gods agree and what you will pay depends on your motivation -- why do you need it?
+Everything the gods once did by hand we are steadily turning into automatic =services= that run on their own, with no living god behind them. Until that rework is finished, some services may be temporarily unavailable.
 
-Typical prices for these services are: corpse retrieval: {C500 qp{x teleport: {C200 qp{x
-
-{CITEMS, CONSTRUCTION{x
-The gods can rename particularly complex items for you: see {y{hchelp restring{x. This will cost {C50 qp{x + a restring coupon.
-
-The gods can create a personal chest for you -- or even build an entire mansion to your blueprints. See {y{hchelp construction{hx{x for details.
-
-A chest costs {C800 qp{x and can be placed in a location suitable for habitation -- such as barracks, houses, caves and the like. It cannot be placed in an open field or a forest.
-
-{CPERSONAL QUESTS{x
-In bygone {hh80epochs{x the Immortals would occasionally select worthy players to burden them with a =personal quest= -- challenging, but with an enviable reward upon completion. In the current epoch there are very few Gods left, and there is no longer time for personal quests. Want to help? We would be glad to consider candidates who are responsible and highly experienced players for the role of {hh92Junior Immortals{x. {hh66Write to us{x if you are interested.
-
-%SA% %H% {hh2clan prices{x, {hh50construction prices{x
+Want to help? We are short of gods. We would be glad to consider responsible, highly experienced players for the role of {hh92Junior Immortals{x. {hh66Write to us{x if you are interested.
 </text>
-    <text l="ru">Иногда боги могут смилостивиться и оказать тебе какую-то {Cуслугу{x. Услуги нельзя требовать, но можно просить. Боги могут оказать ее, а могут и отказаться. {hh92Уважай{x богов и выражай свои просьбы в рамках {hh31отыгрыша{x своего персонажа -- тогда богам будет гораздо проще согласиться тебе помочь. Кстати, у богов тоже свой {hh81отыгрыш{x -- иногда, когда кто-то из богов откажется, другие могут согласиться.
+    <text l="ru">Раньше боги могли смилостивиться и оказать тебе личную =милость=: телепортировать к {hh12трупу{x, перенести в нужное место, переименовать сложную вещь или отстроить жилье по твоим чертежам. Милости всегда были на усмотрение богов -- их нельзя было требовать, можно было только просить.
 
-Если твоя просьба все же будет выполнена, взамен боги обычно возьмут с тебя плату -- иногда {hh125квестовыми очками{x, а иногда и чем-нибудь еще на их усмотрение.
+Сейчас активных {hh92Бессмертных{x почти не осталось, и оказывать личные милости попросту некому. Так что рассчитывать на них не стоит -- сейчас они не оказываются вовсе.
 
-{CТЕЛЕПОРТ И ТРУПОПРИНОШЕНИЕ{x
-Боги владеют способностью переносить одного или нескольких персонажей в любое место мира. Они могут сделать это когда им это заблагорассудится, но в редких случаях их можно об этом попросить -- например, если тебе нужно ну очень срочно куда-то попасть. Аналогично, боги могут телепортировать тебя к {hh12трупу{x или, наоборот, принести труп к тебе. Согласятся ли боги тебе помочь и чем за это придется заплатить будет зависит от твоей мотивации -- зачем тебе это нужно?
+Все, что раньше боги делали своими руками, мы постепенно переводим в автоматические =услуги=, которые работают сами, без живого бога за спиной. Пока эта переделка не закончена, часть услуг может быть временно недоступна.
 
-Обычно цены на эти услуги такие: трупоприношение : {C500 qp{x телепорт : {C200 qp{x
-
-{CВЕЩИ, СТРОИТЕЛЬСТВО{x
-Боги могут переименовать для тебя особо сложные предметы: см. {y{hcсправка рестринг{x Обойдется это в {C50 qp{x + рестринг купон.
-
-Боги могут создать для тебя персональный сундук -- или даже отстроить целый особняк по твоим чертежам. Подробности смотри в {y{hcсправка строительство{hx{x.
-
-Сундук стоит {C800 qp{x и может ставится в место, которое пригодное для жизни, например, казармы, дома, пещеры и т.п. В чистом поле и в лесу ставить нельзя.
-
-{CПЕРСОНАЛЬНЫЕ КВЕСТЫ{x
-В былые {hh80эпохи{x Бессмертные изредка выбирали достойных игроков, чтобы озадачить их =персональным заданием= -- сложным, но с завидной наградой за выполнение. В текущей эпохе Богов осталось очень мало, и времени на персональные квесты уже не хватает. Хочешь помочь? Мы будем рады рассмотреть кандидатуры ответственных и очень опытных игроков на роль {hh92Младших Бессмертных{x. {hh66Напиши нам{x, если интересно.
-
-%SA% %H% {hh2клановые цены{x, {hh50цены на строительство{x
+Хочешь помочь? Нам не хватает богов. Мы будем рады рассмотреть ответственных и очень опытных игроков на роль {hh92Младших Бессмертных{x. {hh66Напиши нам{x, если интересно.
 </text>
-    <text l="ua">Іноді боги можуть змилуватися і надати тобі якусь {Cпослугу{x. Послуг не можна вимагати, але можна просити. Боги можуть її надати -- а можуть і відмовити. {hh92Поважай{x богів і виражай свої прохання в рамках {hh31відіграшу{x свого персонажа -- тоді богам буде набагато простіше погодитися тобі допомогти. До речі, у богів теж є свій {hh81відіграш{x -- іноді, коли хтось із богів відмовить, інші можуть погодитися.
+    <text l="ua">Раніше боги могли змилуватися і надати тобі особисту =милість=: телепортувати до {hh12трупа{x, перенести в потрібне місце, перейменувати складну річ або відбудувати житло за твоїми кресленнями. Милості завжди були на розсуд богів -- їх не можна було вимагати, можна було тільки просити.
 
-Якщо твоє прохання все ж буде виконане, натомість боги зазвичай возьмуть із тебе плату -- іноді {hh125квестовими очками{x, а іноді й чимось іншим на їхній розсуд.
+Зараз активних {hh92Безсмертних{x майже не залишилося, і надавати особисті милості просто нікому. Тож розраховувати на них не варто -- зараз їх не надають зовсім.
 
-{CТЕЛЕПОРТ І ТРУПОПРИНОШЕННЯ{x
-Боги мають здатність переносити одного або кількох персонажів у будь-яке місце світу. Вони можуть зробити це коли їм заманеться, але в рідкісних випадках їх можна про це попросити -- наприклад, якщо тобі конче потрібно кудись потрапити. Аналогічно, боги можуть телепортувати тебе до {hh12трупа{x або, навпаки, принести труп до тебе. Чи погодяться боги тобі допомогти і чим за це доведеться заплатити -- залежить від твоєї мотивації: навіщо тобі це потрібно?
+Усе, що раніше боги робили власними руками, ми поступово переводимо в автоматичні =послуги=, які працюють самі, без живого бога за спиною. Поки ця переробка не завершена, частина послуг може бути тимчасово недоступна.
 
-Зазвичай ціни на ці послуги такі: трупоприношення: {C500 qp{x телепорт: {C200 qp{x
-
-{CРЕЧІ, БУДІВНИЦТВО{x
-Боги можуть перейменувати для тебе особливо складні предмети: дивись {y{hcдовідка рестринг{x. Коштуватиме це {C50 qp{x + купон рестрингу.
-
-Боги можуть створити для тебе особистий скриню -- або навіть побудувати цілий особняк за твоїми кресленнями. Подробиці дивись у {y{hcдовідка будівництво{hx{x.
-
-Скриня коштує {C800 qp{x і може ставитися в місце, придатне для проживання, -- наприклад, казарми, будинки, печери тощо. На чистому полі та в лісі ставити не можна.
-
-{CПЕРСОНАЛЬНІ КВЕСТИ{x
-У давні {hh80епохи{x Безсмертні зрідка обирали гідних гравців, щоб задати їм =персональне завдання= -- складне, але з завидною нагородою за виконання. У нинішню епоху Богів залишилося дуже мало, і часу на персональні квести вже не вистачає. Хочеш допомогти? Ми раді розглянути кандидатури відповідальних і дуже досвідчених гравців на роль {hh92Молодших Безсмертних{x. {hh66Напиши нам{x, якщо цікаво.
-
-%SA% %H% {hh2кланові ціни{x, {hh50ціни на будівництво{x
+Хочеш допомогти? Нам бракує богів. Ми будемо раді розглянути відповідальних і дуже досвідчених гравців на роль {hh92Молодших Безсмертних{x. {hh66Напиши нам{x, якщо цікаво.
 </text>
     <title l="en">Services and favours of the gods</title>
     <title l="ru">Услуги и милости Богов</title>


### PR DESCRIPTION
Favours currently are not rendered at all (no active immortals to grant them), so the old price lists (teleport 200qp / corpse 500qp / restring 50qp / chest 800qp / mansions) were misleading. Body-only rewrite of help.xml node 11 in all three languages: favours unavailable for lack of gods; systematic services being reworked to run automatically; Junior Immortals recruitment kept. id/keywords/title unchanged.