### PR TITLE
combatcast: add heating override

### DIFF
--- a/fight/spell_combat_value.json
+++ b/fight/spell_combat_value.json
@@ -14,6 +14,7 @@
 
     "corruption": 100,
     "poison": 120,
+    "heating": 90,
 
     "ray of truth": 130,
     "dispel evil": 100,


### PR DESCRIPTION
heating (tier 5, no direct damage, 2 items) would phantom-derive a value; add a small explicit override. Found by adversarial review. Trello wKsd9WHE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)