### PR TITLE
help(clan): remove all clan-territory purchases

### DIFF
--- a/helps/clan.xml
+++ b/helps/clan.xml
@@ -1,55 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Help type="HelpContainer">
-  <node id="2" level="0" type="Help" labels="society clan">
-    <keyword l="en">'clan prices'</keyword>
-    <keyword l="ru">'клановые цены'</keyword>
-    <keyword l="ua">'кланові ціни'</keyword>
-    <text l="en">{RWARNING: {WAdding shops and clan pets is no longer possible. Extra exits and portals -- no more than three per clan. Instead of an arms race there is now equality.{x
-
-Clan leadership (leaders and recruiters) can purchase additional perks for their clan territories in exchange for quest points:
-
-{c%A% {C5000 qp:{x add a portal or {hh1016extra exit{x from the clan (no more than three)
-{c%A% {C5000 qp:{x upgrade the rest spot to +400% {hh2130regeneration{x
-{c%A% {C4000 qp:{x add a room to the clan (no more than 20 total)
-{c%A% {C4000 qp:{x change the names of clan ranks for different classes
-{c%A% {C3000 qp:{x add an unlockable chest or cabinet
-{c%A% {C3000 qp:{x add a liquid source
-{c%A% {C3000 qp:{x change the messages on clan guards and shrines
-
-The parameters of all rooms, items, or creatures are approved by the Gods.
-</text>
-    <text l="ru">{RВНИМАНИЕ: {WДобавлять магазины и клановых питомцев теперь нельзя. Экстра-выходов и порталов -- не больше трех на клан. Вместо гонки вооружений теперь равенство.{x
-
-Руководство кланов (лидеры и рекрутеры) могут купить дополнительные плюшки для своих клановых территорий за квестовые очки:
-
-{c%A% {C5000 кп:{x добавить портал или {hh1016экстра-выход{x из клана (не больше трех)
-{c%A% {C5000 кп:{x улучшить лежанку до +400% {hh2130восстановления{x
-{c%A% {C4000 кп:{x добавить комнату в клан (не больше 20 всего)
-{c%A% {C4000 кп:{x поменять названия клановых рангов для разных классов
-{c%A% {C3000 кп:{x добавить незапираемый сундук или шкаф
-{c%A% {C3000 кп:{x добавить источник жидкости
-{c%A% {C3000 кп:{x поменять сообщения у клановых охранников и святынь
-
-Параметры всех комнат, предметов или существ утверждаются Богами.
-</text>
-    <text l="ua">{RУВАГА: {WДодавати крамниці і кланових вихованців тепер не можна. Екстра-виходів і порталів -- не більше трьох на клан. Замість гонки озброєнь тепер рівність.{x
-
-Керівництво кланів (лідери і рекрутери) можуть купити додаткові плюшки для своїх кланових територій за квестові очки:
-
-{c%A% {C5000 кп:{x додати портал або {hh1016екстра-вихід{x з клану (не більше трьох)
-{c%A% {C5000 кп:{x покращити лежанку до +400% {hh2130відновлення{x
-{c%A% {C4000 кп:{x додати кімнату в клан (не більше 20 всього)
-{c%A% {C4000 кп:{x поміняти назви кланових рангів для різних класів
-{c%A% {C3000 кп:{x додати незамкнений скриню або шафу
-{c%A% {C3000 кп:{x додати джерело рідини
-{c%A% {C3000 кп:{x поміняти повідомлення у кланових охоронців і святинь
-
-Параметри всіх кімнат, предметів або істот затверджуються Богами.
-</text>
-    <title l="en">Prices for improving clan territories</title>
-    <title l="ru">Цены на благоустройство клановых территорий</title>
-    <title l="ua">Ціни на облаштування кланових територій</title>
-  </node>
   <node id="3" level="-1" type="Help" labels="society clan hub">
     <extra l="en">bank clan clanguard clanmembers clanpower commands diplomacy invitation leadership leave levels members petition power ranks recruiter guard</extra>
     <extra l="ru">банк дипломатия иерархия клана клангвард кланхолл кланов клановики клановый команды лидер недоверие отношения перемирие петиция покинуть приглашение ранги рекрутер руководство список святыня территория уровень устав внеклановый война 'вступить в клан' 'вступление в клан' 'выйти из клана' звание звания охранник стражник</extra>
@@ -121,7 +71,7 @@ The clanguard is considered a clanmate, so attacking it (even accidentally!) is 
 
 The clanguard also guards the key to the clan =shrine=. If you kill the guard, unlock the clan altar and take the shrine -- all clan skills will stop working.
 
-%SA% the *clan help* command and all its subcommands For clan leadership: %H% {hh2clan prices{x
+%SA% the *clan help* command and all its subcommands
 </text>
     <text l="ru">Кланы или Ордена -- это специальные организации игроков, имеющих общие цели. Основные кланы олицетворяют каждый из {hh81Восьми Путей{x.
 
@@ -188,7 +138,7 @@ The clanguard also guards the key to the clan =shrine=. If you kill the guard, u
 
 Клангвард также охраняет ключ от клановой =святыни=. Если убить стража, отпереть клановый алтарь и забрать святыню -- все умения клана перестанут работать.
 
-%SA% команду *клан помощь* и все ее подкоманды Для руководства кланов: %H% {hh2клановые цены{x
+%SA% команду *клан помощь* и все ее подкоманды
 </text>
     <text l="ua">Клани або Ордени -- це спеціальні організації гравців, що мають спільні цілі. Основні клани уособлюють кожен з {hh81Восьми Шляхів{x.
 
@@ -255,7 +205,7 @@ The clanguard also guards the key to the clan =shrine=. If you kill the guard, u
 
 Клангвард також охороняє ключ від кланової =святині=. Якщо вбити стража, відімкнути клановий вівтар і забрати святиню -- всі вміння клану перестануть працювати.
 
-%SA% команду *клан допомога* і всі її підкоманди Для керівництва кланів: %H% {hh2кланові ціни{x
+%SA% команду *клан допомога* і всі її підкоманди
 </text>
     <title l="en">Clans and orders</title>
     <title l="ru">Кланы и Ордена</title>


### PR DESCRIPTION
Deletes the clan-prices article (node id 2, the qp perk price list) + strips its {hh2 see-also from the clan hub help (EN/RU/UA). Clan purchases retired. Hot-reloads via plug reload most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)