### PR TITLE
combatcast: add _hit_value/_round_attacks knobs

### DIFF
--- a/fight/spell_combat_value.json
+++ b/fight/spell_combat_value.json
@@ -4,6 +4,8 @@
   "_global": 2.68,
   "_level_ref": 50.0,
   "_save_factor": 0.75,
+  "_hit_value": 55.0,
+  "_round_attacks": 4.0,
 
   "overrides": {
     "harm": 187,


### PR DESCRIPTION
Two tunable knobs for extra-attack scoring. Trello wKsd9WHE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)