### PR TITLE
help: document coal tongs in help fire

### DIFF
--- a/behaviors/fire.xml
+++ b/behaviors/fire.xml
@@ -4,15 +4,15 @@
   <description l="ru">{hh1023Используй{x {hh249костер{x, чтобы погреть руки; у огня быстрее восстанавливаются силы и заживают раны.</description>
   <description l="ua">{hh1023Використай{x {hh249багаття{x, щоб погріти руки; біля вогню швидше відновлюються сили і гояться рани.</description>
   <help id="249" level="-1" type="BehaviorHelp">
-    <extra l="en">ignite kindle light burn</extra>
-    <extra l="ru">поджечь разжечь развести сжечь зажечь</extra>
-    <extra l="ua">підпалити розпалити розвести спалити запалити</extra>
+    <extra l="en">ignite kindle light burn tongs</extra>
+    <extra l="ru">поджечь разжечь развести сжечь зажечь щипцы</extra>
+    <extra l="ua">підпалити розпалити розвести спалити запалити щипці</extra>
     <keyword l="en">campfire fire bonfire</keyword>
     <keyword l="ru">костер костер огонь</keyword>
     <keyword l="ua">багаття вогнище вогонь</keyword>
     <text l="en">With something flammable in hand and a source of fire -- a {hh240torch{x, {hh214matches{x, or one of the fire spells -- you can start a campfire. By a fire you recover your strength faster and your wounds {hh2130heal{x more quickly. A fire can also warm you if you are suffering from frostbite or {hh610ice touch{x.
 
-You can keep a fire going by {hh1024feeding{x it flammable objects or by setting other objects on the ground alight. Many things can be burned -- for example, {hh1024containers{x, {hh282logs{x, corpses, vessels holding flammable liquids, and much more -- even your own mortal {hh12body{x! Different objects will burn, melt, or {hh4become red-hot{x depending on their {hh201material{x. A fire stoked too high can turn into a {hh281wildfire{x -- careful!
+You can keep a fire going by {hh1024feeding{x it flammable objects or by setting other objects on the ground alight. Many things can be burned -- for example, {hh1024containers{x, {hh282logs{x, corpses, vessels holding flammable liquids, and much more -- even your own mortal {hh12body{x! Different objects will burn, melt, or {hh4become red-hot{x depending on their {hh201material{x. Snatching a red-hot item back out of a fire scorches bare hands -- clumsy fingers cannot keep their grip at all, and even a nimble grab leaves you singed and fumbling it to the ground; a pair of coal tongs, carried or in hand, pulls anything out cleanly and unburned. A fire stoked too high can turn into a {hh281wildfire{x -- careful!
 
 {hh140Rangers{x start fires automatically when making camp with {hh825field camp{x. Samurai need fire for {hh598tempering blades{x, warriors for {hh670repairs{x, and witches for {hh93brewing potions{x.
 
@@ -20,7 +20,7 @@ A fire can be put out by {hh177flooding{x, heavy {hh1028rain{x, certain ice spel
 </text>
     <text l="ru">Раздобыв что-нибудь горючее, а также источник огня -- {hh240факел{x, {hh214спички{x или одно из огненных заклинаний -- можно развести костер. У костра лучше восстанавливаются силы и быстрее {hh2130заживают{x раны. А еще у костра можно согреться от обморожения или {hh610ледяного касания{x. 
 
-Костер можно поддерживать просто {hh1024подкладывая{x в него горючие предметы или поджигая другие предметы на земле. Сжечь можно много чего -- например, {hh1024контейнеры{x, {hh282бревна{x, трупы, емкости для горючих жидкостей и многое другое -- даже свою собственную бренную {hh12тушку{x! Разные предметы будут гореть, расплавляться или {hh4раскаляться{x в зависимости от своего {hh201материала{x. Слишком сильно раскочегаренный костер может превратиться в {hh281пожар{x, осторожнее!
+Костер можно поддерживать просто {hh1024подкладывая{x в него горючие предметы или поджигая другие предметы на земле. Сжечь можно много чего -- например, {hh1024контейнеры{x, {hh282бревна{x, трупы, емкости для горючих жидкостей и многое другое -- даже свою собственную бренную {hh12тушку{x! Разные предметы будут гореть, расплавляться или {hh4раскаляться{x в зависимости от своего {hh201материала{x. Выхватить раскаленную вещь обратно из огня голыми руками -- обжечься: неловкий и ухватить-то не сумеет, а ловкач хоть и выхватит, да обожжется и обронит ее наземь; а вот щипцы для угля, в руках или в сумке, вытащат из огня что угодно чисто и без ожогов. Слишком сильно раскочегаренный костер может превратиться в {hh281пожар{x, осторожнее!
 
 {hh140Рейнджеры{x разводят костры сразу при разбивке полевого {hh825лагеря{x. Самураям костер пригодится для {hh598закалки мечей{x, воинам -- для {hh670починки{x, а ведьмам -- для {hh93варки зелий{x.
 
@@ -28,7 +28,7 @@ A fire can be put out by {hh177flooding{x, heavy {hh1028rain{x, certain ice spel
 </text>
     <text l="ua">Роздобувши щось горюче, а також джерело вогню -- {hh240факел{x, {hh214сірники{x або одне з вогняних заклинань -- можна розвести багаття. Біля багаття краще відновлюються сили і швидше {hh2130гояться{x рани. А ще біля багаття можна зігрітися від обмороження або {hh610льодяного дотику{x.
 
-Багаття можна підтримувати, просто {hh1024підкидаючи{x в нього горючі предмети або підпалюючи інші предмети на землі. Спалити можна багато чого -- наприклад, {hh1024контейнери{x, {hh282колоди{x, трупи, ємності для горючих рідин і багато іншого -- навіть власну бренну {hh12тушку{x! Різні предмети горітимуть, плавитимуться або {hh4розжарюватимуться{x залежно від свого {hh201матеріалу{x. Надто розпалене багаття може перетворитися на {hh281пожежу{x, обережно!
+Багаття можна підтримувати, просто {hh1024підкидаючи{x в нього горючі предмети або підпалюючи інші предмети на землі. Спалити можна багато чого -- наприклад, {hh1024контейнери{x, {hh282колоди{x, трупи, ємності для горючих рідин і багато іншого -- навіть власну бренну {hh12тушку{x! Різні предмети горітимуть, плавитимуться або {hh4розжарюватимуться{x залежно від свого {hh201матеріалу{x. Вихопити розпечену річ назад із вогню голими руками -- обпектися: незграбний і вхопити не зуміє, а спритник хоч і вихопить, та обпечеться й впустить її додолу; а от щипці для вугілля, в руках чи в торбі, витягнуть із вогню будь-що чисто й без опіків. Надто розпалене багаття може перетворитися на {hh281пожежу{x, обережно!
 
 {hh140Рейнджери{x розводять багаття одразу при розбивці польового {hh825табору{x. Самураям багаття стане в пригоді для {hh598загартування мечів{x, воїнам -- для {hh670ремонту{x, а відьмам -- для {hh93варіння зілля{x.
 


### PR DESCRIPTION
Adds the coal-tongs "pull hot items out of a fire safely" mechanic to **help fire** (behavior help id 249), all three languages, matching the fetch-from-fire tongs feature (dreamland_fenia PR #733).

- One sentence in paragraph 2 (where objects "become red-hot"): bare-handed retrieval burns you and may drop the item; coal tongs pull anything out cleanly.
- Adds `tongs`/`щипцы`/`щипці` to `<extra>` so `help tongs` resolves here.
- Edits an existing help id (249) — no ID-collision risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUckqHagiNBcWPtZAKDBv6