### PR TITLE
affects: trilingual header for worn-gear stat applies

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -3678,6 +3678,10 @@
    "en": "You are under the effect of the following affects:",
    "ua": "Ти перебуваєш під дією таких ефектів:"
   },
+  "От снаряжения:": {
+   "en": "From equipment:",
+   "ua": "Зі спорядження:"
+  },
   "Ты не находишься под действием каких-либо аффектов.": {
    "en": "You are not under the effect of any affects.",
    "ua": "Ти не перебуваєш під дією жодних ефектів."


### PR DESCRIPTION
Adds the `От снаряжения:` catalog entry (en/ua) for the gear stat-applies section in `affects` (paired dreamland_code#1205). Reboot-pending.