### PR TITLE
Add utils/language translation shard (no-effect hush line)

### DIFF
--- a/config/translations/utils.json
+++ b/config/translations/utils.json
@@ -2541,6 +2541,12 @@
    "ua": "Смерть ще жодного разу не торкнулася тебе, %C1."
   }
  },
+ "utils/language": {
+  "{CНа мгновение все вокруг стихло.{x": {
+   "en": "{CFor a moment everything around you falls silent.{x",
+   "ua": "{CНа мить усе навколо стихло.{x"
+  }
+ },
  "utils/room: walkment": {
   "В этом направлении некуда пройти.": {
    "en": "There is nowhere to go in that direction.",


### PR DESCRIPTION
Trilingual catalog entry for .tmp.language.onOutcome's bystander hush line (keyed by codesource 'utils/language'). Values copied from the C++-era plug-ins.json entry. Phase 1 M1, epic trello.com/c/DB9awtma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)