### PR TITLE
help(vault): document the clan vault (id 367)

### DIFF
--- a/commands/vault.xml
+++ b/commands/vault.xml
@@ -17,9 +17,11 @@ On its own, *%CMD%* lists what you have stored, sorted by type. *put* moves an i
 
 Two kinds of item stay in your hands: =unique= items and anything with a running timer -- stored items do not tick, so a timer would freeze half-spent, and a unique's bookkeeping is not safe to bank yet. A few items simply refuse to be stored at all. And you must be standing at a bank for any of this to work.
 
+Your {hh3clan{x has a =vault= of its own. Stand in your clan hall -- no bank needed -- and the same command opens the clan's shared storeroom instead of your personal one: whatever any clanmate stores away, the whole clan can pull back. It has taken over from the old wardrobes, safes and donation pits that used to clutter the halls -- drop your surplus here and it is off the world's shoulders yet still in the clan's hands. *put*, *get*, *find* and *filter* all work just as above.
+
 In the web client the row numbers and the counts on the *By type* line are clickable: one click pulls an item out or filters the list to that type.
 
-%SA% %H% {hh1086bank{x
+%SA% %H% {hh1086bank{x %H% {hh3clan{x
 </text>
     <text l="ru">=хранилище= -- это твой личный склад, спрятанный в задворках мира. Зайди в любой {hh1086банк{x -- и сможешь убирать вещи с глаз долой и доставать их обратно когда угодно; это бесплатно и без всякого предела на то, сколько ты хранишь. Сумка отправляется внутрь целиком, со всем содержимым, как одна запись, так что снаряга, которой ты не пользуешься, не висит на мире, пока тебя нет.
 
@@ -32,9 +34,11 @@ In the web client the row numbers and the counts on the *By type* line are click
 
 Две вещи остаются у тебя в руках: =уникальные= предметы и все, у чего тикает таймер -- сложенное не тикает, поэтому таймер застыл бы на полдороге, а учет уникальных пока небезопасно доверять хранилищу. Кое-что просто отказывается складываться. И чтобы все это работало, надо стоять в банке.
 
+У твоего {hh3клана{x есть свое =хранилище=. Встань в клановом зале -- банк не нужен -- и та же команда открывает общий клановый склад вместо твоего личного: что сложит любой соклановец, то может достать весь клан. Оно пришло на смену старым шкафам, сейфам и ямам для пожертвований, что захламляли залы, -- сбрось сюда излишки, и они уже не висят на мире, но по-прежнему в руках клана. *положить*, *взять*, *найти* и *фильтр* работают точно так же, как выше.
+
 В веб-клиенте номера строк и счетчики в строке *По типу* кликабельны: один клик достает вещь или сужает список до этого типа.
 
-%SA% %H% {hh1086банк{x
+%SA% %H% {hh1086банк{x %H% {hh3клан{x
 </text>
     <text l="ua">=сховище= -- це твій особистий склад, захований на задвірках світу. Зайди в будь-який {hh1086банк{x -- і зможеш ховати речі з очей і діставати їх назад коли завгодно; це безкоштовно і без жодної межі на те, скільки ти тримаєш. Торба вирушає всередину цілком, з усім вмістом, як один запис, тож спорядження, яким ти не користуєшся, не висить на світі, поки тебе нема.
 
@@ -47,9 +51,11 @@ In the web client the row numbers and the counts on the *By type* line are click
 
 Дві речі лишаються в тебе в руках: =унікальні= предмети і все, у чого цокає таймер -- складене не цокає, тож таймер застиг би на півдорозі, а облік унікальних поки небезпечно довіряти сховищу. Дещо просто відмовляється складатися. І щоб усе це працювало, треба стояти в банку.
 
+У твого {hh3клану{x є власне =сховище=. Стань у клановому залі -- банк не потрібен -- і та сама команда відкриває спільний клановий склад замість твого особистого: що складе будь-який співклановець, те може дістати весь клан. Воно прийшло на зміну старим шафам, сейфам та ямам для пожертв, що захаращували зали, -- скинь сюди надлишки, і вони вже не висять на світі, але й досі в руках клану. *покласти*, *взяти*, *знайти* та *фільтр* працюють так само, як вище.
+
 У веб-клієнті номери рядків і лічильники в рядку *За типом* клікабельні: один клік дістає річ або звужує список до цього типу.
 
-%SA% %H% {hh1086банк{x
+%SA% %H% {hh1086банк{x %H% {hh3клан{x
 </text>
   </help>
   <hint l="en">store items out of the world and take them back at a bank</hint>


### PR DESCRIPTION
Adds a clan-vault paragraph (EN/RU/UA) to the vault command help -- same command at a clan hall opens the clan's shared store, replacing the retired wardrobes/safes/pits. {hh3 clan cross-link. Hot-reloads via plug reload most. Owed polish from the clan-vault teardown (aIA078bm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)