### PR TITLE
Fix samurai guild entrance in class-guilds help

### DIFF
--- a/helps/help.xml
+++ b/helps/help.xml
@@ -2326,7 +2326,7 @@ These commands toggle colour output mode on and off.
     <text l="en">Some specialised {hh28class{x skills can be learned at their guilds from the local
 =Guildmaster=. Most guilds are also well hidden and cannot be {hh810shot through{x -- you can take shelter there in case of danger. Naturally, you cannot choose your guild -- your guild depends on the class you have already chosen.
 
-Guilds located in the {hh1392capital{x: {hh133Clerics:{x Inner Monastery Sanctuary (west of Temple Square) {hh142Warriors:{x Tournament and Training Grounds (Swordsmen Guild on Main Street) {hh139Witches:{x Magic Laboratory (in the Mages Guild, on Main Street) {hh134Warlocks:{x Warlock Laboratory (entrance through the tavern, off Dark Alley) {hh136Samurai:{x Samurai Shrine (entrance through the tavern "The Grunting Boar") {hh141Paladins:{x Knights Sanctuary (in the Sacred Temple on Main Street) {hh135Thieves:{x Secret Courtyard (across from the tavern "Toadstool" on Dark Alley) {hh132Ninja:{x Underground Chamber (entrance through the "Dirty Tavern" on Slum Alley) {hh138Anti-paladins:{x Torture Chamber (in the Devil Temple, entrance from Slum Alley)
+Guilds located in the {hh1392capital{x: {hh133Clerics:{x Inner Monastery Sanctuary (west of Temple Square) {hh142Warriors:{x Tournament and Training Grounds (Swordsmen Guild on Main Street) {hh139Witches:{x Magic Laboratory (in the Mages Guild, on Main Street) {hh134Warlocks:{x Warlock Laboratory (entrance through the tavern, off Dark Alley) {hh136Samurai:{x Samurai Shrine (entrance through Andy's Inn) {hh141Paladins:{x Knights Sanctuary (in the Sacred Temple on Main Street) {hh135Thieves:{x Secret Courtyard (across from the tavern "Toadstool" on Dark Alley) {hh132Ninja:{x Underground Chamber (entrance through the "Dirty Tavern" on Slum Alley) {hh138Anti-paladins:{x Torture Chamber (in the Devil Temple, entrance from Slum Alley)
 
 Guilds located in {hh1446Old Midgaard{x: {hh143Necromancers:{x Western end of Main Street, to the north. {hh144Vampires:{x Western end of Main Street, to the south. {hh138Anti-paladins:{x Devil Temple on Trade Street.
 
@@ -2339,7 +2339,7 @@ The {hh140Rangers{x guild is located in {hh1862Haon Dor{x, entrance from the Hid
 {hh142Воины:{x         Двор Турниров и Упражнений (Гильдия Мечников на Главной Улице)
 {hh139Ведьмы:{x        Магическая лаборатория (в Гильдии Магов, на Главной Улице)
 {hh134Колдуны:{x       Лаборатория Варлоков (вход через таверну, с Темной Аллеи)
-{hh136Самураи:{x       Святыня Самураев (вход через таверну "Хрюкающий Кабан")
+{hh136Самураи:{x       Святыня Самураев (вход через Трактир Энди)
 {hh141Паладины:{x      Святилище Рыцарей (в Священном Храме, что на Главной Улице)
 {hh135Воры:{x          Секретный Двор (напротив таверны "Поганка" на Темной Аллее)
 {hh132Ниндзя:{x        Подземная палата (вход через "Грязную Таверну" с Аллеи Бедняков)
@@ -2356,7 +2356,7 @@ The {hh140Rangers{x guild is located in {hh1862Haon Dor{x, entrance from the Hid
 {hh142Воїни:{x         Двір Турнірів та Вправ (Гільдія Мечників на Головній Вулиці)
 {hh139Відьми:{x        Магічна лабораторія (в Гільдії Магів, на Головній Вулиці)
 {hh134Чаклуни:{x       Лабораторія Чаклунів (вхід через таверну, з Темної Алеї)
-{hh136Самураї:{x       Святиня Самураїв (вхід через таверну "Хрюкаючий Кабан")
+{hh136Самураї:{x       Святиня Самураїв (вхід через Трактир Енді)
 {hh141Паладини:{x      Святилище Лицарів (в Священному Храмі, що на Головній Вулиці)
 {hh135Крадії:{x        Таємний Двір (навпроти таверни "Поганка" на Темній Алеї)
 {hh132Ніндзя:{x        Підземна зала (вхід через "Брудну Таверну" з Алеї Бідняків)


### PR DESCRIPTION
Samurai guild is entered through Andy's Inn (room 3357 -> Samurai Bar 3075 -> Shrine 3076), not the Grunting Boar. The Class guilds help named the wrong tavern in EN/RU/UA. Reported in-game by Samuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)