### PR TITLE
paladin skills: add detect good, fix frenzy/holy word ordering

### DIFF
--- a/generic-skills/detect good.xml
+++ b/generic-skills/detect good.xml
@@ -28,6 +28,11 @@
       <maximum>100</maximum>
       <rating>1</rating>
     </node>
+    <node name="paladin">
+      <level>12</level>
+      <maximum>100</maximum>
+      <rating>1</rating>
+    </node>
     <node name="vampire">
       <level>13</level>
       <maximum>100</maximum>

--- a/generic-skills/frenzy.xml
+++ b/generic-skills/frenzy.xml
@@ -19,7 +19,7 @@
       <rating>1</rating>
     </node>
     <node name="paladin">
-      <level>41</level>
+      <level>38</level>
       <maximum>100</maximum>
       <rating>1</rating>
     </node>

--- a/generic-skills/holy word.xml
+++ b/generic-skills/holy word.xml
@@ -13,7 +13,7 @@
       <rating>1</rating>
     </node>
     <node name="paladin">
-      <level>38</level>
+      <level>41</level>
       <maximum>100</maximum>
       <rating>1</rating>
     </node>


### PR DESCRIPTION
- detect good: grant to paladin @12, mirroring detect evil (paladins could
  sense evil auras but not good/blessed-item auras).
- frenzy 41->38, holy word 38->41: holy word (the ultimate prayer) was
  learnable before frenzy, inverted vs cleric (34/48) and anti-paladin (45/68).

Reported by Dementia.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku
