### PR TITLE
Fix broken UA declension pad for the 'root' material

### DIFF
--- a/fight/material.json
+++ b/fight/material.json
@@ -62,7 +62,7 @@
  { "name": "softwood", "breaks_into": "28036", "rho": 240, "hardness": 1, "burns": 2, "floats": 1, "type": "organic wood", "flags": "", "vuln": "wood", "uaname": "м'як|е|ого|ому|е|им|ім дерев|о|а|у|о|ом|і", "rname": "мягк|ое|ого|ому|ое|им|ом дерев|о|а|у|о|ом|е" },
  { "name": "wood", "breaks_into": "28036", "rho": 700, "hardness": 3, "burns": 2, "floats": 1, "type": "organic wood", "flags": "", "vuln": "wood", "uaname": "деревин|а|и|і|у|ою|і", "rname": "древесин|а|ы|е|у|ой|е" },
  { "name": "yew", "breaks_into": "28036", "rho": 670, "hardness": 3, "burns": 3, "floats": 1, "type": "organic wood", "flags": "", "vuln": "wood", "uaname": "тис||у|ові||ом|і", "rname": "тис||а|у||ом|е" },
- { "name": "root", "breaks_into": "28045", "rho": 1150, "hardness": 5, "burns": 4, "floats": 0, "type": "organic wood", "flags": "", "vuln": "wood", "uaname": "корінь||||||", "rname": "кор|ень|ня|ню|ень|нем|не" }, 
+ { "name": "root", "breaks_into": "28045", "rho": 1150, "hardness": 5, "burns": 4, "floats": 0, "type": "organic wood", "flags": "", "vuln": "wood", "uaname": "кор|інь|еня|еню|інь|енем|ені", "rname": "кор|ень|ня|ню|ень|нем|не" },
 
  // cloth: 52-61 (manufactured fabric): can be sewn, can be worn with horns, can be safely kicked
  { "name": "canvas", "breaks_into": "31237", "rho": 110, "hardness": 1, "burns": 3, "floats": 1, "type": "organic cloth", "flags": "", "vuln": "", "uaname": "парусин|а|и|і|у|ою|і", "rname": "холст||а|у||ом|е" },


### PR DESCRIPTION
root.uaname was `корінь||||||` (all six case cells empty), so it never declined -- UA renders like '... з корінь' instead of 'з кореня'. Real pad: корінь/кореня/кореню/корінь/коренем/корені.

Caught by the fable review of the composed-name l10n sweep (inheritMaterial composes '<short> з <material genitive>' and root was the one wood material with a broken pad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)