### PR TITLE
accounts UX bundle: help 5106 + catalog EN/UA for channel/link strings

### DIFF
--- a/commands/account.xml
+++ b/commands/account.xml
@@ -7,40 +7,43 @@
     <extra l="ru">аккаунт аккаунты связка привязка</extra>
     <extra l="ua">акаунт акаунти привʼязка звʼязка</extra>
     <text l="en">%FMT% *%CMD%*
-%FFF% *%CMD%* link
-%FFF% *%CMD%* link discord
+%FFF% *%CMD%* *link*
+%FFF% *%CMD%* *link* *discord*
 
-An account ties your characters together and gives you a way to recover access. It is a layer on top of the character password: your world-entry password does not change. Every account gets a name of its own, such as "Ashen Warden of Old Thalos".
+An account ties your characters together and gives you a way to recover access. It is a layer on top of the character {hh1003password{x: your world-entry password does not change. Every account gets a name of its own, such as "Ashen Warden of Old Thalos".
 
 *%CMD%* -- show your account status: its name, linked identities and characters.
-*%CMD%* link -- mint a one-time linking code. Redeem it in the Telegram or Discord bot, or on the website, to attach this character to an account. The code is single-use, lives ten minutes, and must be kept secret -- whoever redeems it links the character to their account.
-*%CMD%* link discord -- if your Discord is already verified in-game, link an account straight from it, no code needed.
+*%CMD%* *link* -- mint a one-time linking code. Redeem it in the Telegram or Discord bot to attach this character to an account. The code is single-use, lives ten minutes, and must be kept secret -- whoever redeems it links the character to their account.
+*%CMD%* *link* *discord* -- if your Discord is already verified in-game, link an account straight from it, no code needed.
+*%CMD%* *email* _address_, then *%CMD%* *code* _code_ -- (coming) the telnet-only door, for players with no bot or browser.
 
-Account linking is rolling out. Until it opens, *%CMD%* link only tells you so.
+Account linking is rolling out. Until it opens, *%CMD%* *link* only tells you so.
 </text>
     <text l="ru">%FMT% *%CMD%*
-%FFF% *%CMD%* связать
-%FFF% *%CMD%* связать дискорд
+%FFF% *%CMD%* *связать*
+%FFF% *%CMD%* *связать* *дискорд*
 
-Аккаунт связывает твоих персонажей вместе и дает способ восстановить доступ. Это слой поверх пароля персонажа: пароль на вход в мир не меняется. У каждого аккаунта есть свое имя, например "Ashen Warden of Old Thalos".
+Аккаунт связывает твоих персонажей вместе и дает способ восстановить доступ. Это слой поверх {hh1003пароля{x персонажа: пароль на вход в мир не меняется. У каждого аккаунта есть свое имя, например "Ashen Warden of Old Thalos".
 
 *%CMD%* -- показать статус аккаунта: его имя, привязанные способы входа и персонажей.
-*%CMD%* связать -- получить одноразовый код привязки. Введи его в боте Telegram или Discord, либо на сайте, чтобы привязать этого персонажа к аккаунту. Код одноразовый, живет десять минут и должен оставаться в секрете -- кто его введет, привяжет персонажа к своему аккаунту.
-*%CMD%* связать дискорд -- если твой Discord уже подтвержден в игре, привязать аккаунт сразу по нему, без кода.
+*%CMD%* *связать* -- получить одноразовый код привязки. Введи его в боте Telegram или Discord, чтобы привязать этого персонажа к аккаунту. Код одноразовый, живет десять минут и должен оставаться в секрете -- кто его введет, привяжет персонажа к своему аккаунту.
+*%CMD%* *связать* *дискорд* -- если твой Discord уже подтвержден в игре, привязать аккаунт сразу по нему, без кода.
+*%CMD%* *почта* _адрес_, затем *%CMD%* *код* _код_ -- (скоро) вход только по telnet, для тех, у кого нет бота или браузера.
 
-Привязка аккаунтов постепенно открывается. Пока она закрыта, *%CMD%* связать просто скажет об этом.
+Привязка аккаунтов постепенно открывается. Пока она закрыта, *%CMD%* *связать* просто скажет об этом.
 </text>
     <text l="ua">%FMT% *%CMD%*
-%FFF% *%CMD%* звязати
-%FFF% *%CMD%* звязати дискорд
+%FFF% *%CMD%* *звязати*
+%FFF% *%CMD%* *звязати* *дискорд*
 
-Акаунт повʼязує твоїх персонажів разом і дає спосіб відновити доступ. Це шар поверх пароля персонажа: пароль на вхід до світу не змінюється. Кожен акаунт має власну назву, наприклад "Ashen Warden of Old Thalos".
+Акаунт повʼязує твоїх персонажів разом і дає спосіб відновити доступ. Це шар поверх {hh1003пароля{x персонажа: пароль на вхід до світу не змінюється. Кожен акаунт має власну назву, наприклад "Ashen Warden of Old Thalos".
 
 *%CMD%* -- показати статус акаунта: його назву, привʼязані способи входу та персонажів.
-*%CMD%* звязати -- отримати одноразовий код привʼязки. Введи його в боті Telegram чи Discord або на сайті, щоб привʼязати цього персонажа до акаунта. Код одноразовий, живе десять хвилин і має лишатися в секреті -- хто його введе, привʼяже персонажа до свого акаунта.
-*%CMD%* звязати дискорд -- якщо твій Discord уже підтверджено в грі, привʼязати акаунт одразу по ньому, без коду.
+*%CMD%* *звязати* -- отримати одноразовий код привʼязки. Введи його в боті Telegram чи Discord, щоб привʼязати цього персонажа до акаунта. Код одноразовий, живе десять хвилин і має лишатися в секреті -- хто його введе, привʼяже персонажа до свого акаунта.
+*%CMD%* *звязати* *дискорд* -- якщо твій Discord уже підтверджено в грі, привʼязати акаунт одразу по ньому, без коду.
+*%CMD%* *пошта* _адреса_, потім *%CMD%* *код* _код_ -- (скоро) вхід лише через telnet, для тих, хто без бота чи браузера.
 
-Привʼязка акаунтів поступово відкривається. Поки вона закрита, *%CMD%* звязати просто скаже про це.
+Привʼязка акаунтів поступово відкривається. Поки вона закрита, *%CMD%* *звязати* просто скаже про це.
 </text>
     <title l="en">{CAccounts: {xaccount linking</title>
     <title l="ru">{CАккаунты: {xпривязка аккаунта</title>

--- a/commands/account.xml
+++ b/commands/account.xml
@@ -8,42 +8,48 @@
     <extra l="ua">акаунт акаунти привʼязка звʼязка</extra>
     <text l="en">%FMT% *%CMD%*
 %FFF% *%CMD%* *link*
-%FFF% *%CMD%* *link* *discord*
+%FFF% *%CMD%* *discord*
+%FFF% *%CMD%* *telegram*
 
 An account ties your characters together and gives you a way to recover access. It is a layer on top of the character {hh1003password{x: your world-entry password does not change. Every account gets a name of its own, such as "Ashen Warden of Old Thalos".
 
 *%CMD%* -- show your account status: its name, linked identities and characters.
-*%CMD%* *link* -- mint a one-time linking code. Redeem it in the Telegram or Discord bot to attach this character to an account. The code is single-use, lives ten minutes, and must be kept secret -- whoever redeems it links the character to their account.
-*%CMD%* *link* *discord* -- if your Discord is already verified in-game, link an account straight from it, no code needed.
+*%CMD%* *link* -- mint a one-time linking code and redeem it in the Telegram or Discord bot. Single-use, ten minutes, keep it secret -- whoever redeems it links the character to their account.
+*%CMD%* *discord* -- if your Discord is already verified in-game, link an account straight from it in one command, no code. Otherwise it hands you a code for the Discord bot.
+*%CMD%* *telegram* -- always through the Telegram bot: tap the one-time link, or send it the code. A Telegram handle you typed yourself is not proof, so Telegram always confirms through the bot -- unlike Discord, which the game has already verified.
 *%CMD%* *email* _address_, then *%CMD%* *code* _code_ -- (coming) the telnet-only door, for players with no bot or browser.
 
-Account linking is rolling out. Until it opens, *%CMD%* *link* only tells you so.
+Account linking is rolling out. Until it opens, these only tell you so.
 </text>
     <text l="ru">%FMT% *%CMD%*
 %FFF% *%CMD%* *связать*
-%FFF% *%CMD%* *связать* *дискорд*
+%FFF% *%CMD%* *дискорд*
+%FFF% *%CMD%* *телеграм*
 
 Аккаунт связывает твоих персонажей вместе и дает способ восстановить доступ. Это слой поверх {hh1003пароля{x персонажа: пароль на вход в мир не меняется. У каждого аккаунта есть свое имя, например "Ashen Warden of Old Thalos".
 
 *%CMD%* -- показать статус аккаунта: его имя, привязанные способы входа и персонажей.
-*%CMD%* *связать* -- получить одноразовый код привязки. Введи его в боте Telegram или Discord, чтобы привязать этого персонажа к аккаунту. Код одноразовый, живет десять минут и должен оставаться в секрете -- кто его введет, привяжет персонажа к своему аккаунту.
-*%CMD%* *связать* *дискорд* -- если твой Discord уже подтвержден в игре, привязать аккаунт сразу по нему, без кода.
+*%CMD%* *связать* -- получить одноразовый код и ввести его в боте Telegram или Discord. Одноразовый, десять минут, держи в секрете -- кто его введет, привяжет персонажа к своему аккаунту.
+*%CMD%* *дискорд* -- если твой Discord уже подтвержден в игре, привязать аккаунт сразу по нему, одной командой, без кода. Иначе выдаст код для бота Discord.
+*%CMD%* *телеграм* -- всегда через бота Telegram: тапни одноразовую ссылку или отправь ему код. Хендл Telegram, который ты вписал сам, ничего не доказывает, поэтому Telegram всегда подтверждается через бота -- в отличие от Discord, который игра уже проверила.
 *%CMD%* *почта* _адрес_, затем *%CMD%* *код* _код_ -- (скоро) вход только по telnet, для тех, у кого нет бота или браузера.
 
-Привязка аккаунтов постепенно открывается. Пока она закрыта, *%CMD%* *связать* просто скажет об этом.
+Привязка аккаунтов постепенно открывается. Пока она закрыта, это просто скажет об этом.
 </text>
     <text l="ua">%FMT% *%CMD%*
 %FFF% *%CMD%* *звязати*
-%FFF% *%CMD%* *звязати* *дискорд*
+%FFF% *%CMD%* *дискорд*
+%FFF% *%CMD%* *телеграм*
 
 Акаунт повʼязує твоїх персонажів разом і дає спосіб відновити доступ. Це шар поверх {hh1003пароля{x персонажа: пароль на вхід до світу не змінюється. Кожен акаунт має власну назву, наприклад "Ashen Warden of Old Thalos".
 
 *%CMD%* -- показати статус акаунта: його назву, привʼязані способи входу та персонажів.
-*%CMD%* *звязати* -- отримати одноразовий код привʼязки. Введи його в боті Telegram чи Discord, щоб привʼязати цього персонажа до акаунта. Код одноразовий, живе десять хвилин і має лишатися в секреті -- хто його введе, привʼяже персонажа до свого акаунта.
-*%CMD%* *звязати* *дискорд* -- якщо твій Discord уже підтверджено в грі, привʼязати акаунт одразу по ньому, без коду.
+*%CMD%* *звязати* -- отримати одноразовий код і ввести його в боті Telegram чи Discord. Одноразовий, десять хвилин, тримай у секреті -- хто його введе, привʼяже персонажа до свого акаунта.
+*%CMD%* *дискорд* -- якщо твій Discord уже підтверджено в грі, привʼязати акаунт одразу по ньому, однією командою, без коду. Інакше видасть код для бота Discord.
+*%CMD%* *телеграм* -- завжди через бота Telegram: тапни одноразове посилання або надішли йому код. Хендл Telegram, який ти вписав сам, нічого не доводить, тож Telegram завжди підтверджується через бота -- на відміну від Discord, який гра вже перевірила.
 *%CMD%* *пошта* _адреса_, потім *%CMD%* *код* _код_ -- (скоро) вхід лише через telnet, для тих, хто без бота чи браузера.
 
-Привʼязка акаунтів поступово відкривається. Поки вона закрита, *%CMD%* *звязати* просто скаже про це.
+Привʼязка акаунтів поступово відкривається. Поки вона закрита, це просто скаже про це.
 </text>
     <title l="en">{CAccounts: {xaccount linking</title>
     <title l="ru">{CАккаунты: {xпривязка аккаунта</title>

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -3727,6 +3727,50 @@
   "Использование: {yаккаунт{x -- статус, {yаккаунт связать{x -- код привязки.": {
    "en": "Usage: {yaccount{x -- status, {yaccount link{x -- linking code.",
    "ua": "Використання: {yакаунт{x -- статус, {yакаунт звязати{x -- код прив'язки."
+  },
+  "Твой персонаж не привязан к аккаунту. Аккаунт вернет доступ, если потеряешь пароль, и соберет всех персонажей под одним входом; скоро -- перенос qp между своими и перки.": {
+   "en": "Your character is not linked to an account. An account gets you back in if you lose your password and keeps all your characters under one login; coming soon -- move qp between your own characters, and perks.",
+   "ua": "Твій персонаж не прив'язаний до акаунта. Акаунт поверне доступ, якщо втратиш пароль, і збере всіх персонажів під одним входом; скоро -- перенос qp між своїми і перки."
+  },
+  "Набери {yаккаунт связать{x, чтобы начать. Подробнее: {hh5106аккаунт{x.": {
+   "en": "Type {yaccount link{x to begin. More: {hh5106account{x.",
+   "ua": "Набери {yакаунт звязати{x, щоб почати. Докладніше: {hh5106акаунт{x."
+  },
+  "Твой Discord уже подтвержден ({W%1$s{x). Набери {yаккаунт дискорд{x, чтобы привязать аккаунт сразу, без кода.": {
+   "en": "Your Discord is already verified ({W%1$s{x). Type {yaccount discord{x to link an account right away, no code.",
+   "ua": "Твій Discord уже підтверджено ({W%1$s{x). Набери {yакаунт дискорд{x, щоб прив'язати акаунт одразу, без коду."
+  },
+  "Он одноразовый и действует 10 минут. Привяжи его в любом из ботов:": {
+   "en": "It is single-use and valid for 10 minutes. Link it in either bot:",
+   "ua": "Він одноразовий і діє 10 хвилин. Прив'яжи його в будь-якому з ботів:"
+  },
+  "  Telegram {W@%1$s{x -- {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwоткрой https://t.me/%1$s?start=%2$s , либо{Ix команда {W/attach %2$s{x": {
+   "en": "  Telegram {W@%1$s{x -- {IWtap {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwopen https://t.me/%1$s?start=%2$s , or{Ix command {W/attach %2$s{x",
+   "ua": "  Telegram {W@%1$s{x -- {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwвідкрий https://t.me/%1$s?start=%2$s , або{Ix команда {W/attach %2$s{x"
+  },
+  "  Discord Валькирия -- {IW{hlhttps://discord.com/users/%1$s{x{Ix{Iwв привате (discord.com/users/%1$s){Ix команда {W/link %2$s{x": {
+   "en": "  Discord Valkyrie -- {IW{hlhttps://discord.com/users/%1$s{x{Ix{Iwin a DM (discord.com/users/%1$s){Ix command {W/link %2$s{x",
+   "ua": "  Discord Валькірія -- {IW{hlhttps://discord.com/users/%1$s{x{Ix{Iwу приваті (discord.com/users/%1$s){Ix команда {W/link %2$s{x"
+  },
+  "  {WA{x) {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwоткрой https://t.me/%1$s?start=%2$s{Ix -- бот привяжет этот аккаунт.": {
+   "en": "  {WA{x) {IWtap {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwopen https://t.me/%1$s?start=%2$s{Ix -- the bot links this account.",
+   "ua": "  {WA{x) {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwвідкрий https://t.me/%1$s?start=%2$s{Ix -- бот прив'яже цей акаунт."
+  },
+  "  {WB{x) с другого Telegram -- напиши боту {W@%1$s{x команду {W/attach %2$s{x.": {
+   "en": "  {WB{x) from another Telegram -- send the bot {W@%1$s{x the command {W/attach %2$s{x.",
+   "ua": "  {WB{x) з іншого Telegram -- напиши боту {W@%1$s{x команду {W/attach %2$s{x."
+  },
+  "Напиши боту Валькирия {IW({hlhttps://discord.com/users/%1$s{x){Ix{Iw(в привате, discord.com/users/%1$s){Ix команду {W/link %2$s{x.": {
+   "en": "Send the bot Valkyrie {IW({hlhttps://discord.com/users/%1$s{x){Ix{Iw(in a DM, discord.com/users/%1$s){Ix the command {W/link %2$s{x.",
+   "ua": "Напиши боту Валькірія {IW({hlhttps://discord.com/users/%1$s{x){Ix{Iw(у приваті, discord.com/users/%1$s){Ix команду {W/link %2$s{x."
+  },
+  "Никому не показывай код: кто его введет, привяжет этого персонажа к своему аккаунту.": {
+   "en": "Do not share this code: whoever enters it links this character to their account.",
+   "ua": "Нікому не показуй код: хто його введе, прив'яже цього персонажа до свого акаунта."
+  },
+  "Использование: {yаккаунт{x -- статус, {yаккаунт связать{x -- код в любой бот, {yаккаунт дискорд{x / {yаккаунт телеграм{x -- по каналу. Подробнее: {hh5106аккаунт{x.": {
+   "en": "Usage: {yaccount{x -- status, {yaccount link{x -- code into any bot, {yaccount discord{x / {yaccount telegram{x -- by channel. More: {hh5106account{x.",
+   "ua": "Використання: {yакаунт{x -- статус, {yакаунт звязати{x -- код у будь-який бот, {yакаунт дискорд{x / {yакаунт телеграм{x -- за каналом. Докладніше: {hh5106акаунт{x."
   }
  },
  "plug-ins/comm/accountservlet.cpp": {

--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -3744,25 +3744,25 @@
    "en": "It is single-use and valid for 10 minutes. Link it in either bot:",
    "ua": "Він одноразовий і діє 10 хвилин. Прив'яжи його в будь-якому з ботів:"
   },
-  "  Telegram {W@%1$s{x -- {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwоткрой https://t.me/%1$s?start=%2$s , либо{Ix команда {W/attach %2$s{x": {
-   "en": "  Telegram {W@%1$s{x -- {IWtap {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwopen https://t.me/%1$s?start=%2$s , or{Ix command {W/attach %2$s{x",
-   "ua": "  Telegram {W@%1$s{x -- {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwвідкрий https://t.me/%1$s?start=%2$s , або{Ix команда {W/attach %2$s{x"
+  "  Telegram {W@%1$s{x -- {IWоткрой {Ix{hlhttps://t.me/%1$s?start=%2$s{x, команда {W/attach %2$s{x": {
+   "en": "  Telegram {W@%1$s{x -- {IWopen {Ix{hlhttps://t.me/%1$s?start=%2$s{x, command {W/attach %2$s{x",
+   "ua": "  Telegram {W@%1$s{x -- {IWвідкрий {Ix{hlhttps://t.me/%1$s?start=%2$s{x, команда {W/attach %2$s{x"
   },
-  "  Discord Валькирия -- {IW{hlhttps://discord.com/users/%1$s{x{Ix{Iwв привате (discord.com/users/%1$s){Ix команда {W/link %2$s{x": {
-   "en": "  Discord Valkyrie -- {IW{hlhttps://discord.com/users/%1$s{x{Ix{Iwin a DM (discord.com/users/%1$s){Ix command {W/link %2$s{x",
-   "ua": "  Discord Валькірія -- {IW{hlhttps://discord.com/users/%1$s{x{Ix{Iwу приваті (discord.com/users/%1$s){Ix команда {W/link %2$s{x"
+  "  Discord Валькирия -- {IWв привате {Ix{hlhttps://discord.com/users/%1$s{x, команда {W/link %2$s{x": {
+   "en": "  Discord Valkyrie -- {IWin a DM {Ix{hlhttps://discord.com/users/%1$s{x, command {W/link %2$s{x",
+   "ua": "  Discord Валькірія -- {IWу приваті {Ix{hlhttps://discord.com/users/%1$s{x, команда {W/link %2$s{x"
   },
-  "  {WA{x) {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwоткрой https://t.me/%1$s?start=%2$s{Ix -- бот привяжет этот аккаунт.": {
-   "en": "  {WA{x) {IWtap {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwopen https://t.me/%1$s?start=%2$s{Ix -- the bot links this account.",
-   "ua": "  {WA{x) {IWтапни {hlhttps://t.me/%1$s?start=%2$s{x{Ix{Iwвідкрий https://t.me/%1$s?start=%2$s{Ix -- бот прив'яже цей акаунт."
+  "  {WA{x) {IWоткрой {Ix{hlhttps://t.me/%1$s?start=%2$s{x -- бот привяжет этот аккаунт.": {
+   "en": "  {WA{x) {IWopen {Ix{hlhttps://t.me/%1$s?start=%2$s{x -- the bot links this account.",
+   "ua": "  {WA{x) {IWвідкрий {Ix{hlhttps://t.me/%1$s?start=%2$s{x -- бот прив'яже цей акаунт."
   },
   "  {WB{x) с другого Telegram -- напиши боту {W@%1$s{x команду {W/attach %2$s{x.": {
    "en": "  {WB{x) from another Telegram -- send the bot {W@%1$s{x the command {W/attach %2$s{x.",
    "ua": "  {WB{x) з іншого Telegram -- напиши боту {W@%1$s{x команду {W/attach %2$s{x."
   },
-  "Напиши боту Валькирия {IW({hlhttps://discord.com/users/%1$s{x){Ix{Iw(в привате, discord.com/users/%1$s){Ix команду {W/link %2$s{x.": {
-   "en": "Send the bot Valkyrie {IW({hlhttps://discord.com/users/%1$s{x){Ix{Iw(in a DM, discord.com/users/%1$s){Ix the command {W/link %2$s{x.",
-   "ua": "Напиши боту Валькірія {IW({hlhttps://discord.com/users/%1$s{x){Ix{Iw(у приваті, discord.com/users/%1$s){Ix команду {W/link %2$s{x."
+  "Напиши боту Валькирия {IWв привате {Ix{hlhttps://discord.com/users/%1$s{x команду {W/link %2$s{x.": {
+   "en": "Send the bot Valkyrie {IWin a DM {Ix{hlhttps://discord.com/users/%1$s{x the command {W/link %2$s{x.",
+   "ua": "Напиши боту Валькірія {IWу приваті {Ix{hlhttps://discord.com/users/%1$s{x команду {W/link %2$s{x."
   },
   "Никому не показывай код: кто его введет, привяжет этого персонажа к своему аккаунту.": {
    "en": "Do not share this code: whoever enters it links this character to their account.",

--- a/helps/help.xml
+++ b/helps/help.xml
@@ -3600,6 +3600,8 @@ You can often find us on Telegram, Discord, or in the world. If you want to beco
 %PAUSE%
 * {ydreamland.mud@gmail.com{x
 %RESUME%
+
+Those same Telegram and Discord also link your characters into one {hh5106account{x -- a single login and a way back in if you ever lose a password. That is separate from {hh1087config{x, which only sets the messenger on this one character.
 </text>
     <text l="ru">С большинством игроков и {hh1010разработчиков{x можно поболтать или задать любые вопросы даже когда их нет в мире -- приходи к нам в уютный чатик!
 %PAUSE%
@@ -3639,6 +3641,8 @@ You can often find us on Telegram, Discord, or in the world. If you want to beco
 %PAUSE%
 * {ydreamland.mud@gmail.com{x
 %RESUME%
+
+Те же Телеграм и Дискорд связывают твоих персонажей в один {hh5106аккаунт{x -- единый вход и способ вернуться, если потеряешь пароль. Это отдельно от {hh1087режима{x, который лишь задает мессенджер этому персонажу.
 </text>
     <text l="ua">З більшістю гравців і {hh1010розробників{x можна поспілкуватися або поставити будь-які запитання навіть коли їх немає у світі -- приходь до нас у затишний чатик!
 %PAUSE%
@@ -3678,6 +3682,8 @@ You can often find us on Telegram, Discord, or in the world. If you want to beco
 %PAUSE%
 * {ydreamland.mud@gmail.com{x
 %RESUME%
+
+Ті самі Телеграм і Дискорд звʼязують твоїх персонажів в один {hh5106акаунт{x -- єдиний вхід і спосіб повернутися, якщо втратиш пароль. Це окремо від {hh1087режиму{x, який лише задає месенджер цьому персонажу.
 </text>
     <title l="en">How to chat with other players</title>
     <title l="ru">Как пообщаться с другими игроками</title>


### PR DESCRIPTION
World-side companion to dreamland_code#1217 (email-accounts epic, Trello 2zFpQBoW). MUST ride the SAME reboot as the code binary — help docs reference `account discord`/`account telegram` that only exist in that binary. Ships DARK.

- helps/help.xml: help 5106 (discord/telegram forms + verify-asymmetry), help 66 contact cross-ref.
- config/translations/plug-ins.json: catalog EN/UA (11 new strings for the channel/link UX).
- commands/account.xml: command metadata.

fable RELEASE (same bundle review as #1217). Zero file overlap with master since branch base (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)