### PR TITLE
accounts catalog: drop 10 stale account.cpp keys (UX-pass orphans)

### DIFF
--- a/config/translations/plug-ins.json
+++ b/config/translations/plug-ins.json
@@ -3648,18 +3648,6 @@
    "en": "To cancel your suicide attempt, enter {ydelete without password.",
    "ua": "Щоб скасувати спробу самогубства, введи {yвидалити без пароля."
   },
-  "Твой персонаж не привязан к аккаунту.": {
-   "en": "Your character is not linked to an account.",
-   "ua": "Твій персонаж не прив'язаний до акаунта."
-  },
-  "Аккаунт связывает твоих персонажей и дает способ восстановить доступ. Набери {yаккаунт связать{x, чтобы начать.": {
-   "en": "An account ties your characters together and gives you a way to recover access. Type {yaccount link{x to begin.",
-   "ua": "Акаунт з'єднує твоїх персонажів і дає спосіб відновити доступ. Набери {yакаунт звязати{x, щоб почати."
-  },
-  "Твой Discord уже подтвержден ({W%1$s{x). Набери {yаккаунт связать дискорд{x, чтобы привязать аккаунт сразу, без кода.": {
-   "en": "Your Discord is already verified ({W%1$s{x). Type {yaccount link discord{x to link an account right away, no code.",
-   "ua": "Твій Discord уже підтверджено ({W%1$s{x). Набери {yакаунт звязати дискорд{x, щоб прив'язати акаунт одразу, без коду."
-  },
   "Аккаунт {W%1$s{x.": {
    "en": "Account {W%1$s{x.",
    "ua": "Акаунт {W%1$s{x."
@@ -3680,30 +3668,6 @@
    "en": "Your linking code: {W%1$s{x",
    "ua": "Твій код прив'язки: {W%1$s{x"
   },
-  "Он одноразовый и действует 10 минут. Введи его так:": {
-   "en": "It is single-use and valid for 10 minutes. Enter it like this:",
-   "ua": "Він одноразовий і діє 10 хвилин. Введи його так:"
-  },
-  "  Telegram: напиши боту команду {y/attach %1$s{x": {
-   "en": "  Telegram: send the bot the command {y/attach %1$s{x",
-   "ua": "  Telegram: напиши боту команду {y/attach %1$s{x"
-  },
-  "  Discord:  напиши боту команду {y/link %1$s{x": {
-   "en": "  Discord:  send the bot the command {y/link %1$s{x",
-   "ua": "  Discord:  напиши боту команду {y/link %1$s{x"
-  },
-  "  Сайт:     dreamland.rocks": {
-   "en": "  Website:  dreamland.rocks",
-   "ua": "  Сайт:     dreamland.rocks"
-  },
-  "Никому не показывай этот код: кто его введет, привяжет персонажа к своему аккаунту.": {
-   "en": "Do not share this code: whoever enters it links this character to their account.",
-   "ua": "Нікому не показуй цей код: хто його введе, прив'яже цього персонажа до свого акаунта."
-  },
-  "У тебя не подтвержден Discord. Свяжи аккаунт кодом: {yаккаунт связать{x.": {
-   "en": "You have no verified Discord. Link an account with a code instead: {yaccount link{x.",
-   "ua": "У тебе не підтверджено Discord. Зв'яжи акаунт кодом: {yакаунт звязати{x."
-  },
   "Ты уже привязан к аккаунту {W%1$s{x.": {
    "en": "You are already linked to account {W%1$s{x.",
    "ua": "Ти вже прив'язаний до акаунта {W%1$s{x."
@@ -3723,10 +3687,6 @@
   "Привязка по почте появится позже.": {
    "en": "Email linking will come later.",
    "ua": "Прив'язка поштою з'явиться пізніше."
-  },
-  "Использование: {yаккаунт{x -- статус, {yаккаунт связать{x -- код привязки.": {
-   "en": "Usage: {yaccount{x -- status, {yaccount link{x -- linking code.",
-   "ua": "Використання: {yакаунт{x -- статус, {yакаунт звязати{x -- код прив'язки."
   },
   "Твой персонаж не привязан к аккаунту. Аккаунт вернет доступ, если потеряешь пароль, и соберет всех персонажей под одним входом; скоро -- перенос qp между своими и перки.": {
    "en": "Your character is not linked to an account. An account gets you back in if you lose your password and keeps all your characters under one login; coming soon -- move qp between your own characters, and perks.",


### PR DESCRIPTION
Removes 10 dead RU catalog entries from the `plug-ins/comm/account.cpp` group in plug-ins.json — source strings the #1217 UX bundle reworded, so they're never looked up. Deletions only (40 lines), 0 additions, JSON valid, no live key touched. account.cpp group 41 -> 31, 0 stale remain.

fable RELEASE (reviews/2026-09-11-accounts-f5-catalog-sweep.md — verified no live key removed, no EN/UA fallback regression). The 10th key was fable's own catch (a prefix of the live long-form line that a substring scan missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)