### PR TITLE
combat-proc value: add garble 30 (peer with deafen)

### DIFF
--- a/fight/spell_combat_value.json
+++ b/fight/spell_combat_value.json
@@ -35,6 +35,7 @@
   "entangle": 20,
   "confuse": 20,
   "deafen": 30,
+  "garble": 30,
   "fear": 15,
   "calm": 15,
   "faerie fire": 15,


### PR DESCRIPTION
garble is the same 50%-cast-fail mechanic as deafen plus a speech block, but had no entry in spell_combat_value.json, so a combat-proc item casting garble scored 0 from the proc scorer. deafen was set to 30 in #704; garble peers with it.

Closes Trello 2865 (https://trello.com/c/Rh5fHiEA... -> card oP0). Surfaced during the deafen bump review 2026-09-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)