### PR TITLE
Varda help: restriction non-evil (good+neutral)

### DIFF
--- a/religions/varda.xml
+++ b/religions/varda.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Religion type="DefaultReligion">
-  <align>good</align>
-  <description>Мать Богов, верховная богиня</description>
+  <align>good neutral</align>
+  <description l="en"></description>
+  <description l="ru">Мать Богов, верховная богиня</description>
+  <description l="ua"></description>
   <ethos>lawful neutral chaotic</ethos>
   <help id="1565" level="-1" type="ReligionHelp">
     <extra l="en"></extra>
@@ -14,7 +16,7 @@
 
 %A% =Paths:= {WLight{x (supreme goddess), {gNature{x 
 %A% =Gifts:= in battle Varda's mark will envelop you in protective {hh760stardust{x, {x and for elves she will help temporarily shed the vulnerability to iron.
-%A% =Restrictions:= {hh33good{x only
+%A% =Restrictions:= {hh33non-evil{x only
 
 %SA% %H% {hh81Eight Paths{x, {hh80epochs{x
 </text>
@@ -22,7 +24,7 @@
 
 %A% =Пути:= {WСвет{x (верховная богиня), {gПрирода{x 
 %A% =Дары:= в бою знак Варды окутает тебя защитной {hh760звездной пылью{x, {x а эльфам она поможет временно избавиться от уязвимости к железу.
-%A% =Ограничения:= только {hh33добрые{x
+%A% =Ограничения:= только {hh33не-злые{x
 
 %SA% %H% {hh81Восемь Путей{x, {hh80эпохи{x
 </text>
@@ -30,7 +32,7 @@
 
 %A% =Шляхи:= {WСвітло{x (верховна богиня), {gПрирода{x 
 %A% =Дари:= у бою знак Варди огорне тебе захисним {hh760зоряним пилом{x, {x а ельфам вона допоможе тимчасово позбутися вразливості до заліза.
-%A% =Обмеження:= тільки {hh33добрі{x
+%A% =Обмеження:= тільки {hh33не-злі{x
 
 %SA% %H% {hh81Вісім Шляхів{x, {hh80епохи{x
 </text>
@@ -40,8 +42,8 @@
     <liquidFlags></liquidFlags>
   </likes>
   <nameRus>Вард|а|ы|е|у|ой|е</nameRus>
-  <nameUa>Вард|а|и|і|у|ою|і</nameUa>
   <nameRusFemale></nameRusFemale>
+  <nameUa>Вард|а|и|і|у|ою|і</nameUa>
   <patronsRaces registry="race">elf</patronsRaces>
   <sex>female</sex>
   <shortDescr>Varda</shortDescr>


### PR DESCRIPTION
Fix the Varda religion help to match Kit's live reledit change (align good -> good neutral, opening her to neutral druids per lore). Restriction line goes 'good only' -> 'non-evil' in EN/RU/UA, reusing the {hh33 idiom ahuramazda already uses for the good+neutral set. The committed file also captures live's current align/serialization so a per-file deploy won't rewind the reledit change.